### PR TITLE
feat(obs): land the hosting-observability instrument set ahead of what it measures

### DIFF
--- a/crates/core/benches/transport_extended.rs
+++ b/crates/core/benches/transport_extended.rs
@@ -141,7 +141,7 @@ pub fn bench_high_latency_sustained(c: &mut Criterion) {
                         // Send from A to B
                         let send_result = conn_a.send(message).await;
                         let sent_ok = match send_result {
-                            Ok(()) => true,
+                            Ok(_bytes_sent) => true,
                             Err(e) => {
                                 eprintln!("sustained send failed: {:?}", e);
                                 false

--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -3120,20 +3120,18 @@ mod tests {
         let got = probe_release_tag_at(&server.url_str("/releases/latest"))
             .await
             .expect("a 403 is a normal outcome, not a transport error");
-        match got {
-            ProbeResult::RateLimited { retry_after } => {
-                let secs = retry_after
-                    .expect("reset header must yield a wait")
-                    .as_secs();
-                // Converted from absolute to delta; allow a second of clock drift
-                // between the header being built and being parsed.
-                assert!(
-                    (1_499..=1_500).contains(&secs),
-                    "expected ~1500s derived from x-ratelimit-reset, got {secs}"
-                );
-            }
-            other => panic!("403 must classify as rate-limited, got {other:?}"),
-        }
+        let ProbeResult::RateLimited { retry_after } = &got else {
+            panic!("403 must classify as rate-limited, got {got:?}");
+        };
+        let secs = retry_after
+            .expect("reset header must yield a wait")
+            .as_secs();
+        // Converted from absolute to delta; allow a second of clock drift
+        // between the header being built and being parsed.
+        assert!(
+            (1_499..=1_500).contains(&secs),
+            "expected ~1500s derived from x-ratelimit-reset, got {secs}"
+        );
     }
 
     #[tokio::test]
@@ -3256,13 +3254,13 @@ mod tests {
                 )),
         );
 
-        match probe_release_tag_at(&server.url_str("/releases/latest"))
+        let got = probe_release_tag_at(&server.url_str("/releases/latest"))
             .await
-            .expect("an off-host redirect must resolve to Unusable, not error")
-        {
-            ProbeResult::Unusable { status, .. } => assert_eq!(status, 301),
-            other => panic!("off-host redirect must not be followed, got {other:?}"),
-        }
+            .expect("an off-host redirect must resolve to Unusable, not error");
+        let ProbeResult::Unusable { status, .. } = &got else {
+            panic!("off-host redirect must not be followed, got {got:?}");
+        };
+        assert_eq!(*status, 301);
     }
 
     #[test]
@@ -3352,14 +3350,14 @@ mod tests {
             .expect("exceeding the deadline is a normal outcome, not an error");
         let elapsed = started.elapsed();
 
-        match got {
-            ProbeResult::Aborted { reason } => assert!(
-                reason.contains("chain deadline"),
-                "hitting the deadline must say so, so an operator can tell it from \
-                 a malformed redirect"
-            ),
-            other => panic!("a chain that never resolves must end Unusable, got {other:?}"),
-        }
+        let ProbeResult::Aborted { reason } = &got else {
+            panic!("a chain that never resolves must end Unusable, got {got:?}");
+        };
+        assert!(
+            reason.contains("chain deadline"),
+            "hitting the deadline must say so, so an operator can tell it from \
+             a malformed redirect"
+        );
         // Generous upper bound: the point is that it stops near the deadline
         // rather than running all 4 hops (800ms+), not that it is precise.
         assert!(
@@ -3423,18 +3421,16 @@ mod tests {
                 .respond_with(status_code(302).append_header("location", "/loop")),
         );
 
-        match probe_release_tag_at(&server.url_str("/loop"))
+        let got = probe_release_tag_at(&server.url_str("/loop"))
             .await
-            .expect("a redirect loop must terminate, not error out")
-        {
-            ProbeResult::Aborted { reason } => {
-                assert!(
-                    reason.contains("redirect limit"),
-                    "giving up on a loop should say so"
-                );
-            }
-            other => panic!("a redirect loop must end Unusable, got {other:?}"),
-        }
+            .expect("a redirect loop must terminate, not error out");
+        let ProbeResult::Aborted { reason } = &got else {
+            panic!("a redirect loop must end Unusable, got {got:?}");
+        };
+        assert!(
+            reason.contains("redirect limit"),
+            "giving up on a loop should say so"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -108,6 +108,19 @@ static FREENET_REVOCATION_PUBKEY: [u8; 32] = [
 ///     auto-update.
 const REQUIRE_RELEASE_SIGNATURE: bool = false;
 
+// Tripwire for the two-release rollout, checked at compile time so flipping
+// the constant fails the build immediately rather than only when the test
+// suite happens to run. Flipping this to `true` makes an ABSENT signature
+// refuse the install, which bricks auto-update for any node still updating
+// from an unsigned older release. Only flip it (and then update this
+// assertion) once every release a live node could be updating from publishes
+// SHA256SUMS.txt.sig. See REQUIRE_RELEASE_SIGNATURE's doc comment above.
+const _: () = assert!(
+    !REQUIRE_RELEASE_SIGNATURE,
+    "do not require signatures until the signed floor is established; \
+     see the two-release transition note on REQUIRE_RELEASE_SIGNATURE"
+);
+
 /// Exit code returned when the binary is already up to date (no update performed).
 /// Used by the service wrapper to avoid unnecessary restarts.
 pub const EXIT_CODE_ALREADY_UP_TO_DATE: i32 = 2;
@@ -4093,19 +4106,10 @@ done
             .expect("baked-in revocation public key must be a valid ed25519 point");
     }
 
-    #[test]
-    fn transition_flag_is_false_until_signed_floor_established() {
-        // Tripwire for the two-release rollout. Flipping this to `true` makes
-        // an ABSENT signature refuse the install, which bricks auto-update for
-        // any node still updating from an unsigned older release. Only flip it
-        // (and then update this test) once every release a live node could be
-        // updating from publishes SHA256SUMS.txt.sig. See REQUIRE_RELEASE_SIGNATURE.
-        assert!(
-            !REQUIRE_RELEASE_SIGNATURE,
-            "do not require signatures until the signed floor is established; \
-             see the two-release transition note on REQUIRE_RELEASE_SIGNATURE"
-        );
-    }
+    // transition_flag_is_false_until_signed_floor_established: superseded by
+    // the `const _: () = assert!(...)` compile-time tripwire next to
+    // REQUIRE_RELEASE_SIGNATURE's definition, which catches the flip at
+    // build time instead of only when this test happens to run.
 
     #[test]
     fn valid_signature_accepted() {

--- a/crates/core/src/client_events/user_op_rate_limit.rs
+++ b/crates/core/src/client_events/user_op_rate_limit.rs
@@ -668,7 +668,6 @@ mod tests {
                 let limiter = limiter.clone();
                 let admitted = admitted.clone();
                 let barrier = barrier.clone();
-                let user = user;
                 scope.spawn(move || {
                     // Line everyone up so the acquires actually overlap.
                     barrier.wait();

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -2756,9 +2756,15 @@ mod tests {
         tokio::spawn(async move {
             while let Some(conn) = req_rx.recv().await {
                 if let ClientConnection::NewConnection { callbacks, .. } = conn {
-                    let _ = callbacks.send(HostCallbackResult::NewId {
-                        id: ClientId::next(),
-                    });
+                    if callbacks
+                        .send(HostCallbackResult::NewId {
+                            id: ClientId::next(),
+                        })
+                        .is_err()
+                    {
+                        // The connection under test hung up; nothing left to serve.
+                        break;
+                    }
                 }
             }
         });
@@ -2769,19 +2775,23 @@ mod tests {
         ) -> impl IntoResponse {
             ws.on_upgrade(move |socket| async move {
                 // `token_is_invalid = true` drives the stale-token close path.
-                let _ = websocket_interface(
-                    rs,
-                    None,
-                    None,
-                    ConnectionScope::Local,
-                    None,
-                    None,
-                    true,
-                    EncodingProtocol::Native,
-                    ApiVersion::V1,
-                    socket,
-                )
-                .await;
+                // The interface's own return value is not the signal under test:
+                // the assertion is the close CODE the client observes.
+                drop(
+                    websocket_interface(
+                        rs,
+                        None,
+                        None,
+                        ConnectionScope::Local,
+                        None,
+                        None,
+                        true,
+                        EncodingProtocol::Native,
+                        ApiVersion::V1,
+                        socket,
+                    )
+                    .await,
+                );
             })
         }
 
@@ -2793,7 +2803,9 @@ mod tests {
             .unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
+            // Serving ends when the test drops the listener task; its result is
+            // teardown noise, not a signal.
+            drop(axum::serve(listener, app).await);
         });
 
         let (mut client, _resp) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
@@ -2804,6 +2816,10 @@ mod tests {
         // skip anything that is not a Close and read the close code.
         let observed_close_code = tokio::time::timeout(Duration::from_secs(5), async {
             while let Some(frame) = client.next().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "the test reads the CLOSE frame only; every other tungstenite frame kind is deliberately skipped, and that stays right for any variant tungstenite adds"
+                )]
                 match frame.expect("ws frame") {
                     tokio_tungstenite::tungstenite::Message::Close(Some(cf)) => {
                         return Some(u16::from(cf.code));
@@ -3487,15 +3503,13 @@ mod tests {
             !matches!(err, DelegateError::Missing(_)),
             "throttling must not masquerade as an unregistered delegate"
         );
-        match &err {
-            DelegateError::ExecutionError(msg) => {
-                assert!(
-                    msg.contains("rate limited"),
-                    "the cause should be legible in the message: {msg}"
-                );
-            }
-            other => panic!("expected ExecutionError, got {other:?}"),
-        }
+        let DelegateError::ExecutionError(msg) = &err else {
+            panic!("expected ExecutionError, got {err:?}");
+        };
+        assert!(
+            msg.contains("rate limited"),
+            "the cause should be legible in the message: {msg}"
+        );
 
         // And it carries no key, so it cannot be mistaken for a per-delegate
         // failure by the tracker.

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1674,6 +1674,14 @@ mod tests {
     mod byte_bounded_lru_cache_tests {
         use super::*;
 
+        // `&Vec<u8>` (not `&[u8]`) is required here: this is passed as a
+        // `fn(&V) -> usize` to `ByteBoundedLruCache::new` with `V = Vec<u8>`,
+        // and a bare fn-item's signature must match the generic parameter's
+        // instantiated type exactly — `&[u8]` would not coerce.
+        #[allow(
+            clippy::ptr_arg,
+            reason = "must match ByteBoundedLruCache<_, Vec<u8>>'s fn(&V) -> usize weigh signature exactly"
+        )]
         fn vec_len(v: &Vec<u8>) -> usize {
             v.len()
         }
@@ -2471,20 +2479,23 @@ mod tests {
                 !put_err.is_contract_exec_rejection(),
                 "a Put variant is NOT an UPDATE-side exec rejection"
             );
-            match put_err.unwrap_request() {
-                RequestError::ContractError(StdContractError::Put { .. }) => {}
-                other => panic!("fresh-PUT validation error must be a Put variant, got {other:?}"),
-            }
+            let put_request_err = put_err.unwrap_request();
+            let RequestError::ContractError(StdContractError::Put { .. }) = &put_request_err else {
+                panic!("fresh-PUT validation error must be a Put variant, got {put_request_err:?}");
+            };
 
             // UPDATE op → Update variant, is_contract_exec_rejection true, timeout true.
             let upd_err =
                 ExecutorError::execution(mk(), Some(super::super::InnerOpError::Upsert(key)));
             assert!(upd_err.is_wasm_timeout());
             assert!(upd_err.is_contract_exec_rejection());
-            match upd_err.unwrap_request() {
-                RequestError::ContractError(StdContractError::Update { .. }) => {}
-                other => panic!("UPDATE validation error must be an Update variant, got {other:?}"),
-            }
+            let upd_request_err = upd_err.unwrap_request();
+            let RequestError::ContractError(StdContractError::Update { .. }) = &upd_request_err
+            else {
+                panic!(
+                    "UPDATE validation error must be an Update variant, got {upd_request_err:?}"
+                );
+            };
         }
 
         /// Source-scrape pin (#4864 round-7 Codex P1, updated round-9 item 4): the

--- a/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/summarize_delta_cache_tests.rs
@@ -470,9 +470,12 @@ async fn summary_cache_covers_live_hosted_count_not_fixed_cap() {
             )
             .await
             .expect("PUT");
-            op_manager
-                .ring
-                .host_contract(key, state.as_ref().len() as u64, AccessType::Get);
+            op_manager.ring.host_contract(
+                key,
+                state.as_ref().len() as u64,
+                AccessType::Get,
+                crate::ring::HostingCause::Other,
+            );
             keys.push(key);
         }
         assert_eq!(

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1797,12 +1797,10 @@ mod remove_contract_tests {
                 None,
             )
             .expect("register-with-predecessors must succeed");
-        match resp {
-            HostResponse::DelegateResponse { key, .. } => {
-                assert_eq!(&key, succ.key(), "response carries the successor key");
-            }
-            other => panic!("expected DelegateResponse, got {other:?}"),
-        }
+        let HostResponse::DelegateResponse { key, .. } = &resp else {
+            panic!("expected DelegateResponse, got {resp:?}");
+        };
+        assert_eq!(key, succ.key(), "response carries the successor key");
 
         // The predecessor's Local secret must NOT be copied — the copy-forward
         // is unconditionally disabled (GHSA-824h-7x5x-wfmf), even though the supplied

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -619,7 +619,10 @@ mod resolve_message_origin_tests {
         // handler rejects it against MAX_MIGRATION_PREDECESSORS).
         let many: Vec<DelegateKey> = (0u8..200).map(dkey).collect();
         assert_eq!(dedupe_predecessors(many).len(), 200);
-        assert!(200 > MAX_MIGRATION_PREDECESSORS);
+        // Compile-time tripwire: if MAX_MIGRATION_PREDECESSORS is ever raised to
+        // >= 200 this fails the build, so the "many" fixture above always stays
+        // large enough to actually exercise the over-cap scenario elsewhere.
+        const _: () = assert!(200 > MAX_MIGRATION_PREDECESSORS);
     }
 
     /// Caller delegate identity wins over a concurrently-supplied WebApp

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -1327,6 +1327,10 @@ mod tests {
         let bytes = bincode::serialize(&msg).expect("serialize SummaryDigests");
         let decoded: InterestMessage =
             bincode::deserialize(&bytes).expect("deserialize SummaryDigests");
+        #[allow(
+            clippy::wildcard_enum_match_arm,
+            reason = "a round-trip test asserts ONE variant; any other variant is a loud panic, not a silent fallthrough"
+        )]
         match decoded {
             InterestMessage::SummaryDigests { entries, .. } => {
                 assert_eq!(entries.len(), 2);
@@ -1349,10 +1353,10 @@ mod tests {
         let bytes = bincode::serialize(&req).expect("serialize SummaryRequest");
         let decoded: InterestMessage =
             bincode::deserialize(&bytes).expect("deserialize SummaryRequest");
-        match decoded {
-            InterestMessage::SummaryRequest { hashes } => assert_eq!(hashes, vec![1, 2, 3]),
-            other => panic!("expected SummaryRequest, got {other:?}"),
-        }
+        let InterestMessage::SummaryRequest { hashes } = &decoded else {
+            panic!("expected SummaryRequest, got {decoded:?}");
+        };
+        assert_eq!(hashes, &vec![1, 2, 3]);
     }
 
     /// A `SummaryDigests` message must be dramatically smaller than the
@@ -1742,19 +1746,17 @@ mod tests {
         );
 
         let decoded: InterestMessage = bincode::deserialize(&notification).expect("deserialize");
-        match decoded {
-            InterestMessage::Summaries { entries, emitter } => {
-                assert_eq!(entries.len(), 1, "payload must survive the round trip");
-                assert_eq!(entries[0].hash, 0xDEAD_BEEF);
-                assert_eq!(
-                    emitter,
-                    SummariesEmitter::Other,
-                    "a decoded message carries no provenance, so it must land \
-                     in the residual arm rather than claim an emitter"
-                );
-            }
-            other => panic!("expected Summaries, got {other:?}"),
-        }
+        let InterestMessage::Summaries { entries, emitter } = &decoded else {
+            panic!("expected Summaries, got {decoded:?}");
+        };
+        assert_eq!(entries.len(), 1, "payload must survive the round trip");
+        assert_eq!(entries[0].hash, 0xDEAD_BEEF);
+        assert_eq!(
+            *emitter,
+            SummariesEmitter::Other,
+            "a decoded message carries no provenance, so it must land \
+             in the residual arm rather than claim an emitter"
+        );
     }
 
     #[test]

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -6043,6 +6043,13 @@ mod tests {
         let handler_key = key;
         let _handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "a stand-in executor loop: it only serves the two \
+                              queries this test issues, and ContractHandlerEvent \
+                              has 20+ variants — any other event reaching it is \
+                              an unexpected-input panic, not a silent fallthrough"
+                )]
                 let response = match ev {
                     ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
                         key: Some(handler_key),
@@ -6162,6 +6169,14 @@ mod tests {
         let handler_flag = update_query_seen.clone();
         let _handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "a stand-in executor loop: it only serves the one \
+                              query this test expects, and ContractHandlerEvent \
+                              has 20+ variants — any other event reaching it is \
+                              the regression under test, so it panics rather \
+                              than falling through silently"
+                )]
                 let response = match ev {
                     ContractHandlerEvent::UpdateQuery { .. } => {
                         handler_flag.store(true, Ordering::SeqCst);
@@ -6291,6 +6306,13 @@ mod tests {
         let handler_flag = update_query_seen.clone();
         let _handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "a stand-in executor loop: it only serves the one \
+                              query this test expects, and ContractHandlerEvent \
+                              has 20+ variants — any other event reaching it is \
+                              an unexpected-input panic, not a silent fallthrough"
+                )]
                 let response = match ev {
                     ContractHandlerEvent::UpdateQuery { .. } => {
                         handler_flag.store(true, Ordering::SeqCst);
@@ -8975,6 +8997,14 @@ mod tests {
             let queries_for_handler = std::sync::Arc::clone(&summary_queries);
             let handler = tokio::spawn(async move {
                 while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                    #[allow(
+                        clippy::wildcard_enum_match_arm,
+                        reason = "a stand-in executor loop: it only serves the \
+                                  three queries this test issues, and \
+                                  ContractHandlerEvent has 20+ variants — any \
+                                  other event reaching it is an unexpected-input \
+                                  panic, not a silent fallthrough"
+                    )]
                     let response = match ev {
                         ContractHandlerEvent::GetSummaryQuery { key } => {
                             queries_for_handler.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3107,9 +3107,16 @@ pub(crate) fn full_summaries_message(
 /// IDENTICAL heal path rather than growing a second copy that can drift. The
 /// hash-first exchange must not cost convergence, so there is exactly one
 /// implementation of "we decided this peer is stale, now fix it".
+///
+/// `peer_key` is the stable identity of `source`, carried in solely so the
+/// shadow-mode futile-repair detector can attribute the attempt to the same
+/// (contract, peer) edge the outcome is later observed on
+/// (`crate::ring::futile_repair`). It gates nothing: a `None` here suppresses
+/// only the diagnostic recording, never a heal.
 async fn emit_stale_peer_syncs(
     op_manager: &Arc<OpManager>,
     source: std::net::SocketAddr,
+    peer_key: Option<&crate::ring::interest::PeerKey>,
     mut stale_contracts: Vec<freenet_stdlib::prelude::ContractKey>,
 ) {
     // #3798 Gap 1: cap the number of SyncStateToPeer events emitted per
@@ -3176,6 +3183,17 @@ async fn emit_stale_peer_syncs(
         // the budget — the dropped event is retried next cycle exactly like an
         // over-cap one.
         emitted += 1;
+        // SHADOW MODE (futile-repair detector, `crate::ring::futile_repair`).
+        // Recorded HERE — past the ban and no-local-state gates and inside the
+        // budget — because those three skips mean no repair was sent. Charging
+        // the edge for a heal we never emitted would make the detector measure
+        // our own emit budget rather than whether repair works. Pure
+        // accounting: no gate, no early return, no behaviour change.
+        if let Some(pk) = peer_key {
+            op_manager
+                .interest_manager
+                .record_repair_attempt(&contract, pk);
+        }
         // Fires per stale-peer detection during interest sync, which is
         // dominant on hot contracts. Diagnostic-grade rather than
         // user-actionable; keep accessible via RUST_LOG=…=debug.
@@ -3457,7 +3475,13 @@ async fn handle_interest_sync_message(
             let mut confirmed_states: Vec<(freenet_stdlib::prelude::ContractKey, String)> =
                 Vec::new();
 
-            if let Some(pk) = peer_key {
+            // Cloned rather than moved so `peer_key` survives for the
+            // `emit_stale_peer_syncs` call below, which needs the peer's stable
+            // identity to attribute the heal to a futile-repair edge. A
+            // `PeerKey` wraps an x25519 `PublicKey` — a 32-byte `Copy` — so
+            // this is a byte copy, not a key operation, and it happens once per
+            // InterestSync message.
+            if let Some(pk) = peer_key.clone() {
                 // Per-message budget for semantic-staleness WASM probes
                 // (`get_state_delta`), spent across ALL entries/contracts in
                 // this Summaries message. Bounds the DoS surface of a peer
@@ -3601,6 +3625,27 @@ async fn handle_interest_sync_message(
                             _ => false,
                         };
 
+                        // SHADOW MODE (futile-repair detector,
+                        // `crate::ring::futile_repair`). This is the OUTCOME
+                        // observation: a two-sided comparison — both sides
+                        // reported a real summary — that settles whatever heal
+                        // we last sent on this edge. Gated on two-sidedness
+                        // because a one-sided comparison is not a verdict about
+                        // convergence; the `(None, Some(_))` and `_` arms above
+                        // return `false` for "no basis to heal", not for
+                        // "agreed", and feeding that in would score every
+                        // contract we don't host as a successful repair.
+                        //
+                        // Passing `!is_stale` rather than a constant is the
+                        // whole detector: it is what separates a repair that
+                        // failed to converge from one that worked. Pure
+                        // accounting, no behaviour change.
+                        if our_summary.is_some() && their_summary.is_some() {
+                            op_manager
+                                .interest_manager
+                                .record_repair_outcome(&contract, &pk, !is_stale);
+                        }
+
                         // #4952: upsert (not update) when the peer reported a
                         // real summary, so the ~5-min anti-entropy exchange can
                         // seed a summary for an advertised co-host we don't
@@ -3656,7 +3701,7 @@ async fn handle_interest_sync_message(
             // many peers reported mismatches within the same heartbeat cycle.
             // The bounded, targeted emission lives in `emit_stale_peer_syncs`,
             // shared verbatim with the `SummaryDigests` arm.
-            emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
+            emit_stale_peer_syncs(op_manager, source, peer_key.as_ref(), stale_contracts).await;
 
             // Emit deferred StateConfirmed telemetry so the convergence
             // checker has up-to-date state hashes for CRDT-merged state.
@@ -3726,7 +3771,13 @@ async fn handle_interest_sync_message(
                 Vec::new();
             let mut request_hashes: Vec<u32> = Vec::new();
 
-            if let Some(pk) = peer_key {
+            // Cloned rather than moved so `peer_key` survives for the
+            // `emit_stale_peer_syncs` call below, which needs the peer's stable
+            // identity to attribute the heal to a futile-repair edge. A
+            // `PeerKey` wraps an x25519 `PublicKey` — a 32-byte `Copy` — so
+            // this is a byte copy, not a key operation, and it happens once per
+            // InterestSync message.
+            if let Some(pk) = peer_key.clone() {
                 // See `MAX_SUMMARY_HASHES_PER_MESSAGE`: entries are
                 // peer-supplied and cheap for the peer to fabricate, so
                 // deduplicate by hash and process a bounded window. The window
@@ -3947,6 +3998,19 @@ async fn handle_interest_sync_message(
                                 let is_stale = crate::ring::interest::summary_indicates_stale_peer(
                                     &ours, &ours, None,
                                 );
+                                // SHADOW MODE (futile-repair detector,
+                                // `crate::ring::futile_repair`). Two-sided by
+                                // construction: the digest PROVED the peer's
+                                // summary bytes are ours, so this settles an
+                                // outstanding heal on the edge exactly as the
+                                // `Summaries` arm does. `NeedBytes` deliberately
+                                // records nothing — it defers to the full-bytes
+                                // `Summaries` reply, which observes there, so
+                                // one divergence is never counted twice. Pure
+                                // accounting, no behaviour change.
+                                op_manager
+                                    .interest_manager
+                                    .record_repair_outcome(&contract, &pk, !is_stale);
                                 // #4952: seed the peer-summary cache so an
                                 // advertised co-host does not stay a
                                 // full-state broadcast target. Fact, not
@@ -4014,7 +4078,7 @@ async fn handle_interest_sync_message(
             // sub-second RTT is not a convergence risk, but it is a real
             // regression in heal LATENCY on the legs that ship digests, and it
             // is the price of not shipping the summary every cycle.
-            emit_stale_peer_syncs(op_manager, source, stale_contracts).await;
+            emit_stale_peer_syncs(op_manager, source, peer_key.as_ref(), stale_contracts).await;
 
             // A contract on the mismatch path is confirmed TWICE: once here,
             // once again when the requested bytes arrive at the `Summaries`
@@ -8562,6 +8626,127 @@ mod tests {
                  breaks simulation determinism"
             );
         }
+
+        /// Source-scrape pin: the shadow-mode futile-repair attempt is recorded
+        /// only where a heal is ACTUALLY emitted.
+        ///
+        /// The behavioural tests in `futile_repair_shadow` cannot see this: the
+        /// harness contract is never banned, always has local state, and never
+        /// exceeds the emit budget, so moving `record_repair_attempt` above
+        /// those gates leaves them all green. But a heal we did not send is not
+        /// a repair, and counting one would turn the detector into a measure of
+        /// our own emit budget — the exact "metric re-derived away from the
+        /// decision" failure in `.claude/rules/bug-prevention-patterns.md`.
+        #[test]
+        fn futile_repair_attempt_is_recorded_only_where_the_heal_is_emitted() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let start = SOURCE
+                .find("for contract in stale_contracts {")
+                .expect("stale-contract emission loop not found");
+            let window_end = SOURCE[start..]
+                .find("for (key, state_hash) in confirmed_states {")
+                .map(|off| start + off)
+                .unwrap_or(SOURCE.len());
+            let window = &SOURCE[start..window_end];
+
+            let record = window.find("record_repair_attempt(").expect(
+                "the futile-repair attempt is no longer recorded in the heal \
+                 emission loop — the detector cannot pair an outcome with an \
+                 attempt that was never recorded",
+            );
+            for (gate, why) in [
+                (
+                    "if emitted >= emit_budget {",
+                    "an over-budget contract is deferred, not healed",
+                ),
+                (
+                    "is_banned(contract.id())",
+                    "a banned contract is skipped, not healed",
+                ),
+                (
+                    "Skipping stale-peer sync",
+                    "a contract with no local state is skipped, not healed",
+                ),
+                (
+                    "emitted += 1;",
+                    "the attempt must be counted with the emission it belongs to",
+                ),
+            ] {
+                let gate_pos = window.find(gate).unwrap_or_else(|| {
+                    panic!("heal-loop gate `{gate}` not found — update this pin")
+                });
+                assert!(
+                    gate_pos < record,
+                    "record_repair_attempt must come AFTER `{gate}`: {why}, so \
+                     charging the edge for it makes the futile-repair detector \
+                     measure our own emit budget instead of whether repair works"
+                );
+            }
+        }
+
+        /// Source-scrape pin: the outcome sites must pass the COMPARISON
+        /// VERDICT, not a constant.
+        ///
+        /// This is the mutation the feature is defined against — a detector fed
+        /// `false` unconditionally counts every repair as futile and is
+        /// measuring load. `futile_repair_shadow` fails under that mutation
+        /// too; this pin survives a `#[cfg(test)]` module being cut, and names
+        /// the two observation sites so a third one cannot be added silently.
+        #[test]
+        fn futile_repair_outcome_sites_pass_the_staleness_verdict() {
+            use crate::node::tests::code_only;
+
+            const SOURCE: &str = include_str!("node.rs");
+            let handler = SOURCE
+                .find("async fn handle_interest_sync_message(")
+                .expect("handle_interest_sync_message not found");
+            // Bound the window to the handler region. Without this the pin
+            // matches its OWN source (this test names every needle it looks
+            // for) and passes no matter what the handler does — the
+            // self-matching-needle trap.
+            let handler_end = handler
+                + SOURCE[handler..]
+                    .find("\n#[cfg(test)]")
+                    .or_else(|| SOURCE[handler..].find("\nmod tests {"))
+                    .expect("end of handler region not found");
+            let body = code_only(&SOURCE[handler..handler_end]);
+
+            let sites: Vec<_> = body.match_indices("record_repair_outcome(").collect();
+            assert_eq!(
+                sites.len(),
+                2,
+                "expected exactly two futile-repair outcome sites (the \
+                 `Summaries` two-sided comparison and the `SummaryDigests` \
+                 agreement); found {}. A new site must be a genuinely \
+                 two-sided comparison, or the detector starts scoring \
+                 one-sided reports as successful repairs",
+                sites.len()
+            );
+            for (pos, _) in sites {
+                let call = &body[pos..body[pos..]
+                    .find(");")
+                    .map(|o| pos + o)
+                    .unwrap_or(body.len())];
+                assert!(
+                    call.contains("!is_stale"),
+                    "a futile-repair outcome site passes something other than \
+                     `!is_stale`: the verdict IS the detector — a constant \
+                     there measures repair volume, not repair failure. Got: \
+                     {call}"
+                );
+            }
+            // Whitespace-stripped so rustfmt wrapping the condition cannot
+            // break the pin.
+            let squashed: String = body.split_whitespace().collect();
+            assert!(
+                squashed.contains("our_summary.is_some()&&their_summary.is_some()"),
+                "the `Summaries` outcome site no longer gates on a TWO-SIDED \
+                 comparison — the one-sided arms return `false` for \"no basis \
+                 to heal\", not for \"converged\", and feeding those in scores \
+                 every contract we do not host as a successful repair"
+            );
+        }
     }
 
     // ───────────────────────────────────────────────────────────
@@ -10679,7 +10864,9 @@ mod tests {
                 .expect("end of SummaryDigests arm not found");
             let body = &code_only(&src[arm..arm + end]);
             assert!(
-                body.contains("emit_stale_peer_syncs(op_manager, source, stale_contracts)"),
+                body.contains(
+                    "emit_stale_peer_syncs(op_manager, source, peer_key.as_ref(), stale_contracts)"
+                ),
                 "the SummaryDigests arm must delegate healing to the shared \
                  emit_stale_peer_syncs"
             );
@@ -10708,6 +10895,198 @@ mod tests {
                  identical/differing comparison, or the telemetry that \
                  justifies this change stops being able to measure it"
             );
+        }
+
+        /// End-to-end wiring for the SHADOW-MODE futile-repair detector
+        /// (`crate::ring::futile_repair`).
+        ///
+        /// The detector's whole claim is that it measures an OUTCOME — whether
+        /// this node's repair actually made the edge converge — rather than
+        /// how much repair traffic there is. These tests drive the REAL
+        /// `handle_interest_sync_message` and hold the attempt count fixed
+        /// while varying only what the peer reports back, so a detector that
+        /// counted attempts (or scored every outcome as failure) cannot pass
+        /// them.
+        mod futile_repair_shadow {
+            use super::*;
+            use crate::ring::futile_repair::QUARANTINE_THRESHOLD;
+
+            /// Feed one full-bytes `Summaries` report from `peer` and return
+            /// the heals it produced.
+            async fn report_summary(
+                h: &mut Harness,
+                peer: SocketAddr,
+                summary: &[u8],
+            ) -> Vec<(ContractKey, SocketAddr)> {
+                let hash = contract_hash(&h.key);
+                handle_interest_sync_message(
+                    &h.op_manager,
+                    peer,
+                    InterestMessage::Summaries {
+                        emitter: crate::message::SummariesEmitter::Other,
+                        entries: vec![SummaryEntry {
+                            hash,
+                            summary_bytes: Some(summary.to_vec()),
+                        }],
+                    },
+                )
+                .await;
+                h.drain_heals()
+            }
+
+            /// THE test for this feature. Two peers, the SAME number of
+            /// repairs emitted to each. The only difference is what the next
+            /// summary exchange said: one peer stays diverged forever (the
+            /// non-commutative-merge signature), the other converges after
+            /// every heal.
+            ///
+            /// A detector that counted repair ATTEMPTS would score these two
+            /// edges identically and report `would_quarantine == 2` with
+            /// `productive == 0`. That is exactly the documented mutation:
+            /// replacing `!is_stale` with `false` at the `Summaries` arm's
+            /// `record_repair_outcome` call makes this test fail on both
+            /// counts.
+            #[tokio::test]
+            async fn a_stuck_edge_is_separated_from_a_converging_one() {
+                let ours = vec![5u8; 128];
+                let theirs = vec![6u8; 128];
+                let mut h = build_harness("futile-shadow", 17100, ours.clone()).await;
+                let (stuck_peer, healthy_peer, key) = (h.new_peer, h.old_peer, h.key);
+
+                // STUCK edge: the peer reports a divergent summary every
+                // round and never moves — no heal can land.
+                //
+                // One extra round because the first exchange has no
+                // outstanding attempt to settle: round 1 only emits the first
+                // heal, rounds 2..=N+1 each settle the previous one as futile.
+                for round in 0..=QUARANTINE_THRESHOLD {
+                    let heals = report_summary(&mut h, stuck_peer, &theirs).await;
+                    assert_eq!(
+                        heals.len(),
+                        1,
+                        "round {round}: shadow mode must not suppress the heal \
+                         — every diverged round still emits exactly one \
+                         targeted SyncStateToPeer"
+                    );
+                    assert_eq!(heals[0], (key, stuck_peer), "the heal must stay targeted");
+                }
+
+                // CONVERGING edge: same number of heals emitted, but each one
+                // lands, so the following round reports OUR summary back.
+                for _ in 0..QUARANTINE_THRESHOLD {
+                    let heals = report_summary(&mut h, healthy_peer, &theirs).await;
+                    assert_eq!(heals.len(), 1, "a diverged round emits one heal");
+                    let healed = report_summary(&mut h, healthy_peer, &ours).await;
+                    assert!(healed.is_empty(), "a converged round must not emit a heal");
+                }
+
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(
+                    snap.attempts,
+                    u64::from(QUARANTINE_THRESHOLD) * 2 + 1,
+                    "both edges were healed the same number of times \
+                     (the stuck edge has one extra opening round)"
+                );
+                assert_eq!(
+                    snap.futile,
+                    u64::from(QUARANTINE_THRESHOLD),
+                    "only the stuck edge's repairs left the summaries differing"
+                );
+                assert_eq!(
+                    snap.productive,
+                    u64::from(QUARANTINE_THRESHOLD),
+                    "every repair to the converging edge landed — a detector \
+                     that ignored the comparison verdict would report zero here"
+                );
+                assert_eq!(
+                    snap.would_quarantine, 1,
+                    "exactly ONE edge reached the shadow threshold; a detector \
+                     counting attempts rather than outcomes would report two"
+                );
+                assert_eq!(
+                    snap.edges_at_threshold, 1,
+                    "the converging edge must never be at the threshold"
+                );
+                assert_eq!(
+                    snap.evictions, 0,
+                    "two edges cannot overflow the LRU — a non-zero eviction \
+                     count here would mean the counts above are unreliable"
+                );
+            }
+
+            /// A repair that lands resets the streak, so an edge that recovers
+            /// one round before the threshold never crosses it. This is what
+            /// stops a busy-but-healthy contract from being flagged.
+            #[tokio::test]
+            async fn a_late_recovery_clears_the_streak() {
+                let ours = vec![9u8; 64];
+                let theirs = vec![8u8; 64];
+                let mut h = build_harness("futile-recover", 17110, ours.clone()).await;
+                let peer = h.new_peer;
+
+                // Diverge for one round short of the threshold...
+                for _ in 0..QUARANTINE_THRESHOLD {
+                    report_summary(&mut h, peer, &theirs).await;
+                }
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(snap.futile, u64::from(QUARANTINE_THRESHOLD) - 1);
+                assert_eq!(snap.would_quarantine, 0, "not yet at the threshold");
+
+                // ...then the heal finally lands.
+                report_summary(&mut h, peer, &ours).await;
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(snap.productive, 1);
+                assert_eq!(
+                    snap.would_quarantine, 0,
+                    "one landed repair clears the streak"
+                );
+                assert_eq!(snap.edges_at_threshold, 0);
+            }
+
+            /// A peer that agrees from the outset produces no attempts and no
+            /// futility — the detector must not manufacture a signal out of
+            /// ordinary anti-entropy traffic. Covers BOTH wire forms, since
+            /// the `SummaryDigests` agreement arm is a second observation site
+            /// that could drift from the `Summaries` one.
+            #[tokio::test]
+            async fn an_agreeing_peer_produces_no_futility_on_either_wire_form() {
+                let ours = vec![3u8; 32];
+                let mut h = build_harness("futile-agree", 17120, ours.clone()).await;
+                let hash = contract_hash(&h.key);
+                let peer = h.new_peer;
+
+                for _ in 0..QUARANTINE_THRESHOLD {
+                    assert!(report_summary(&mut h, peer, &ours).await.is_empty());
+                    handle_interest_sync_message(
+                        &h.op_manager,
+                        peer,
+                        InterestMessage::SummaryDigests {
+                            emitter: crate::message::SummariesEmitter::Other,
+                            entries: vec![SummaryDigestEntry {
+                                hash,
+                                summary_digest: Some(summary_digest(&ours)),
+                            }],
+                        },
+                    )
+                    .await;
+                    assert!(h.drain_heals().is_empty());
+                }
+
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(
+                    snap.attempts, 0,
+                    "nothing was healed, so nothing was attempted"
+                );
+                assert_eq!(snap.futile, 0);
+                assert_eq!(snap.would_quarantine, 0);
+                assert_eq!(
+                    snap.observations_unpaired,
+                    u64::from(QUARANTINE_THRESHOLD) * 2,
+                    "both wire forms must reach the detector as observations — \
+                     a zero here on either arm means that observation site is \
+                     not wired at all"
+                );
+            }
         }
     }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -11301,15 +11301,12 @@ mod tests {
                     ContractInstanceId::new([77u8; 32]),
                     CodeHash::new([78u8; 32]),
                 );
-                let _ = h
-                    .op_manager
-                    .ring
-                    .host_contract(
-                        filler,
-                        128,
-                        crate::ring::AccessType::Put,
-                        crate::ring::HostingCause::Other,
-                    );
+                let _ = h.op_manager.ring.host_contract(
+                    filler,
+                    128,
+                    crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::Other,
+                );
                 h.op_manager
                     .interest_manager
                     .register_local_hosting(&filler);

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3534,6 +3534,17 @@ async fn handle_interest_sync_message(
                         // differ byte-wise; ask the contract itself whether we
                         // hold state the peer lacks. See
                         // `summary_indicates_stale_peer`.
+                        // SHADOW MODE (futile-repair detector). What the
+                        // `is_stale` below actually RESTS ON. `is_stale` is the
+                        // right heal decision in all three cases, but only one
+                        // of them is evidence about convergence: the other two
+                        // default to stale with nothing behind them, and their
+                        // frequency grows with peer breadth and node load
+                        // rather than with brokenness. Tracked alongside rather
+                        // than re-derived afterwards, because only the branch
+                        // that TOOK the default knows it took one. See
+                        // `crate::ring::futile_repair::OutcomeEvidence`.
+                        let mut evidence = crate::ring::futile_repair::OutcomeEvidence::Verdict;
                         let is_stale = match (our_summary.as_ref(), their_summary.as_ref()) {
                             (Some(ours), Some(theirs)) => {
                                 let identical = ours.as_ref() == theirs.as_ref();
@@ -3580,12 +3591,22 @@ async fn handle_interest_sync_message(
                                         }
                                         StalenessProbeAction::RunProbe => {
                                             staleness_probes_used += 1;
-                                            op_manager
+                                            let verdict = op_manager
                                                 .interest_manager
                                                 .peer_summary_has_pending_state(
                                                     op_manager, &contract, theirs, ours,
                                                 )
-                                                .await
+                                                .await;
+                                            if verdict.is_none() {
+                                                // The probe ran and produced no
+                                                // answer (delta error, timeout,
+                                                // unexpected response), so the
+                                                // byte-compare default below is
+                                                // not a convergence verdict.
+                                                evidence = crate::ring::futile_repair::
+                                                    OutcomeEvidence::ProbeUnavailable;
+                                            }
+                                            verdict
                                         }
                                         StalenessProbeAction::BudgetExhaustedFallBack => {
                                             // Budget spent for this message: fall
@@ -3595,6 +3616,15 @@ async fn handle_interest_sync_message(
                                             // Re-evaluated next heartbeat once the
                                             // cache warms. `None` => byte-compare in
                                             // `summary_indicates_stale_peer`.
+                                            //
+                                            // This is the load-correlated channel:
+                                            // everything past the 32-probe budget
+                                            // reads as stale every round with no
+                                            // divergence at all, so it must never
+                                            // reach the futile-repair detector as a
+                                            // verdict.
+                                            evidence = crate::ring::futile_repair::
+                                                OutcomeEvidence::ProbeBudgetExhausted;
                                             None
                                         }
                                     }
@@ -3638,12 +3668,13 @@ async fn handle_interest_sync_message(
                         //
                         // Passing `!is_stale` rather than a constant is the
                         // whole detector: it is what separates a repair that
-                        // failed to converge from one that worked. Pure
-                        // accounting, no behaviour change.
+                        // failed to converge from one that worked. `evidence`
+                        // is what keeps the two conservative defaults out of
+                        // that number. Pure accounting, no behaviour change.
                         if our_summary.is_some() && their_summary.is_some() {
                             op_manager
                                 .interest_manager
-                                .record_repair_outcome(&contract, &pk, !is_stale);
+                                .record_repair_outcome(&contract, &pk, !is_stale, evidence);
                         }
 
                         // #4952: upsert (not update) when the peer reported a
@@ -4006,11 +4037,21 @@ async fn handle_interest_sync_message(
                                 // `Summaries` arm does. `NeedBytes` deliberately
                                 // records nothing — it defers to the full-bytes
                                 // `Summaries` reply, which observes there, so
-                                // one divergence is never counted twice. Pure
-                                // accounting, no behaviour change.
-                                op_manager
-                                    .interest_manager
-                                    .record_repair_outcome(&contract, &pk, !is_stale);
+                                // one divergence is never counted twice.
+                                //
+                                // Evidence is `Verdict` by construction and NOT
+                                // a shortcut: `summary_indicates_stale_peer` is
+                                // called on byte-identical operands here, which
+                                // short-circuits before any delta probe, so no
+                                // probe budget is consulted and no default can
+                                // be taken. Pure accounting, no behaviour
+                                // change.
+                                op_manager.interest_manager.record_repair_outcome(
+                                    &contract,
+                                    &pk,
+                                    !is_stale,
+                                    crate::ring::futile_repair::OutcomeEvidence::Verdict,
+                                );
                                 // #4952: seed the peer-summary cache so an
                                 // advertised co-host does not stay a
                                 // full-state broadcast target. Fact, not
@@ -8641,14 +8682,27 @@ mod tests {
         fn futile_repair_attempt_is_recorded_only_where_the_heal_is_emitted() {
             const SOURCE: &str = include_str!("node.rs");
 
-            let start = SOURCE
-                .find("for contract in stale_contracts {")
-                .expect("stale-contract emission loop not found");
-            let window_end = SOURCE[start..]
-                .find("for (key, state_hash) in confirmed_states {")
-                .map(|off| start + off)
-                .unwrap_or(SOURCE.len());
-            let window = &SOURCE[start..window_end];
+            // Scoped to `emit_stale_peer_syncs`'s OWN body. An earlier revision
+            // ran the window from the loop header to an anchor ~500 lines later
+            // in the `Summaries` arm, so it stayed green for a
+            // `record_repair_attempt` moved clean out of the function — which
+            // is precisely the regression it names. The function's body ends at
+            // the first `\n}` in column 0 after its signature, which is what a
+            // top-level `fn` terminator looks like in this file.
+            let fn_start = SOURCE
+                .find("async fn emit_stale_peer_syncs(")
+                .expect("emit_stale_peer_syncs not found — update this pin");
+            let fn_end = fn_start
+                + SOURCE[fn_start..]
+                    .find("\n}\n")
+                    .expect("end of emit_stale_peer_syncs not found")
+                + 1;
+            let body = &SOURCE[fn_start..fn_end];
+            let start = fn_start
+                + body
+                    .find("for contract in stale_contracts {")
+                    .expect("stale-contract emission loop not found");
+            let window = &SOURCE[start..fn_end];
 
             let record = window.find("record_repair_attempt(").expect(
                 "the futile-repair attempt is no longer recorded in the heal \
@@ -8723,19 +8777,52 @@ mod tests {
                  one-sided reports as successful repairs",
                 sites.len()
             );
+            let mut passes_tracked_evidence = 0usize;
             for (pos, _) in sites {
                 let call = &body[pos..body[pos..]
                     .find(");")
                     .map(|o| pos + o)
                     .unwrap_or(body.len())];
+                // Whitespace-stripped: rustfmt collapses or explodes an
+                // argument list depending on how long the arguments are, so a
+                // pin that matches raw source breaks the first time an argument
+                // is renamed — and a broken pin gets weakened, not fixed. Only
+                // the argument SEQUENCE is load-bearing here.
+                let squashed_call: String = call.split_whitespace().collect();
                 assert!(
-                    call.contains("!is_stale"),
+                    squashed_call.contains("!is_stale"),
                     "a futile-repair outcome site passes something other than \
                      `!is_stale`: the verdict IS the detector — a constant \
                      there measures repair volume, not repair failure. Got: \
                      {call}"
                 );
+                // The verdict alone is not enough. `is_stale` also comes out
+                // `true` when the per-message probe budget ran out or the delta
+                // probe failed, neither of which is evidence about convergence,
+                // and the first of those grows with peer breadth rather than
+                // with brokenness. Every site must say which it is.
+                assert!(
+                    squashed_call.contains("evidence")
+                        || squashed_call.contains("OutcomeEvidence::"),
+                    "a futile-repair outcome site no longer passes an \
+                     `OutcomeEvidence`: without it the load-correlated \
+                     budget-exhausted default is counted as futility and the \
+                     headline number tracks how busy this node is. Got: {call}"
+                );
+                if squashed_call.contains("!is_stale,evidence") {
+                    passes_tracked_evidence += 1;
+                }
             }
+            assert_eq!(
+                passes_tracked_evidence, 1,
+                "exactly one outcome site (the `Summaries` arm) must pass the \
+                 `evidence` TRACKED alongside the staleness decision. \
+                 Hard-coding `OutcomeEvidence::Verdict` there re-derives the \
+                 provenance away from the branch that took the default, which \
+                 is the whole finding — only the `SummaryDigests` agreement \
+                 arm may name a literal, and only because it compares \
+                 byte-identical operands and can take no default"
+            );
             // Whitespace-stripped so rustfmt wrapping the condition cannot
             // break the pin.
             let squashed: String = body.split_whitespace().collect();
@@ -9087,7 +9174,41 @@ mod tests {
         /// `contract_state_present` returns `true` when no hosting storage is
         /// attached, so the `should_summarize_or_broadcast` gate is satisfied
         /// by `host_contract` alone and no redb temp dir is needed.
+        /// What the stand-in contract handler answers a `GetDeltaQuery` — the
+        /// semantic-staleness probe (#4857) — with.
+        ///
+        /// These are the three things `interest::peer_summary_has_pending_state`
+        /// can return, and they produce three DIFFERENT provenances for one
+        /// `is_stale: bool`. The futile-repair detector has to tell them apart
+        /// (see `crate::ring::futile_repair::OutcomeEvidence`), so the harness
+        /// has to be able to produce them.
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum DeltaBehavior {
+            /// The contract holds state the peer lacks: a byte mismatch is a
+            /// real divergence and heals. The default, and what every
+            /// pre-existing test here assumes.
+            NonEmpty,
+            /// The contract says the peer is logically converged despite
+            /// differing summary bytes — the non-deterministic-serialization
+            /// shape #4857 exists for. A real verdict, and it is NOT stale.
+            Empty,
+            /// The probe produced no verdict at all.
+            /// `summary_indicates_stale_peer` then falls back to the
+            /// conservative byte compare, so the peer reads STALE on no
+            /// evidence whatsoever.
+            Failing,
+        }
+
         async fn build_harness(id: &str, port_base: u16, our_summary: Vec<u8>) -> Harness {
+            build_harness_with(id, port_base, our_summary, DeltaBehavior::NonEmpty).await
+        }
+
+        async fn build_harness_with(
+            id: &str,
+            port_base: u16,
+            our_summary: Vec<u8>,
+            delta_behavior: DeltaBehavior,
+        ) -> Harness {
             let config_args = crate::config::ConfigArgs {
                 id: Some(id.to_string()),
                 mode: Some(crate::contract::OperationMode::Local),
@@ -9177,18 +9298,29 @@ mod tests {
                                 }),
                             }
                         }
-                        // The semantic-staleness probe (#4857): a NON-EMPTY
-                        // delta is the contract answering "yes, I hold state
-                        // this peer lacks", which is what turns a byte
-                        // mismatch into a real heal. Returning an empty delta
-                        // here would make every divergence test vacuous.
+                        // The semantic-staleness probe (#4857). The default
+                        // (`NonEmpty`) is the contract answering "yes, I hold
+                        // state this peer lacks", which is what turns a byte
+                        // mismatch into a real heal — returning an empty delta
+                        // by default would make every divergence test vacuous.
+                        // The other two variants exist so a test can produce
+                        // the OTHER two provenances of `is_stale`; see
+                        // `DeltaBehavior`.
                         ContractHandlerEvent::GetDeltaQuery { key, .. } => {
-                            ContractHandlerEvent::GetDeltaResponse {
-                                key,
-                                delta: Ok(freenet_stdlib::prelude::StateDelta::from(vec![
-                                    1u8, 2, 3,
-                                ])),
-                            }
+                            let delta = match delta_behavior {
+                                DeltaBehavior::NonEmpty => {
+                                    Ok(freenet_stdlib::prelude::StateDelta::from(vec![1u8, 2, 3]))
+                                }
+                                DeltaBehavior::Empty => {
+                                    Ok(freenet_stdlib::prelude::StateDelta::from(Vec::<u8>::new()))
+                                }
+                                DeltaBehavior::Failing => {
+                                    Err(crate::contract::ExecutorError::other(
+                                        crate::contract::ContractQueueFull,
+                                    ))
+                                }
+                            };
+                            ContractHandlerEvent::GetDeltaResponse { key, delta }
                         }
                         other => panic!("unexpected handler event: {other:?}"),
                     };
@@ -11085,6 +11217,205 @@ mod tests {
                     "both wire forms must reach the detector as observations — \
                      a zero here on either arm means that observation site is \
                      not wired at all"
+                );
+            }
+
+            /// HIGH-2, the load-correlated false-positive channel, end to end.
+            ///
+            /// `MAX_STALENESS_PROBES_PER_SUMMARIES` caps semantic-staleness
+            /// probes at 32 per `Summaries` message. Past that,
+            /// `summary_indicates_stale_peer` takes the conservative
+            /// bytes-differ-means-stale DEFAULT — correct as a heal decision,
+            /// but it means everything after position 32 reads as stale every
+            /// round with no divergence at all. If that fed the detector, the
+            /// headline number would grow with how many contracts a peer
+            /// reports, i.e. with peer breadth and node load, rather than with
+            /// brokenness.
+            ///
+            /// This drives exactly that shape through the real handler: a
+            /// filler contract burns the whole probe budget, and the contract
+            /// we track is always the entry past the budget. Its bytes differ
+            /// every round, but the contract's own delta is EMPTY — it is
+            /// logically converged (the #4857 non-deterministic-summary shape)
+            /// and would be scored converged if it were ever probed. Nothing
+            /// here is broken.
+            ///
+            /// Mutation that must fail this test: pass
+            /// `OutcomeEvidence::Verdict` unconditionally at the `Summaries`
+            /// outcome site — i.e. the pre-fix code, which passed `!is_stale`
+            /// alone. The tracked contract then accrues a futile streak of
+            /// `QUARANTINE_THRESHOLD` from load alone and reports
+            /// `would_quarantine == 1`.
+            #[tokio::test]
+            async fn probe_budget_exhaustion_is_not_counted_as_futility() {
+                let ours = vec![5u8; 128];
+                let mut h =
+                    build_harness_with("futile-budget", 17130, ours.clone(), DeltaBehavior::Empty)
+                        .await;
+                let peer = h.new_peer;
+
+                // A second hosted contract, purely to burn the probe budget.
+                // The one from the harness (`h.key`) is the one we track.
+                let filler = ContractKey::from_id_and_code(
+                    ContractInstanceId::new([77u8; 32]),
+                    CodeHash::new([78u8; 32]),
+                );
+                let _ = h
+                    .op_manager
+                    .ring
+                    .host_contract(filler, 128, crate::ring::AccessType::Put);
+                h.op_manager
+                    .interest_manager
+                    .register_local_hosting(&filler);
+
+                let filler_hash = contract_hash(&filler);
+                let tracked_hash = contract_hash(&h.key);
+                // Novel bytes every entry and every round, so every lookup is a
+                // genuine cache MISS — a cache hit costs no budget and would
+                // answer with a real verdict, defeating the setup.
+                let mut nonce = 0u16;
+                let mut novel = |len: usize| {
+                    nonce += 1;
+                    let mut bytes = vec![0u8; len];
+                    bytes[0] = (nonce & 0xff) as u8;
+                    bytes[1] = (nonce >> 8) as u8;
+                    bytes
+                };
+
+                // One extra round for the same reason as the stuck-edge test:
+                // the opening round has no outstanding attempt to settle.
+                for _ in 0..=QUARANTINE_THRESHOLD {
+                    let mut entries: Vec<SummaryEntry> = (0..MAX_STALENESS_PROBES_PER_SUMMARIES)
+                        .map(|_| SummaryEntry {
+                            hash: filler_hash,
+                            summary_bytes: Some(novel(64)),
+                        })
+                        .collect();
+                    // The budget is now spent, so THIS entry is defaulted.
+                    entries.push(SummaryEntry {
+                        hash: tracked_hash,
+                        summary_bytes: Some(novel(64)),
+                    });
+                    handle_interest_sync_message(
+                        &h.op_manager,
+                        peer,
+                        InterestMessage::Summaries {
+                            emitter: crate::message::SummariesEmitter::Other,
+                            entries,
+                        },
+                    )
+                    .await;
+                    // SHADOW MODE: the defaulted verdict still heals, exactly
+                    // as before. Only the accounting changes.
+                    let heals = h.drain_heals();
+                    assert_eq!(
+                        heals,
+                        vec![(h.key, peer)],
+                        "the conservative default must still emit its heal — \
+                         this change must not alter behaviour"
+                    );
+                }
+
+                // The harm first, so a regression names it rather than naming
+                // a bookkeeping row.
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(
+                    snap.would_quarantine, 0,
+                    "a contract that is logically CONVERGED reached the shadow \
+                     threshold purely because the peer reported more contracts \
+                     than the probe budget covers — the headline is now a load \
+                     metric: {snap:?}"
+                );
+                assert_eq!(
+                    snap.futile, 0,
+                    "running out of probe budget is not evidence that a repair \
+                     failed — counting it makes the headline grow with peer \
+                     breadth and node load instead of with brokenness"
+                );
+                assert_eq!(
+                    snap.outcomes_probe_budget_exhausted,
+                    u64::from(QUARANTINE_THRESHOLD) + 1,
+                    "every round's over-budget entry must be recorded as a \
+                     defaulted verdict, one per message"
+                );
+                assert_eq!(snap.edges_at_threshold, 0);
+                assert!(
+                    snap.attempts >= u64::from(QUARANTINE_THRESHOLD),
+                    "the heals were emitted and charged as attempts; only \
+                     their OUTCOMES are unclassifiable, got {snap:?}"
+                );
+                // The readable signature of the "we cannot tell" regime, and
+                // the one an evasion attempt would produce (see the module
+                // docs' second known limitation): heals keep going out and
+                // keep being superseded unsettled, while `futile` and
+                // `productive` both stay flat. A defaulted outcome must NOT
+                // consume the attempt, so the count rises.
+                assert!(
+                    snap.attempts_superseded >= u64::from(QUARANTINE_THRESHOLD) - 1,
+                    "an unclassifiable outcome must leave the attempt \
+                     outstanding, so the next heal supersedes it — that pairing \
+                     of high `attempts_superseded` with flat futile/productive \
+                     is how the regime is recognised in the field: {snap:?}"
+                );
+            }
+
+            /// The other evidence-free provenance: the probe RAN and produced
+            /// no verdict (delta error / timeout). `summary_indicates_stale_peer`
+            /// falls back to the byte compare and reports stale, so without the
+            /// evidence split a contract-side or runtime-side fault would
+            /// manufacture a full futility streak on a healthy edge.
+            ///
+            /// Mutation that must fail this test: as above, pass
+            /// `OutcomeEvidence::Verdict` unconditionally — `would_quarantine`
+            /// goes to 1 and `futile` to `QUARANTINE_THRESHOLD`.
+            #[tokio::test]
+            async fn a_failed_delta_probe_is_not_counted_as_futility() {
+                let ours = vec![5u8; 128];
+                let mut h = build_harness_with(
+                    "futile-probe-fail",
+                    17140,
+                    ours.clone(),
+                    DeltaBehavior::Failing,
+                )
+                .await;
+                let peer = h.new_peer;
+
+                let mut rounds = 0u64;
+                for round in 0..=QUARANTINE_THRESHOLD {
+                    // Novel bytes each round: a repeated pair would be served
+                    // from the delta cache rather than re-probed.
+                    let theirs = vec![(round as u8).wrapping_add(1); 64];
+                    let heals = report_summary(&mut h, peer, &theirs).await;
+                    assert_eq!(
+                        heals.len(),
+                        1,
+                        "a failed probe still falls back to the byte compare \
+                         and still heals — behaviour is unchanged"
+                    );
+                    rounds += 1;
+                }
+
+                // The harm first, so a regression names it rather than naming
+                // a bookkeeping row.
+                let snap = h.op_manager.interest_manager.futile_repair_snapshot();
+                assert_eq!(
+                    snap.would_quarantine, 0,
+                    "a contract-side or runtime-side probe fault manufactured a \
+                     quarantine candidate on a healthy edge: {snap:?}"
+                );
+                assert_eq!(
+                    snap.futile, 0,
+                    "a probe that produced no verdict is not evidence that a \
+                     repair failed"
+                );
+                assert_eq!(
+                    snap.outcomes_probe_unavailable, rounds,
+                    "each round's unanswerable probe must be recorded as its \
+                     own class, separate from budget exhaustion"
+                );
+                assert_eq!(
+                    snap.attempts, rounds,
+                    "every round still emitted (and charged) its heal"
                 );
             }
         }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -8943,9 +8943,12 @@ mod tests {
             // Hosted + locally interested + hash-indexed, so
             // `summary_if_hosted_or_in_use` will summarize it and
             // `lookup_by_hash` will resolve the peer's advertised hash to it.
-            let _ = op_manager
-                .ring
-                .host_contract(key, 128, crate::ring::AccessType::Put);
+            let _ = op_manager.ring.host_contract(
+                key,
+                128,
+                crate::ring::AccessType::Put,
+                crate::ring::HostingCause::Other,
+            );
             op_manager.interest_manager.register_local_hosting(&key);
 
             // Two connected peers, distinguished ONLY by whether a remote
@@ -9250,10 +9253,12 @@ mod tests {
                 code[4] = 0xC0;
                 let key =
                     ContractKey::from_id_and_code(ContractInstanceId::new(id), CodeHash::new(code));
-                let _ = h
-                    .op_manager
-                    .ring
-                    .host_contract(key, 128, crate::ring::AccessType::Put);
+                let _ = h.op_manager.ring.host_contract(
+                    key,
+                    128,
+                    crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::Other,
+                );
                 h.op_manager.interest_manager.register_local_hosting(&key);
                 keys.push(key);
             }
@@ -9995,10 +10000,12 @@ mod tests {
             // and makes the dropped entry invisible.
             let h = build_harness("hf-collision", 17080, vec![3u8; 64]).await;
             for k in [key_a, key_b] {
-                let _ = h
-                    .op_manager
-                    .ring
-                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                let _ = h.op_manager.ring.host_contract(
+                    k,
+                    128,
+                    crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::Other,
+                );
                 h.op_manager.interest_manager.register_local_hosting(&k);
             }
 
@@ -10191,10 +10198,12 @@ mod tests {
                     ContractInstanceId::new([i.wrapping_add(100); 32]),
                     CodeHash::new([i; 32]),
                 );
-                let _ = h
-                    .op_manager
-                    .ring
-                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                let _ = h.op_manager.ring.host_contract(
+                    k,
+                    128,
+                    crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::Other,
+                );
                 h.op_manager.interest_manager.register_local_hosting(&k);
                 hashes.push(contract_hash(&k));
             }
@@ -10279,10 +10288,12 @@ mod tests {
                     ContractInstanceId::new([i.wrapping_add(160); 32]),
                     CodeHash::new([i.wrapping_add(3); 32]),
                 );
-                let _ = h
-                    .op_manager
-                    .ring
-                    .host_contract(k, 128, crate::ring::AccessType::Put);
+                let _ = h.op_manager.ring.host_contract(
+                    k,
+                    128,
+                    crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::Other,
+                );
                 h.op_manager.interest_manager.register_local_hosting(&k);
                 hashes.push(contract_hash(&k));
             }

--- a/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
+++ b/crates/core/src/node/network_bridge/broadcast_payload_mix.rs
@@ -2020,6 +2020,7 @@ mod tests {
     ///   * the total map can cap while the full-state map still admits, giving
     ///     a contract full-state bytes with no total entry, i.e. a denominator
     ///     smaller than its own numerator.
+    ///
     /// #5057 wants to size a per-contract budget from this distribution, so a
     /// silently truncated tail is exactly the wrong failure.
     #[test]

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -6569,7 +6569,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn install_pending_op_callback_replaces_a_closed_incumbent() {
         use crate::transport::ExpectedInboundTracker;
-        use tokio::sync::mpsc::error::TryRecvError;
 
         let mut state = super::EventListenerState::new(ExpectedInboundTracker::empty_for_test());
         let tx = crate::dev_tool::Transaction::new::<crate::operations::put::PutMsg>();

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -503,9 +503,13 @@ async fn append_contracts(
         );
         match mode {
             super::SeedMode::Subscribed => {
-                op_manager
-                    .ring
-                    .host_contract(key, state_size, crate::ring::AccessType::Put);
+                op_manager.ring.host_contract(
+                    key,
+                    state_size,
+                    crate::ring::AccessType::Put,
+                    // Harness seed: models the state a relay PUT hop leaves.
+                    crate::ring::HostingCause::RelayPut,
+                );
                 // In the new lease-based model, register an active subscription
                 op_manager.ring.subscribe(key);
                 // OPT-IN (default off): register the contract in the
@@ -543,9 +547,14 @@ async fn append_contracts(
                 // originator gate would NOT serve (its third term was
                 // `is_hosting && has_local_client_access`), forcing a whole GET
                 // through the network for a copy the node already held fresh.
-                op_manager
-                    .ring
-                    .host_contract(key, state_size, crate::ring::AccessType::Get);
+                op_manager.ring.host_contract(
+                    key,
+                    state_size,
+                    crate::ring::AccessType::Get,
+                    // Harness seed: models the every-hop store a RELAY hop
+                    // leaves on a GET return path, matching the AccessType.
+                    crate::ring::HostingCause::RelayGet,
+                );
                 let _ = op_manager.interest_manager.register_local_hosting(&key);
                 // Advertisement is a separate concern from the local serve gate
                 // (which keys on `has_local_interest`, a purely local signal), so

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -508,7 +508,7 @@ async fn append_contracts(
                     state_size,
                     crate::ring::AccessType::Put,
                     // Harness seed: models the state a relay PUT hop leaves.
-                    crate::ring::HostingCause::RelayPut,
+                    crate::ring::HostingCause::TransitPut,
                 );
                 // In the new lease-based model, register an active subscription
                 op_manager.ring.subscribe(key);
@@ -553,7 +553,7 @@ async fn append_contracts(
                     crate::ring::AccessType::Get,
                     // Harness seed: models the every-hop store a RELAY hop
                     // leaves on a GET return path, matching the AccessType.
-                    crate::ring::HostingCause::RelayGet,
+                    crate::ring::HostingCause::TransitGet,
                 );
                 let _ = op_manager.interest_manager.register_local_hosting(&key);
                 // Advertisement is a separate concern from the local serve gate

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -440,6 +440,7 @@ async fn drive_client_get_inner(
         "get",
         &mut driver,
         /* emit_route_failure_on_retry */ true,
+        crate::ring::HostingCause::ClientGet,
     )
     .await;
 
@@ -507,6 +508,7 @@ async fn drive_client_get_inner(
                         state.clone(),
                         contract.clone(),
                         true, // client driver: this node initiated the GET
+                        crate::ring::HostingCause::ClientGet,
                     )
                     .await;
                     *key
@@ -1119,6 +1121,11 @@ async fn drive_get_with_assembly_retry(
     op_label: &str,
     driver: &mut GetRetryDriver<'_>,
     emit_route_failure_on_retry: bool,
+    // Hosting attribution for the streamed store this wrapper performs. Both the
+    // client driver and the sub-op driver use this wrapper, and the stream store
+    // is unconditionally `is_client_requester = true`, so the flag cannot tell
+    // them apart — the caller names itself instead. Telemetry only.
+    cause: crate::ring::HostingCause,
 ) -> (RetryLoopOutcome<Terminal>, AssemblyOutcome) {
     let mut attempt_tx = first_tx;
     let mut assembly = AssemblyOutcome::default();
@@ -1217,8 +1224,15 @@ async fn drive_get_with_assembly_retry(
         };
 
         let stream_start = tokio::time::Instant::now();
-        match assemble_and_cache_stream(op_manager, peer_addr, stream_id, key, includes_contract)
-            .await
+        match assemble_and_cache_stream(
+            op_manager,
+            peer_addr,
+            stream_id,
+            key,
+            includes_contract,
+            cause,
+        )
+        .await
         {
             Ok(progress) => {
                 assembly.transfer_duration = Some(stream_start.elapsed());
@@ -1471,6 +1485,12 @@ fn synthetic_key(instance_id: &ContractInstanceId) -> ContractKey {
 ///    (i.e., `access_result.is_new && put_persisted`). NOT gated on
 ///    `is_client_requester`; legacy announces on any first-time relay
 ///    cache too (`get.rs:2278, 2370`).
+///
+/// `cause` names WHY this store may begin hosting (client GET, relay transit,
+/// or a sub-op fetch). It is TELEMETRY ONLY and is threaded from the call site
+/// because only the call site knows which driver it is: `is_client_requester`
+/// cannot stand in for it, since the streaming originator path passes `true`
+/// for BOTH the client and the sub-op driver.
 // NAMING LANDMINE: "cache"/"store" here means HOSTING, not a lesser cache tier. A
 // peer stores a contract because a GET routed through it, and a routed GET is a
 // demand signal, so the peer HOSTS the contract (WASM+state, kept fresh in the
@@ -1482,6 +1502,7 @@ async fn cache_contract_locally(
     state: WrappedState,
     contract: Option<ContractContainer>,
     is_client_requester: bool,
+    cause: crate::ring::HostingCause,
 ) -> bool {
     // EXPERIMENT-ONLY (findability_probe): suppress RELAY-path GET-return caching
     // so the seeded copy cannot self-scatter along successful GET return paths
@@ -1585,7 +1606,7 @@ async fn cache_contract_locally(
     // or put failed). This mirrors the legacy invariant that a
     // successful wire-level GET must refresh the hosting LRU/TTL
     // regardless of what the local executor did with the state.
-    let access_result = op_manager.ring.record_get_access(key, state_size);
+    let access_result = op_manager.ring.record_get_access(key, state_size, cause);
     // Sticky flag gating subscription renewal; only the client-originating
     // node sets it. Relays that pass through a Found MUST NOT taint their
     // own hosting cache with another node's client access. Legacy mirror:
@@ -1701,6 +1722,8 @@ async fn assemble_and_cache_stream(
     stream_id: StreamId,
     expected_key: ContractKey,
     includes_contract: bool,
+    // Hosting attribution for the store below; see `cache_contract_locally`.
+    cause: crate::ring::HostingCause,
 ) -> Result<StreamProgress, AssemblyFailure> {
     // Test-only deterministic fault injection (#4345). Returning before
     // the claim mirrors the production claim-timeout failure (the inbound
@@ -1830,7 +1853,7 @@ async fn assemble_and_cache_stream(
     // but it uses its own inline assemble+cache with `local_client_access =
     // false`; this path is the originator, which IS the client requester, so
     // the sticky `local_client_access` flag applies here.
-    cache_contract_locally(op_manager, payload.key, state, contract, true).await;
+    cache_contract_locally(op_manager, payload.key, state, contract, true, cause).await;
     Ok(StreamProgress {
         fragments_received,
         total_fragments,
@@ -2267,6 +2290,7 @@ async fn drive_sub_op_get(
         // on the sub-op path), so skip the per-retry failure events.
         /* emit_route_failure_on_retry */
         false,
+        crate::ring::HostingCause::SubOpGet,
     )
     .await;
 
@@ -2289,6 +2313,7 @@ async fn drive_sub_op_get(
                         state.clone(),
                         contract.clone(),
                         false, // sub-op: not a client-originating GET
+                        crate::ring::HostingCause::SubOpGet,
                     )
                     .await;
                 }
@@ -3279,7 +3304,15 @@ where
             hop_count,
         )
         .await;
-        cache_contract_locally(op_manager, key, state, contract, false).await;
+        cache_contract_locally(
+            op_manager,
+            key,
+            state,
+            contract,
+            false,
+            crate::ring::HostingCause::RelayGet,
+        )
+        .await;
         send_result?;
         return Ok(());
     }
@@ -3369,7 +3402,15 @@ where
                         hop_count,
                     )
                     .await;
-                    cache_contract_locally(op_manager, key, state, contract, false).await;
+                    cache_contract_locally(
+                        op_manager,
+                        key,
+                        state,
+                        contract,
+                        false,
+                        crate::ring::HostingCause::RelayGet,
+                    )
+                    .await;
                     send_result?;
                     return Ok(());
                 }
@@ -3758,8 +3799,15 @@ where
                 // hosting at a relay is still broadcast (matches legacy
                 // `get.rs:2370` which announces on any first-time relay
                 // cache).
-                let state_present =
-                    cache_contract_locally(op_manager, key, state, contract, false).await;
+                let state_present = cache_contract_locally(
+                    op_manager,
+                    key,
+                    state,
+                    contract,
+                    false,
+                    crate::ring::HostingCause::RelayGet,
+                )
+                .await;
                 send_result?;
 
                 // Register the requester as a downstream subscriber (subscribe
@@ -3900,6 +3948,7 @@ where
                                         state,
                                         contract,
                                         false,
+                                        crate::ring::HostingCause::RelayGet,
                                     )
                                     .await;
                                     // Loopback delivery succeeded (state cached
@@ -4035,6 +4084,7 @@ where
                                     state,
                                     contract,
                                     false,
+                                    crate::ring::HostingCause::RelayGet,
                                 )
                                 .await
                             } else {
@@ -6721,15 +6771,57 @@ mod tests {
                 panic!("unterminated cache_contract_locally call at relay callsite #{idx}")
             });
             let call = &tail[..=end];
-            // The last argument must be `false`. Normalize whitespace.
-            let normalized: String = call.chars().filter(|c| !c.is_whitespace()).collect();
-            assert!(
-                normalized.ends_with("false,).await")
-                    || normalized.ends_with("false)")
-                    || normalized.ends_with("false,)"),
+            // Split the argument list at depth 1 and check arguments BY
+            // POSITION. The older form of this check asserted the call "ends
+            // with `false`", which silently stopped testing `is_client_requester`
+            // the moment a sixth argument was appended — position is what the
+            // invariant is actually about.
+            let args_start = call.find('(').expect("call must have an arg list");
+            let inner = &call[args_start + 1..call.len() - 1];
+            let mut args: Vec<String> = Vec::new();
+            let mut arg_depth: i32 = 0;
+            let mut current = String::new();
+            for c in inner.chars() {
+                match c {
+                    '(' | '[' | '<' => {
+                        arg_depth += 1;
+                        current.push(c);
+                    }
+                    ')' | ']' | '>' => {
+                        arg_depth -= 1;
+                        current.push(c);
+                    }
+                    ',' if arg_depth == 0 => {
+                        args.push(current.trim().to_string());
+                        current.clear();
+                    }
+                    _ => current.push(c),
+                }
+            }
+            if !current.trim().is_empty() {
+                args.push(current.trim().to_string());
+            }
+            assert_eq!(
+                args.len(),
+                6,
+                "relay callsite #{idx} should pass six arguments (op_manager, \
+                 key, state, contract, is_client_requester, cause). \
+                 Call text: {call}"
+            );
+            assert_eq!(
+                args[4], "false",
                 "Relay callsite #{idx} of cache_contract_locally must pass \
                  `false` for is_client_requester (relay is not the client). \
                  Call text: {call}"
+            );
+            // The hosting attribution must match the same fact: a relay callsite
+            // records TRANSIT, so a `ClientGet` here would report someone else's
+            // request as this node's own client demand.
+            assert!(
+                args[5].ends_with("HostingCause::RelayGet"),
+                "Relay callsite #{idx} of cache_contract_locally must attribute \
+                 hosting to `HostingCause::RelayGet` — this node is forwarding \
+                 someone else's GET, not serving its own client. Call text: {call}"
             );
         }
     }
@@ -6796,9 +6888,25 @@ mod tests {
         let fn_pos = src
             .find("async fn cache_contract_locally(")
             .expect("cache_contract_locally must exist");
-        // Look in the 1500 chars before the fn for the docstring.
-        let window_start = fn_pos.saturating_sub(1500);
-        let window = &src[window_start..fn_pos];
+        // Take the WHOLE contiguous comment block above the fn, walking back
+        // until a non-comment line. A fixed-size character window (what this
+        // used to be) silently drops the TOP of the docstring the moment the
+        // docstring grows, which turns a rot guard into a length guard.
+        let head = &src[..fn_pos];
+        let doc_len: usize = head
+            .lines()
+            .rev()
+            .take_while(|line| {
+                let trimmed = line.trim_start();
+                trimmed.starts_with("//") || trimmed.starts_with("#[")
+            })
+            .map(|line| line.len() + 1)
+            .sum();
+        let window = &head[head.len().saturating_sub(doc_len)..];
+        assert!(
+            !window.trim().is_empty(),
+            "cache_contract_locally must keep a docstring above it"
+        );
         assert!(
             window.contains("is_client_requester"),
             "cache_contract_locally docstring must describe the \

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -3087,6 +3087,31 @@ where
     }
 }
 
+/// Hosting attribution for a local store made by the GET forwarding driver:
+/// did this node's OWN request put the contract here, or did someone else's
+/// merely transit?
+///
+/// `node.rs` maps a locally-originated GET (`source_addr = None`) to
+/// `upstream_addr = own_addr` and drives it through this same forwarding driver,
+/// so "this driver is running" does NOT imply transit. Counting that loopback as
+/// transit defeats the whole point of the enum, which exists to separate our own
+/// demand from someone else's. `start_relay_get` already applies exactly this
+/// gate before `record_relayed_get`; this is the hosting-side twin of it.
+///
+/// Fails safe to [`HostingCause::TransitGet`] when our own address is unknown:
+/// an unattributable store is someone else's until proven otherwise, and the
+/// symmetric mistake (inflating this node's own demand) is the one that would
+/// mislead a hosting-policy decision.
+fn relay_get_hosting_cause(
+    own_addr: Option<SocketAddr>,
+    upstream_addr: SocketAddr,
+) -> crate::ring::HostingCause {
+    match own_addr {
+        Some(own) if own == upstream_addr => crate::ring::HostingCause::ClientGet,
+        _ => crate::ring::HostingCause::TransitGet,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn drive_relay_get_inner<CB>(
     op_manager: &Arc<OpManager>,
@@ -3157,9 +3182,19 @@ where
         return Ok(());
     }
 
+    let own_addr = op_manager.ring.connection_manager.get_own_addr();
+
+    // Hosting attribution for EVERY local store this driver makes. Computed once
+    // here, at the one place that knows whether this driver invocation is transit
+    // at all, and threaded down — a per-callsite literal is how the loopback case
+    // leaked into the transit row in the first place. See
+    // `relay_get_hosting_cause` for why loopback is not transit; `start_relay_get`
+    // applies the identical gate to `record_relayed_get`.
+    let hosting_cause = relay_get_hosting_cause(own_addr, upstream_addr);
+
     // ── Update visited set: mark this peer and the upstream ─────────────
     let mut new_visited = visited.with_transaction(&incoming_tx);
-    if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
+    if let Some(own_addr) = own_addr {
         new_visited.mark_visited(own_addr);
     }
     new_visited.mark_visited(upstream_addr);
@@ -3304,15 +3339,7 @@ where
             hop_count,
         )
         .await;
-        cache_contract_locally(
-            op_manager,
-            key,
-            state,
-            contract,
-            false,
-            crate::ring::HostingCause::RelayGet,
-        )
-        .await;
+        cache_contract_locally(op_manager, key, state, contract, false, hosting_cause).await;
         send_result?;
         return Ok(());
     }
@@ -3402,15 +3429,8 @@ where
                         hop_count,
                     )
                     .await;
-                    cache_contract_locally(
-                        op_manager,
-                        key,
-                        state,
-                        contract,
-                        false,
-                        crate::ring::HostingCause::RelayGet,
-                    )
-                    .await;
+                    cache_contract_locally(op_manager, key, state, contract, false, hosting_cause)
+                        .await;
                     send_result?;
                     return Ok(());
                 }
@@ -3799,15 +3819,9 @@ where
                 // hosting at a relay is still broadcast (matches legacy
                 // `get.rs:2370` which announces on any first-time relay
                 // cache).
-                let state_present = cache_contract_locally(
-                    op_manager,
-                    key,
-                    state,
-                    contract,
-                    false,
-                    crate::ring::HostingCause::RelayGet,
-                )
-                .await;
+                let state_present =
+                    cache_contract_locally(op_manager, key, state, contract, false, hosting_cause)
+                        .await;
                 send_result?;
 
                 // Register the requester as a downstream subscriber (subscribe
@@ -3948,7 +3962,7 @@ where
                                         state,
                                         contract,
                                         false,
-                                        crate::ring::HostingCause::RelayGet,
+                                        hosting_cause,
                                     )
                                     .await;
                                     // Loopback delivery succeeded (state cached
@@ -4084,7 +4098,7 @@ where
                                     state,
                                     contract,
                                     false,
-                                    crate::ring::HostingCause::RelayGet,
+                                    hosting_cause,
                                 )
                                 .await
                             } else {
@@ -6814,16 +6828,73 @@ mod tests {
                  `false` for is_client_requester (relay is not the client). \
                  Call text: {call}"
             );
-            // The hosting attribution must match the same fact: a relay callsite
-            // records TRANSIT, so a `ClientGet` here would report someone else's
-            // request as this node's own client demand.
-            assert!(
-                args[5].ends_with("HostingCause::RelayGet"),
-                "Relay callsite #{idx} of cache_contract_locally must attribute \
-                 hosting to `HostingCause::RelayGet` — this node is forwarding \
-                 someone else's GET, not serving its own client. Call text: {call}"
+            // The hosting attribution must be the DRIVER-COMPUTED `hosting_cause`,
+            // never a per-callsite literal. `is_client_requester` is `false` at
+            // every one of these sites because a forwarder is never the client;
+            // the CAUSE is not that simple, because dispatch drives a
+            // locally-originated GET through this same driver with
+            // `upstream_addr = own_addr`. A hardcoded `TransitGet` here therefore
+            // reports this node's OWN request as someone else's transit, which is
+            // precisely the distinction the enum exists to make. Threading one
+            // value computed by `relay_get_hosting_cause` is what keeps that
+            // impossible; a literal at any site re-opens it.
+            assert_eq!(
+                args[5], "hosting_cause",
+                "Relay callsite #{idx} of cache_contract_locally must pass the \
+                 driver-computed `hosting_cause`, not a hardcoded variant — \
+                 dispatch routes an originator-loopback GET through this same \
+                 driver, so a literal `HostingCause::TransitGet` would file this \
+                 node's own request under transit. Call text: {call}"
             );
         }
+        // ...and `hosting_cause` must be the loopback-aware value, not a
+        // constant bound to make the assertion above pass. Matched with
+        // whitespace stripped so a future rustfmt line-split cannot disarm it.
+        let packed: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            packed.contains("lethosting_cause=relay_get_hosting_cause(own_addr,upstream_addr);"),
+            "drive_relay_get_inner must bind `hosting_cause` from \
+             `relay_get_hosting_cause(own_addr, upstream_addr)`; binding it to a \
+             constant would satisfy the per-callsite check while re-introducing \
+             the mislabelling."
+        );
+    }
+
+    /// The loopback gate itself: `relay_get_hosting_cause` must map an
+    /// originator-loopback GET to `ClientGet` and a genuine forward to
+    /// `TransitGet`.
+    ///
+    /// Dispatch (`node.rs`) maps a locally-originated GET (`source_addr = None`)
+    /// to `upstream_addr = own_addr` and runs it through the forwarding driver,
+    /// so the driver cannot infer transit from its own existence. Recording that
+    /// case as transit is not a cosmetic mislabel: the ONLY thing this enum adds
+    /// over `AccessType` is the own-demand-vs-transit split, so leaking one into
+    /// the other empties the counter of meaning while it keeps reporting
+    /// plausible numbers.
+    #[test]
+    fn relay_get_hosting_cause_attributes_originator_loopback_to_client_get() {
+        let own: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+        let peer: SocketAddr = "127.0.0.1:5001".parse().unwrap();
+
+        assert_eq!(
+            super::relay_get_hosting_cause(Some(own), own),
+            crate::ring::HostingCause::ClientGet,
+            "an originator-loopback GET (upstream == own_addr) is this node's \
+             OWN demand, not transit"
+        );
+        assert_eq!(
+            super::relay_get_hosting_cause(Some(own), peer),
+            crate::ring::HostingCause::TransitGet,
+            "a GET forwarded from a genuine upstream peer is transit"
+        );
+        // Fail safe: an unknown own address must not be read as loopback, or a
+        // node that has not yet learned its address would file every forwarded
+        // GET as its own client demand.
+        assert_eq!(
+            super::relay_get_hosting_cause(None, peer),
+            crate::ring::HostingCause::TransitGet,
+            "unknown own address must fall back to transit"
+        );
     }
 
     /// The `client_driver`-side callsite (drive_client_get_inner's

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -1020,7 +1020,8 @@ mod tests {
     fn put_msg_probe_response_serde_roundtrip() {
         let key = make_contract_key(4);
         // (holder_found, hop_count, holder_summary bytes, reverse_delta bytes)
-        let cases: [(bool, usize, Option<Vec<u8>>, Option<Vec<u8>>); 3] = [
+        type ProbeResponseCase = (bool, usize, Option<Vec<u8>>, Option<Vec<u8>>);
+        let cases: [ProbeResponseCase; 3] = [
             // No holder: both trailing fields absent.
             (false, 0usize, None, None),
             // Holder found, originator current-or-ahead: summary present, no

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -631,6 +631,8 @@ async fn try_summary_first_put(
         related.clone(),
         htl,
         crate::contract::Priority::ClientLocal,
+        // Summary-first PUT runs on the ORIGINATOR: a real client-initiated PUT.
+        crate::ring::HostingCause::ClientPut,
     )
     .await
     {
@@ -1695,6 +1697,7 @@ where
         related_contracts.clone(),
         htl,
         store_priority,
+        put_store_cause(op_manager, upstream_addr),
     )
     .await?;
 
@@ -2424,6 +2427,24 @@ fn put_store_priority(
     }
 }
 
+/// Hosting attribution for a relay-driver local store: is this PUT actually our
+/// own client's (dispatch maps an originator-loopback PUT to
+/// `upstream_addr == own_addr`), or someone else's PUT in transit?
+///
+/// Reads the SAME authoritative signal as [`put_store_priority`] rather than
+/// inferring the cause from the priority it returns: priority is a scheduling
+/// lane that may be re-tuned, and a counter that reads a proxy silently
+/// re-labels itself when the proxy moves.
+fn put_store_cause(
+    op_manager: &Arc<OpManager>,
+    upstream_addr: SocketAddr,
+) -> crate::ring::HostingCause {
+    match op_manager.ring.connection_manager.get_own_addr() {
+        Some(own) if own == upstream_addr => crate::ring::HostingCause::ClientPut,
+        _ => crate::ring::HostingCause::RelayPut,
+    }
+}
+
 // NAMING LANDMINE: "store" (and the "relay_" prefix) here means HOSTING, not a
 // lesser cache tier or a hollow relay. A peer stores a contract because a PUT routed
 // through it, and a routed PUT is a demand signal, so the peer HOSTS the contract
@@ -2440,6 +2461,13 @@ async fn relay_put_store_locally(
     related_contracts: RelatedContracts<'static>,
     htl: usize,
     priority: crate::contract::Priority,
+    // Hosting attribution: this one chokepoint serves BOTH the client-loopback
+    // PUT and the relay-hop PUT (see the comment on the `host_contract` call
+    // below), so the caller names which it is. `priority` correlates today
+    // (`ClientLocal` vs `NetworkRelay`) but is a scheduling knob, not an
+    // attribution: deriving the cause from it would silently re-label the
+    // counter the first time a lane is re-tuned. Telemetry only.
+    cause: crate::ring::HostingCause,
 ) -> Result<WrappedState, OpError> {
     // EXPERIMENT-ONLY (findability_probe): suppress the every-hop PUT store so
     // the copy lands ONLY at the routing terminus (stored there explicitly by
@@ -2514,6 +2542,7 @@ async fn relay_put_store_locally(
         key,
         merged_value.size() as u64,
         crate::ring::AccessType::Put,
+        cause,
     );
 
     // Gate the first-time-hosting side effects on the ATOMIC `host_contract`
@@ -2726,6 +2755,7 @@ async fn relay_put_finalize_scatter_disabled_store(
                     key,
                     merged.size() as u64,
                     crate::ring::AccessType::Put,
+                    crate::ring::HostingCause::RelayPut,
                 );
             }
         }
@@ -3473,6 +3503,7 @@ where
         related_contracts,
         htl,
         store_priority,
+        put_store_cause(op_manager, upstream_addr),
     )
     .await?;
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -1687,7 +1687,11 @@ where
     // Originator-loopback (a local client's own PUT, mapped to
     // upstream_addr=own_addr in dispatch) is ClientLocal so it lands in the
     // reserved fair-queue lane; a genuine relay store stays NetworkRelay (#4534).
-    let store_priority = put_store_priority(op_manager, upstream_addr);
+    let originator_loopback = put_is_originator_loopback(
+        op_manager.ring.connection_manager.get_own_addr(),
+        upstream_addr,
+    );
+    let store_priority = put_store_priority(originator_loopback);
     let merged_value = relay_put_store_locally(
         op_manager,
         incoming_tx,
@@ -1697,7 +1701,7 @@ where
         related_contracts.clone(),
         htl,
         store_priority,
-        put_store_cause(op_manager, upstream_addr),
+        put_store_cause(originator_loopback),
     )
     .await?;
 
@@ -2412,36 +2416,44 @@ where
 /// `put_failure` telemetry event and propagate.
 /// Fair-queue priority for a relay PUT's local store (#4534).
 ///
-/// A local client's own PUT enters the relay driver via originator-loopback,
-/// which dispatch maps to `upstream_addr = own_addr` (see operations.md). That
-/// case is `ClientLocal` so the store uses the reserved admission lane; any
-/// genuine upstream peer is `NetworkRelay`. If our own address is unknown we
-/// fail safe to `NetworkRelay` (never over-prioritize an ambiguous store).
-fn put_store_priority(
-    op_manager: &Arc<OpManager>,
-    upstream_addr: SocketAddr,
-) -> crate::contract::Priority {
-    match op_manager.ring.connection_manager.get_own_addr() {
-        Some(own) if own == upstream_addr => crate::contract::Priority::ClientLocal,
-        _ => crate::contract::Priority::NetworkRelay,
+/// A local client's own PUT enters the forwarding driver via originator-loopback,
+/// which dispatch maps to `upstream_addr = own_addr` (see operations.md) — see
+/// [`put_is_originator_loopback`], which is where that fact is read. That case is
+/// `ClientLocal` so the store uses the reserved admission lane; any genuine
+/// upstream peer is `NetworkRelay`.
+fn put_store_priority(originator_loopback: bool) -> crate::contract::Priority {
+    if originator_loopback {
+        crate::contract::Priority::ClientLocal
+    } else {
+        crate::contract::Priority::NetworkRelay
     }
 }
 
-/// Hosting attribution for a relay-driver local store: is this PUT actually our
-/// own client's (dispatch maps an originator-loopback PUT to
-/// `upstream_addr == own_addr`), or someone else's PUT in transit?
+/// Did this PUT reach the forwarding driver via originator-loopback — i.e. is it
+/// our OWN client's PUT rather than someone else's in transit?
 ///
-/// Reads the SAME authoritative signal as [`put_store_priority`] rather than
-/// inferring the cause from the priority it returns: priority is a scheduling
-/// lane that may be re-tuned, and a counter that reads a proxy silently
-/// re-labels itself when the proxy moves.
-fn put_store_cause(
-    op_manager: &Arc<OpManager>,
-    upstream_addr: SocketAddr,
-) -> crate::ring::HostingCause {
-    match op_manager.ring.connection_manager.get_own_addr() {
-        Some(own) if own == upstream_addr => crate::ring::HostingCause::ClientPut,
-        _ => crate::ring::HostingCause::RelayPut,
+/// The single authoritative read of that fact. Both the scheduling lane
+/// ([`put_store_priority`]) and the hosting attribution ([`put_store_cause`])
+/// derive from it, so they cannot disagree, and the `get_own_addr()` lock is
+/// taken once per store rather than once per consumer.
+///
+/// Fails safe to `false` when our own address is unknown: never over-prioritize
+/// an ambiguous store, and never credit an unattributable one to a local client.
+fn put_is_originator_loopback(own_addr: Option<SocketAddr>, upstream_addr: SocketAddr) -> bool {
+    matches!(own_addr, Some(own) if own == upstream_addr)
+}
+
+/// Hosting attribution for a forwarding-driver local store.
+///
+/// Derived from the same [`put_is_originator_loopback`] fact as
+/// [`put_store_priority`], NOT from the priority that function returns:
+/// priority is a scheduling lane that may be re-tuned, and a counter that reads
+/// a proxy silently re-labels itself when the proxy moves.
+fn put_store_cause(originator_loopback: bool) -> crate::ring::HostingCause {
+    if originator_loopback {
+        crate::ring::HostingCause::ClientPut
+    } else {
+        crate::ring::HostingCause::TransitPut
     }
 }
 
@@ -2755,7 +2767,7 @@ async fn relay_put_finalize_scatter_disabled_store(
                     key,
                     merged.size() as u64,
                     crate::ring::AccessType::Put,
-                    crate::ring::HostingCause::RelayPut,
+                    crate::ring::HostingCause::TransitPut,
                 );
             }
         }
@@ -3492,8 +3504,13 @@ where
     // forward (#4509) before the store consumes `related_contracts`.
     let replicate_payload =
         terminus_replicate_to.map(|addr| (addr, contract.clone(), related_contracts.clone()));
-    // Originator-loopback client PUT → ClientLocal reserved lane (#4534).
-    let store_priority = put_store_priority(op_manager, upstream_addr);
+    // Originator-loopback client PUT → ClientLocal reserved lane (#4534), and the
+    // same fact names the hosting cause.
+    let originator_loopback = put_is_originator_loopback(
+        op_manager.ring.connection_manager.get_own_addr(),
+        upstream_addr,
+    );
+    let store_priority = put_store_priority(originator_loopback);
     let merged_value = relay_put_store_locally(
         op_manager,
         incoming_tx,
@@ -3503,7 +3520,7 @@ where
         related_contracts,
         htl,
         store_priority,
-        put_store_cause(op_manager, upstream_addr),
+        put_store_cause(originator_loopback),
     )
     .await?;
 
@@ -4822,6 +4839,55 @@ mod tests {
             "drive_client_put_inner must reference both advancement \
              caps by name in the selection so future readers see the \
              split — bare integer literals are forbidden here."
+        );
+    }
+
+    /// The scheduling lane and the hosting attribution must BOTH follow the
+    /// originator-loopback fact, and must agree — they are two readings of one
+    /// question ("is this our own client's PUT?"), and a node whose store runs
+    /// in the client-reserved lane while its telemetry files the contract under
+    /// transit is reporting something no operator could reconcile.
+    ///
+    /// Both derive from `put_is_originator_loopback` for that reason, so this
+    /// pins the mapping rather than the (now impossible) disagreement.
+    #[test]
+    fn put_store_lane_and_cause_follow_originator_loopback() {
+        let own: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+        let peer: SocketAddr = "127.0.0.1:5001".parse().unwrap();
+
+        assert!(
+            super::put_is_originator_loopback(Some(own), own),
+            "upstream == own_addr is the originator-loopback PUT"
+        );
+        assert!(
+            !super::put_is_originator_loopback(Some(own), peer),
+            "a genuine upstream peer is not loopback"
+        );
+        // Fail safe: unknown own address must not be read as loopback, or a node
+        // that has not yet learned its address would both over-prioritize every
+        // forwarded store and credit it to a local client.
+        assert!(
+            !super::put_is_originator_loopback(None, peer),
+            "unknown own address must not be treated as loopback"
+        );
+
+        assert_eq!(
+            super::put_store_priority(true),
+            crate::contract::Priority::ClientLocal
+        );
+        assert_eq!(
+            super::put_store_priority(false),
+            crate::contract::Priority::NetworkRelay
+        );
+        assert_eq!(
+            super::put_store_cause(true),
+            crate::ring::HostingCause::ClientPut,
+            "our own client's PUT is ClientPut, never transit"
+        );
+        assert_eq!(
+            super::put_store_cause(false),
+            crate::ring::HostingCause::TransitPut,
+            "someone else's PUT storing at this hop is transit"
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3432,9 +3432,12 @@ mod tests {
         let (op_manager, mut rx, _guard) =
             build_notification_test_node("notif-exclusion-subset-4965").await;
         let key = crate::operations::test_utils::make_contract_key(11);
-        op_manager
-            .ring
-            .host_contract(key, 1024, crate::ring::AccessType::Put);
+        op_manager.ring.host_contract(
+            key,
+            1024,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
 
         // A and B: advertised co-hosts AND interested — the excluded
         //          population. TWO of them, deliberately: with only one, a

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3041,7 +3041,7 @@ mod tests {
         let cohosts: HashSet<TransportPublicKey> = [cohost.0.clone()].into_iter().collect();
 
         let targets = proactive_summary_targets(
-            &[cohost.clone()],
+            std::slice::from_ref(&cohost),
             &cohosts,
             "127.0.0.1:9999".parse().unwrap(),
             None,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -4126,6 +4126,10 @@ mod tests {
 
         let handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "a stand-in handler that serves exactly the two events this test drives; any other event is an unexpected-input panic, and enumerating all 20+ ContractHandlerEvent variants to reach the same panic would only rot"
+                )]
                 let response = match ev {
                     ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
                         key: None,
@@ -4404,6 +4408,10 @@ mod tests {
         let counter = update_query_count.clone();
         let handler = tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                #[allow(
+                    clippy::wildcard_enum_match_arm,
+                    reason = "a stand-in handler that serves exactly the two events this test drives; any other event is an unexpected-input panic, and enumerating all 20+ ContractHandlerEvent variants to reach the same panic would only rot"
+                )]
                 let response = match ev {
                     ContractHandlerEvent::GetQuery { .. } => ContractHandlerEvent::GetResponse {
                         key: None,
@@ -4568,7 +4576,7 @@ mod tests {
 
         // Two delta failures (count = 2, below the trip threshold).
         for bytes in [vec![1u8], vec![2u8]] {
-            let _ = drive_relay_broadcast_to(
+            let driven = drive_relay_broadcast_to(
                 &op_manager,
                 Transaction::new::<UpdateMsg>(),
                 key,
@@ -4578,6 +4586,12 @@ mod tests {
                 crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
+            // Pin the PREMISE: these two must actually fail, or the backoff
+            // count below never advances and the test passes vacuously.
+            assert!(
+                driven.is_err(),
+                "the stand-in executor must reject this delta, got {driven:?}"
+            );
             let _ = drain_resync_targets(&mut notification_rx, key);
         }
         // A full-state broadcast SUCCEEDS via the stand-in — but must NOT reset
@@ -4600,7 +4614,7 @@ mod tests {
 
         // A 3rd delta failure now trips (count 2 → 3), proving the success did
         // NOT reset it to 0 (else the count would only reach 1 here).
-        let _ = drive_relay_broadcast_to(
+        let third = drive_relay_broadcast_to(
             &op_manager,
             Transaction::new::<UpdateMsg>(),
             key,
@@ -4610,6 +4624,10 @@ mod tests {
             crate::ring::broadcast_coverage::CoveredPeers::empty(),
         )
         .await;
+        assert!(
+            third.is_err(),
+            "the tripping delta must actually fail, got {third:?}"
+        );
         let _ = drain_resync_targets(&mut notification_rx, key);
         let queries_after_trip = update_queries.load(Ordering::Relaxed);
 
@@ -4654,7 +4672,7 @@ mod tests {
 
         // Sender A trips its own Invalid channel (3 consecutive delta failures).
         for bytes in [vec![1u8], vec![2u8], vec![3u8]] {
-            let _ = drive_relay_broadcast_to(
+            let driven = drive_relay_broadcast_to(
                 &op_manager,
                 Transaction::new::<UpdateMsg>(),
                 key,
@@ -4664,6 +4682,12 @@ mod tests {
                 crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
+            // Pin the PREMISE: A must actually fail 3 times, or it never trips
+            // and the per-sender scoping below is never exercised.
+            assert!(
+                driven.is_err(),
+                "the stand-in executor must reject A's delta, got {driven:?}"
+            );
             let _ = drain_resync_targets(&mut notification_rx, key);
         }
         assert_eq!(
@@ -4734,7 +4758,7 @@ mod tests {
         // Five consecutive queue-full delta failures (well past the N=3 Invalid
         // trip threshold). None may be recorded to the backoff.
         for bytes in [vec![1u8], vec![2u8], vec![3u8], vec![4u8], vec![5u8]] {
-            let _ = drive_relay_broadcast_to(
+            let driven = drive_relay_broadcast_to(
                 &op_manager,
                 Transaction::new::<UpdateMsg>(),
                 key,
@@ -4744,6 +4768,12 @@ mod tests {
                 crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
+            // Pin the PREMISE: every one of the five must be a queue-full
+            // failure, else "5 failures did not trip the backoff" proves nothing.
+            assert!(
+                driven.is_err(),
+                "the stand-in executor must report queue-full, got {driven:?}"
+            );
             let _ = drain_resync_targets(&mut notification_rx, key);
         }
         assert_eq!(
@@ -4783,7 +4813,7 @@ mod tests {
         let sender_count = 6u16;
         for i in 0..sender_count {
             let sender: SocketAddr = format!("127.0.0.1:{}", 13000 + i).parse().unwrap();
-            let _ = drive_relay_broadcast_to(
+            let driven = drive_relay_broadcast_to(
                 &op_manager,
                 Transaction::new::<UpdateMsg>(),
                 key,
@@ -4793,6 +4823,12 @@ mod tests {
                 crate::ring::broadcast_coverage::CoveredPeers::empty(),
             )
             .await;
+            // Pin the PREMISE: each sender's delta must actually hit queue-full,
+            // or the emit cap below is never put under pressure.
+            assert!(
+                driven.is_err(),
+                "the stand-in executor must report queue-full, got {driven:?}"
+            );
         }
         // The global per-contract emit cap (EMIT_BURST = 2) bounds total emissions
         // regardless of sender count — NOT one per sender.
@@ -6010,7 +6046,10 @@ mod tests {
                 break;
             }
         }
-        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("the resend task must finish once the deadline passes")
+            .expect("the resend task must not panic");
 
         assert!(
             !fired.is_empty(),

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -5102,9 +5102,12 @@ mod tests {
         );
         // Make the local node host the contract so drive_client_update's
         // target=None path applies the update locally instead of erroring.
-        op_manager
-            .ring
-            .host_contract(key, 100, crate::ring::AccessType::Put);
+        op_manager.ring.host_contract(
+            key,
+            100,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
 
         let remote_sender: SocketAddr = "127.0.0.1:12700".parse().unwrap();
         let probe_sender: SocketAddr = "127.0.0.1:12800".parse().unwrap();
@@ -5188,9 +5191,12 @@ mod tests {
             ContractInstanceId::new([63u8; 32]),
             CodeHash::new([64u8; 32]),
         );
-        op_manager
-            .ring
-            .host_contract(key, 100, crate::ring::AccessType::Put);
+        op_manager.ring.host_contract(
+            key,
+            100,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
 
         let remote_sender: SocketAddr = "127.0.0.1:15100".parse().unwrap();
         let probe_sender: SocketAddr = "127.0.0.1:15200".parse().unwrap();
@@ -5273,9 +5279,12 @@ mod tests {
             ContractInstanceId::new([65u8; 32]),
             CodeHash::new([66u8; 32]),
         );
-        op_manager
-            .ring
-            .host_contract(key, 100, crate::ring::AccessType::Put);
+        op_manager.ring.host_contract(
+            key,
+            100,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
 
         let remote_sender: SocketAddr = "127.0.0.1:15300".parse().unwrap();
         let probe_sender: SocketAddr = "127.0.0.1:15400".parse().unwrap();

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -8311,6 +8311,57 @@ mod instant_now_pin_test {
     }
 }
 
+/// Wiring pin for the shadow-mode futile-repair rows on
+/// `network_efficiency_v1` (`crate::ring::futile_repair`).
+///
+/// The detector's state machine is unit-tested in its own module and its
+/// handler wiring in `node.rs`. What NEITHER can see is the assignment in
+/// `router_snapshot_telemetry` that connects the two: drop it, or feed a row
+/// from the wrong source, and every one of those tests stays green while the
+/// fleet publishes zeros — for a release whose entire purpose is to establish
+/// the detector's real frequency in production. That is the #4009/#4010
+/// manually-mirrored-telemetry footgun, and the snapshot loop is a 30-minute
+/// background cadence inside a fully-built `Ring`, which is why it is pinned by
+/// source scrape rather than executed.
+#[cfg(test)]
+mod futile_repair_wiring_pin {
+    /// Production source only: the needles below appear in this module too, and
+    /// a pin that matches its own source is a pin that can never fail.
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("ring.rs");
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("ring.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    #[test]
+    fn network_efficiency_block_is_fed_from_the_futile_repair_snapshot() {
+        let src = production_source();
+        assert!(
+            src.contains(
+                "let futile_repair = op_manager.interest_manager.futile_repair_snapshot();"
+            ),
+            "the futile-repair snapshot is no longer taken in the \
+             router_snapshot block — the detector then collects its counters \
+             and exports nothing, while every test for it still passes"
+        );
+        for (field, source_expr) in [
+            ("futile", "futile_repair.to_row()"),
+            ("futile_ladder", "futile_repair.ladder"),
+        ] {
+            let needle = format!("{field}: {source_expr},");
+            assert!(
+                src.contains(&needle),
+                "`NetworkEfficiencyV1.{field}` must be populated as `{needle}` \
+                 in the router_snapshot block. Dropping it, or feeding it from \
+                 anything else, publishes an empty or wrong series with no \
+                 failing test — #4009/#4010."
+            );
+        }
+    }
+}
+
 /// Pin tests for the periodic hosting-advertisement re-request (#4642 spec step
 /// 1, "Fix 1"): the reliability backstop that heals a dropped on-connect
 /// advertisement exchange or a dropped per-eviction retraction. It is PIGGYBACKED

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -86,6 +86,8 @@ mod connection_backoff;
 mod connection_manager;
 pub(crate) mod contract_ban_list;
 pub(crate) mod delta_incompat;
+/// Shadow-mode detector for repairs that never converge (see the module docs).
+pub(crate) mod futile_repair;
 pub(crate) use connection_manager::ConnectionManager;
 // Nearest-neighbor ring lattice (successor+predecessor base edges).
 // `nn_lattice_active_for` is the full activation gate — the flag AND the
@@ -2089,6 +2091,12 @@ impl Ring {
                 )
             {
                 let lifecycle = op_manager.interest_manager.interest_lifecycle_snapshot();
+                // SHADOW MODE: futile-repair evidence (#nc-merge). Rides the
+                // same fixed-cardinality block for the same reason the rest of
+                // it does — `network_efficiency_v1` is the only family that
+                // bypasses both the node rate limiter and the collector's 5%
+                // sampler, so a rare-but-decisive counter is not sampled away.
+                let futile_repair = op_manager.interest_manager.futile_repair_snapshot();
                 let receiver = op_manager.payload_mix.receiver_apply_stats();
                 let queue = crate::node::BROADCAST_QUEUE_EFFICIENCY_METRICS.snapshot();
                 let state_rejections = crate::contract::state_size_rejection_snapshot();
@@ -2222,6 +2230,8 @@ impl Ring {
                     tel,
                     shadow,
                     eff: telemetry.network_efficiency_delivery,
+                    futile: futile_repair.to_row(),
+                    futile_ladder: futile_repair.ladder,
                 });
             }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -105,6 +105,9 @@ pub(crate) use broken_invariants::{BrokenInvariant, BrokenInvariantsTracker};
 /// executor chokepoints so a write that would overflow the aggregate disk
 /// budget is refused before any bytes land.
 pub(crate) use hosting::DiskBudgetExceeded;
+/// Hosting-BEGIN attribution: WHY this peer started hosting a contract. Every
+/// production caller of [`Ring::host_contract`] names one.
+pub(crate) use hosting::HostingCause;
 /// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
 /// `config::ConfigArgs::build` so an upgraded node re-derives its hosting budget
 /// instead of keeping the historically-pinned default (#4565).
@@ -128,6 +131,10 @@ pub use hosting::{AccessType, RecordAccessResult};
 /// `hosting-disk-pct` / `max-hosting-disk` defaults from these so the operator-
 /// facing defaults and the in-code sizing math share one source of truth.
 pub(crate) use hosting::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTES};
+/// Widths of the two hosted-set demand-signal histograms carried on the router
+/// snapshot, re-exported so `router` sizes its wire arrays from the same
+/// definition the bucketing code uses.
+pub(crate) use hosting::{GENUINE_ACCESS_RECENCY_BUCKETS, READ_COUNT_HIST_BUCKETS};
 /// Clamp bounds re-exported only for the config-default round-trip test.
 #[cfg(test)]
 pub(crate) use hosting::{MAX_DEFAULT_HOSTING_BUDGET_BYTES, MIN_DEFAULT_HOSTING_BUDGET_BYTES};
@@ -2222,6 +2229,14 @@ impl Ring {
                     tel,
                     shadow,
                     eff: telemetry.network_efficiency_delivery,
+                    // Hosting observability (#4642): WHY this peer began hosting
+                    // each contract, and the two demand-signal gauges the
+                    // eviction ranking is built on. `hosting` is the same
+                    // `hosting_cache_stats()` read that feeds `vict_n`/`vict_b`
+                    // above, so all four describe one consistent hosted set.
+                    host_begin: hosting.hosting_begins,
+                    host_reads: hosting.read_count_hist,
+                    host_recency: hosting.genuine_access_recency,
                 });
             }
 
@@ -3299,22 +3314,33 @@ impl Ring {
     /// Returns a `RecordAccessResult` containing:
     /// - `is_new`: Whether this contract was newly added (vs. refreshed existing)
     /// - `evicted`: Contracts that were evicted to make room
+    ///
+    /// `cause` attributes WHY this peer is (possibly) starting to host: the
+    /// caller is the only code that knows whether this is its own client's
+    /// request, someone else's request in transit, or a sub-op fetch. It feeds
+    /// telemetry only — it changes nothing about what is hosted or evicted.
     pub fn host_contract(
         &self,
         key: ContractKey,
         size_bytes: u64,
         access_type: AccessType,
+        cause: HostingCause,
     ) -> RecordAccessResult {
         self.hosting_manager
-            .record_contract_access(key, size_bytes, access_type)
+            .record_contract_access(key, size_bytes, access_type, cause)
     }
 
     /// Record a GET access to a contract in the hosting cache.
     ///
     /// Returns a `RecordAccessResult` indicating whether this was a new addition
     /// and which contracts were evicted (if any).
-    pub fn record_get_access(&self, key: ContractKey, size_bytes: u64) -> RecordAccessResult {
-        self.host_contract(key, size_bytes, AccessType::Get)
+    pub fn record_get_access(
+        &self,
+        key: ContractKey,
+        size_bytes: u64,
+        cause: HostingCause,
+    ) -> RecordAccessResult {
+        self.host_contract(key, size_bytes, AccessType::Get, cause)
     }
 
     /// Record that a local-client GET was answered from local hosted state
@@ -8667,6 +8693,48 @@ mod sleep_or_shutdown_tests {
     }
 }
 
+/// Wiring pin for the hosting-observability rows on `network_efficiency_v1`.
+///
+/// The counters themselves are unit-tested in `ring::hosting` (attribution) and
+/// `tracing::telemetry` (serialization). What NEITHER can see is the assignment
+/// in `router_snapshot_telemetry` that connects them: drop it, or feed a row
+/// from the wrong source, and every one of those tests stays green while the
+/// fleet publishes zeros or the wrong series. That is the #4009/#4010
+/// manually-mirrored-telemetry footgun, and the snapshot loop is a 30-minute
+/// background cadence inside a fully-built `Ring`, which is why it is pinned by
+/// source scrape rather than executed.
+#[cfg(test)]
+mod hosting_observability_wiring_pin {
+    /// Production source only: the needles below appear in this module too, and
+    /// a pin that matches its own source is a pin that can never fail.
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("ring.rs");
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod ")
+            .expect("ring.rs must have a top-level #[cfg(test)] mod section");
+        &FULL[..cutoff]
+    }
+
+    #[test]
+    fn network_efficiency_block_is_fed_from_the_hosting_cache_stats() {
+        let src = production_source();
+        for (field, source_expr) in [
+            ("host_begin", "hosting.hosting_begins"),
+            ("host_reads", "hosting.read_count_hist"),
+            ("host_recency", "hosting.genuine_access_recency"),
+        ] {
+            let needle = format!("{field}: {source_expr},");
+            assert!(
+                src.contains(&needle),
+                "`NetworkEfficiencyV1.{field}` must be populated as `{needle}` in \
+                 the router_snapshot block. Without this assignment the hosting \
+                 counters are collected and never exported, and every unit test \
+                 for them still passes — the exact failure mode of #4009/#4010."
+            );
+        }
+    }
+}
+
 /// End-to-end seam test for cost-aware eviction (#4861 / #4903 review):
 /// drives the message axis through the REAL production reporter
 /// (`Ring::report_contract_resource_usage` → topology meter) and the REAL
@@ -8740,9 +8808,24 @@ mod cost_pressure_seam_tests {
         let read_hot = seam_key(3);
 
         // Host all three through the production entry point (PUT seeds).
-        let _ = ring.host_contract(junk, 121, crate::ring::AccessType::Put);
-        let _ = ring.host_contract(subscribed, 121, crate::ring::AccessType::Put);
-        let _ = ring.host_contract(read_hot, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(
+            junk,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
+        let _ = ring.host_contract(
+            subscribed,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
+        let _ = ring.host_contract(
+            read_hot,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
         assert!(ring.is_hosting_contract(&junk), "precondition: hosted");
 
         // Age the PUT-seed recency stamps past the cost window, so only the
@@ -8761,7 +8844,7 @@ mod cost_pressure_seam_tests {
             ),
             crate::ring::hosting::AddSubscriberOutcome::Rejected
         ));
-        let _ = ring.record_get_access(read_hot, 121);
+        let _ = ring.record_get_access(read_hot, 121, crate::ring::HostingCause::Other);
 
         // The FX2j storm profile, reported for ALL THREE contracts through
         // the production reporter: one 58-target fan-out dispatch every 1.6s
@@ -8935,8 +9018,18 @@ mod cost_pressure_seam_tests {
         let junk = seam_key(1);
         let subscribed = seam_key(2);
 
-        let _ = ring.host_contract(junk, 121, crate::ring::AccessType::Put);
-        let _ = ring.host_contract(subscribed, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(
+            junk,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
+        let _ = ring.host_contract(
+            subscribed,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
         // Both advertised to co-hosts — the state this fix is about. Set directly
         // (not via `announce_contract_hosted`) so the only `HostingAnnounce` the
         // channel can carry is a retraction.
@@ -9031,7 +9124,12 @@ mod cost_pressure_seam_tests {
 
         // (1) Re-hosted: present in the hosting cache when the reclaim runs.
         let rehosted = seam_key(4);
-        let _ = ring.host_contract(rehosted, 121, crate::ring::AccessType::Put);
+        let _ = ring.host_contract(
+            rehosted,
+            121,
+            crate::ring::AccessType::Put,
+            crate::ring::HostingCause::Other,
+        );
         op_manager.neighbor_hosting.on_contract_hosted(&rehosted);
 
         // (2) Back in use: absent from the hosting cache, but a downstream

--- a/crates/core/src/ring/futile_repair.rs
+++ b/crates/core/src/ring/futile_repair.rs
@@ -1,0 +1,759 @@
+//! Shadow-mode detector for **futile repair** on a (peer, contract) edge.
+//!
+//! # Why this exists
+//!
+//! Freenet requires a contract's merge to be commutative
+//! (`crates/core/.claude/rules/contracts.md`: "Merge MUST be commutative").
+//! Nothing enforces it, and nothing can: the core cannot verify contract
+//! correctness. When a contract violates it, two peers hold states that no
+//! exchange can reconcile — last-write-wins merges oscillate forever, and
+//! mutually-rejecting merges (`merge(X, Y) == X` while `merge(Y, X) == Y`)
+//! never move at all. Anti-entropy detects the divergence every heartbeat,
+//! sends a heal, the heal cannot land, and the next heartbeat detects the same
+//! divergence. That loop is unbounded and invisible.
+//!
+//! Measured on the live network on 2026-08-09, seven contract instances
+//! accounted for **32.7% of all update applies** for exactly this reason.
+//!
+//! # What it measures
+//!
+//! The core cannot check a contract's merge, but it *can* check whether its own
+//! repair worked. That is the signal here, and it is an OUTCOME rather than a
+//! threshold on size or rate — a hostile contract cannot evade it by staying
+//! small or slow, because staying small and slow while never converging still
+//! registers.
+//!
+//! Per (contract, peer) edge:
+//!
+//! * A **repair attempt** is a `SyncStateToPeer` heal this node actually
+//!   emitted for that edge (see `node::emit_stale_peer_syncs`). Contracts the
+//!   heal loop skips — banned, no local state, or over the per-message emit
+//!   budget — are NOT attempts: no repair was sent, so the peer cannot be
+//!   blamed for not converging.
+//! * An **outcome observation** is the next *two-sided* summary comparison on
+//!   that edge: both this node and the peer reported a summary for the
+//!   contract, and the anti-entropy staleness predicate ruled on them. This
+//!   happens in `node::handle_interest_sync_message`, in the `Summaries` arm
+//!   (full-bytes comparison) and in the `SummaryDigests` arm's
+//!   `DigestVerdict::Agree` branch (the digest proved the peer's summary bytes
+//!   are ours, so the same predicate runs on real operands).
+//! * The attempt is **futile** when that observation still says the peer is
+//!   stale, and **productive** when it says the two sides agree.
+//!
+//! `consecutive_futile` counts futile outcomes back-to-back on one edge; a
+//! single productive outcome resets it to zero. When it reaches
+//! [`QUARANTINE_THRESHOLD`] the edge is recorded as one this node WOULD
+//! quarantine.
+//!
+//! # Shadow mode
+//!
+//! Nothing here changes behaviour. There is no quarantine, no suppression, no
+//! eviction, no rate limit, no early return. The detector observes and counts;
+//! every heal that would have been emitted is still emitted. This release
+//! exists to establish the real frequency in production and to prove the
+//! detector fires on the known-true positives before it is allowed to act.
+//!
+//! # What a futile count does NOT prove
+//!
+//! A non-commutative merge is the motivating cause, but it is not the only way
+//! to produce this signature. A contract under continuous write load can be
+//! genuinely diverged at every observation without any merge defect; so can an
+//! edge whose heals are being dropped on a full channel or lost in transit.
+//! The detector deliberately does not try to separate those — telling them
+//! apart is what the shadow-mode field data is for. Read a high count as "this
+//! edge is not converging", never as "this contract's merge is broken".
+//!
+//! # Bounded state
+//!
+//! Per-edge state lives in a fixed-capacity LRU ([`EDGE_CAPACITY`]); the key is
+//! remote-influenced (any peer can be interested in any contract), so it MUST
+//! be bounded — see the per-key-collection rule in `.claude/rules/code-style.md`.
+//! Eviction is not silent: [`FutileRepairSnapshot::tracked_edges`],
+//! [`FutileRepairSnapshot::evictions`] and
+//! [`FutileRepairSnapshot::evictions_losing_streak`] make saturation directly
+//! readable. That is a deliberate correction of the `ms_unt_age` failure
+//! (`crate::ring::interest::MISSING_SUMMARY_HISTORY_SIZE`), where a saturated
+//! LRU evicting continuously made "no record" indistinguishable from "evicted"
+//! and rendered the counter useless in production.
+
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use freenet_stdlib::prelude::ContractKey;
+use lru::LruCache;
+use tokio::time::Instant;
+
+use crate::ring::interest::PeerKey;
+
+/// Consecutive futile repairs on one edge before it is recorded as one this
+/// node WOULD quarantine.
+///
+/// Anti-entropy runs on a ~5-minute heartbeat, so five consecutive futile
+/// repairs is roughly 25 minutes of an edge failing to converge despite this
+/// node repeatedly shipping it state. That is far outside the ordinary
+/// transient (a lost heal, a write landing between the heal and the next
+/// comparison, a peer mid-resync), while still firing inside an hour on a
+/// genuinely non-convergent contract — the whole point of a shadow release is
+/// to find out whether that separation actually holds in the field, so this is
+/// a starting hypothesis rather than a tuned value.
+///
+/// SHADOW ONLY: crossing this threshold increments a counter. It does not
+/// quarantine, suppress, throttle, or evict anything.
+pub(crate) const QUARANTINE_THRESHOLD: u32 = 5;
+
+/// Hard cap on tracked (contract, peer) edges.
+///
+/// Entries are created only by an emitted repair, never by an observation, so
+/// the population is "edges this node has actually healed" rather than the full
+/// (hosted contract x connected peer) product. On a busy gateway that product
+/// is ~421K (nova: ~2,811 contracts x ~150 connections), but the diverging
+/// subset that draws a heal is a small fraction of it, and the per-message emit
+/// budget (`node::MAX_STALE_SYNCS_PER_SUMMARIES` = 32) bounds how fast new
+/// edges can enter.
+///
+/// 32,768 entries at ~200 bytes (the key is a `ContractKey` plus a
+/// `TransportPublicKey`; the value is ~24 bytes) is a worst case of ~7 MB, in
+/// the same range as the 65,536-entry sibling LRU in
+/// `crate::ring::interest`. It is chosen for headroom over the expected
+/// diverging-edge population, not derived from a measured working set — which
+/// is precisely why `tracked_edges` and the two eviction counters are exported.
+/// If `tracked_edges` sits at capacity and `evictions_losing_streak` is
+/// non-zero in production, this cap is too small and the futility counts are an
+/// UNDERCOUNT (an evicted streak restarts at zero and may never reach the
+/// threshold). Do not read the counters as a floor without checking those two
+/// first.
+pub(crate) const EDGE_CAPACITY: usize = 32_768;
+
+/// A pending attempt older than this is not treated as the cause of the
+/// observation that follows it.
+///
+/// Attempts and outcomes are paired by event order, not by a token on the wire,
+/// so a peer that disconnects with a heal outstanding and reconnects hours
+/// later would otherwise have that stale attempt settled by an unrelated
+/// comparison. At the ~5-minute anti-entropy heartbeat, 30 minutes is six
+/// cycles of headroom over a legitimate outcome while still discarding an
+/// attempt whose context is gone. Expired attempts are counted separately
+/// ([`FutileRepairSnapshot::attempts_expired`]) and classified as neither
+/// futile nor productive.
+pub(crate) const ATTEMPT_MAX_AGE: Duration = Duration::from_secs(30 * 60);
+
+/// Consecutive-futility rungs reported as a survival curve.
+///
+/// `ladder[i]` counts how many times any edge's consecutive-futile streak
+/// REACHED `LADDER_RUNGS[i]`, at most once per rung per streak. The series is
+/// monotonically non-increasing in `i`, so it reads directly as "of the streaks
+/// that got to 1, how many got to 2, to 4, to 32" — which is the distribution
+/// asked for, at fixed cardinality and with no per-contract or per-peer label.
+pub(crate) const LADDER_RUNGS: [u32; 8] = [1, 2, 3, 4, 5, 8, 16, 32];
+
+/// Number of rungs in [`LADDER_RUNGS`].
+pub(crate) const LADDER_LEN: usize = LADDER_RUNGS.len();
+
+/// Per-edge shadow state. 16 bytes; deliberately holds no state bytes, no
+/// summary, and no timing history beyond the one pending attempt.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct EdgeState {
+    /// When a repair was emitted whose outcome has not been observed yet.
+    pending_since: Option<Instant>,
+    /// Futile outcomes back-to-back; reset to zero by one productive outcome.
+    consecutive_futile: u32,
+    /// How many rungs of [`LADDER_RUNGS`] the CURRENT streak has already been
+    /// counted for, so a long streak contributes to each rung once.
+    ladder_recorded: u8,
+    /// Whether this edge is currently at or above [`QUARANTINE_THRESHOLD`].
+    /// Drives the `edges_at_threshold` gauge and stops one long streak
+    /// re-counting the crossing on every further futile outcome.
+    at_threshold: bool,
+}
+
+impl EdgeState {
+    fn has_streak(&self) -> bool {
+        self.consecutive_futile > 0
+    }
+}
+
+/// Fixed-cardinality counters copied into telemetry snapshots.
+///
+/// Aggregate only: no contract key, no peer identity, no label whose
+/// cardinality a remote peer could influence.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct FutileRepairSnapshot {
+    /// Repair attempts recorded — `SyncStateToPeer` heals actually emitted.
+    pub(crate) attempts: u64,
+    /// Attempts whose next two-sided comparison still showed divergence.
+    pub(crate) futile: u64,
+    /// Attempts whose next two-sided comparison showed the edge converged.
+    pub(crate) productive: u64,
+    /// Two-sided comparisons on an edge with no attempt outstanding. Not an
+    /// error — a converged edge is re-compared every heartbeat without anyone
+    /// healing it — but it is the denominator that keeps `futile + productive`
+    /// from being read as "all anti-entropy comparisons".
+    pub(crate) observations_unpaired: u64,
+    /// Attempts replaced by a newer attempt on the same edge before any outcome
+    /// was observed. Expected to be near zero: the heal is emitted after the
+    /// comparison that settles the previous one, in the same handler call. A
+    /// large value means attempts and outcomes are not interleaving as assumed
+    /// and the futility counts are an undercount.
+    pub(crate) attempts_superseded: u64,
+    /// Attempts discarded unsettled because the next observation arrived more
+    /// than [`ATTEMPT_MAX_AGE`] later.
+    pub(crate) attempts_expired: u64,
+    /// Times an edge's consecutive-futile streak reached
+    /// [`QUARANTINE_THRESHOLD`] — the headline "would have been quarantined"
+    /// count. Counted once per streak: a streak that keeps growing past the
+    /// threshold does not re-count, but an edge that converges and later
+    /// crosses again does.
+    pub(crate) would_quarantine: u64,
+    /// Edges currently at or above [`QUARANTINE_THRESHOLD`]. A gauge, not a
+    /// counter — this is the live population a real quarantine would hold.
+    ///
+    /// An edge leaves this gauge only by converging or by being evicted, so a
+    /// peer that disconnects mid-streak keeps its slot until the LRU forgets
+    /// it. Read the gauge as "edges that last looked stuck", not "edges stuck
+    /// right now"; `would_quarantine` is the unambiguous count.
+    pub(crate) edges_at_threshold: u64,
+    /// Current LRU occupancy. Sitting at [`EDGE_CAPACITY`] means saturated.
+    pub(crate) tracked_edges: u64,
+    /// Entries evicted from the LRU.
+    pub(crate) evictions: u64,
+    /// Evictions whose entry carried a non-zero streak, so a genuine futility
+    /// streak was forgotten and restarts at zero. Non-zero means the counts
+    /// above are an undercount.
+    pub(crate) evictions_losing_streak: u64,
+    /// Survival curve over [`LADDER_RUNGS`]; see that constant.
+    pub(crate) ladder: [u64; LADDER_LEN],
+}
+
+/// Number of scalar counters in [`FutileRepairSnapshot`] before the ladder.
+pub(crate) const SNAPSHOT_SCALARS: usize = 11;
+
+impl FutileRepairSnapshot {
+    /// Flatten to the fixed-width row exported in
+    /// `router::NetworkEfficiencyV1::futile`. Order is load-bearing — it is the
+    /// wire contract for the collector — and is documented on that field.
+    pub(crate) fn to_row(self) -> [u64; SNAPSHOT_SCALARS] {
+        [
+            self.attempts,
+            self.futile,
+            self.productive,
+            self.observations_unpaired,
+            self.attempts_superseded,
+            self.attempts_expired,
+            self.would_quarantine,
+            self.edges_at_threshold,
+            self.tracked_edges,
+            self.evictions,
+            self.evictions_losing_streak,
+        ]
+    }
+}
+
+struct Metrics {
+    attempts: AtomicU64,
+    futile: AtomicU64,
+    productive: AtomicU64,
+    observations_unpaired: AtomicU64,
+    attempts_superseded: AtomicU64,
+    attempts_expired: AtomicU64,
+    would_quarantine: AtomicU64,
+    evictions: AtomicU64,
+    evictions_losing_streak: AtomicU64,
+    ladder: [AtomicU64; LADDER_LEN],
+}
+
+impl Metrics {
+    fn new() -> Self {
+        Self {
+            attempts: AtomicU64::new(0),
+            futile: AtomicU64::new(0),
+            productive: AtomicU64::new(0),
+            observations_unpaired: AtomicU64::new(0),
+            attempts_superseded: AtomicU64::new(0),
+            attempts_expired: AtomicU64::new(0),
+            would_quarantine: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+            evictions_losing_streak: AtomicU64::new(0),
+            ladder: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+}
+
+/// Shadow-mode futile-repair detector. See the module docs.
+pub(crate) struct FutileRepairDetector {
+    edges: Mutex<LruCache<(ContractKey, PeerKey), EdgeState>>,
+    /// Live count of edges at or above [`QUARANTINE_THRESHOLD`]. Maintained
+    /// incrementally rather than scanned, and decremented on eviction so an
+    /// evicted at-threshold edge does not leak into the gauge forever.
+    edges_at_threshold: AtomicU64,
+    metrics: Metrics,
+}
+
+impl Default for FutileRepairDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FutileRepairDetector {
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(EDGE_CAPACITY)
+    }
+
+    /// Construct with an explicit capacity. Tests use a tiny cap to exercise
+    /// eviction without allocating the production LRU.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            edges: Mutex::new(LruCache::new(
+                NonZeroUsize::new(capacity).expect("futile-repair capacity must be > 0"),
+            )),
+            edges_at_threshold: AtomicU64::new(0),
+            metrics: Metrics::new(),
+        }
+    }
+
+    /// Record that a `SyncStateToPeer` heal was emitted for this edge.
+    ///
+    /// Call ONLY where the heal is actually sent. A contract skipped for being
+    /// banned, having no local state, or exceeding the per-message emit budget
+    /// is not an attempt: no repair was made, so its failure to converge is not
+    /// evidence about the peer or the contract's merge.
+    pub(crate) fn record_repair_attempt(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        now: Instant,
+    ) {
+        self.metrics.attempts.fetch_add(1, Ordering::Relaxed);
+        let mut edges = self.lock();
+        let key = (*contract, peer.clone());
+        if let Some(state) = edges.get_mut(&key) {
+            if state.pending_since.is_some() {
+                self.metrics
+                    .attempts_superseded
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            state.pending_since = Some(now);
+            return;
+        }
+        let state = EdgeState {
+            pending_since: Some(now),
+            ..EdgeState::default()
+        };
+        if let Some((_, evicted)) = edges.push(key, state) {
+            self.note_eviction(evicted);
+        }
+    }
+
+    /// Record the result of a two-sided summary comparison for this edge.
+    ///
+    /// `converged` is the anti-entropy staleness verdict inverted: `true` when
+    /// the predicate ruled the peer is NOT stale. Both operands must be real
+    /// summaries — a comparison where either side reported nothing is not an
+    /// outcome and must not be passed here, because there is no divergence to
+    /// have repaired.
+    ///
+    /// Only an observation that follows an outstanding attempt is classified.
+    /// Everything else is counted as unpaired and changes no streak: the point
+    /// of the detector is whether OUR REPAIRS work, and an edge nobody healed
+    /// says nothing about that either way.
+    pub(crate) fn record_repair_outcome(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        converged: bool,
+        now: Instant,
+    ) {
+        let mut edges = self.lock();
+        let key = (*contract, peer.clone());
+        let Some(state) = edges.get_mut(&key) else {
+            self.metrics
+                .observations_unpaired
+                .fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        let Some(pending_since) = state.pending_since.take() else {
+            self.metrics
+                .observations_unpaired
+                .fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        if now.saturating_duration_since(pending_since) > ATTEMPT_MAX_AGE {
+            self.metrics
+                .attempts_expired
+                .fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        if converged {
+            self.metrics.productive.fetch_add(1, Ordering::Relaxed);
+            state.consecutive_futile = 0;
+            state.ladder_recorded = 0;
+            if std::mem::take(&mut state.at_threshold) {
+                self.edges_at_threshold.fetch_sub(1, Ordering::Relaxed);
+            }
+            return;
+        }
+
+        self.metrics.futile.fetch_add(1, Ordering::Relaxed);
+        state.consecutive_futile = state.consecutive_futile.saturating_add(1);
+        let streak = state.consecutive_futile;
+        while (state.ladder_recorded as usize) < LADDER_LEN
+            && streak >= LADDER_RUNGS[state.ladder_recorded as usize]
+        {
+            self.metrics.ladder[state.ladder_recorded as usize].fetch_add(1, Ordering::Relaxed);
+            state.ladder_recorded += 1;
+        }
+        if !state.at_threshold && streak >= QUARANTINE_THRESHOLD {
+            state.at_threshold = true;
+            self.metrics
+                .would_quarantine
+                .fetch_add(1, Ordering::Relaxed);
+            self.edges_at_threshold.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> FutileRepairSnapshot {
+        let load = |value: &AtomicU64| value.load(Ordering::Relaxed);
+        let tracked_edges = self.lock().len() as u64;
+        FutileRepairSnapshot {
+            attempts: load(&self.metrics.attempts),
+            futile: load(&self.metrics.futile),
+            productive: load(&self.metrics.productive),
+            observations_unpaired: load(&self.metrics.observations_unpaired),
+            attempts_superseded: load(&self.metrics.attempts_superseded),
+            attempts_expired: load(&self.metrics.attempts_expired),
+            would_quarantine: load(&self.metrics.would_quarantine),
+            edges_at_threshold: load(&self.edges_at_threshold),
+            tracked_edges,
+            evictions: load(&self.metrics.evictions),
+            evictions_losing_streak: load(&self.metrics.evictions_losing_streak),
+            ladder: std::array::from_fn(|i| load(&self.metrics.ladder[i])),
+        }
+    }
+
+    fn note_eviction(&self, evicted: EdgeState) {
+        self.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+        if evicted.has_streak() {
+            self.metrics
+                .evictions_losing_streak
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if evicted.at_threshold {
+            self.edges_at_threshold.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, LruCache<(ContractKey, PeerKey), EdgeState>> {
+        self.edges.lock().unwrap_or_else(|poisoned| {
+            // Diagnostic-only state: a poisoned lock must never take down the
+            // anti-entropy path it is observing.
+            poisoned.into_inner()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId};
+
+    /// Deterministic-and-distinct, mirroring the sibling helper in
+    /// `crate::ring::interest`'s test module.
+    fn contract(seed: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([seed; 32]),
+            CodeHash::new([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    fn peer(seed: u8) -> PeerKey {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        PeerKey(crate::transport::TransportPublicKey::from_bytes(bytes))
+    }
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    /// The load-bearing test: futility is an OUTCOME, not a count of attempts.
+    ///
+    /// Two edges receive the SAME number of repair attempts. The only
+    /// difference is what the following comparison said. If the detector
+    /// counted attempts (or counted every outcome as futile), both edges would
+    /// look identical and this test fails — which is the mutation documented in
+    /// the PR: replacing `converged` with `false` at the outcome site makes
+    /// `productive` 0, `futile` 6, and `would_quarantine` 2.
+    #[test]
+    fn futility_counts_the_outcome_not_the_attempt() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let converging = contract(1);
+        let stuck = contract(2);
+        let p = peer(1);
+
+        // Edge that converges: every repair lands.
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&converging, &p, now);
+            detector.record_repair_outcome(&converging, &p, true, now);
+        }
+        // Edge that never converges: identical attempt count, opposite outcome.
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&stuck, &p, now);
+            detector.record_repair_outcome(&stuck, &p, false, now);
+        }
+
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.attempts,
+            u64::from(QUARANTINE_THRESHOLD) * 2,
+            "both edges attempted the same number of repairs"
+        );
+        assert_eq!(
+            snap.productive,
+            u64::from(QUARANTINE_THRESHOLD),
+            "the converging edge's repairs must all count as productive"
+        );
+        assert_eq!(
+            snap.futile,
+            u64::from(QUARANTINE_THRESHOLD),
+            "only the non-convergent edge's repairs are futile"
+        );
+        assert_eq!(
+            snap.would_quarantine, 1,
+            "exactly one edge reached the threshold — a detector counting \
+             attempts rather than outcomes would report two"
+        );
+        assert_eq!(
+            snap.edges_at_threshold, 1,
+            "the converging edge must never be at the threshold"
+        );
+    }
+
+    /// A single productive repair clears the streak, so an edge that converges
+    /// just before the threshold never reaches it however many times it has
+    /// already failed.
+    #[test]
+    fn one_productive_repair_resets_the_streak() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(3);
+        let p = peer(1);
+
+        for _ in 0..(QUARANTINE_THRESHOLD - 1) {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(&key, &p, false, now);
+        }
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(&key, &p, true, now);
+        assert_eq!(detector.snapshot().would_quarantine, 0);
+
+        // ...and the streak restarts from zero, so it takes the full threshold
+        // again rather than one more failure.
+        for _ in 0..(QUARANTINE_THRESHOLD - 1) {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(&key, &p, false, now);
+        }
+        assert_eq!(
+            detector.snapshot().would_quarantine,
+            0,
+            "the streak must restart at zero after a productive repair"
+        );
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(&key, &p, false, now);
+        let snap = detector.snapshot();
+        assert_eq!(snap.would_quarantine, 1);
+        assert_eq!(
+            snap.productive, 1,
+            "the one landed repair stays visible as productive"
+        );
+    }
+
+    /// An unhealed edge is not evidence. Comparisons with no outstanding
+    /// attempt are counted separately and move no streak.
+    #[test]
+    fn observations_without_an_attempt_are_unpaired() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(4);
+        let p = peer(1);
+
+        for _ in 0..10 {
+            detector.record_repair_outcome(&key, &p, false, now);
+        }
+        let snap = detector.snapshot();
+        assert_eq!(snap.observations_unpaired, 10);
+        assert_eq!(
+            snap.futile, 0,
+            "no repair was attempted, so none was futile"
+        );
+        assert_eq!(snap.would_quarantine, 0);
+        assert_eq!(snap.tracked_edges, 0, "observations must not create edges");
+
+        // A second observation after the attempt is settled is also unpaired.
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(&key, &p, false, now);
+        detector.record_repair_outcome(&key, &p, false, now);
+        let snap = detector.snapshot();
+        assert_eq!(snap.futile, 1, "one attempt, one futile outcome");
+        assert_eq!(snap.observations_unpaired, 11);
+    }
+
+    #[test]
+    fn a_stale_attempt_expires_rather_than_being_settled() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(5);
+        let p = peer(1);
+
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(
+            &key,
+            &p,
+            false,
+            now + ATTEMPT_MAX_AGE + Duration::from_secs(1),
+        );
+        let snap = detector.snapshot();
+        assert_eq!(snap.attempts_expired, 1);
+        assert_eq!(snap.futile, 0);
+        assert_eq!(snap.productive, 0);
+
+        // Inside the window it settles normally.
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(&key, &p, false, now + ATTEMPT_MAX_AGE);
+        assert_eq!(detector.snapshot().futile, 1);
+    }
+
+    #[test]
+    fn repeated_attempts_without_an_outcome_are_counted_as_superseded() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(6);
+        let p = peer(1);
+
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_attempt(&key, &p, now);
+        let snap = detector.snapshot();
+        assert_eq!(snap.attempts, 3);
+        assert_eq!(snap.attempts_superseded, 2);
+        assert_eq!(snap.futile, 0);
+    }
+
+    /// The ladder is a survival curve: each streak counts once per rung it
+    /// reaches, so the series is monotonically non-increasing.
+    #[test]
+    fn ladder_is_a_monotone_survival_curve() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let p = peer(1);
+        // Three edges with streaks of 1, 4 and 32.
+        for (seed, streak) in [(10u8, 1u32), (11, 4), (12, 32)] {
+            let key = contract(seed);
+            for _ in 0..streak {
+                detector.record_repair_attempt(&key, &p, now);
+                detector.record_repair_outcome(&key, &p, false, now);
+            }
+        }
+        let ladder = detector.snapshot().ladder;
+        // Rungs are 1, 2, 3, 4, 5, 8, 16, 32.
+        assert_eq!(ladder, [3, 2, 2, 2, 1, 1, 1, 1]);
+        for window in ladder.windows(2) {
+            assert!(
+                window[0] >= window[1],
+                "survival curve must be non-increasing, got {ladder:?}"
+            );
+        }
+    }
+
+    /// LRU eviction is visible, not silent — the `ms_unt_age` lesson.
+    #[test]
+    fn eviction_is_observable() {
+        let detector = FutileRepairDetector::with_capacity(2);
+        let now = t0();
+        let p = peer(1);
+
+        // Build a streak on edge 20, then push it out with two other edges.
+        let victim = contract(20);
+        detector.record_repair_attempt(&victim, &p, now);
+        detector.record_repair_outcome(&victim, &p, false, now);
+        for seed in [21u8, 22] {
+            detector.record_repair_attempt(&contract(seed), &p, now);
+        }
+        let snap = detector.snapshot();
+        assert_eq!(snap.tracked_edges, 2, "occupancy is capped");
+        assert_eq!(snap.evictions, 1);
+        assert_eq!(
+            snap.evictions_losing_streak, 1,
+            "an evicted streak must be reported, or futility counts silently \
+             undercount"
+        );
+    }
+
+    /// An at-threshold edge evicted from the LRU must leave the live gauge,
+    /// otherwise `edges_at_threshold` drifts upward forever.
+    #[test]
+    fn eviction_releases_the_at_threshold_gauge() {
+        let detector = FutileRepairDetector::with_capacity(1);
+        let now = t0();
+        let p = peer(1);
+        let victim = contract(30);
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&victim, &p, now);
+            detector.record_repair_outcome(&victim, &p, false, now);
+        }
+        assert_eq!(detector.snapshot().edges_at_threshold, 1);
+        detector.record_repair_attempt(&contract(31), &p, now);
+        let snap = detector.snapshot();
+        assert_eq!(snap.edges_at_threshold, 0);
+        assert_eq!(
+            snap.would_quarantine, 1,
+            "the crossing already happened and stays counted"
+        );
+    }
+
+    /// Distinct peers on the same contract are distinct edges: one peer failing
+    /// to converge must not be charged to another that did.
+    #[test]
+    fn edges_are_per_peer_not_per_contract() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(40);
+        let stuck = peer(1);
+        let healthy = peer(2);
+
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&key, &stuck, now);
+            detector.record_repair_outcome(&key, &stuck, false, now);
+            detector.record_repair_attempt(&key, &healthy, now);
+            detector.record_repair_outcome(&key, &healthy, true, now);
+        }
+        let snap = detector.snapshot();
+        assert_eq!(snap.would_quarantine, 1);
+        assert_eq!(snap.edges_at_threshold, 1);
+        assert_eq!(snap.futile, u64::from(QUARANTINE_THRESHOLD));
+        assert_eq!(snap.productive, u64::from(QUARANTINE_THRESHOLD));
+    }
+
+    #[test]
+    fn snapshot_row_order_is_the_documented_wire_contract() {
+        let snap = FutileRepairSnapshot {
+            attempts: 1,
+            futile: 2,
+            productive: 3,
+            observations_unpaired: 4,
+            attempts_superseded: 5,
+            attempts_expired: 6,
+            would_quarantine: 7,
+            edges_at_threshold: 8,
+            tracked_edges: 9,
+            evictions: 10,
+            evictions_losing_streak: 11,
+            ladder: [0; LADDER_LEN],
+        };
+        assert_eq!(snap.to_row(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    }
+}

--- a/crates/core/src/ring/futile_repair.rs
+++ b/crates/core/src/ring/futile_repair.rs
@@ -38,12 +38,47 @@
 //!   `DigestVerdict::Agree` branch (the digest proved the peer's summary bytes
 //!   are ours, so the same predicate runs on real operands).
 //! * The attempt is **futile** when that observation still says the peer is
-//!   stale, and **productive** when it says the two sides agree.
+//!   stale, and **productive** when it says the two sides agree — but only when
+//!   the verdict rests on real evidence; see [`OutcomeEvidence`].
 //!
 //! `consecutive_futile` counts futile outcomes back-to-back on one edge; a
 //! single productive outcome resets it to zero. When it reaches
 //! [`QUARANTINE_THRESHOLD`] the edge is recorded as one this node WOULD
 //! quarantine.
+//!
+//! # Pairing an attempt with its outcome
+//!
+//! An attempt stays pending until the **next comparison on that edge, whenever
+//! it happens.** There is deliberately no wall-clock deadline, because the
+//! interval between two comparisons of one contract is NOT the anti-entropy
+//! heartbeat. On links that still take the full-bytes fallback the reply is
+//! byte-budgeted (`node::MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`) and carries
+//! only a rotating window of the shared set, so on the heaviest links — which
+//! are exactly the heavy-summary rooms this detector is hunting — a given
+//! contract comes back round on the order of **ten hours**, not five minutes
+//! (see the rustdoc on that constant). An earlier revision expired a pending
+//! attempt after 30 minutes, justified as "six heartbeats of headroom"; on
+//! those links every single attempt would have expired unsettled, so `futile`
+//! and `productive` would both have stayed at zero and `would_quarantine`
+//! could never fire. The detector would have been structurally blind on the
+//! population it exists to find. (The post-#5238 digest path does not rotate,
+//! so this bites hardest during a mixed-version rollout.)
+//!
+//! What the wall-clock deadline was really guarding against is a peer that
+//! disconnects with a heal outstanding and comes back much later, so that an
+//! unrelated comparison settles a long-dead attempt. That case is now handled
+//! directly rather than by a timer: peer-interest teardown discards the edge
+//! (see [`FutileRepairDetector::discard_peer_attempts`], wired to
+//! `InterestManager::remove_all_peer_interests_for`, which runs after the
+//! disconnect grace period). An attempt's lifetime is therefore the edge's own
+//! lifetime.
+//!
+//! The residual confound — a long gap in which something OTHER than our heal
+//! changed the state — is measured rather than gated:
+//! [`FutileRepairSnapshot::outcomes_after_long_gap`] counts outcomes settled
+//! more than [`LONG_GAP_THRESHOLD`] after their attempt. Those are still
+//! classified; the counter is there so the field data can say how much of the
+//! headline is carried by them.
 //!
 //! # Shadow mode
 //!
@@ -56,12 +91,36 @@
 //! # What a futile count does NOT prove
 //!
 //! A non-commutative merge is the motivating cause, but it is not the only way
-//! to produce this signature. A contract under continuous write load can be
-//! genuinely diverged at every observation without any merge defect; so can an
-//! edge whose heals are being dropped on a full channel or lost in transit.
-//! The detector deliberately does not try to separate those — telling them
-//! apart is what the shadow-mode field data is for. Read a high count as "this
-//! edge is not converging", never as "this contract's merge is broken".
+//! to produce this signature, and the counters do not separate the causes. Read
+//! a high count as "this edge is not converging", never as "this contract's
+//! merge is broken". Specifically:
+//!
+//! * **`futile : productive` is not a repair-efficacy ratio.** Attempts are
+//!   recorded only for anti-entropy heals, but an edge can converge by another
+//!   route entirely — the proximity-overlap heal in the connect handler, or
+//!   plain live UPDATE fan-out — and neither records anything, so the next
+//!   comparison credits that recovery to whatever anti-entropy heal happened to
+//!   be outstanding. `productive` means "the edge had converged by the next
+//!   comparison", not "our heal is what converged it".
+//! * **A contract with a degenerate delta scores healthiest.** The convergence
+//!   verdict comes from the contract's own WASM `get_state_delta`
+//!   (`interest::peer_summary_has_pending_state`), and an empty delta reads as
+//!   converged, counts productive, and RESETS the streak. A contract that
+//!   always returns an empty delta is therefore invisible here — the same trust
+//!   assumption the broadcast delta-optimization path already makes, but worth
+//!   stating because it runs opposite to this detector's purpose.
+//! * **A stuck edge is counted by BOTH of its ends.** Divergence is symmetric:
+//!   A sees B stale while B sees A stale (`node.rs`, `Summaries` arm), so both
+//!   peers heal, both observe futility, and both count it. Every counter here
+//!   is therefore PER OBSERVER. A fleet sum of `would_quarantine` is roughly
+//!   **twice** the number of distinct stuck edges, and there is no per-edge
+//!   identity on the wire to deduplicate with. Halve it, or read it as an upper
+//!   bound.
+//! * **Continuous write load looks the same.** A contract written faster than
+//!   it converges is genuinely diverged at every observation with no merge
+//!   defect at all, as is an edge whose heals are dropped on a full channel or
+//!   lost in transit. Telling these apart is what the shadow-mode field data is
+//!   for.
 //!
 //! # Bounded state
 //!
@@ -75,6 +134,34 @@
 //! (`crate::ring::interest::MISSING_SUMMARY_HISTORY_SIZE`), where a saturated
 //! LRU evicting continuously made "no record" indistinguishable from "evicted"
 //! and rendered the counter useless in production.
+//!
+//! # Known limitations, BOTH of which must be resolved before anything ACTS
+//!
+//! Neither matters while the detector only counts. Both become
+//! attacker-controlled the moment a streak gates behaviour.
+//!
+//! * **A peer can flush other peers' entries out of the LRU.** Each
+//!   `Summaries` message can create up to `node::MAX_STALE_SYNCS_PER_SUMMARIES`
+//!   (32) fresh keys, so roughly 1,024 such messages sweep the whole cache. The
+//!   underlying amplification is pre-existing and capped by that same budget,
+//!   and in shadow mode the consequence is only an undercount that
+//!   `evictions_losing_streak` reports. Acting on a streak would make this a
+//!   way to clear another peer's streak, so this cache needs per-peer fairness
+//!   (or per-peer capacity) first.
+//! * **A peer chooses which of its contracts get a real verdict.** Entries are
+//!   evaluated in the order the sender wrote them and the probe budget is
+//!   per-message, so padding a message with 32 novel-byte entries puts
+//!   everything after them into [`OutcomeEvidence::ProbeBudgetExhausted`] —
+//!   never classified, streak never advanced. That is the RIGHT trade for a
+//!   measurement (counting those as futility is a guaranteed false positive
+//!   that grows with load, which is the whole reason they are excluded), but it
+//!   is an evasion channel for an enforcement mechanism. Watch
+//!   `outcomes_probe_budget_exhausted` against `attempts` and
+//!   `attempts_superseded`: an edge that is healed every round while never
+//!   producing a verdict is the signature, and it is exactly what a contract
+//!   hiding from a future quarantine would look like. Closing it means making
+//!   the probe budget per-CONTRACT-position-independent (e.g. reserving budget
+//!   for contracts with an outstanding attempt) rather than first-come.
 
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
@@ -91,13 +178,15 @@ use crate::ring::interest::PeerKey;
 /// node WOULD quarantine.
 ///
 /// Anti-entropy runs on a ~5-minute heartbeat, so five consecutive futile
-/// repairs is roughly 25 minutes of an edge failing to converge despite this
-/// node repeatedly shipping it state. That is far outside the ordinary
-/// transient (a lost heal, a write landing between the heal and the next
-/// comparison, a peer mid-resync), while still firing inside an hour on a
-/// genuinely non-convergent contract — the whole point of a shadow release is
-/// to find out whether that separation actually holds in the field, so this is
-/// a starting hypothesis rather than a tuned value.
+/// repairs is at least ~25 minutes of an edge failing to converge despite this
+/// node repeatedly shipping it state — and considerably longer on links whose
+/// summary rotation is slow (see "Pairing an attempt with its outcome"). That
+/// is far outside the ordinary transient (a lost heal, a write landing between
+/// the heal and the next comparison, a peer mid-resync), while still firing
+/// inside an hour on a genuinely non-convergent contract on a fast link. The
+/// whole point of a shadow release is to find out whether that separation
+/// actually holds in the field, so this is a starting hypothesis rather than a
+/// tuned value.
 ///
 /// SHADOW ONLY: crossing this threshold increments a counter. It does not
 /// quarantine, suppress, throttle, or evict anything.
@@ -126,18 +215,19 @@ pub(crate) const QUARANTINE_THRESHOLD: u32 = 5;
 /// first.
 pub(crate) const EDGE_CAPACITY: usize = 32_768;
 
-/// A pending attempt older than this is not treated as the cause of the
-/// observation that follows it.
+/// An attempt settled more than this long after it was emitted is still
+/// classified, but is ALSO counted in
+/// [`FutileRepairSnapshot::outcomes_after_long_gap`].
 ///
-/// Attempts and outcomes are paired by event order, not by a token on the wire,
-/// so a peer that disconnects with a heal outstanding and reconnects hours
-/// later would otherwise have that stale attempt settled by an unrelated
-/// comparison. At the ~5-minute anti-entropy heartbeat, 30 minutes is six
-/// cycles of headroom over a legitimate outcome while still discarding an
-/// attempt whose context is gone. Expired attempts are counted separately
-/// ([`FutileRepairSnapshot::attempts_expired`]) and classified as neither
-/// futile nor productive.
-pub(crate) const ATTEMPT_MAX_AGE: Duration = Duration::from_secs(30 * 60);
+/// This is a visibility marker, NOT a gate — see "Pairing an attempt with its
+/// outcome" in the module docs for why gating on wall-clock age made the
+/// detector blind on exactly the links it targets. One hour is well past the
+/// ~5-minute heartbeat and past a few missed cycles, so a long gap means the
+/// edge's summary rotation is slow (or the peer was quiet), and the chance that
+/// something other than our heal moved the state in the meantime is materially
+/// higher. If the headline futility count turns out to be carried by long-gap
+/// outcomes, it is measuring rotation latency more than repair failure.
+pub(crate) const LONG_GAP_THRESHOLD: Duration = Duration::from_secs(60 * 60);
 
 /// Consecutive-futility rungs reported as a survival curve.
 ///
@@ -151,8 +241,47 @@ pub(crate) const LADDER_RUNGS: [u32; 8] = [1, 2, 3, 4, 5, 8, 16, 32];
 /// Number of rungs in [`LADDER_RUNGS`].
 pub(crate) const LADDER_LEN: usize = LADDER_RUNGS.len();
 
-/// Per-edge shadow state. 16 bytes; deliberately holds no state bytes, no
-/// summary, and no timing history beyond the one pending attempt.
+/// What the staleness verdict handed to
+/// [`FutileRepairDetector::record_repair_outcome`] actually rests on.
+///
+/// The anti-entropy handler collapses three very different situations into one
+/// `is_stale: bool`, and only one of them is evidence about convergence. The
+/// distinction is load-bearing for this detector because the non-evidence cases
+/// default to STALE, and their frequency grows with how many contracts a peer
+/// reports rather than with how broken anything is: everything past the
+/// per-message probe budget (`node::MAX_STALENESS_PROBES_PER_SUMMARIES` = 32)
+/// is classified stale every round with no divergence at all. Folding that into
+/// `futile` would make the headline number track peer breadth and node load —
+/// precisely the "metric re-derived away from the decision" failure in
+/// `.claude/rules/bug-prevention-patterns.md`.
+///
+/// So only [`OutcomeEvidence::Verdict`] classifies. The other two are counted
+/// in their own rows and leave the streak — and the outstanding attempt —
+/// untouched, so a real verdict on the next exchange still settles it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OutcomeEvidence {
+    /// The verdict rests on real evidence about this pair of summaries: the
+    /// bytes were identical (trivially converged), or the contract's own
+    /// `get_state_delta` answered (freshly probed, or served from the shared
+    /// delta cache).
+    Verdict,
+    /// The summaries differed byte-wise and no semantic verdict was available
+    /// because this message's WASM probe budget was already spent, so
+    /// `interest::summary_indicates_stale_peer` fell back to the conservative
+    /// bytes-differ-means-stale default. Correct as a HEAL decision (the heal
+    /// is cheap and the contract is re-evaluated next heartbeat), useless as
+    /// evidence that a repair failed.
+    ProbeBudgetExhausted,
+    /// The summaries differed byte-wise and the probe itself returned no
+    /// verdict — the contract's `get_state_delta` errored, timed out, or the
+    /// handler answered something unexpected. Same conservative default, same
+    /// lack of evidence, different cause: this one tracks contract/runtime
+    /// health rather than peer breadth.
+    ProbeUnavailable,
+}
+
+/// Per-edge shadow state. Deliberately holds no state bytes, no summary, and no
+/// timing history beyond the one pending attempt.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct EdgeState {
     /// When a repair was emitted whose outcome has not been observed yet.
@@ -177,14 +306,32 @@ impl EdgeState {
 /// Fixed-cardinality counters copied into telemetry snapshots.
 ///
 /// Aggregate only: no contract key, no peer identity, no label whose
-/// cardinality a remote peer could influence.
+/// cardinality a remote peer could influence. Every counter is PER OBSERVER —
+/// both ends of a diverged edge run this detector and both count it, so a fleet
+/// sum is roughly double the distinct population (see the module docs).
+///
+/// The five outcome rows partition every outcome observation: the sum of
+/// `futile`, `productive`, `observations_unpaired`,
+/// `outcomes_probe_budget_exhausted` and `outcomes_probe_unavailable` is the
+/// total number of comparisons that reached the detector.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct FutileRepairSnapshot {
     /// Repair attempts recorded — `SyncStateToPeer` heals actually emitted.
     pub(crate) attempts: u64,
-    /// Attempts whose next two-sided comparison still showed divergence.
+    /// Attempts whose next evidence-backed comparison still showed divergence.
+    ///
+    /// NOT the numerator of a repair-efficacy ratio; see `productive`.
     pub(crate) futile: u64,
-    /// Attempts whose next two-sided comparison showed the edge converged.
+    /// Attempts whose next evidence-backed comparison showed the edge
+    /// converged.
+    ///
+    /// This says the edge HAD converged by the next comparison, not that our
+    /// heal is what converged it. An edge also converges via the
+    /// proximity-overlap heal or ordinary live UPDATE fan-out, neither of which
+    /// records an attempt, and the next comparison credits whichever
+    /// anti-entropy heal was outstanding. So `futile : productive` bounds how
+    /// often repair is FOLLOWED BY convergence; it is not a measure of this
+    /// node's repair efficacy.
     pub(crate) productive: u64,
     /// Two-sided comparisons on an edge with no attempt outstanding. Not an
     /// error — a converged edge is re-compared every heartbeat without anyone
@@ -192,31 +339,64 @@ pub(crate) struct FutileRepairSnapshot {
     /// from being read as "all anti-entropy comparisons".
     pub(crate) observations_unpaired: u64,
     /// Attempts replaced by a newer attempt on the same edge before any outcome
-    /// was observed. Expected to be near zero: the heal is emitted after the
-    /// comparison that settles the previous one, in the same handler call. A
-    /// large value means attempts and outcomes are not interleaving as assumed
-    /// and the futility counts are an undercount.
+    /// was observed. A large value means attempts and outcomes are not
+    /// interleaving as assumed and the futility counts are an undercount. It is
+    /// expected to be non-zero on links whose summary rotation is slow, where
+    /// several heartbeats can heal the same edge before the contract comes back
+    /// round to be compared.
     pub(crate) attempts_superseded: u64,
-    /// Attempts discarded unsettled because the next observation arrived more
-    /// than [`ATTEMPT_MAX_AGE`] later.
-    pub(crate) attempts_expired: u64,
+    /// Attempts dropped unsettled because the edge was torn down — the peer
+    /// stayed disconnected past the interest grace period, so nothing will ever
+    /// settle the attempt. Any streak on that edge is dropped with it, which
+    /// costs nothing: a departed peer's streak could not have continued.
+    ///
+    /// This replaces an earlier wall-clock expiry that made the detector blind
+    /// on slow-rotation links; see "Pairing an attempt with its outcome".
+    pub(crate) attempts_discarded: u64,
+    /// Comparisons where the summaries differed but the per-message WASM probe
+    /// budget was spent, so "stale" was a DEFAULT rather than a verdict
+    /// ([`OutcomeEvidence::ProbeBudgetExhausted`]). Neither futile nor
+    /// productive; the outstanding attempt is left outstanding.
+    ///
+    /// **Read this before the headline.** It grows with how many contracts a
+    /// peer reports per message, so a large value means load is being
+    /// classified as staleness in the heal path — safe for healing, but a
+    /// load-correlated false positive if it were counted as futility.
+    pub(crate) outcomes_probe_budget_exhausted: u64,
+    /// Comparisons where the summaries differed and the contract's delta probe
+    /// produced no verdict ([`OutcomeEvidence::ProbeUnavailable`]). Neither
+    /// futile nor productive; the outstanding attempt is left outstanding.
+    /// Tracks contract or runtime health rather than peer breadth.
+    pub(crate) outcomes_probe_unavailable: u64,
+    /// Of the classified outcomes (`futile + productive`), how many were
+    /// settled more than [`LONG_GAP_THRESHOLD`] after their attempt. Not a
+    /// separate class — these ARE counted in `futile`/`productive` — but the
+    /// longer the gap, the likelier something other than our heal moved the
+    /// state. If this dominates, the headline is measuring summary-rotation
+    /// latency more than repair failure.
+    pub(crate) outcomes_after_long_gap: u64,
     /// Times an edge's consecutive-futile streak reached
     /// [`QUARANTINE_THRESHOLD`] — the headline "would have been quarantined"
     /// count. Counted once per streak: a streak that keeps growing past the
     /// threshold does not re-count, but an edge that converges and later
     /// crosses again does.
+    ///
+    /// PER OBSERVER: a fleet sum is ~2x the number of distinct stuck edges,
+    /// because both ends of a diverged edge count it.
     pub(crate) would_quarantine: u64,
     /// Edges currently at or above [`QUARANTINE_THRESHOLD`]. A gauge, not a
     /// counter — this is the live population a real quarantine would hold.
     ///
-    /// An edge leaves this gauge only by converging or by being evicted, so a
-    /// peer that disconnects mid-streak keeps its slot until the LRU forgets
-    /// it. Read the gauge as "edges that last looked stuck", not "edges stuck
-    /// right now"; `would_quarantine` is the unambiguous count.
+    /// An edge leaves this gauge only by converging, by being torn down with
+    /// its peer, or by being evicted, so a peer that goes quiet mid-streak
+    /// keeps its slot until one of those happens. Read the gauge as "edges that
+    /// last looked stuck", not "edges stuck right now"; `would_quarantine` is
+    /// the unambiguous count.
     pub(crate) edges_at_threshold: u64,
     /// Current LRU occupancy. Sitting at [`EDGE_CAPACITY`] means saturated.
     pub(crate) tracked_edges: u64,
-    /// Entries evicted from the LRU.
+    /// Entries evicted from the LRU by capacity pressure. Replacing the value
+    /// of a key that is already tracked is not an eviction and is not counted.
     pub(crate) evictions: u64,
     /// Evictions whose entry carried a non-zero streak, so a genuine futility
     /// streak was forgotten and restarts at zero. Non-zero means the counts
@@ -227,7 +407,7 @@ pub(crate) struct FutileRepairSnapshot {
 }
 
 /// Number of scalar counters in [`FutileRepairSnapshot`] before the ladder.
-pub(crate) const SNAPSHOT_SCALARS: usize = 11;
+pub(crate) const SNAPSHOT_SCALARS: usize = 14;
 
 impl FutileRepairSnapshot {
     /// Flatten to the fixed-width row exported in
@@ -240,7 +420,10 @@ impl FutileRepairSnapshot {
             self.productive,
             self.observations_unpaired,
             self.attempts_superseded,
-            self.attempts_expired,
+            self.attempts_discarded,
+            self.outcomes_probe_budget_exhausted,
+            self.outcomes_probe_unavailable,
+            self.outcomes_after_long_gap,
             self.would_quarantine,
             self.edges_at_threshold,
             self.tracked_edges,
@@ -256,7 +439,10 @@ struct Metrics {
     productive: AtomicU64,
     observations_unpaired: AtomicU64,
     attempts_superseded: AtomicU64,
-    attempts_expired: AtomicU64,
+    attempts_discarded: AtomicU64,
+    outcomes_probe_budget_exhausted: AtomicU64,
+    outcomes_probe_unavailable: AtomicU64,
+    outcomes_after_long_gap: AtomicU64,
     would_quarantine: AtomicU64,
     evictions: AtomicU64,
     evictions_losing_streak: AtomicU64,
@@ -271,7 +457,10 @@ impl Metrics {
             productive: AtomicU64::new(0),
             observations_unpaired: AtomicU64::new(0),
             attempts_superseded: AtomicU64::new(0),
-            attempts_expired: AtomicU64::new(0),
+            attempts_discarded: AtomicU64::new(0),
+            outcomes_probe_budget_exhausted: AtomicU64::new(0),
+            outcomes_probe_unavailable: AtomicU64::new(0),
+            outcomes_after_long_gap: AtomicU64::new(0),
             would_quarantine: AtomicU64::new(0),
             evictions: AtomicU64::new(0),
             evictions_losing_streak: AtomicU64::new(0),
@@ -284,8 +473,9 @@ impl Metrics {
 pub(crate) struct FutileRepairDetector {
     edges: Mutex<LruCache<(ContractKey, PeerKey), EdgeState>>,
     /// Live count of edges at or above [`QUARANTINE_THRESHOLD`]. Maintained
-    /// incrementally rather than scanned, and decremented on eviction so an
-    /// evicted at-threshold edge does not leak into the gauge forever.
+    /// incrementally rather than scanned, and decremented on eviction and on
+    /// teardown so a removed at-threshold edge does not leak into the gauge
+    /// forever.
     edges_at_threshold: AtomicU64,
     metrics: Metrics,
 }
@@ -341,8 +531,18 @@ impl FutileRepairDetector {
             pending_since: Some(now),
             ..EdgeState::default()
         };
-        if let Some((_, evicted)) = edges.push(key, state) {
-            self.note_eviction(evicted);
+        // `LruCache::push` returns the displaced entry for BOTH a capacity
+        // eviction and a plain replacement of an already-present key, and only
+        // the first is an eviction. The `get_mut` fast path above already
+        // returns early for a present key, so today only the eviction case can
+        // reach here — but `note_eviction` decrements an unsigned gauge, so a
+        // replacement slipping through would underflow `edges_at_threshold` to
+        // ~1.8e19 and destroy the series. Compare the returned key instead of
+        // depending on that fast path staying where it is.
+        if let Some((displaced_key, displaced)) = edges.push(key.clone(), state)
+            && displaced_key != key
+        {
+            self.note_eviction(displaced);
         }
     }
 
@@ -354,6 +554,12 @@ impl FutileRepairDetector {
     /// outcome and must not be passed here, because there is no divergence to
     /// have repaired.
     ///
+    /// `evidence` says what that verdict rests on, and only
+    /// [`OutcomeEvidence::Verdict`] classifies the attempt. See that type: the
+    /// other two are conservative defaults whose frequency tracks node load and
+    /// peer breadth, so folding them in would make the headline number grow
+    /// with how busy this node is rather than with how stuck the network is.
+    ///
     /// Only an observation that follows an outstanding attempt is classified.
     /// Everything else is counted as unpaired and changes no streak: the point
     /// of the detector is whether OUR REPAIRS work, and an edge nobody healed
@@ -363,8 +569,28 @@ impl FutileRepairDetector {
         contract: &ContractKey,
         peer: &PeerKey,
         converged: bool,
+        evidence: OutcomeEvidence,
         now: Instant,
     ) {
+        // Checked BEFORE the pending attempt is consumed: a defaulted verdict
+        // teaches us nothing about the outstanding heal, so the attempt stays
+        // outstanding for the next comparison that does carry evidence.
+        match evidence {
+            OutcomeEvidence::ProbeBudgetExhausted => {
+                self.metrics
+                    .outcomes_probe_budget_exhausted
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+            OutcomeEvidence::ProbeUnavailable => {
+                self.metrics
+                    .outcomes_probe_unavailable
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+            OutcomeEvidence::Verdict => {}
+        }
+
         let mut edges = self.lock();
         let key = (*contract, peer.clone());
         let Some(state) = edges.get_mut(&key) else {
@@ -379,11 +605,12 @@ impl FutileRepairDetector {
                 .fetch_add(1, Ordering::Relaxed);
             return;
         };
-        if now.saturating_duration_since(pending_since) > ATTEMPT_MAX_AGE {
+        // Visibility only — the outcome is classified either way. See
+        // `LONG_GAP_THRESHOLD`.
+        if now.saturating_duration_since(pending_since) > LONG_GAP_THRESHOLD {
             self.metrics
-                .attempts_expired
+                .outcomes_after_long_gap
                 .fetch_add(1, Ordering::Relaxed);
-            return;
         }
 
         if converged {
@@ -414,6 +641,35 @@ impl FutileRepairDetector {
         }
     }
 
+    /// Drop this peer's edges for `contracts`, because the peer's interest
+    /// state is being torn down (it stayed disconnected past the grace period).
+    ///
+    /// This is what bounds an attempt's lifetime now that pairing is not
+    /// wall-clock gated: nothing will ever settle a heal sent to a peer that is
+    /// gone, so leaving the attempt outstanding would let a comparison after
+    /// some later reconnect settle it as though the long-dead heal had just
+    /// failed. See "Pairing an attempt with its outcome" in the module docs.
+    pub(crate) fn discard_peer_attempts<'a>(
+        &self,
+        peer: &PeerKey,
+        contracts: impl IntoIterator<Item = &'a ContractKey>,
+    ) {
+        let mut edges = self.lock();
+        for contract in contracts {
+            let Some(state) = edges.pop(&(*contract, peer.clone())) else {
+                continue;
+            };
+            if state.pending_since.is_some() {
+                self.metrics
+                    .attempts_discarded
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if state.at_threshold {
+                self.edges_at_threshold.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+    }
+
     pub(crate) fn snapshot(&self) -> FutileRepairSnapshot {
         let load = |value: &AtomicU64| value.load(Ordering::Relaxed);
         let tracked_edges = self.lock().len() as u64;
@@ -423,7 +679,10 @@ impl FutileRepairDetector {
             productive: load(&self.metrics.productive),
             observations_unpaired: load(&self.metrics.observations_unpaired),
             attempts_superseded: load(&self.metrics.attempts_superseded),
-            attempts_expired: load(&self.metrics.attempts_expired),
+            attempts_discarded: load(&self.metrics.attempts_discarded),
+            outcomes_probe_budget_exhausted: load(&self.metrics.outcomes_probe_budget_exhausted),
+            outcomes_probe_unavailable: load(&self.metrics.outcomes_probe_unavailable),
+            outcomes_after_long_gap: load(&self.metrics.outcomes_after_long_gap),
             would_quarantine: load(&self.metrics.would_quarantine),
             edges_at_threshold: load(&self.edges_at_threshold),
             tracked_edges,
@@ -498,12 +757,12 @@ mod tests {
         // Edge that converges: every repair lands.
         for _ in 0..QUARANTINE_THRESHOLD {
             detector.record_repair_attempt(&converging, &p, now);
-            detector.record_repair_outcome(&converging, &p, true, now);
+            detector.record_repair_outcome(&converging, &p, true, OutcomeEvidence::Verdict, now);
         }
         // Edge that never converges: identical attempt count, opposite outcome.
         for _ in 0..QUARANTINE_THRESHOLD {
             detector.record_repair_attempt(&stuck, &p, now);
-            detector.record_repair_outcome(&stuck, &p, false, now);
+            detector.record_repair_outcome(&stuck, &p, false, OutcomeEvidence::Verdict, now);
         }
 
         let snap = detector.snapshot();
@@ -545,17 +804,17 @@ mod tests {
 
         for _ in 0..(QUARANTINE_THRESHOLD - 1) {
             detector.record_repair_attempt(&key, &p, now);
-            detector.record_repair_outcome(&key, &p, false, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
         }
         detector.record_repair_attempt(&key, &p, now);
-        detector.record_repair_outcome(&key, &p, true, now);
+        detector.record_repair_outcome(&key, &p, true, OutcomeEvidence::Verdict, now);
         assert_eq!(detector.snapshot().would_quarantine, 0);
 
         // ...and the streak restarts from zero, so it takes the full threshold
         // again rather than one more failure.
         for _ in 0..(QUARANTINE_THRESHOLD - 1) {
             detector.record_repair_attempt(&key, &p, now);
-            detector.record_repair_outcome(&key, &p, false, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
         }
         assert_eq!(
             detector.snapshot().would_quarantine,
@@ -563,7 +822,7 @@ mod tests {
             "the streak must restart at zero after a productive repair"
         );
         detector.record_repair_attempt(&key, &p, now);
-        detector.record_repair_outcome(&key, &p, false, now);
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
         let snap = detector.snapshot();
         assert_eq!(snap.would_quarantine, 1);
         assert_eq!(
@@ -582,7 +841,7 @@ mod tests {
         let p = peer(1);
 
         for _ in 0..10 {
-            detector.record_repair_outcome(&key, &p, false, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
         }
         let snap = detector.snapshot();
         assert_eq!(snap.observations_unpaired, 10);
@@ -595,18 +854,80 @@ mod tests {
 
         // A second observation after the attempt is settled is also unpaired.
         detector.record_repair_attempt(&key, &p, now);
-        detector.record_repair_outcome(&key, &p, false, now);
-        detector.record_repair_outcome(&key, &p, false, now);
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
         let snap = detector.snapshot();
         assert_eq!(snap.futile, 1, "one attempt, one futile outcome");
         assert_eq!(snap.observations_unpaired, 11);
     }
 
+    /// HIGH-1 regression: an attempt is settled by the NEXT comparison on the
+    /// edge, however long that takes.
+    ///
+    /// The heavy-summary links this detector hunts are exactly the ones whose
+    /// full-bytes summary rotation is byte-budgeted, so one contract comes back
+    /// round on the order of ten hours rather than at the ~5-minute heartbeat
+    /// (see `node::MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`). Under the 30-minute
+    /// wall-clock expiry this replaces, every attempt on such a link expired
+    /// unsettled: `futile` and `productive` both stayed 0 and
+    /// `would_quarantine` could never fire.
+    ///
+    /// Mutation that must fail this test: reinstate any wall-clock gate that
+    /// drops the attempt (`if now - pending_since > THIRTY_MINUTES { return; }`)
+    /// ahead of classification.
     #[test]
-    fn a_stale_attempt_expires_rather_than_being_settled() {
+    fn a_slow_rotation_still_settles_the_attempt() {
         let detector = FutileRepairDetector::with_capacity(16);
         let now = t0();
         let key = contract(5);
+        let p = peer(1);
+        // The reconstructed worst case from the fallback-rotation rustdoc.
+        let ten_hours = Duration::from_secs(10 * 60 * 60);
+
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(
+                &key,
+                &p,
+                false,
+                OutcomeEvidence::Verdict,
+                now + ten_hours,
+            );
+        }
+
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.futile,
+            u64::from(QUARANTINE_THRESHOLD),
+            "an outcome observed a rotation period later must still settle its \
+             attempt — a wall-clock expiry here blinds the detector on exactly \
+             the heavy-summary links it exists to find"
+        );
+        assert_eq!(
+            snap.would_quarantine, 1,
+            "the streak must be able to reach the threshold on a slow link"
+        );
+        assert_eq!(
+            snap.outcomes_after_long_gap,
+            u64::from(QUARANTINE_THRESHOLD),
+            "long-gap settlements are classified, but must stay separately \
+             visible so the field data can say how much of the headline they \
+             carry"
+        );
+        assert_eq!(
+            snap.attempts_discarded, 0,
+            "nothing was torn down, so nothing was discarded"
+        );
+    }
+
+    /// The other half of HIGH-1: a settlement inside the long-gap window is not
+    /// flagged, so `outcomes_after_long_gap` genuinely discriminates instead of
+    /// counting everything.
+    #[test]
+    fn a_prompt_settlement_is_not_flagged_as_a_long_gap() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(6);
         let p = peer(1);
 
         detector.record_repair_attempt(&key, &p, now);
@@ -614,24 +935,191 @@ mod tests {
             &key,
             &p,
             false,
-            now + ATTEMPT_MAX_AGE + Duration::from_secs(1),
+            OutcomeEvidence::Verdict,
+            now + LONG_GAP_THRESHOLD,
         );
         let snap = detector.snapshot();
-        assert_eq!(snap.attempts_expired, 1);
-        assert_eq!(snap.futile, 0);
-        assert_eq!(snap.productive, 0);
+        assert_eq!(snap.futile, 1);
+        assert_eq!(
+            snap.outcomes_after_long_gap, 0,
+            "at the threshold exactly is not past it"
+        );
 
-        // Inside the window it settles normally.
         detector.record_repair_attempt(&key, &p, now);
-        detector.record_repair_outcome(&key, &p, false, now + ATTEMPT_MAX_AGE);
+        detector.record_repair_outcome(
+            &key,
+            &p,
+            false,
+            OutcomeEvidence::Verdict,
+            now + LONG_GAP_THRESHOLD + Duration::from_secs(1),
+        );
+        assert_eq!(detector.snapshot().outcomes_after_long_gap, 1);
+    }
+
+    /// Peer teardown, not a timer, is what bounds an attempt's lifetime: after
+    /// the edge is discarded a later comparison is unpaired rather than being
+    /// settled as if the long-dead heal had just failed.
+    #[test]
+    fn peer_teardown_discards_the_outstanding_attempt() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(7);
+        let p = peer(1);
+        let other = peer(2);
+
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_attempt(&key, &other, now);
+        detector.discard_peer_attempts(&p, [&key]);
+
+        let snap = detector.snapshot();
+        assert_eq!(snap.attempts_discarded, 1);
+        assert_eq!(
+            snap.tracked_edges, 1,
+            "only the departing peer's edge is dropped"
+        );
+
+        // A comparison after the teardown has nothing to settle.
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.futile, 0,
+            "a heal to a peer that left must not be settled by a comparison \
+             made after it came back"
+        );
+        assert_eq!(snap.observations_unpaired, 1);
+
+        // The surviving peer's edge is untouched.
+        detector.record_repair_outcome(&key, &other, false, OutcomeEvidence::Verdict, now);
         assert_eq!(detector.snapshot().futile, 1);
+    }
+
+    /// Tearing down an at-threshold edge must release the live gauge, exactly
+    /// as eviction does, or `edges_at_threshold` drifts upward forever.
+    #[test]
+    fn teardown_releases_the_at_threshold_gauge() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(8);
+        let p = peer(1);
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        }
+        assert_eq!(detector.snapshot().edges_at_threshold, 1);
+
+        detector.discard_peer_attempts(&p, [&key]);
+        let snap = detector.snapshot();
+        assert_eq!(snap.edges_at_threshold, 0);
+        assert_eq!(
+            snap.would_quarantine, 1,
+            "the crossing already happened and stays counted"
+        );
+        assert_eq!(
+            snap.attempts_discarded, 0,
+            "the last outcome settled the attempt, so there was nothing \
+             outstanding to discard"
+        );
+    }
+
+    /// HIGH-2: a verdict that is really the conservative default must not be
+    /// counted as futility.
+    ///
+    /// Past `node::MAX_STALENESS_PROBES_PER_SUMMARIES` (32) byte-differing
+    /// contracts in one `Summaries` message, `summary_indicates_stale_peer`
+    /// defaults to STALE with no probe run. That frequency grows with peer
+    /// breadth and node load, not with brokenness, so folding it into `futile`
+    /// would make the headline number a load metric.
+    ///
+    /// Mutation that must fail this test: pass `OutcomeEvidence::Verdict` at
+    /// the outcome sites regardless of how the verdict was reached — which is
+    /// exactly the pre-fix behaviour, where `is_stale` alone was passed.
+    #[test]
+    fn a_defaulted_verdict_is_not_futility() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(9);
+        let p = peer(1);
+
+        detector.record_repair_attempt(&key, &p, now);
+        for _ in 0..QUARANTINE_THRESHOLD {
+            // "stale", but only because the probe budget was spent.
+            detector.record_repair_outcome(
+                &key,
+                &p,
+                false,
+                OutcomeEvidence::ProbeBudgetExhausted,
+                now,
+            );
+        }
+        for _ in 0..QUARANTINE_THRESHOLD {
+            // "stale", but only because the contract's delta probe failed.
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::ProbeUnavailable, now);
+        }
+
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.futile, 0,
+            "a default is not evidence that a repair failed"
+        );
+        assert_eq!(snap.would_quarantine, 0);
+        assert_eq!(
+            snap.outcomes_probe_budget_exhausted,
+            u64::from(QUARANTINE_THRESHOLD),
+            "budget-exhausted defaults get their own row so the headline is \
+             readable against them"
+        );
+        assert_eq!(
+            snap.outcomes_probe_unavailable,
+            u64::from(QUARANTINE_THRESHOLD),
+            "probe failures are a distinct cause from budget exhaustion"
+        );
+        assert_eq!(
+            snap.observations_unpaired, 0,
+            "an evidence-free comparison is its own class, not an unpaired one"
+        );
+
+        // The attempt is still outstanding: the first comparison that DOES
+        // carry evidence settles it.
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.futile, 1,
+            "a defaulted comparison must not consume the outstanding attempt"
+        );
+        assert_eq!(snap.attempts, 1, "one heal was emitted, so one attempt");
+    }
+
+    /// The evidence-free classes must not silently swallow a real convergence
+    /// either — the streak is untouched in BOTH directions.
+    #[test]
+    fn a_defaulted_verdict_does_not_reset_a_streak() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(10);
+        let p = peer(1);
+
+        for _ in 0..(QUARANTINE_THRESHOLD - 1) {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        }
+        // A "converged" reading with no evidence behind it must not clear the
+        // streak that four real verdicts built.
+        detector.record_repair_outcome(&key, &p, true, OutcomeEvidence::ProbeUnavailable, now);
+        detector.record_repair_attempt(&key, &p, now);
+        detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+
+        assert_eq!(
+            detector.snapshot().would_quarantine,
+            1,
+            "an evidence-free reading must move the streak in neither direction"
+        );
     }
 
     #[test]
     fn repeated_attempts_without_an_outcome_are_counted_as_superseded() {
         let detector = FutileRepairDetector::with_capacity(16);
         let now = t0();
-        let key = contract(6);
+        let key = contract(11);
         let p = peer(1);
 
         detector.record_repair_attempt(&key, &p, now);
@@ -641,6 +1129,60 @@ mod tests {
         assert_eq!(snap.attempts, 3);
         assert_eq!(snap.attempts_superseded, 2);
         assert_eq!(snap.futile, 0);
+        assert_eq!(
+            snap.evictions, 0,
+            "re-recording an attempt on a tracked edge replaces its value; \
+             that is not an eviction and must never be counted as one — \
+             `note_eviction` decrements an unsigned gauge"
+        );
+    }
+
+    /// Re-recording an attempt on an edge that is ALREADY at the threshold must
+    /// not be mistaken for an eviction.
+    ///
+    /// `LruCache::push` returns the displaced entry for a plain replacement as
+    /// well as for a capacity eviction, and `note_eviction` decrements
+    /// `edges_at_threshold`, which is unsigned: charging a replacement as an
+    /// eviction drives the gauge below the population it is counting and then
+    /// wraps it to ~1.8e19, and inflates `evictions` /
+    /// `evictions_losing_streak` — the two rows a reader is told to check
+    /// FIRST to decide whether the counts are trustworthy. Today the `get_mut`
+    /// fast path returns before `push` is reached, so the guard at the push
+    /// site is what makes this safe structurally rather than by the ordering of
+    /// two statements. This test states the invariant so a refactor of that
+    /// fast path has something to break.
+    #[test]
+    fn re_recording_an_attempt_on_an_at_threshold_edge_is_not_an_eviction() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let key = contract(12);
+        let p = peer(1);
+
+        for _ in 0..QUARANTINE_THRESHOLD {
+            detector.record_repair_attempt(&key, &p, now);
+            detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
+        }
+        assert_eq!(detector.snapshot().edges_at_threshold, 1);
+
+        // The next heartbeat heals the same stuck edge again.
+        detector.record_repair_attempt(&key, &p, now);
+
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.evictions, 0,
+            "replacing a tracked edge's value is not an eviction: {snap:?}"
+        );
+        assert_eq!(
+            snap.evictions_losing_streak, 0,
+            "nothing was forgotten, so the undercount signal must stay clean: \
+             {snap:?}"
+        );
+        assert_eq!(
+            snap.edges_at_threshold, 1,
+            "the at-threshold gauge must survive re-healing a stuck edge: \
+             {snap:?}"
+        );
+        assert_eq!(snap.tracked_edges, 1);
     }
 
     /// The ladder is a survival curve: each streak counts once per rung it
@@ -651,11 +1193,11 @@ mod tests {
         let now = t0();
         let p = peer(1);
         // Three edges with streaks of 1, 4 and 32.
-        for (seed, streak) in [(10u8, 1u32), (11, 4), (12, 32)] {
+        for (seed, streak) in [(20u8, 1u32), (21, 4), (22, 32)] {
             let key = contract(seed);
             for _ in 0..streak {
                 detector.record_repair_attempt(&key, &p, now);
-                detector.record_repair_outcome(&key, &p, false, now);
+                detector.record_repair_outcome(&key, &p, false, OutcomeEvidence::Verdict, now);
             }
         }
         let ladder = detector.snapshot().ladder;
@@ -676,11 +1218,11 @@ mod tests {
         let now = t0();
         let p = peer(1);
 
-        // Build a streak on edge 20, then push it out with two other edges.
-        let victim = contract(20);
+        // Build a streak on edge 30, then push it out with two other edges.
+        let victim = contract(30);
         detector.record_repair_attempt(&victim, &p, now);
-        detector.record_repair_outcome(&victim, &p, false, now);
-        for seed in [21u8, 22] {
+        detector.record_repair_outcome(&victim, &p, false, OutcomeEvidence::Verdict, now);
+        for seed in [31u8, 32] {
             detector.record_repair_attempt(&contract(seed), &p, now);
         }
         let snap = detector.snapshot();
@@ -700,13 +1242,13 @@ mod tests {
         let detector = FutileRepairDetector::with_capacity(1);
         let now = t0();
         let p = peer(1);
-        let victim = contract(30);
+        let victim = contract(40);
         for _ in 0..QUARANTINE_THRESHOLD {
             detector.record_repair_attempt(&victim, &p, now);
-            detector.record_repair_outcome(&victim, &p, false, now);
+            detector.record_repair_outcome(&victim, &p, false, OutcomeEvidence::Verdict, now);
         }
         assert_eq!(detector.snapshot().edges_at_threshold, 1);
-        detector.record_repair_attempt(&contract(31), &p, now);
+        detector.record_repair_attempt(&contract(41), &p, now);
         let snap = detector.snapshot();
         assert_eq!(snap.edges_at_threshold, 0);
         assert_eq!(
@@ -721,15 +1263,15 @@ mod tests {
     fn edges_are_per_peer_not_per_contract() {
         let detector = FutileRepairDetector::with_capacity(16);
         let now = t0();
-        let key = contract(40);
+        let key = contract(50);
         let stuck = peer(1);
         let healthy = peer(2);
 
         for _ in 0..QUARANTINE_THRESHOLD {
             detector.record_repair_attempt(&key, &stuck, now);
-            detector.record_repair_outcome(&key, &stuck, false, now);
+            detector.record_repair_outcome(&key, &stuck, false, OutcomeEvidence::Verdict, now);
             detector.record_repair_attempt(&key, &healthy, now);
-            detector.record_repair_outcome(&key, &healthy, true, now);
+            detector.record_repair_outcome(&key, &healthy, true, OutcomeEvidence::Verdict, now);
         }
         let snap = detector.snapshot();
         assert_eq!(snap.would_quarantine, 1);
@@ -746,14 +1288,56 @@ mod tests {
             productive: 3,
             observations_unpaired: 4,
             attempts_superseded: 5,
-            attempts_expired: 6,
-            would_quarantine: 7,
-            edges_at_threshold: 8,
-            tracked_edges: 9,
-            evictions: 10,
-            evictions_losing_streak: 11,
+            attempts_discarded: 6,
+            outcomes_probe_budget_exhausted: 7,
+            outcomes_probe_unavailable: 8,
+            outcomes_after_long_gap: 9,
+            would_quarantine: 10,
+            edges_at_threshold: 11,
+            tracked_edges: 12,
+            evictions: 13,
+            evictions_losing_streak: 14,
             ladder: [0; LADDER_LEN],
         };
-        assert_eq!(snap.to_row(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        assert_eq!(
+            snap.to_row(),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        );
+    }
+
+    /// The five outcome rows must partition every outcome observation, which is
+    /// what lets a reader check the headline against the rows that qualify it.
+    #[test]
+    fn outcome_rows_partition_every_observation() {
+        let detector = FutileRepairDetector::with_capacity(16);
+        let now = t0();
+        let p = peer(1);
+        let mut observations = 0u64;
+
+        for (seed, converged, evidence) in [
+            (60u8, false, OutcomeEvidence::Verdict),
+            (61, true, OutcomeEvidence::Verdict),
+            (62, false, OutcomeEvidence::ProbeBudgetExhausted),
+            (63, false, OutcomeEvidence::ProbeUnavailable),
+        ] {
+            let key = contract(seed);
+            detector.record_repair_attempt(&key, &p, now);
+            for _ in 0..3 {
+                detector.record_repair_outcome(&key, &p, converged, evidence, now);
+                observations += 1;
+            }
+        }
+
+        let snap = detector.snapshot();
+        assert_eq!(
+            snap.futile
+                + snap.productive
+                + snap.observations_unpaired
+                + snap.outcomes_probe_budget_exhausted
+                + snap.outcomes_probe_unavailable,
+            observations,
+            "every call to record_repair_outcome must land in exactly one of \
+             the five outcome rows: {snap:?}"
+        );
     }
 }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3336,15 +3336,15 @@ mod tests {
         let relayed = make_contract_key(1);
         let fetched = make_contract_key(2);
 
-        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::RelayPut);
+        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::TransitPut);
         // A repeat PUT of the same contract: recency refresh, NOT a new hosting
         // decision — the counter must not move.
-        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::RelayPut);
+        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::TransitPut);
         manager.record_contract_access(fetched, 100, AccessType::Get, HostingCause::SubOpGet);
 
         let stats = manager.hosting_cache_stats();
         assert_eq!(
-            stats.hosting_begins[HostingCause::RelayPut.index()],
+            stats.hosting_begins[HostingCause::TransitPut.index()],
             1,
             "two PUTs of one contract are ONE hosting begin; a 2 here means the \
              counter fires on refresh and is really counting writes"

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -38,6 +38,11 @@ pub(crate) mod reconcile;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
 use crate::util::time_source::{DynTimeSource, InstantTimeSrc, TimeSource};
+/// Hosting-BEGIN attribution (#5090-family observability): WHY a peer started
+/// hosting a contract. Re-exported so the operation drivers — the only code that
+/// knows whether a store is client-originated, transit, or a sub-op fetch — can
+/// name their cause at the `Ring::host_contract` boundary.
+pub(crate) use cache::HostingCause;
 pub(crate) use cache::HostingContractScore;
 /// The pre-A2 flat 1 GiB budget, used as the upgrade-migration sentinel in
 /// `config::ConfigArgs::build` (see the constant's docs).
@@ -72,6 +77,10 @@ pub(crate) use cache::{COST_RATE_MIN_WINDOW, CostAxisPressure, build_cost_axes};
 /// so `config` can resolve the persisted `hosting-disk-pct` / `max-hosting-disk`
 /// defaults and `ring`/`HostingManager` can size the eviction floor.
 pub(crate) use cache::{DEFAULT_HOSTING_DISK_PCT, DEFAULT_MAX_HOSTING_DISK_BYTES};
+/// Widths of the two hosted-set demand-signal histograms exported on the router
+/// snapshot. Re-exported so `router` can size the wire arrays from the single
+/// definition next to the bucketing code.
+pub(crate) use cache::{GENUINE_ACCESS_RECENCY_BUCKETS, READ_COUNT_HIST_BUCKETS};
 use cache::{HostingCache, HostingCacheStats, disk_budget_for_clamped};
 use dashmap::{DashMap, DashSet};
 use demand::ProximityPrior;
@@ -2092,11 +2101,16 @@ impl HostingManager {
     ///
     /// Automatically persists hosting metadata for the accessed contract and
     /// removes persisted metadata for evicted contracts.
+    ///
+    /// `cause` is the hosting ATTRIBUTION (see [`HostingCause`]); it is passed
+    /// straight through to the cache, which counts it only if this access
+    /// actually begins hosting. It influences nothing else.
     pub fn record_contract_access(
         &self,
         key: ContractKey,
         size_bytes: u64,
         access_type: AccessType,
+        cause: HostingCause,
     ) -> RecordAccessResult {
         // `contract_in_use` reads only the client_subscriptions /
         // downstream_subscribers / active_subscriptions DashMaps — never
@@ -2124,6 +2138,7 @@ impl HostingManager {
             access_type,
             current_generation,
             predicted_demand,
+            cause,
             |k: &ContractKey| self.local_and_downstream_counts(k),
         );
 
@@ -3304,6 +3319,59 @@ mod tests {
         )
     }
 
+    /// End-to-end through the PRODUCTION entry point (`record_contract_access`,
+    /// which `Ring::host_contract` delegates to): the caller's cause reaches the
+    /// exported stats, and only a real hosting BEGIN moves it.
+    ///
+    /// The manager layer is where the attribution could most plausibly be lost —
+    /// it re-shapes the result (teardown lists, demand training, metadata
+    /// persistence) between the caller and the cache. This asserts the pass-
+    /// through survives all of that.
+    ///
+    /// Mutation verified to FAIL: replacing the forwarded `cause` with a
+    /// constant, and deleting the increment in the cache's insert branch.
+    #[tokio::test]
+    async fn record_contract_access_reports_hosting_begins_by_cause() {
+        let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
+        let relayed = make_contract_key(1);
+        let fetched = make_contract_key(2);
+
+        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::RelayPut);
+        // A repeat PUT of the same contract: recency refresh, NOT a new hosting
+        // decision — the counter must not move.
+        manager.record_contract_access(relayed, 100, AccessType::Put, HostingCause::RelayPut);
+        manager.record_contract_access(fetched, 100, AccessType::Get, HostingCause::SubOpGet);
+
+        let stats = manager.hosting_cache_stats();
+        assert_eq!(
+            stats.hosting_begins[HostingCause::RelayPut.index()],
+            1,
+            "two PUTs of one contract are ONE hosting begin; a 2 here means the \
+             counter fires on refresh and is really counting writes"
+        );
+        assert_eq!(
+            stats.hosting_begins[HostingCause::SubOpGet.index()],
+            1,
+            "a subscribe-fetch / auto-fetch travels the ordinary GET driver — \
+             this row is the only thing that separates it from a client GET"
+        );
+        assert_eq!(
+            stats.hosting_begins[HostingCause::ClientGet.index()],
+            0,
+            "no caller named ClientGet"
+        );
+        assert_eq!(
+            stats.hosting_begins[HostingCause::Other.index()],
+            0,
+            "a production path must never lose its attribution"
+        );
+        assert_eq!(
+            stats.hosting_begins.iter().sum::<u64>(),
+            stats.contract_count,
+            "with no evictions, begins and the hosted set agree"
+        );
+    }
+
     #[tokio::test]
     async fn test_subscribe_creates_new_subscription() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
@@ -3338,8 +3406,8 @@ mod tests {
         );
         let junk = make_contract_key(1);
         let hot_subscribed = make_contract_key(2);
-        manager.record_contract_access(junk, 121, AccessType::Put);
-        manager.record_contract_access(hot_subscribed, 121, AccessType::Put);
+        manager.record_contract_access(junk, 121, AccessType::Put, HostingCause::Other);
+        manager.record_contract_access(hot_subscribed, 121, AccessType::Put, HostingCause::Other);
         manager.add_downstream_subscriber(&hot_subscribed, make_peer_key(10));
         // Age the PUT-seed genuine-access stamps past the cost window: the
         // storm has been running long past it with no genuine GET/PUT.
@@ -3543,14 +3611,19 @@ mod tests {
             DEFAULT_HOSTING_BUDGET_BYTES,
             std::sync::Arc::new(clock.clone()),
         );
-        manager.record_contract_access(junk, 121, AccessType::Put);
-        manager.record_contract_access(read_hot, 121, AccessType::Put);
-        manager.record_contract_access(burst, 5 * 1024 * 1024, AccessType::Put);
-        manager.record_contract_access(old_then_burst, 121, AccessType::Put);
+        manager.record_contract_access(junk, 121, AccessType::Put, HostingCause::Other);
+        manager.record_contract_access(read_hot, 121, AccessType::Put, HostingCause::Other);
+        manager.record_contract_access(
+            burst,
+            5 * 1024 * 1024,
+            AccessType::Put,
+            HostingCause::Other,
+        );
+        manager.record_contract_access(old_then_burst, 121, AccessType::Put, HostingCause::Other);
         // The storm has run long past the cost window with no genuine access…
         clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
         // …but read_hot was genuinely GET-read just now.
-        manager.record_contract_access(read_hot, 121, AccessType::Get);
+        manager.record_contract_access(read_hot, 121, AccessType::Get, HostingCause::Other);
 
         let result = manager.sweep_expired_hosting_with_cost(&axes);
         let expired_keys: Vec<ContractKey> = result.expired.iter().map(|(k, _)| *k).collect();
@@ -3633,7 +3706,7 @@ mod tests {
             DEFAULT_HOSTING_BUDGET_BYTES,
             std::sync::Arc::new(clock.clone()),
         );
-        manager.record_contract_access(fast_junk, 121, AccessType::Put);
+        manager.record_contract_access(fast_junk, 121, AccessType::Put, HostingCause::Other);
         // Long past the cost window with no genuine access.
         clock.advance_time(cache::COST_RATE_MIN_WINDOW + Duration::from_secs(1));
 
@@ -3654,7 +3727,7 @@ mod tests {
     async fn sweep_without_cost_axes_never_cost_evicts() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let junk = make_contract_key(1);
-        manager.record_contract_access(junk, 121, AccessType::Put);
+        manager.record_contract_access(junk, 121, AccessType::Put, HostingCause::Other);
         let result = manager.sweep_expired_hosting();
         assert!(result.expired.is_empty());
         assert!(manager.is_hosting_contract(&junk));
@@ -3796,8 +3869,8 @@ mod tests {
         // Learn our location, then read the contract twice. The second read has
         // non-zero residency (floored at 1s), so it yields a training sample.
         manager.set_own_location(Location::new(0.5));
-        manager.record_contract_access(key, 1_000, AccessType::Get);
-        manager.record_contract_access(key, 1_000, AccessType::Get);
+        manager.record_contract_access(key, 1_000, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(key, 1_000, AccessType::Get, HostingCause::Other);
 
         assert_eq!(
             manager.demand_estimator.read().len(),
@@ -3822,8 +3895,8 @@ mod tests {
         let key = make_contract_key(1);
         manager.set_own_location(Location::new(0.5));
 
-        manager.record_contract_access(key, 1_000, AccessType::Put);
-        manager.record_contract_access(key, 1_000, AccessType::Put);
+        manager.record_contract_access(key, 1_000, AccessType::Put, HostingCause::Other);
+        manager.record_contract_access(key, 1_000, AccessType::Put, HostingCause::Other);
 
         assert_eq!(
             manager.demand_estimator.read().len(),
@@ -3861,7 +3934,7 @@ mod tests {
 
         // Host the contract (a new-entry insert yields no rate sample), then
         // serve it locally: the touch has non-zero residency so it trains.
-        manager.record_contract_access(key, 1_000, AccessType::Get);
+        manager.record_contract_access(key, 1_000, AccessType::Get, HostingCause::Other);
         let before = manager.demand_estimator.read().len();
         manager.touch_hosting(&key);
         assert!(
@@ -4118,7 +4191,7 @@ mod tests {
         assert!(!manager.is_hosting_contract(&key));
         assert_eq!(manager.hosting_contracts_count(), 0);
 
-        manager.record_contract_access(key, 1000, AccessType::Put);
+        manager.record_contract_access(key, 1000, AccessType::Put, HostingCause::Other);
 
         assert!(manager.is_hosting_contract(&key));
         assert_eq!(manager.hosting_contracts_count(), 1);
@@ -4154,7 +4227,7 @@ mod tests {
         assert!(!manager.should_host(&contract));
 
         // Add to hosting cache
-        manager.record_contract_access(contract, 1000, AccessType::Put);
+        manager.record_contract_access(contract, 1000, AccessType::Put, HostingCause::Other);
         assert!(manager.should_host(&contract));
     }
 
@@ -4164,7 +4237,7 @@ mod tests {
     fn test_hosted_contract_not_in_renewal_after_restart() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(42);
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         assert!(manager.is_hosting_contract(&contract));
         assert!(
             manager.contracts_needing_renewal().is_empty(),
@@ -4183,7 +4256,7 @@ mod tests {
         assert!(!manager.is_receiving_updates(&contract));
 
         // Add to hosting cache only — should_host true, is_receiving_updates false
-        manager.record_contract_access(contract, 1000, AccessType::Put);
+        manager.record_contract_access(contract, 1000, AccessType::Put, HostingCause::Other);
         assert!(manager.should_host(&contract));
         assert!(
             !manager.is_receiving_updates(&contract),
@@ -4266,8 +4339,8 @@ mod tests {
         // is no longer a `min_ttl` cold-start floor to protect it.
         let evictable = make_contract_key(2);
         let pinned = make_contract_key(3);
-        manager.record_contract_access(evictable, 100, AccessType::Get);
-        manager.record_contract_access(pinned, 100, AccessType::Get);
+        manager.record_contract_access(evictable, 100, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(pinned, 100, AccessType::Get, HostingCause::Other);
         // Pin `pinned` with a local client subscription → contract_in_use true.
         let client = crate::client_events::ClientId::next();
         manager.add_client_subscription(pinned.id(), client);
@@ -4299,7 +4372,7 @@ mod tests {
         let contract = make_contract_key(1);
 
         // Add to hosting cache (simulating GET operation)
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
 
         // Hosted-only contracts should NOT be renewed -- subscribing to all
         // hosted contracts causes subscription storms (#3546). The local
@@ -4390,7 +4463,7 @@ mod tests {
     fn test_hosted_contract_renewed_despite_no_interest() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(42);
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         assert!(manager.is_hosting_contract(&contract));
         // Before #3546: contracts_needing_renewal() included this during startup window
         // After #3546: hosted-only contracts are never included
@@ -4408,7 +4481,7 @@ mod tests {
     fn test_startup_revalidation_includes_hosted_contracts() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         // Before #3546: during startup window, this would be in renewal list
         // After #3546: hosted-only contracts are never renewed
         let needs_renewal = manager.contracts_needing_renewal();
@@ -4424,7 +4497,7 @@ mod tests {
     fn test_startup_revalidation_skips_already_subscribed() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         manager.subscribe(contract);
         let needs_renewal = manager.contracts_needing_renewal();
         assert!(
@@ -4439,7 +4512,7 @@ mod tests {
     fn test_startup_revalidation_window_expires() {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         let needs_renewal = manager.contracts_needing_renewal();
         assert!(
             !needs_renewal.contains(&contract),
@@ -4455,9 +4528,9 @@ mod tests {
         let contract_a = make_contract_key(1);
         let contract_b = make_contract_key(2);
         let contract_c = make_contract_key(3);
-        manager.record_contract_access(contract_a, 1000, AccessType::Get);
-        manager.record_contract_access(contract_b, 1000, AccessType::Get);
-        manager.record_contract_access(contract_c, 1000, AccessType::Get);
+        manager.record_contract_access(contract_a, 1000, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(contract_b, 1000, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(contract_c, 1000, AccessType::Get, HostingCause::Other);
         manager.subscribe(contract_b);
         let client_id = crate::client_events::ClientId::next();
         manager.add_client_subscription(contract_c.id(), client_id);
@@ -4489,7 +4562,7 @@ mod tests {
         // Simulate 200 relay-cached contracts loaded from disk
         for i in 0..200u8 {
             let contract = make_contract_key(i);
-            manager.record_contract_access(contract, 1000, AccessType::Get);
+            manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         }
         assert_eq!(manager.hosting_contracts_count(), 200);
 
@@ -5806,7 +5879,7 @@ mod tests {
         assert_eq!(manager.state_generation(&key), 3);
 
         // Recording the access captures the current generation (3).
-        manager.record_contract_access(key, 100, AccessType::Get);
+        manager.record_contract_access(key, 100, AccessType::Get, HostingCause::Other);
 
         // Simulate a state write that races ahead of `EvictContract`.
         let new_generation = manager.bump_state_generation(&key);
@@ -5818,7 +5891,8 @@ mod tests {
         // `RuntimePool::remove_contract` will compare this captured
         // value (3) against the current `state_generation` (4) and
         // SKIP the on-disk reclamation, closing the re-host race.
-        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(trigger, 100, AccessType::Get, HostingCause::Other);
         assert_eq!(
             result.evicted,
             vec![(key, 3)],
@@ -5874,7 +5948,7 @@ mod tests {
         let new_gen = manager.bump_state_generation(&key);
         assert_eq!(new_gen, 1);
         manager.refresh_cache_generation(&key, new_gen);
-        manager.record_contract_access(key, 100, AccessType::Get);
+        manager.record_contract_access(key, 100, AccessType::Get, HostingCause::Other);
 
         // Simulate an UPDATE that bumps the counter to 2 AND refreshes
         // the cached snapshot — this is the bump+refresh pair installed
@@ -5888,7 +5962,8 @@ mod tests {
         // would carry the stale snapshot (1), and `RuntimePool::remove_contract`
         // would see a mismatch against the current generation (2) and
         // SKIP reclamation — leaking the on-disk state forever.
-        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(trigger, 100, AccessType::Get, HostingCause::Other);
         assert_eq!(
             result.evicted,
             vec![(key, 2)],
@@ -5992,13 +6067,14 @@ mod tests {
         manager.add_client_subscription(in_use.id(), client);
         assert!(manager.contract_in_use(&in_use));
 
-        manager.record_contract_access(in_use, 100, AccessType::Get);
-        manager.record_contract_access(filler, 100, AccessType::Get);
+        manager.record_contract_access(in_use, 100, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(filler, 100, AccessType::Get, HostingCause::Other);
 
         // Inserting `trigger` puts the cache over budget. A naive LRU would evict
         // `in_use` (oldest) — but it is locally subscribed so it is ordered LAST,
         // and one eviction of the zero-subscriber `filler` is enough.
-        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(trigger, 100, AccessType::Get, HostingCause::Other);
         assert_eq!(
             result.evicted,
             vec![(filler, 0)],
@@ -6019,7 +6095,8 @@ mod tests {
         manager.remove_client_subscription(in_use.id(), client);
         assert!(!manager.contract_in_use(&in_use));
 
-        let result = manager.record_contract_access(filler, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(filler, 100, AccessType::Get, HostingCause::Other);
         assert!(
             result.evicted.iter().any(|(k, _)| *k == in_use),
             "once the subscription is removed the contract is evicted normally \
@@ -6065,15 +6142,16 @@ mod tests {
             manager.add_downstream_subscriber(&trigger, p.clone());
         }
 
-        manager.record_contract_access(few, 100, AccessType::Get);
-        manager.record_contract_access(many, 100, AccessType::Get);
+        manager.record_contract_access(few, 100, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(many, 100, AccessType::Get, HostingCause::Other);
         assert!(manager.contract_in_use(&few));
         assert!(manager.contract_in_use(&many));
 
         // Insert `trigger` over budget. Nothing is zero-subscriber, so the fewest-
         // downstream contract `few` (1 sub) is shed as the last resort ahead of
         // `many` (3 subs).
-        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(trigger, 100, AccessType::Get, HostingCause::Other);
         assert_eq!(
             result.evicted,
             vec![(few, 0)],
@@ -6138,14 +6216,15 @@ mod tests {
             manager.subscribe(*k);
         }
 
-        manager.record_contract_access(victim, 100, AccessType::Get);
-        manager.record_contract_access(keep, 100, AccessType::Get);
+        manager.record_contract_access(victim, 100, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(keep, 100, AccessType::Get, HostingCause::Other);
         assert!(manager.contract_in_use(&victim));
 
         // Insert `trigger` over budget. Every contract is locally subscribed
         // (local = 1), so ties break by least-recent GET → `victim` (accessed
         // first) is shed as the last resort and torn down.
-        let result = manager.record_contract_access(trigger, 100, AccessType::Get);
+        let result =
+            manager.record_contract_access(trigger, 100, AccessType::Get, HostingCause::Other);
         assert_eq!(
             result.evicted_in_use,
             vec![victim],
@@ -6479,8 +6558,8 @@ mod tests {
         let relay_contract = make_contract_key(2);
 
         // Both contracts get hosted via GET
-        manager.record_contract_access(local_contract, 1000, AccessType::Get);
-        manager.record_contract_access(relay_contract, 1000, AccessType::Get);
+        manager.record_contract_access(local_contract, 1000, AccessType::Get, HostingCause::Other);
+        manager.record_contract_access(relay_contract, 1000, AccessType::Get, HostingCause::Other);
 
         // Only the local one gets marked as locally accessed
         manager.mark_local_client_access(&local_contract);
@@ -6513,9 +6592,19 @@ mod tests {
         let subscribed_size = 3 * 1024 * 1024;
         let recent_size = 4 * 1024 * 1024;
 
-        manager.record_contract_access(eligible, eligible_size, AccessType::Get);
-        manager.record_contract_access(subscribed, subscribed_size, AccessType::Get);
-        manager.record_contract_access(recent, recent_size, AccessType::Get);
+        manager.record_contract_access(
+            eligible,
+            eligible_size,
+            AccessType::Get,
+            HostingCause::Other,
+        );
+        manager.record_contract_access(
+            subscribed,
+            subscribed_size,
+            AccessType::Get,
+            HostingCause::Other,
+        );
+        manager.record_contract_access(recent, recent_size, AccessType::Get, HostingCause::Other);
         manager.add_downstream_subscriber(&subscribed, make_peer_key(12));
 
         clock.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
@@ -6565,7 +6654,7 @@ mod tests {
         // Simulate 200 relay-cached contracts (no local_client_access)
         for i in 0..200u8 {
             let contract = make_contract_key(i);
-            manager.record_contract_access(contract, 1000, AccessType::Get);
+            manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         }
 
         // Mark only 2 as locally accessed (simulating River user)
@@ -6592,7 +6681,7 @@ mod tests {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         manager.mark_local_client_access(&contract);
         manager.subscribe(contract);
 
@@ -6623,12 +6712,12 @@ mod tests {
         let manager = HostingManager::new(DEFAULT_HOSTING_BUDGET_BYTES);
         let contract = make_contract_key(1);
 
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         manager.mark_local_client_access(&contract);
         assert!(manager.has_local_client_access(&contract));
 
         // Refresh via a relay PUT -- should NOT clear the local flag
-        manager.record_contract_access(contract, 1000, AccessType::Put);
+        manager.record_contract_access(contract, 1000, AccessType::Put, HostingCause::Other);
         assert!(
             manager.has_local_client_access(&contract),
             "local_client_access should persist across access type changes"
@@ -6692,21 +6781,21 @@ mod tests {
         let contract_c = make_contract_key(3);
 
         // Add A (locally accessed) and B
-        manager.record_contract_access(contract_a, 100, AccessType::Get);
+        manager.record_contract_access(contract_a, 100, AccessType::Get, HostingCause::Other);
         manager.mark_local_client_access(&contract_a);
-        manager.record_contract_access(contract_b, 100, AccessType::Get);
+        manager.record_contract_access(contract_b, 100, AccessType::Get, HostingCause::Other);
 
         assert!(manager.has_local_client_access(&contract_a));
 
         // Add C -- should evict A (oldest in LRU)
-        manager.record_contract_access(contract_c, 100, AccessType::Get);
+        manager.record_contract_access(contract_c, 100, AccessType::Get, HostingCause::Other);
         assert!(
             !manager.is_hosting_contract(&contract_a),
             "contract_a should have been evicted"
         );
 
         // Re-add A via relay (no mark_local_client_access)
-        manager.record_contract_access(contract_a, 100, AccessType::Get);
+        manager.record_contract_access(contract_a, 100, AccessType::Get, HostingCause::Other);
         assert!(
             !manager.has_local_client_access(&contract_a),
             "Re-added via relay should NOT have local_client_access"
@@ -6913,7 +7002,7 @@ mod tests {
         // the hosting cache (record_contract_access ≈ what
         // `host_contract` does in production).
         manager.bump_state_generation(&contract);
-        manager.record_contract_access(contract, 128, AccessType::Put);
+        manager.record_contract_access(contract, 128, AccessType::Put, HostingCause::Other);
         assert!(manager.is_hosting_contract(&contract));
 
         // The `RuntimePool::remove_contract` generation-mismatch +
@@ -6962,7 +7051,7 @@ mod tests {
         // should_unsubscribe_upstream() reads only has_client_subscriptions()
         // + has_downstream_subscribers(), never the hosting cache or the lease
         // map. The decision keys solely off the downstream-subscriber map here.
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         manager.subscribe(contract);
         assert!(
             manager
@@ -7016,7 +7105,7 @@ mod tests {
         let contract = make_contract_key(0x33);
 
         // Contract is in the hosting cache (durable fallback) ...
-        manager.record_contract_access(contract, 1000, AccessType::Get);
+        manager.record_contract_access(contract, 1000, AccessType::Get, HostingCause::Other);
         assert!(manager.is_hosting_contract(&contract));
 
         // ... and an active, non-expired subscription reads as receiving.
@@ -7068,7 +7157,12 @@ mod tests {
         // 50 purely-cached contracts (e.g. relay-cached from GETs) — no
         // subscription, no client, no local-client access.
         for i in 0..50u8 {
-            manager.record_contract_access(make_contract_key(i), 1000, AccessType::Get);
+            manager.record_contract_access(
+                make_contract_key(i),
+                1000,
+                AccessType::Get,
+                HostingCause::Other,
+            );
         }
         assert_eq!(manager.hosting_contracts_count(), 50);
         assert!(
@@ -7112,7 +7206,7 @@ mod tests {
             lease.expires_at = Instant::now() + Duration::from_secs(30);
         }
         let expired = make_contract_key(0xE0);
-        manager.record_contract_access(expired, 1000, AccessType::Get);
+        manager.record_contract_access(expired, 1000, AccessType::Get, HostingCause::Other);
         manager.subscribe(expired);
         if let Some(mut lease) = manager.active_subscriptions.get_mut(&expired) {
             lease.expires_at = Instant::now() - Duration::from_secs(1);
@@ -7345,6 +7439,7 @@ mod tests {
                     make_contract_key((i % 250) as u8),
                     i % 4096,
                     AccessType::Get,
+                    HostingCause::Other,
                 );
             }
         });

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -336,6 +336,30 @@ pub(crate) struct HostingCacheStats {
     /// byte-budget zero-demand, byte-budget in-use, cost pressure.
     pub eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     pub eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Monotonic count of times this peer BEGAN hosting a contract, attributed
+    /// by [`HostingCause`] (array order is [`HostingCause::ALL`]). Only a
+    /// transition into hosting is counted — a refresh of an already-hosted
+    /// contract is not — because the question these answer is "why is this peer
+    /// hosting this contract", which a refresh does not re-decide. Incremented
+    /// at the two branches that actually insert (see [`HostingCause`]), never
+    /// re-derived from cache sizes. Aggregate, fixed-cardinality: no
+    /// per-contract or per-peer labels.
+    pub hosting_begins: [u64; HostingCause::COUNT],
+    /// Point-in-time distribution of `read_count` across the CURRENTLY hosted
+    /// set (buckets: 0, 1, 2-3, 4-9, 10-99, >=100 — see
+    /// [`READ_COUNT_HIST_UPPER_BOUNDS`]). `read_count` is half the demand signal
+    /// the subscriber-primary eviction ranking is built on, and until now it
+    /// reached only this node's own local HTML dashboard: no `send_event` call
+    /// site touched it, so the fleet-wide shape of the signal the policy depends
+    /// on was unobservable. A gauge, not a counter — do NOT difference it.
+    pub read_count_hist: [u64; READ_COUNT_HIST_BUCKETS],
+    /// Point-in-time distribution of `last_genuine_access` AGE across the
+    /// currently hosted set. Bucket 0 is "within [`COST_RATE_MIN_WINDOW`]" — the
+    /// share of the hosted set that cost-pressure eviction currently treats as
+    /// recently-accessed — then <20 min, <2 h, older, and finally "never
+    /// genuinely accessed" (`None`). The other half of the demand signal, same
+    /// invisibility as [`Self::read_count_hist`]. A gauge, not a counter.
+    pub genuine_access_recency: [u64; GENUINE_ACCESS_RECENCY_BUCKETS],
 }
 
 /// Per-contract Greedy-Dual priority row for the local-peer dashboard.
@@ -381,6 +405,112 @@ pub enum AccessType {
     /// Used in tests and reserved for future use when explicit SUBSCRIBE triggers hosting
     #[cfg_attr(not(test), allow(dead_code))]
     Subscribe,
+}
+
+/// WHY this peer began hosting a contract — the attribution that
+/// [`AccessType`] is structurally unable to carry.
+///
+/// `AccessType` says only GET-vs-PUT, which cannot separate a contract this
+/// node's OWN client asked for from one that merely transited it on a routed
+/// GET/PUT return path. That distinction is the entire question every hosting
+/// policy decision rests on ("why is this peer hosting this contract"), and
+/// before this enum nothing recorded it: `EventKind` had no hosting variant and
+/// `network_status` had only a `hosted_contracts` gauge.
+///
+/// Counted ONLY at the branch that actually begins hosting — the insert arm of
+/// [`HostingCache::record_access_with_demand`] and the insert in
+/// [`HostingCache::load_persisted_entry_with_demand`] — never re-derived by a
+/// caller from `is_new` or from cache-size arithmetic (the
+/// `.claude/rules/bug-prevention-patterns.md` "metric describing a decision"
+/// rule; three wrong counts in a row came from re-derivation).
+///
+/// Fixed cardinality, no per-contract or per-peer labels: the whole array is
+/// [`COUNT`](Self::COUNT) counters wide, exported as one aggregate row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HostingCause {
+    /// A GET this node's own client originated (`is_client_requester`), stored
+    /// on the client driver's return path.
+    ClientGet = 0,
+    /// The GET return-path store on a node that was merely RELAYING someone
+    /// else's GET — transit, not local demand.
+    RelayGet = 1,
+    /// A sub-operation GET: subscribe-fetch (`operations/subscribe.rs` spawns a
+    /// sub-op GET when it must fetch state before subscribing), related-contract
+    /// auto-fetch, phantom repair. Structurally indistinguishable from a plain
+    /// GET without this attribution, because it travels the same driver.
+    SubOpGet = 2,
+    /// A PUT this node's own client originated (originator loopback).
+    ClientPut = 3,
+    /// The every-hop PUT store on a node relaying someone else's PUT.
+    RelayPut = 4,
+    /// Restored from the persisted hosting metadata at startup — NOT a fresh
+    /// hosting decision at all. Kept separate so a restart's bulk reload cannot
+    /// masquerade as live demand (the same confound `seeded_this_run` exists to
+    /// keep out of the unread-seed falsifier).
+    StartupRestore = 5,
+    /// No cause was supplied. Reached only by the neutral-demand test wrapper
+    /// [`HostingCache::record_access`]; every production hosting path passes a
+    /// real cause. A NONZERO value in the field therefore means a production
+    /// path began hosting without attribution — read it as a leak detector for
+    /// this enum, not as a real category.
+    Other = 6,
+}
+
+impl HostingCause {
+    /// Every variant, in discriminant order. This is the exported array order
+    /// for `NetworkEfficiencyV1::host_begin`; appending is safe, reordering is
+    /// not (it silently relabels historical series).
+    pub(crate) const ALL: [HostingCause; 7] = [
+        HostingCause::ClientGet,
+        HostingCause::RelayGet,
+        HostingCause::SubOpGet,
+        HostingCause::ClientPut,
+        HostingCause::RelayPut,
+        HostingCause::StartupRestore,
+        HostingCause::Other,
+    ];
+
+    pub(crate) const COUNT: usize = Self::ALL.len();
+
+    #[inline]
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Upper bounds (inclusive) of the first `READ_COUNT_HIST_BUCKETS - 1` buckets
+/// of the hosted-set `read_count` histogram; the final bucket is the overflow
+/// bin. Log-ish spacing: 0 (never read), 1, 2-3, 4-9, 10-99, >=100.
+pub(crate) const READ_COUNT_HIST_UPPER_BOUNDS: [u32; 5] = [0, 1, 3, 9, 99];
+
+/// Width of the hosted-set `read_count` histogram
+/// (`READ_COUNT_HIST_UPPER_BOUNDS` plus the overflow bin).
+pub(crate) const READ_COUNT_HIST_BUCKETS: usize = READ_COUNT_HIST_UPPER_BOUNDS.len() + 1;
+
+/// Width of the hosted-set `last_genuine_access` recency histogram. Buckets, in
+/// order: within [`COST_RATE_MIN_WINDOW`] (the cost window), <20 min, <2 h,
+/// older, and finally "never genuinely accessed since it was hosted/reloaded"
+/// (`last_genuine_access == None`).
+pub(crate) const GENUINE_ACCESS_RECENCY_BUCKETS: usize = 5;
+
+/// Bucket index for a hosted contract's `read_count`.
+fn read_count_bucket(read_count: u32) -> usize {
+    READ_COUNT_HIST_UPPER_BOUNDS
+        .iter()
+        .position(|bound| read_count <= *bound)
+        .unwrap_or(READ_COUNT_HIST_BUCKETS - 1)
+}
+
+/// Bucket index for a hosted contract's `last_genuine_access` age. `None` (never
+/// genuinely accessed) lands in the final bucket.
+fn genuine_access_recency_bucket(age: Option<Duration>) -> usize {
+    match age {
+        None => GENUINE_ACCESS_RECENCY_BUCKETS - 1,
+        Some(age) if age < COST_RATE_MIN_WINDOW => 0,
+        Some(age) if age < Duration::from_secs(20 * 60) => 1,
+        Some(age) if age < Duration::from_secs(2 * 60 * 60) => 2,
+        Some(_) => 3,
+    }
 }
 
 /// Coarse memory-pressure state handed to the over-budget eviction sweep, which
@@ -773,6 +903,12 @@ pub struct HostingCache<T: TimeSource> {
     cost_evictions_total: u64,
     eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
+    /// Monotonic hosting-BEGIN counts by [`HostingCause`]. Incremented ONLY by
+    /// the two insert branches (`record_access_with_demand`'s not-cached arm and
+    /// `load_persisted_entry_with_demand`'s insert), so it counts transitions
+    /// into hosting and nothing else. See
+    /// [`HostingCacheStats::hosting_begins`].
+    hosting_begins: [u64; HostingCause::COUNT],
     /// Time source for testability
     time_source: T,
 }
@@ -1017,8 +1153,22 @@ impl<T: TimeSource> HostingCache<T> {
             cost_evictions_total: 0,
             eviction_victim_counts: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             eviction_victim_bytes: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
+            hosting_begins: [0; HostingCause::COUNT],
             time_source,
         }
+    }
+
+    /// Record that this peer BEGAN hosting a contract, attributed to `cause`.
+    ///
+    /// Deliberately private and deliberately tiny: the only callers are the two
+    /// branches that actually insert into `contracts`. Keeping the increment
+    /// adjacent to the insert (rather than at a caller that inspects
+    /// `is_new`, or that diffs `len()` before/after) is what stops the counter
+    /// from silently absorbing refreshes — the failure mode
+    /// `.claude/rules/bug-prevention-patterns.md` records for decision metrics.
+    #[inline]
+    fn note_hosting_begin(&mut self, cause: HostingCause) {
+        self.hosting_begins[cause.index()] = self.hosting_begins[cause.index()].saturating_add(1);
     }
 
     /// Next monotonic access sequence number, stamped onto an entry on every
@@ -1296,8 +1446,11 @@ impl<T: TimeSource> HostingCache<T> {
     /// then-current generation at deletion time.
     // Neutral-demand convenience wrapper. Production always goes through
     // `record_access_with_demand` (the `HostingManager` supplies the
-    // proximity-prior estimate), so in a non-test build this wrapper is unused;
-    // it is retained for callers/tests that have no demand estimate.
+    // proximity-prior estimate AND the real `HostingCause`), so in a non-test
+    // build this wrapper is unused; it is retained for callers/tests that have
+    // no demand estimate. Hosting begins through it are attributed
+    // `HostingCause::Other` — see that variant's doc: a nonzero `Other` in the
+    // field means a production path lost its attribution.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn record_access<G>(
         &mut self,
@@ -1321,6 +1474,7 @@ impl<T: TimeSource> HostingCache<T> {
             access_type,
             write_generation,
             NEUTRAL_DEMAND,
+            HostingCause::Other,
             subscriber_counts,
         )
     }
@@ -1345,6 +1499,17 @@ impl<T: TimeSource> HostingCache<T> {
     ///   generation, the stored `predicted_demand`, AND `recency_seq` (a PUT is
     ///   genuine client access — invariant 3, decision 2026-07-08), but no read
     ///   count and no `keep_score` refresh (a PUT is a write, not a read).
+    ///
+    /// `cause` is the hosting ATTRIBUTION (see [`HostingCause`]) and is consumed
+    /// on the not-cached branch only, where it counts a hosting BEGIN. It has no
+    /// effect on eviction, retention, or any returned value: this is
+    /// observability, never policy.
+    // 8 parameters: this is the single hosting-record chokepoint, and each
+    // argument is an independent input the cache cannot derive (identity, size,
+    // access kind, write generation, demand prior, attribution, subscriber
+    // lookup). Bundling them into a struct would only move the same fields
+    // behind one more name at every call site.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_access_with_demand<G>(
         &mut self,
         key: ContractKey,
@@ -1352,6 +1517,7 @@ impl<T: TimeSource> HostingCache<T> {
         access_type: AccessType,
         write_generation: u64,
         predicted_demand: f64,
+        cause: HostingCause,
         subscriber_counts: G,
     ) -> RecordAccessResult
     where
@@ -1449,6 +1615,12 @@ impl<T: TimeSource> HostingCache<T> {
             };
             self.contracts.insert(key, contract);
             self.current_bytes = self.current_bytes.saturating_add(size_bytes);
+            // THIS is the branch that begins hosting — the same branch that sets
+            // `is_new = true` below. Counting here rather than at a caller is the
+            // point: a caller-side increment would have to re-test `is_new`, and
+            // the recurring regression is exactly that the re-test drifts (or is
+            // dropped) and the counter starts including refreshes.
+            self.note_hosting_begin(cause);
 
             // A fresh insert always evicts under AtCapacity: an insert never
             // constitutes genuine RAM overflow, so it must not pierce the op-scoped
@@ -1752,7 +1924,28 @@ impl<T: TimeSource> HostingCache<T> {
     /// Snapshot the cache's aggregate resource gauges under a single read for
     /// per-node telemetry. See [`HostingCacheStats`].
     pub fn stats(&self) -> HostingCacheStats {
+        // Demand-signal gauges (`read_count` / `last_genuine_access`): bucketed
+        // here, under the same read that produces the resource gauges, so the
+        // exported shape can never disagree with the hosted set it describes.
+        // Aggregate only — the per-contract identities never leave this loop.
+        let now = self.time_source.now();
+        let mut read_count_hist = [0_u64; READ_COUNT_HIST_BUCKETS];
+        let mut genuine_access_recency = [0_u64; GENUINE_ACCESS_RECENCY_BUCKETS];
+        for entry in self.contracts.values() {
+            let read_bucket = read_count_bucket(entry.read_count);
+            read_count_hist[read_bucket] = read_count_hist[read_bucket].saturating_add(1);
+            let recency_bucket = genuine_access_recency_bucket(
+                entry
+                    .last_genuine_access
+                    .map(|at| now.saturating_duration_since(at)),
+            );
+            genuine_access_recency[recency_bucket] =
+                genuine_access_recency[recency_bucket].saturating_add(1);
+        }
         HostingCacheStats {
+            hosting_begins: self.hosting_begins,
+            read_count_hist,
+            genuine_access_recency,
             budget_bytes: self.budget_bytes,
             current_bytes: self.current_bytes,
             contract_count: self.contracts.len() as u64,
@@ -2155,6 +2348,12 @@ impl<T: TimeSource> HostingCache<T> {
 
         self.contracts.insert(key, contract);
         self.current_bytes = self.current_bytes.saturating_add(size_bytes);
+        // Counted HERE, past the `contains_key` early-return above, so a
+        // duplicate load is not counted as a second begin. The four
+        // `HostingManager` call sites cannot make that distinction — the
+        // early-return is invisible to them — which is precisely why the
+        // increment does not live there.
+        self.note_hosting_begin(HostingCause::StartupRestore);
     }
 
     /// Neutral-demand convenience wrapper over
@@ -2232,6 +2431,266 @@ mod tests {
         let time_source = SharedMockTimeSource::new();
         let cache = HostingCache::new(budget, time_source.clone());
         (cache, time_source)
+    }
+
+    /// Hosting-begin count for one cause, read through the exported stats.
+    fn begins(cache: &HostingCache<SharedMockTimeSource>, cause: HostingCause) -> u64 {
+        cache.stats().hosting_begins[cause.index()]
+    }
+
+    /// The counter must fire ONLY on the transition into hosting, and must land
+    /// in the row the caller named.
+    ///
+    /// # Why the refresh half is the load-bearing half
+    ///
+    /// The regression this guards is not "the counter is missing" (loud, and any
+    /// smoke test finds it) but "the counter is wired to a site that also fires
+    /// on refresh" — which yields a plausible, monotonically-rising, WRONG
+    /// number. A hot contract re-PUT every few seconds would dominate
+    /// `hosting_begins` while beginning hosting exactly once, and the answer to
+    /// "why is this peer hosting this contract" would silently become "how often
+    /// is it written". So the second access below is not a nicety: an assertion
+    /// that only checks the first access passes under precisely the mutation
+    /// that matters.
+    ///
+    /// Mutations verified to FAIL this test:
+    /// 1. delete the `note_hosting_begin(cause)` call in the insert branch;
+    /// 2. move it above the `if let Some(existing)` so it also counts refreshes
+    ///    (caught by the `== 1` after the repeat access, not by the first);
+    /// 3. attribute a constant cause instead of the caller's.
+    #[test]
+    fn hosting_begin_counts_the_insert_only_and_by_cause() {
+        let (mut cache, _) = make_cache(10_000);
+        let relayed = make_key(1);
+        let client = make_key(2);
+
+        cache.record_access_with_demand(
+            relayed,
+            100,
+            AccessType::Put,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::RelayPut,
+            |_| (0, 0),
+        );
+        assert_eq!(begins(&cache, HostingCause::RelayPut), 1);
+
+        // Same contract again: a REFRESH, not a new hosting decision. The whole
+        // point of the counter is that this does not move it.
+        cache.record_access_with_demand(
+            relayed,
+            100,
+            AccessType::Put,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::RelayPut,
+            |_| (0, 0),
+        );
+        // ... and again through a DIFFERENT cause, which must not open a second
+        // row for a contract that is already hosted.
+        cache.record_access_with_demand(
+            relayed,
+            100,
+            AccessType::Get,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::ClientGet,
+            |_| (0, 0),
+        );
+        assert_eq!(
+            begins(&cache, HostingCause::RelayPut),
+            1,
+            "a refresh of an already-hosted contract is not a hosting BEGIN — if \
+             this reads 2, the increment fires on the refresh path too and the \
+             counter is measuring write frequency, not hosting decisions"
+        );
+        assert_eq!(
+            begins(&cache, HostingCause::ClientGet),
+            0,
+            "a refresh must not open a row for its cause either"
+        );
+
+        // A genuinely new contract, attributed to the cause its caller named.
+        cache.record_access_with_demand(
+            client,
+            100,
+            AccessType::Get,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::ClientGet,
+            |_| (0, 0),
+        );
+        assert_eq!(begins(&cache, HostingCause::ClientGet), 1);
+        assert_eq!(begins(&cache, HostingCause::RelayPut), 1);
+
+        // Nothing leaked into the rows nobody named.
+        for cause in [
+            HostingCause::RelayGet,
+            HostingCause::SubOpGet,
+            HostingCause::ClientPut,
+            HostingCause::StartupRestore,
+            HostingCause::Other,
+        ] {
+            assert_eq!(begins(&cache, cause), 0, "unexpected count in {cause:?}");
+        }
+    }
+
+    /// A restart's bulk reload is counted, counted ONCE per contract, and never
+    /// as live demand. The duplicate load is the reason the increment lives past
+    /// `load_persisted_entry_with_demand`'s `contains_key` early-return rather
+    /// than at the four `HostingManager` call sites, which cannot see it.
+    #[test]
+    fn startup_restore_counted_once_per_contract_and_never_as_live_demand() {
+        let (mut cache, _) = make_cache(10_000);
+        let key = make_key(7);
+
+        cache.load_persisted_entry(key, 100, AccessType::Get, Duration::from_secs(30), false);
+        cache.load_persisted_entry(key, 100, AccessType::Get, Duration::from_secs(30), false);
+
+        assert_eq!(
+            begins(&cache, HostingCause::StartupRestore),
+            1,
+            "a duplicate load short-circuits and must not count a second begin"
+        );
+        for cause in [
+            HostingCause::ClientGet,
+            HostingCause::RelayGet,
+            HostingCause::SubOpGet,
+            HostingCause::ClientPut,
+            HostingCause::RelayPut,
+            HostingCause::Other,
+        ] {
+            assert_eq!(
+                begins(&cache, cause),
+                0,
+                "a reload is not live demand; {cause:?} must stay 0"
+            );
+        }
+    }
+
+    /// The two demand-signal gauges describe the CURRENTLY hosted set: reads
+    /// bucketed by `read_count`, recency bucketed by `last_genuine_access` age.
+    #[test]
+    fn demand_signal_gauges_bucket_the_hosted_set() {
+        let (mut cache, time) = make_cache(10_000);
+
+        // never read, and (after the advance below) genuinely accessed long ago
+        let seeded = make_key(1);
+        cache.record_access_with_demand(
+            seeded,
+            100,
+            AccessType::Put,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::RelayPut,
+            |_| (0, 0),
+        );
+        // A SUBSCRIBE-only entry never stamps `last_genuine_access` at all.
+        let subscribed_only = make_key(2);
+        cache.record_access_with_demand(
+            subscribed_only,
+            100,
+            AccessType::Subscribe,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::SubOpGet,
+            |_| (0, 0),
+        );
+
+        time.advance_time(COST_RATE_MIN_WINDOW + Duration::from_secs(1));
+
+        // read four times => read_count 4 (bucket 3: 4-9) and genuinely accessed
+        // inside the cost window (bucket 0).
+        let hot = make_key(3);
+        for _ in 0..4 {
+            cache.record_access_with_demand(
+                hot,
+                100,
+                AccessType::Get,
+                0,
+                NEUTRAL_DEMAND,
+                HostingCause::ClientGet,
+                |_| (0, 0),
+            );
+        }
+
+        let stats = cache.stats();
+        assert_eq!(
+            stats.read_count_hist,
+            // 0 reads: seeded; 1 read: subscribed_only (SUBSCRIBE counts as a
+            // read for read_count); 4-9 reads: hot.
+            [1, 1, 0, 1, 0, 0],
+            "read_count histogram must describe the hosted set"
+        );
+        assert_eq!(
+            stats.genuine_access_recency,
+            // within the cost window: hot; >= cost window but < 20 min: seeded
+            // (a PUT stamps genuine access); never: subscribed_only.
+            [1, 1, 0, 0, 1],
+            "genuine-access recency histogram must describe the hosted set"
+        );
+        assert_eq!(
+            stats.read_count_hist.iter().sum::<u64>(),
+            stats.contract_count,
+            "every hosted contract lands in exactly one read bucket"
+        );
+        assert_eq!(
+            stats.genuine_access_recency.iter().sum::<u64>(),
+            stats.contract_count,
+            "every hosted contract lands in exactly one recency bucket"
+        );
+    }
+
+    /// The exported gauges are a snapshot of the CURRENT hosted set, so an
+    /// evicted contract leaves them — while the monotonic begin counter keeps
+    /// its record of the decision that hosted it. Guards against someone
+    /// "simplifying" the histograms into monotonic counters, which would make
+    /// them un-interpretable as a distribution.
+    #[test]
+    fn demand_signal_gauges_follow_eviction_but_begins_do_not() {
+        let (mut cache, _) = make_cache(100);
+        let first = make_key(1);
+        let second = make_key(2);
+
+        cache.record_access_with_demand(
+            first,
+            100,
+            AccessType::Get,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::ClientGet,
+            |_| (0, 0),
+        );
+        // Budget is exactly one contract wide, so this insert sheds `first`.
+        let result = cache.record_access_with_demand(
+            second,
+            100,
+            AccessType::Get,
+            0,
+            NEUTRAL_DEMAND,
+            HostingCause::RelayGet,
+            |_| (0, 0),
+        );
+        assert_eq!(
+            result.evicted,
+            vec![(first, 0)],
+            "premise: `first` was shed"
+        );
+
+        let stats = cache.stats();
+        assert_eq!(stats.contract_count, 1);
+        assert_eq!(
+            stats.read_count_hist.iter().sum::<u64>(),
+            1,
+            "the gauge tracks the live hosted set, not everything ever hosted"
+        );
+        assert_eq!(
+            stats.hosting_begins[HostingCause::ClientGet.index()],
+            1,
+            "the begin counter is monotonic: eviction does not un-decide the \
+             hosting that happened"
+        );
+        assert_eq!(stats.hosting_begins[HostingCause::RelayGet.index()], 1);
     }
 
     /// Project the `(key, write_generation)` reclaim pairs out of a
@@ -3891,13 +4350,29 @@ mod tests {
         let key = make_key(1);
 
         // Insert at floor 0 with demand 3.0 -> keep_score 3.0.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 3.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            key,
+            100,
+            AccessType::Get,
+            0,
+            3.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.get(&key).unwrap().keep_score, 3.0);
         assert_eq!(cache.get(&key).unwrap().predicted_demand, 3.0);
         assert_eq!(cache.get(&key).unwrap().read_count, 1);
 
         // A read with a new demand estimate refreshes keep_score = floor + demand.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            key,
+            100,
+            AccessType::Get,
+            0,
+            5.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.get(&key).unwrap().keep_score, 5.0);
         assert_eq!(cache.get(&key).unwrap().read_count, 2);
     }
@@ -3918,16 +4393,39 @@ mod tests {
 
         // `high` inserted first (older) with strong demand; `low` inserted after
         // with weak demand. A recency-only (LRU) policy would evict `high`.
-        cache.record_access_with_demand(high, 100, AccessType::Get, 0, 10.0, |_| (0, 0));
-        cache.record_access_with_demand(low, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            high,
+            100,
+            AccessType::Get,
+            0,
+            10.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
+        cache.record_access_with_demand(
+            low,
+            100,
+            AccessType::Get,
+            0,
+            1.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.current_bytes(), 200);
 
         time.advance_time(Duration::from_secs(61));
 
         // Over-budget insert must evict the LOWEST keep_score (`low`), not the
         // oldest (`high`).
-        let result =
-            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
+        let result = cache.record_access_with_demand(
+            trigger,
+            100,
+            AccessType::Get,
+            0,
+            1.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(
             result.evicted,
             vec![(low, 0)],
@@ -3972,8 +4470,24 @@ mod tests {
         let trigger = make_key(3);
 
         // Insert both cold (zero samples), scored only by the distance prior.
-        cache.record_access_with_demand(near, 100, AccessType::Get, 0, near_demand, |_| (0, 0));
-        cache.record_access_with_demand(far, 100, AccessType::Get, 0, far_demand, |_| (0, 0));
+        cache.record_access_with_demand(
+            near,
+            100,
+            AccessType::Get,
+            0,
+            near_demand,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
+        cache.record_access_with_demand(
+            far,
+            100,
+            AccessType::Get,
+            0,
+            far_demand,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.current_bytes(), 200);
         assert!(
             cache.get(&near).unwrap().keep_score > cache.get(&far).unwrap().keep_score,
@@ -3990,6 +4504,7 @@ mod tests {
             AccessType::Get,
             0,
             NEUTRAL_DEMAND,
+            HostingCause::Other,
             |_| (0, 0),
         );
         assert_eq!(
@@ -4042,7 +4557,15 @@ mod tests {
 
         // Seed the room with strong demand, then read it repeatedly (simulating
         // recurring GETs). These reads are the room's LAST accesses.
-        cache.record_access_with_demand(room, 100, AccessType::Get, 0, 10.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            room,
+            100,
+            AccessType::Get,
+            0,
+            10.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         for _ in 0..3 {
             time.advance_time(Duration::from_secs(5));
             cache.touch(&room);
@@ -4051,7 +4574,15 @@ mod tests {
         // Junk arrives AFTER the room's last read, so junk is the more-recently-
         // accessed entry — and carries weak demand.
         time.advance_time(Duration::from_secs(5));
-        cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            junk,
+            100,
+            AccessType::Get,
+            0,
+            1.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
 
         // Advance so BOTH are past TTL and eviction-eligible; the room, last read
         // 5s before junk, is the least-recently-accessed of the two.
@@ -4076,8 +4607,15 @@ mod tests {
         // Over-budget insert: the fuel gauge evicts the lowest keep_score (junk).
         // Byte-LRU-with-TTL would instead evict the room (the oldest past-TTL
         // entry) — so this assertion is what fails under a recency-only policy.
-        let result =
-            cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
+        let result = cache.record_access_with_demand(
+            trigger,
+            100,
+            AccessType::Get,
+            0,
+            1.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(
             result.evicted,
             vec![(junk, 0)],
@@ -4108,10 +4646,26 @@ mod tests {
         // Insert a demand-7 contract, let it age, then evict it via an
         // over-budget insert; the floor must climb to 7.
         let a = make_key(1);
-        cache.record_access_with_demand(a, 100, AccessType::Get, 0, 7.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            a,
+            100,
+            AccessType::Get,
+            0,
+            7.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         time.advance_time(Duration::from_secs(61));
         let b = make_key(2);
-        let r = cache.record_access_with_demand(b, 100, AccessType::Get, 0, 2.0, |_| (0, 0));
+        let r = cache.record_access_with_demand(
+            b,
+            100,
+            AccessType::Get,
+            0,
+            2.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(r.evicted, vec![(a, 0)]);
         assert_eq!(
             cache.eviction_floor(),
@@ -4123,7 +4677,15 @@ mod tests {
         // lower-scored victim must not drop the floor below 7.
         time.advance_time(Duration::from_secs(61));
         let c = make_key(3);
-        let r = cache.record_access_with_demand(c, 100, AccessType::Get, 0, 1.0, |_| (0, 0));
+        let r = cache.record_access_with_demand(
+            c,
+            100,
+            AccessType::Get,
+            0,
+            1.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(r.evicted, vec![(b, 0)], "b (keep_score 2) evicts");
         assert_eq!(
             cache.eviction_floor(),
@@ -4141,14 +4703,30 @@ mod tests {
         let key = make_key(1);
 
         // Seed via PUT: keep_score = floor(0) + demand, read_count 0.
-        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 2.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            key,
+            100,
+            AccessType::Put,
+            0,
+            2.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.get(&key).unwrap().read_count, 0, "PUT is not a read");
         let seed_score = cache.get(&key).unwrap().keep_score;
         assert_eq!(seed_score, 2.0);
 
         // Manually raise the floor by evicting something else would be indirect;
         // instead assert that a re-PUT does NOT refresh keep_score or read_count.
-        cache.record_access_with_demand(key, 100, AccessType::Put, 0, 9.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            key,
+            100,
+            AccessType::Put,
+            0,
+            9.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(
             cache.get(&key).unwrap().read_count,
             0,
@@ -4161,7 +4739,15 @@ mod tests {
         );
 
         // A GET, by contrast, IS read-demand and refreshes both.
-        cache.record_access_with_demand(key, 100, AccessType::Get, 0, 9.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            key,
+            100,
+            AccessType::Get,
+            0,
+            9.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(cache.get(&key).unwrap().read_count, 1);
         assert_eq!(cache.get(&key).unwrap().keep_score, 9.0);
     }
@@ -4179,7 +4765,15 @@ mod tests {
         time.advance_time(Duration::from_secs(61));
         // Evict it by inserting a higher-demand junk (so read_twice is the victim).
         let junk = make_key(2);
-        let r = cache.record_access_with_demand(junk, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
+        let r = cache.record_access_with_demand(
+            junk,
+            100,
+            AccessType::Get,
+            0,
+            5.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(r.evicted, vec![(read_twice, 0)]);
         assert_eq!(
             cache.stats().evictions_of_recently_read_total,
@@ -4191,7 +4785,15 @@ mod tests {
         time.advance_time(Duration::from_secs(61));
         let seed = make_key(3);
         // junk currently has demand 5 (>seed's), so make the new one higher.
-        let r = cache.record_access_with_demand(seed, 100, AccessType::Get, 0, 9.0, |_| (0, 0));
+        let r = cache.record_access_with_demand(
+            seed,
+            100,
+            AccessType::Get,
+            0,
+            9.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         assert_eq!(r.evicted, vec![(junk, 0)], "junk (read once) evicts");
         assert_eq!(
             cache.stats().evictions_of_recently_read_total,
@@ -4213,16 +4815,38 @@ mod tests {
         let other = make_key(2);
         let trigger = make_key(3);
 
-        cache.record_access_with_demand(subscribed, 100, AccessType::Get, 0, 0.1, |_| (0, 0));
-        cache.record_access_with_demand(other, 100, AccessType::Get, 0, 5.0, |_| (0, 0));
+        cache.record_access_with_demand(
+            subscribed,
+            100,
+            AccessType::Get,
+            0,
+            0.1,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
+        cache.record_access_with_demand(
+            other,
+            100,
+            AccessType::Get,
+            0,
+            5.0,
+            HostingCause::Other,
+            |_| (0, 0),
+        );
         time.advance_time(Duration::from_secs(61));
 
         // Over budget by one entry: `subscribed` has the lowest keep_score and a
         // naive demand order would evict it first, but it is downstream-subscribed
         // so it sorts LAST — the zero-subscriber `other` is shed instead.
-        let result = cache.record_access_with_demand(trigger, 100, AccessType::Get, 0, 5.0, |k| {
-            (0, (*k == subscribed) as usize)
-        });
+        let result = cache.record_access_with_demand(
+            trigger,
+            100,
+            AccessType::Get,
+            0,
+            5.0,
+            HostingCause::Other,
+            |k| (0, (*k == subscribed) as usize),
+        );
         assert_eq!(
             result.evicted,
             vec![(other, 0)],

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -426,14 +426,24 @@ pub enum AccessType {
 ///
 /// Fixed cardinality, no per-contract or per-peer labels: the whole array is
 /// [`COUNT`](Self::COUNT) counters wide, exported as one aggregate row.
+///
+/// NAMING: the two forwarding variants are `Transit*`, NOT `Relay*`.
+/// `.claude/rules/hosting-invariants.md` records that "relay" is a fossil of the
+/// hollow-relay firefight against #3763 and says outright: do not name new code
+/// `relay`. Forwarding a request toward its key is ROUTING, not a persistent
+/// role — which is exactly what these two variants mean.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HostingCause {
-    /// A GET this node's own client originated (`is_client_requester`), stored
-    /// on the client driver's return path.
+    /// A GET this node itself originated: either its own client's GET
+    /// (`is_client_requester`, stored on the client driver's return path) or a
+    /// node-internal loopback GET, which dispatch routes through the SAME
+    /// forwarding driver with `upstream_addr = own_addr` (see
+    /// `get/op_ctx_task.rs::relay_get_hosting_cause`). Both are this node's own
+    /// demand; neither is transit.
     ClientGet = 0,
-    /// The GET return-path store on a node that was merely RELAYING someone
+    /// The GET return-path store on a node that was merely FORWARDING someone
     /// else's GET — transit, not local demand.
-    RelayGet = 1,
+    TransitGet = 1,
     /// A sub-operation GET: subscribe-fetch (`operations/subscribe.rs` spawns a
     /// sub-op GET when it must fetch state before subscribing), related-contract
     /// auto-fetch, phantom repair. Structurally indistinguishable from a plain
@@ -441,8 +451,8 @@ pub(crate) enum HostingCause {
     SubOpGet = 2,
     /// A PUT this node's own client originated (originator loopback).
     ClientPut = 3,
-    /// The every-hop PUT store on a node relaying someone else's PUT.
-    RelayPut = 4,
+    /// The every-hop PUT store on a node forwarding someone else's PUT.
+    TransitPut = 4,
     /// Restored from the persisted hosting metadata at startup — NOT a fresh
     /// hosting decision at all. Kept separate so a restart's bulk reload cannot
     /// masquerade as live demand (the same confound `seeded_this_run` exists to
@@ -459,13 +469,15 @@ pub(crate) enum HostingCause {
 impl HostingCause {
     /// Every variant, in discriminant order. This is the exported array order
     /// for `NetworkEfficiencyV1::host_begin`; appending is safe, reordering is
-    /// not (it silently relabels historical series).
+    /// not (it silently relabels historical series). RENAMING a variant is also
+    /// safe — the wire carries positions, not names. Pinned by
+    /// `hosting_cause_all_is_in_discriminant_order`.
     pub(crate) const ALL: [HostingCause; 7] = [
         HostingCause::ClientGet,
-        HostingCause::RelayGet,
+        HostingCause::TransitGet,
         HostingCause::SubOpGet,
         HostingCause::ClientPut,
-        HostingCause::RelayPut,
+        HostingCause::TransitPut,
         HostingCause::StartupRestore,
         HostingCause::Other,
     ];
@@ -2438,6 +2450,86 @@ mod tests {
         cache.stats().hosting_begins[cause.index()]
     }
 
+    /// This file's source with the test module cut off, so a source pin cannot
+    /// match its own needle in a test's string literal.
+    fn production_source() -> &'static str {
+        const FULL: &str = include_str!("cache.rs");
+        // Anchor on the module header, NOT a bare `#[cfg(test)]`: several
+        // test-only methods inside the production `impl` carry that attribute,
+        // and cutting at the first one would hide most of the file from every
+        // pin below (silently, while still passing).
+        let cutoff = FULL
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("file must end with a `#[cfg(test)] mod tests` block");
+        &FULL[..cutoff]
+    }
+
+    /// `HostingCause::ALL` is the EXPORT ORDER of `NetworkEfficiencyV1::host_begin`
+    /// and `index()` is the discriminant used to address the counter array. If
+    /// they ever disagree, every historical series is silently relabelled: the
+    /// dashboards keep drawing, the numbers stay plausible, and "client GET" now
+    /// means something else.
+    ///
+    /// Nothing else checks this — `ALL` is hand-written next to the discriminants,
+    /// which is exactly the kind of hand-maintained parallel list that drifts when
+    /// a variant is inserted rather than appended.
+    #[test]
+    fn hosting_cause_all_is_in_discriminant_order() {
+        for (i, cause) in HostingCause::ALL.iter().enumerate() {
+            assert_eq!(
+                cause.index(),
+                i,
+                "HostingCause::ALL[{i}] is {cause:?}, whose discriminant is {}. \
+                 ALL must stay in discriminant order: it is the exported row \
+                 order, so a mismatch relabels historical telemetry series \
+                 rather than failing loudly.",
+                cause.index(),
+            );
+        }
+        assert_eq!(
+            HostingCause::COUNT,
+            HostingCause::ALL.len(),
+            "COUNT is the counter-array width and must equal ALL's length"
+        );
+    }
+
+    /// Exactly two branches insert into `contracts`, and each one attributes the
+    /// hosting begin it just made.
+    ///
+    /// The counter's whole design is that it is incremented AT the branch that
+    /// decides, never re-derived by a caller (`.claude/rules/bug-prevention-patterns.md`).
+    /// That only holds while the set of deciding branches is the set that counts:
+    /// a third insert added later would begin hosting without attribution, and the
+    /// symptom is a counter that is quietly LOW while still rising — the failure
+    /// mode that terminates investigation rather than starting one.
+    #[test]
+    fn every_hosting_insert_site_records_its_cause() {
+        let src = production_source();
+        let sites: Vec<usize> = src
+            .match_indices("self.contracts.insert(")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            sites.len(),
+            2,
+            "expected exactly two `self.contracts.insert(` sites (the \
+             record_access_with_demand insert arm and the \
+             load_persisted_entry_with_demand insert); found {}. A new insert \
+             begins hosting, so it must also call note_hosting_begin — update \
+             this pin deliberately once it does.",
+            sites.len(),
+        );
+        for (idx, site) in sites.into_iter().enumerate() {
+            let window = &src[site..(site + 900).min(src.len())];
+            assert!(
+                window.contains("self.note_hosting_begin("),
+                "insert site #{idx} must be followed by a \
+                 `self.note_hosting_begin(..)` call attributing the hosting \
+                 begin it just made. Window: {window}"
+            );
+        }
+    }
+
     /// The counter must fire ONLY on the transition into hosting, and must land
     /// in the row the caller named.
     ///
@@ -2470,10 +2562,10 @@ mod tests {
             AccessType::Put,
             0,
             NEUTRAL_DEMAND,
-            HostingCause::RelayPut,
+            HostingCause::TransitPut,
             |_| (0, 0),
         );
-        assert_eq!(begins(&cache, HostingCause::RelayPut), 1);
+        assert_eq!(begins(&cache, HostingCause::TransitPut), 1);
 
         // Same contract again: a REFRESH, not a new hosting decision. The whole
         // point of the counter is that this does not move it.
@@ -2483,7 +2575,7 @@ mod tests {
             AccessType::Put,
             0,
             NEUTRAL_DEMAND,
-            HostingCause::RelayPut,
+            HostingCause::TransitPut,
             |_| (0, 0),
         );
         // ... and again through a DIFFERENT cause, which must not open a second
@@ -2498,7 +2590,7 @@ mod tests {
             |_| (0, 0),
         );
         assert_eq!(
-            begins(&cache, HostingCause::RelayPut),
+            begins(&cache, HostingCause::TransitPut),
             1,
             "a refresh of an already-hosted contract is not a hosting BEGIN — if \
              this reads 2, the increment fires on the refresh path too and the \
@@ -2521,11 +2613,11 @@ mod tests {
             |_| (0, 0),
         );
         assert_eq!(begins(&cache, HostingCause::ClientGet), 1);
-        assert_eq!(begins(&cache, HostingCause::RelayPut), 1);
+        assert_eq!(begins(&cache, HostingCause::TransitPut), 1);
 
         // Nothing leaked into the rows nobody named.
         for cause in [
-            HostingCause::RelayGet,
+            HostingCause::TransitGet,
             HostingCause::SubOpGet,
             HostingCause::ClientPut,
             HostingCause::StartupRestore,
@@ -2554,10 +2646,10 @@ mod tests {
         );
         for cause in [
             HostingCause::ClientGet,
-            HostingCause::RelayGet,
+            HostingCause::TransitGet,
             HostingCause::SubOpGet,
             HostingCause::ClientPut,
-            HostingCause::RelayPut,
+            HostingCause::TransitPut,
             HostingCause::Other,
         ] {
             assert_eq!(
@@ -2582,7 +2674,7 @@ mod tests {
             AccessType::Put,
             0,
             NEUTRAL_DEMAND,
-            HostingCause::RelayPut,
+            HostingCause::TransitPut,
             |_| (0, 0),
         );
         // A SUBSCRIBE-only entry never stamps `last_genuine_access` at all.
@@ -2668,7 +2760,7 @@ mod tests {
             AccessType::Get,
             0,
             NEUTRAL_DEMAND,
-            HostingCause::RelayGet,
+            HostingCause::TransitGet,
             |_| (0, 0),
         );
         assert_eq!(
@@ -2690,7 +2782,7 @@ mod tests {
             "the begin counter is monotonic: eviction does not un-decide the \
              hosting that happened"
         );
-        assert_eq!(stats.hosting_begins[HostingCause::RelayGet.index()], 1);
+        assert_eq!(stats.hosting_begins[HostingCause::TransitGet.index()], 1);
     }
 
     /// Project the `(key, write_generation)` reclaim pairs out of a

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -62,7 +62,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::time::Instant;
 
-use crate::ring::futile_repair::{FutileRepairDetector, FutileRepairSnapshot};
+use crate::ring::futile_repair::{FutileRepairDetector, FutileRepairSnapshot, OutcomeEvidence};
 use crate::transport::TransportPublicKey;
 use crate::util::time_source::TimeSource;
 
@@ -1589,16 +1589,23 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// `converged` is the anti-entropy staleness verdict inverted: pass
     /// `!is_stale` from the comparison that produced it. Only call this where
     /// BOTH sides reported a real summary — a one-sided comparison is not an
-    /// outcome, because there was no divergence to repair. Changes no
-    /// behaviour.
+    /// outcome, because there was no divergence to repair.
+    ///
+    /// `evidence` says what that verdict rests on. `is_stale` collapses a real
+    /// verdict together with two conservative defaults (probe budget spent,
+    /// probe unavailable) that classify as STALE with nothing behind them, and
+    /// whose frequency grows with load; pass the right
+    /// [`OutcomeEvidence`] so the detector can keep them out of the headline.
+    /// Changes no behaviour.
     pub(crate) fn record_repair_outcome(
         &self,
         contract: &ContractKey,
         peer: &PeerKey,
         converged: bool,
+        evidence: OutcomeEvidence,
     ) {
         self.futile_repair
-            .record_repair_outcome(contract, peer, converged, self.now());
+            .record_repair_outcome(contract, peer, converged, evidence, self.now());
     }
 
     pub(crate) fn futile_repair_snapshot(&self) -> FutileRepairSnapshot {
@@ -2278,6 +2285,20 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             .iter()
             .filter(|contract| self.remove_peer_interest_for(contract, peer, cause))
             .count();
+
+        // SHADOW MODE (futile-repair detector). The edge's state dies with the
+        // peer's interest state: this is what bounds the lifetime of an
+        // outstanding repair attempt now that pairing an attempt with its
+        // outcome is NOT wall-clock gated (a wall-clock gate expired every
+        // attempt on slow-rotation links — see `crate::ring::futile_repair`,
+        // "Pairing an attempt with its outcome"). Nothing will settle a heal
+        // sent to a peer that is gone, so the attempt is discarded rather than
+        // left for a comparison after some later reconnect. Pure accounting:
+        // no gate, no behaviour change. Deliberately hooked HERE and not in
+        // the per-contract `remove_peer_interest`, so ordinary interest churn
+        // (a `ChangeInterests` message) does not throw away live attempts.
+        self.futile_repair
+            .discard_peer_attempts(peer, contracts.iter());
 
         if removed_count > 0 {
             tracing::debug!(removed_count, "Removed peer interests on disconnect");
@@ -3369,6 +3390,70 @@ mod tests {
         let time_source = SharedMockTimeSource::new();
         let manager = InterestManager::new(time_source.clone());
         (manager, time_source)
+    }
+
+    /// Wiring pin for the SHADOW-MODE futile-repair detector's attempt
+    /// lifetime.
+    ///
+    /// Pairing an attempt with its outcome is deliberately not wall-clock
+    /// gated: on links still taking the byte-budgeted full-bytes summary
+    /// fallback a contract is re-compared on the order of ten hours, and the
+    /// 30-minute expiry this replaces would have expired every attempt on
+    /// exactly the heavy-summary links the detector exists to find. What bounds
+    /// the attempt instead is the edge's own lifetime — so peer-interest
+    /// teardown MUST discard it, or a comparison made after some later
+    /// reconnect settles a long-dead heal as though it had just failed.
+    ///
+    /// The detector's own unit tests cover `discard_peer_attempts`; what they
+    /// cannot see is whether disconnect teardown actually calls it.
+    #[test]
+    fn disconnect_teardown_discards_outstanding_repair_attempts() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(1);
+        let departing = make_peer_key(1);
+        let staying = make_peer_key(2);
+
+        for peer in [&departing, &staying] {
+            manager.register_peer_interest(&contract, peer.clone(), None, false);
+            manager.record_repair_attempt(&contract, peer);
+        }
+        assert_eq!(manager.futile_repair_snapshot().tracked_edges, 2);
+
+        manager.remove_all_peer_interests(&departing);
+
+        let snap = manager.futile_repair_snapshot();
+        assert_eq!(
+            snap.attempts_discarded, 1,
+            "the departing peer's outstanding heal must be discarded when its \
+             interest state is torn down — nothing will ever settle it"
+        );
+        assert_eq!(
+            snap.tracked_edges, 1,
+            "only the departing peer's edge is dropped"
+        );
+
+        // The departed peer's attempt is gone, so a comparison after a
+        // reconnect is unpaired rather than futile...
+        manager.record_repair_outcome(
+            &contract,
+            &departing,
+            false,
+            crate::ring::futile_repair::OutcomeEvidence::Verdict,
+        );
+        // ...while the peer that stayed still has its attempt to settle.
+        manager.record_repair_outcome(
+            &contract,
+            &staying,
+            false,
+            crate::ring::futile_repair::OutcomeEvidence::Verdict,
+        );
+
+        let snap = manager.futile_repair_snapshot();
+        assert_eq!(snap.observations_unpaired, 1);
+        assert_eq!(
+            snap.futile, 1,
+            "teardown must be scoped to the departing peer, not to the contract"
+        );
     }
 
     /// [`summary_digest`] must be a FIXED function of the bytes — identical on

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -4024,19 +4024,19 @@ mod tests {
             InterestRegistrationSource::SubscribeRelay,
         ));
 
-        let first = match manager.begin_peer_summary_broadcast(&contract, &missing_peer) {
-            PeerSummaryForBroadcast::Missing {
-                attempt: Some(attempt),
-                ..
-            } => attempt,
-            _ => panic!("missing peer must produce a tracked attempt"),
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(first),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &missing_peer)
+        else {
+            panic!("missing peer must produce a tracked attempt");
         };
-        let second = match manager.begin_peer_summary_broadcast(&contract, &missing_peer) {
-            PeerSummaryForBroadcast::Missing {
-                attempt: Some(attempt),
-                ..
-            } => attempt,
-            _ => panic!("overlapping missing send must produce another attempt"),
+        let PeerSummaryForBroadcast::Missing {
+            attempt: Some(second),
+            ..
+        } = manager.begin_peer_summary_broadcast(&contract, &missing_peer)
+        else {
+            panic!("overlapping missing send must produce another attempt");
         };
         assert_eq!(second.class, MissingSummaryClass::TrackedRepeatInflight);
         drop(manager.missing_summary_attempt_guard(first));
@@ -4091,15 +4091,15 @@ mod tests {
         let (manager, _time) = make_manager();
 
         for seed in 0..=MISSING_SUMMARY_HISTORY_SIZE as u32 {
-            let attempt = match manager.begin_peer_summary_broadcast(
+            let PeerSummaryForBroadcast::Missing {
+                attempt: Some(attempt),
+                ..
+            } = manager.begin_peer_summary_broadcast(
                 &make_unique_contract_key(seed),
                 &make_unique_peer_key(seed),
-            ) {
-                PeerSummaryForBroadcast::Missing {
-                    attempt: Some(attempt),
-                    ..
-                } => attempt,
-                _ => panic!("untracked pair must produce an attempt"),
+            )
+            else {
+                panic!("untracked pair must produce an attempt");
             };
             drop(manager.missing_summary_attempt_guard(attempt));
         }
@@ -4111,15 +4111,15 @@ mod tests {
         let active_probe_start = MISSING_SUMMARY_HISTORY_SIZE as u32 + 10_000;
         for seed in active_probe_start..active_probe_start + MISSING_SUMMARY_ACTIVE_SIZE as u32 + 1
         {
-            let attempt = match manager.begin_peer_summary_broadcast(
+            let PeerSummaryForBroadcast::Missing {
+                attempt: Some(attempt),
+                ..
+            } = manager.begin_peer_summary_broadcast(
                 &make_unique_contract_key(seed),
                 &make_unique_peer_key(seed),
-            ) {
-                PeerSummaryForBroadcast::Missing {
-                    attempt: Some(attempt),
-                    ..
-                } => attempt,
-                _ => panic!("untracked pair must produce an attempt"),
+            )
+            else {
+                panic!("untracked pair must produce an attempt");
             };
             guards.push(manager.missing_summary_attempt_guard(attempt));
         }
@@ -4152,15 +4152,15 @@ mod tests {
         );
 
         for seed in 0..WORKING_SET {
-            let attempt = match manager.begin_peer_summary_broadcast(
+            let PeerSummaryForBroadcast::Missing {
+                attempt: Some(attempt),
+                ..
+            } = manager.begin_peer_summary_broadcast(
                 &make_unique_contract_key(seed),
                 &make_unique_peer_key(seed),
-            ) {
-                PeerSummaryForBroadcast::Missing {
-                    attempt: Some(attempt),
-                    ..
-                } => attempt,
-                _ => panic!("untracked pair must produce an attempt"),
+            )
+            else {
+                panic!("untracked pair must produce an attempt");
             };
             drop(manager.missing_summary_attempt_guard(attempt));
         }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -62,6 +62,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::time::Instant;
 
+use crate::ring::futile_repair::{FutileRepairDetector, FutileRepairSnapshot};
 use crate::transport::TransportPublicKey;
 use crate::util::time_source::TimeSource;
 
@@ -1146,6 +1147,12 @@ pub struct InterestManager<T: TimeSource> {
     /// concurrent racers, not fixed at one).
     missing_summary_active: DashMap<(ContractKey, PeerKey), u16>,
     interest_lifecycle_metrics: InterestLifecycleMetrics,
+
+    /// SHADOW MODE. Counts (contract, peer) edges whose repairs keep failing to
+    /// converge — the observable signature of a contract whose merge is not
+    /// commutative. Observes only: it never gates, throttles, or suppresses a
+    /// heal. See [`crate::ring::futile_repair`].
+    futile_repair: FutileRepairDetector,
 }
 
 /// Delivery-gated lifecycle accounting. Dropping an unmarked guard records no
@@ -1204,6 +1211,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             )),
             missing_summary_active: DashMap::new(),
             interest_lifecycle_metrics: InterestLifecycleMetrics::new(),
+            futile_repair: FutileRepairDetector::new(),
         }
     }
 
@@ -1560,6 +1568,41 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     .fetch_add(1, Ordering::Relaxed);
             }
         }
+    }
+
+    /// SHADOW MODE — record that a `SyncStateToPeer` heal was actually emitted
+    /// for this (contract, peer) edge.
+    ///
+    /// Call from the one site that emits the heal
+    /// (`node::emit_stale_peer_syncs`) and only for contracts that really got
+    /// one: a contract skipped for being banned, having no local state, or
+    /// exceeding the per-message emit budget is not an attempt. Changes no
+    /// behaviour — see [`crate::ring::futile_repair`].
+    pub(crate) fn record_repair_attempt(&self, contract: &ContractKey, peer: &PeerKey) {
+        self.futile_repair
+            .record_repair_attempt(contract, peer, self.now());
+    }
+
+    /// SHADOW MODE — record the verdict of a TWO-SIDED summary comparison for
+    /// this (contract, peer) edge, settling any outstanding repair attempt.
+    ///
+    /// `converged` is the anti-entropy staleness verdict inverted: pass
+    /// `!is_stale` from the comparison that produced it. Only call this where
+    /// BOTH sides reported a real summary — a one-sided comparison is not an
+    /// outcome, because there was no divergence to repair. Changes no
+    /// behaviour.
+    pub(crate) fn record_repair_outcome(
+        &self,
+        contract: &ContractKey,
+        peer: &PeerKey,
+        converged: bool,
+    ) {
+        self.futile_repair
+            .record_repair_outcome(contract, peer, converged, self.now());
+    }
+
+    pub(crate) fn futile_repair_snapshot(&self) -> FutileRepairSnapshot {
+        self.futile_repair.snapshot()
     }
 
     pub(crate) fn interest_lifecycle_snapshot(&self) -> InterestLifecycleSnapshot {

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -294,8 +294,8 @@ pub(crate) struct NetworkEfficiencyV1 {
     /// `TelemetryLocalMetricsSnapshot::network_efficiency_delivery`.
     pub eff: [u64; 8],
     /// Monotonic hosting-BEGIN counts by CAUSE; row order is
-    /// `ring::hosting::HostingCause::ALL`: client GET, relay GET, sub-op GET,
-    /// client PUT, relay PUT, startup restore, unattributed.
+    /// `ring::hosting::HostingCause::ALL`: client GET, transit GET, sub-op GET,
+    /// client PUT, transit PUT, startup restore, unattributed.
     ///
     /// Answers "why is this peer hosting this contract" in aggregate, which
     /// nothing recorded before: `AccessType` distinguishes only GET from PUT and

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -302,17 +302,59 @@ pub(crate) struct NetworkEfficiencyV1 {
     ///
     /// Order (`FutileRepairSnapshot::to_row`, which is the wire contract):
     /// attempts, futile, productive, observations_unpaired,
-    /// attempts_superseded, attempts_expired, would_quarantine,
-    /// edges_at_threshold, tracked_edges, evictions,
-    /// evictions_losing_streak.
+    /// attempts_superseded, attempts_discarded,
+    /// outcomes_probe_budget_exhausted, outcomes_probe_unavailable,
+    /// outcomes_after_long_gap, would_quarantine, edges_at_threshold,
+    /// tracked_edges, evictions, evictions_losing_streak.
     ///
     /// `would_quarantine` is the headline: edges that reached
     /// `futile_repair::QUARANTINE_THRESHOLD` consecutive futile repairs.
-    /// NOTHING is quarantined — this release only measures. Read
-    /// `tracked_edges` against `futile_repair::EDGE_CAPACITY` and
-    /// `evictions_losing_streak` BEFORE reading the rest: a saturated LRU makes
-    /// every futility count an undercount, which is how `ms_unt_age` became
-    /// useless.
+    /// NOTHING is quarantined — this release only measures.
+    ///
+    /// # Read these four rows BEFORE the headline
+    ///
+    /// Each is a way the headline can be wrong, in the direction named:
+    ///
+    /// * `outcomes_probe_budget_exhausted` — comparisons where "stale" was the
+    ///   conservative DEFAULT because the per-message WASM probe budget
+    ///   (`node::MAX_STALENESS_PROBES_PER_SUMMARIES` = 32) was spent, not a
+    ///   verdict. Excluded from `futile` for exactly this reason: it grows with
+    ///   peer breadth and node load, so a large value means the heal path is
+    ///   classifying load as staleness and any future gating threshold has to
+    ///   be set knowing that.
+    /// * `outcomes_probe_unavailable` — the same default, but because the
+    ///   contract's own `get_state_delta` errored or timed out. Contract or
+    ///   runtime health, not divergence.
+    /// * `outcomes_after_long_gap` — classified outcomes settled more than
+    ///   `futile_repair::LONG_GAP_THRESHOLD` after their attempt. Not a
+    ///   separate class (these ARE in `futile`/`productive`), but the longer the
+    ///   gap the likelier something other than our heal moved the state. On
+    ///   links still taking the byte-budgeted full-bytes fallback a contract is
+    ///   re-compared on the order of ten hours, so these can dominate; if they
+    ///   do, the headline is measuring rotation latency.
+    /// * `attempts_discarded` — attempts dropped unsettled because the peer's
+    ///   interest state was torn down after the disconnect grace period. An
+    ///   undercount, and the honest denominator for `futile + productive`
+    ///   alongside `attempts`.
+    ///
+    /// Then read `tracked_edges` against `futile_repair::EDGE_CAPACITY`
+    /// together with `evictions_losing_streak`: a saturated LRU makes every
+    /// futility count an undercount, which is how `ms_unt_age` became useless.
+    ///
+    /// # Two things a fleet aggregation gets wrong by default
+    ///
+    /// * **Every row is PER OBSERVER.** Divergence is symmetric — A sees B
+    ///   stale while B sees A stale — so both ends of a stuck edge heal it,
+    ///   observe futility, and count it. A fleet SUM of `would_quarantine` is
+    ///   roughly **2x** the number of distinct stuck edges, and nothing on the
+    ///   wire carries an edge identity to deduplicate with. Halve it, or treat
+    ///   it as an upper bound.
+    /// * **`futile : productive` is not a repair-efficacy ratio.** Attempts are
+    ///   recorded only for anti-entropy heals, but an edge also converges via
+    ///   the proximity-overlap heal or plain live UPDATE fan-out, neither of
+    ///   which records anything — so `productive` credits the outstanding
+    ///   anti-entropy heal for whatever actually fixed it. It says "converged
+    ///   by the next comparison", not "our heal converged it".
     pub futile: [u64; crate::ring::futile_repair::SNAPSHOT_SCALARS],
     /// Survival curve of consecutive-futility streaks over the rungs
     /// `futile_repair::LADDER_RUNGS` (1, 2, 3, 4, 5, 8, 16, 32): entry `i`
@@ -1851,6 +1893,66 @@ pub enum RouteOutcome {
 #[cfg(test)]
 mod tests {
     use crate::ring::Distance;
+
+    /// `NetworkEfficiencyV1`'s `futile` rustdoc, isolated from this test module
+    /// — the needles below appear here too, and a pin that matches its own
+    /// source can never fail.
+    fn futile_row_doc() -> &'static str {
+        const FULL: &str = include_str!("router.rs");
+        let start = FULL
+            .find("pub(crate) struct NetworkEfficiencyV1")
+            .expect("NetworkEfficiencyV1 not found");
+        let end = FULL[start..]
+            .find("pub futile_ladder")
+            .map(|off| start + off)
+            .expect("the futile row must still be declared on NetworkEfficiencyV1");
+        &FULL[start..end]
+    }
+
+    /// The `futile` row's rustdoc is the only place a reader of the fleet data
+    /// meets these counters, and several of them are wrong in a specific,
+    /// plausible direction if read naively. Each caveat below was a review
+    /// finding; each would regress into a wrong published number rather than a
+    /// failing test, so the doc is pinned like code.
+    #[test]
+    fn futile_row_doc_carries_the_reading_caveats() {
+        let doc = futile_row_doc();
+        for (needle, why) in [
+            (
+                "outcomes_probe_budget_exhausted",
+                "the load-correlated channel: past the 32-probe budget every \
+                 further contract reads as stale with no divergence at all, so \
+                 the reader has to be able to size it",
+            ),
+            (
+                "outcomes_after_long_gap",
+                "on byte-budgeted fallback links a contract is re-compared on \
+                 the order of ten hours, so the headline can be carried by \
+                 outcomes whose attempt is long stale",
+            ),
+            (
+                "attempts_discarded",
+                "attempts dropped at peer teardown are where the undercount \
+                 lives, and are the counter most likely to be non-zero",
+            ),
+            (
+                "PER OBSERVER",
+                "both ends of a diverged edge count the same stuck edge, so a \
+                 fleet SUM of would_quarantine is ~2x the distinct population",
+            ),
+            (
+                "not a repair-efficacy ratio",
+                "an edge also converges via the proximity-overlap heal or live \
+                 UPDATE fan-out, neither of which records an attempt, so \
+                 `productive` credits our heal for someone else's fix",
+            ),
+        ] {
+            assert!(
+                doc.contains(needle),
+                "the `futile` row rustdoc no longer mentions `{needle}` — {why}"
+            );
+        }
+    }
 
     use super::*;
 

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -293,6 +293,33 @@ pub(crate) struct NetworkEfficiencyV1 {
     /// Delivery path for this diagnostic block itself; order is documented in
     /// `TelemetryLocalMetricsSnapshot::network_efficiency_delivery`.
     pub eff: [u64; 8],
+    /// SHADOW-MODE futile-repair detector (`crate::ring::futile_repair`): how
+    /// often does an anti-entropy heal leave the (contract, peer) edge still
+    /// diverged? A non-commutative contract merge cannot converge, so the
+    /// repair loop runs forever — seven contract instances were 32.7% of all
+    /// update applies on 2026-08-09 for exactly this reason. Aggregate only,
+    /// no per-contract or per-peer label.
+    ///
+    /// Order (`FutileRepairSnapshot::to_row`, which is the wire contract):
+    /// attempts, futile, productive, observations_unpaired,
+    /// attempts_superseded, attempts_expired, would_quarantine,
+    /// edges_at_threshold, tracked_edges, evictions,
+    /// evictions_losing_streak.
+    ///
+    /// `would_quarantine` is the headline: edges that reached
+    /// `futile_repair::QUARANTINE_THRESHOLD` consecutive futile repairs.
+    /// NOTHING is quarantined — this release only measures. Read
+    /// `tracked_edges` against `futile_repair::EDGE_CAPACITY` and
+    /// `evictions_losing_streak` BEFORE reading the rest: a saturated LRU makes
+    /// every futility count an undercount, which is how `ms_unt_age` became
+    /// useless.
+    pub futile: [u64; crate::ring::futile_repair::SNAPSHOT_SCALARS],
+    /// Survival curve of consecutive-futility streaks over the rungs
+    /// `futile_repair::LADDER_RUNGS` (1, 2, 3, 4, 5, 8, 16, 32): entry `i`
+    /// counts streaks that REACHED rung `i`, at most once per rung per streak,
+    /// so the series is monotonically non-increasing and reads as "of the
+    /// streaks that got to 1, how many got to 32".
+    pub futile_ladder: [u64; crate::ring::futile_repair::LADDER_LEN],
 }
 
 /// Periodic snapshot of the router model state for telemetry.

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -293,6 +293,36 @@ pub(crate) struct NetworkEfficiencyV1 {
     /// Delivery path for this diagnostic block itself; order is documented in
     /// `TelemetryLocalMetricsSnapshot::network_efficiency_delivery`.
     pub eff: [u64; 8],
+    /// Monotonic hosting-BEGIN counts by CAUSE; row order is
+    /// `ring::hosting::HostingCause::ALL`: client GET, relay GET, sub-op GET,
+    /// client PUT, relay PUT, startup restore, unattributed.
+    ///
+    /// Answers "why is this peer hosting this contract" in aggregate, which
+    /// nothing recorded before: `AccessType` distinguishes only GET from PUT and
+    /// so cannot separate a client's own request from transit — the distinction
+    /// every hosting-policy decision rests on. In particular a subscribe-fetch
+    /// travels the ordinary GET driver as a sub-op, and was indistinguishable
+    /// from a plain GET until this split.
+    ///
+    /// Counted at the cache branch that inserts, so a refresh of an
+    /// already-hosted contract is NOT counted. `Other` (last row) is a leak
+    /// detector, not a category: it should be 0 in the field, and a nonzero
+    /// value means some production path began hosting without naming a cause.
+    pub host_begin: [u64; crate::ring::HostingCause::COUNT],
+    /// GAUGE (not a counter — do not difference): distribution of `read_count`
+    /// across the currently hosted set. Buckets: 0, 1, 2-3, 4-9, 10-99, >=100.
+    ///
+    /// `read_count` is half of the demand signal the subscriber-primary eviction
+    /// ranking is built on, and it previously reached only the node's own local
+    /// HTML dashboard — no `send_event` call site touched it — so the shape of
+    /// the signal the policy depends on was unobservable fleet-wide.
+    pub host_reads: [u64; crate::ring::READ_COUNT_HIST_BUCKETS],
+    /// GAUGE: distribution of `last_genuine_access` AGE across the currently
+    /// hosted set. Buckets: within the 5-minute cost window, <20 min, <2 h,
+    /// older, never genuinely accessed. Bucket 0 over the hosted-set total is
+    /// the share cost-pressure eviction currently treats as recently-accessed.
+    /// The other half of the previously node-local demand signal.
+    pub host_recency: [u64; crate::ring::GENUINE_ACCESS_RECENCY_BUCKETS],
 }
 
 /// Periodic snapshot of the router model state for telemetry.

--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -228,6 +228,19 @@ fn retry_loading_page() -> String {
     )
 }
 
+/// Minimal HTML entity escaping for error bodies rendered at the node origin.
+///
+/// Deliberately duplicated from `permission_prompts::html_escape` rather than
+/// shared: this module is on the error path of every route and must not depend
+/// on a sibling that may itself fail to build.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -470,17 +483,4 @@ mod tests {
         let response = err.into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
-}
-
-/// Minimal HTML entity escaping for error bodies rendered at the node origin.
-///
-/// Deliberately duplicated from `permission_prompts::html_escape` rather than
-/// shared: this module is on the error path of every route and must not depend
-/// on a sibling that may itself fail to build.
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#x27;")
 }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3362,8 +3362,27 @@ mod tests {
 
         const BUSY_FLEET_COUNTER: u64 = 999_999;
         const MAX_EMPTY_JSON_BYTES: usize = 2_048;
-        const MAX_BUSY_JSON_BYTES: usize = 5_120;
-        const MAX_WORST_CASE_JSON_BYTES: usize = 14_336;
+        // Raised from 5_120 to admit `futile` + `futile_ladder`, the
+        // shadow-mode futile-repair block (`crate::ring::futile_repair`). This
+        // is the first time the JSON-bytes budgets have moved, so the same
+        // arithmetic the OTLP budgets carry is owed here:
+        //
+        //   19 new counters (11 scalars + an 8-rung survival ladder)
+        //   +162 JSON bytes at busy-fleet values (5095 measured -> 5257)
+        //   emitted once per ~30 min per peer, ~2000 reporting peers
+        //   => 48 * 2000 * ~162 B ~= 16 MB/day
+        //
+        // against a collector ingesting ~88.8 GB/day: about 0.02%. The block
+        // is already the minimum that answers its question — the ladder is 8
+        // rungs rather than a per-value histogram, and there is deliberately
+        // no per-contract or per-peer label (the cardinality would be
+        // attacker-controlled). Do NOT raise this again without redoing the
+        // arithmetic.
+        const MAX_BUSY_JSON_BYTES: usize = 5_376;
+        // Raised from 14_336 alongside the busy budget, same 19 counters. This
+        // is the MATHEMATICAL ceiling (every counter at u64::MAX, 20 digits),
+        // so it constrains schema shape rather than real bytes.
+        const MAX_WORST_CASE_JSON_BYTES: usize = 14_848;
         const MAX_EMPTY_OTLP_MARGINAL_BYTES: usize = 2_048;
         // Raised from 5_120 (2026-08-07) to admit `ms_size` + `ms_unt_age`,
         // the two counters added for #5153. The budget exists to force this
@@ -3379,12 +3398,15 @@ mod tests {
         // of 10 classes (the other 6 are a measured zero) and 6 size buckets
         // rather than 8. Do NOT raise this again without redoing the
         // arithmetic; the JSON-bytes budgets above are deliberately unchanged.
-        const MAX_BUSY_OTLP_MARGINAL_BYTES: usize = 5_376;
+        // Raised again from 5_376 for the 19 futile-repair counters; see the
+        // arithmetic on MAX_BUSY_JSON_BYTES above.
+        const MAX_BUSY_OTLP_MARGINAL_BYTES: usize = 5_632;
         // Raised from 14_336 alongside the busy budget above, same 30 new
-        // counters, same #5153 rationale. This bound is the MATHEMATICAL
-        // ceiling (every counter at u64::MAX, 20 digits); no fleet value
-        // approaches it, so it constrains schema shape rather than real bytes.
-        const MAX_WORST_OTLP_MARGINAL_BYTES: usize = 14_592;
+        // counters, same #5153 rationale, then again for the 19 futile-repair
+        // counters. This bound is the MATHEMATICAL ceiling (every counter at
+        // u64::MAX, 20 digits); no fleet value approaches it, so it constrains
+        // schema shape rather than real bytes.
+        const MAX_WORST_OTLP_MARGINAL_BYTES: usize = 15_104;
         const MAX_NULL_OTLP_MARGINAL_BYTES: usize = 64;
 
         let diagnostic = |value| crate::router::NetworkEfficiencyV1 {
@@ -3421,6 +3443,8 @@ mod tests {
             tel: [value; 15],
             shadow: [[value; 9]; 7],
             eff: [value; 8],
+            futile: [value; crate::ring::futile_repair::SNAPSHOT_SCALARS],
+            futile_ladder: [value; crate::ring::futile_repair::LADDER_LEN],
         };
 
         let mut u = arbitrary::Unstructured::new(&[0_u8; 32_768]);
@@ -3434,7 +3458,7 @@ mod tests {
         let object = block
             .as_object()
             .expect("network_efficiency_v1 must remain a JSON object");
-        assert_eq!(object.len(), 33, "schema must remain fixed-cardinality");
+        assert_eq!(object.len(), 35, "schema must remain fixed-cardinality");
         let encoded = serde_json::to_vec(block).expect("serialize diagnostic block");
         assert!(
             encoded.len() <= MAX_BUSY_JSON_BYTES,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3367,10 +3367,10 @@ mod tests {
         // is the first time the JSON-bytes budgets have moved, so the same
         // arithmetic the OTLP budgets carry is owed here:
         //
-        //   19 new counters (11 scalars + an 8-rung survival ladder)
-        //   +162 JSON bytes at busy-fleet values (5095 measured -> 5257)
+        //   22 new counters (14 scalars + an 8-rung survival ladder)
+        //   +183 JSON bytes at busy-fleet values (5095 measured -> 5278)
         //   emitted once per ~30 min per peer, ~2000 reporting peers
-        //   => 48 * 2000 * ~162 B ~= 16 MB/day
+        //   => 48 * 2000 * ~183 B ~= 18 MB/day
         //
         // against a collector ingesting ~88.8 GB/day: about 0.02%. The block
         // is already the minimum that answers its question — the ladder is 8
@@ -3378,8 +3378,14 @@ mod tests {
         // no per-contract or per-peer label (the cardinality would be
         // attacker-controlled). Do NOT raise this again without redoing the
         // arithmetic.
+        //
+        // The scalar count went 11 -> 14 during review (the three rows that
+        // say when the headline must NOT be read at face value:
+        // `outcomes_probe_budget_exhausted`, `outcomes_probe_unavailable`,
+        // `outcomes_after_long_gap`). That cost 21 bytes and needed no further
+        // raise — the figure above is re-measured, not extrapolated.
         const MAX_BUSY_JSON_BYTES: usize = 5_376;
-        // Raised from 14_336 alongside the busy budget, same 19 counters. This
+        // Raised from 14_336 alongside the busy budget, same 22 counters. This
         // is the MATHEMATICAL ceiling (every counter at u64::MAX, 20 digits),
         // so it constrains schema shape rather than real bytes.
         const MAX_WORST_CASE_JSON_BYTES: usize = 14_848;
@@ -3398,11 +3404,11 @@ mod tests {
         // of 10 classes (the other 6 are a measured zero) and 6 size buckets
         // rather than 8. Do NOT raise this again without redoing the
         // arithmetic; the JSON-bytes budgets above are deliberately unchanged.
-        // Raised again from 5_376 for the 19 futile-repair counters; see the
+        // Raised again from 5_376 for the 22 futile-repair counters; see the
         // arithmetic on MAX_BUSY_JSON_BYTES above.
         const MAX_BUSY_OTLP_MARGINAL_BYTES: usize = 5_632;
         // Raised from 14_336 alongside the busy budget above, same 30 new
-        // counters, same #5153 rationale, then again for the 19 futile-repair
+        // counters, same #5153 rationale, then again for the 22 futile-repair
         // counters. This bound is the MATHEMATICAL ceiling (every counter at
         // u64::MAX, 20 digits); no fleet value approaches it, so it constrains
         // schema shape rather than real bytes.

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3362,8 +3362,29 @@ mod tests {
 
         const BUSY_FLEET_COUNTER: u64 = 999_999;
         const MAX_EMPTY_JSON_BYTES: usize = 2_048;
-        const MAX_BUSY_JSON_BYTES: usize = 5_120;
-        const MAX_WORST_CASE_JSON_BYTES: usize = 14_336;
+        // Raised from 5_120 (2026-08-09) to admit the hosting-observability
+        // counters: `host_begin` (7 causes) + `host_reads` (6 buckets) +
+        // `host_recency` (5 buckets). Arithmetic, as the budget demands:
+        //
+        //   18 new counters
+        //   +173 JSON bytes at busy-fleet values (5095 -> 5268 measured)
+        //   emitted once per ~30 min per peer, ~2000 reporting peers
+        //   => 48 * 2000 * ~173 B ~= 17 MB/day
+        //
+        // against a collector ingesting ~88.8 GB/day: about 0.019%. The block
+        // is deliberately narrow for what it buys — the hosting-begin row is
+        // the ONLY record of why a peer hosts anything, and the two histograms
+        // are the only fleet-wide view of `read_count` / `last_genuine_access`,
+        // the demand signals the eviction ranking is built on (they previously
+        // reached the node's own HTML dashboard and nothing else). Per-contract
+        // labels were never an option: contract keys are attacker-chosen, so
+        // labelling would hand an attacker control of collector cardinality.
+        const MAX_BUSY_JSON_BYTES: usize = 5_376;
+        // Raised from 14_336 alongside the busy budget, same 18 counters. This
+        // is the MATHEMATICAL ceiling (every counter at u64::MAX, 20 digits),
+        // measured 14_704; no fleet value approaches it, so it constrains
+        // schema shape rather than real bytes.
+        const MAX_WORST_CASE_JSON_BYTES: usize = 14_848;
         const MAX_EMPTY_OTLP_MARGINAL_BYTES: usize = 2_048;
         // Raised from 5_120 (2026-08-07) to admit `ms_size` + `ms_unt_age`,
         // the two counters added for #5153. The budget exists to force this
@@ -3380,11 +3401,12 @@ mod tests {
         // rather than 8. Do NOT raise this again without redoing the
         // arithmetic; the JSON-bytes budgets above are deliberately unchanged.
         const MAX_BUSY_OTLP_MARGINAL_BYTES: usize = 5_376;
-        // Raised from 14_336 alongside the busy budget above, same 30 new
-        // counters, same #5153 rationale. This bound is the MATHEMATICAL
-        // ceiling (every counter at u64::MAX, 20 digits); no fleet value
-        // approaches it, so it constrains schema shape rather than real bytes.
-        const MAX_WORST_OTLP_MARGINAL_BYTES: usize = 14_592;
+        // Raised from 14_336 for #5153, then from 14_592 (2026-08-09) for the
+        // 18 hosting-observability counters — measured 14_772. Same
+        // MATHEMATICAL-ceiling character as `MAX_WORST_CASE_JSON_BYTES`: no
+        // fleet value approaches it. The busy OTLP marginal moved 5157 -> 5336
+        // and still fits its unchanged 5_376 budget.
+        const MAX_WORST_OTLP_MARGINAL_BYTES: usize = 14_848;
         const MAX_NULL_OTLP_MARGINAL_BYTES: usize = 64;
 
         let diagnostic = |value| crate::router::NetworkEfficiencyV1 {
@@ -3421,6 +3443,9 @@ mod tests {
             tel: [value; 15],
             shadow: [[value; 9]; 7],
             eff: [value; 8],
+            host_begin: [value; 7],
+            host_reads: [value; 6],
+            host_recency: [value; 5],
         };
 
         let mut u = arbitrary::Unstructured::new(&[0_u8; 32_768]);
@@ -3434,7 +3459,7 @@ mod tests {
         let object = block
             .as_object()
             .expect("network_efficiency_v1 must remain a JSON object");
-        assert_eq!(object.len(), 33, "schema must remain fixed-cardinality");
+        assert_eq!(object.len(), 36, "schema must remain fixed-cardinality");
         let encoded = serde_json::to_vec(block).expect("serialize diagnostic block");
         assert!(
             encoded.len() <= MAX_BUSY_JSON_BYTES,
@@ -3512,6 +3537,50 @@ mod tests {
         assert!(
             worst_otlp <= MAX_WORST_OTLP_MARGINAL_BYTES,
             "worst-case OTLP marginal {worst_otlp} > {MAX_WORST_OTLP_MARGINAL_BYTES}"
+        );
+    }
+
+    /// The hosting-observability rows must survive SERIALIZATION into the
+    /// `router_snapshot` body, not merely exist as struct fields.
+    ///
+    /// `network_efficiency_v1` is the only telemetry family that bypasses both
+    /// the node-side rate limiter (which drops ~69-77% of operational events,
+    /// load-proportionally) and the collector's 5% sampler, so a field that
+    /// silently fails to serialize is not "degraded" — it is absent, with no
+    /// second path to notice by. Each row is given a DISTINCT value so a
+    /// transposed assignment (`host_reads` fed from `host_recency`, say) fails
+    /// here instead of quietly publishing the wrong series.
+    #[test]
+    fn router_snapshot_json_carries_hosting_observability_rows() {
+        use arbitrary::Arbitrary;
+
+        let mut u = arbitrary::Unstructured::new(&[0_u8; 32_768]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        let mut block_bytes = arbitrary::Unstructured::new(&[0_u8; 32_768]);
+        let mut block = crate::router::NetworkEfficiencyV1::arbitrary(&mut block_bytes)
+            .expect("construct NetworkEfficiencyV1 for test");
+        block.host_begin = [11, 12, 13, 14, 15, 16, 17];
+        block.host_reads = [21, 22, 23, 24, 25, 26];
+        block.host_recency = [31, 32, 33, 34, 35];
+        info.network_efficiency_v1 = Some(block);
+
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        let efficiency = &json["network_efficiency_v1"];
+        assert_eq!(
+            efficiency["host_begin"],
+            serde_json::json!([11, 12, 13, 14, 15, 16, 17]),
+            "hosting-begin causes must reach the OTLP body"
+        );
+        assert_eq!(
+            efficiency["host_reads"],
+            serde_json::json!([21, 22, 23, 24, 25, 26]),
+            "the read_count gauge must reach the OTLP body"
+        );
+        assert_eq!(
+            efficiency["host_recency"],
+            serde_json::json!([31, 32, 33, 34, 35]),
+            "the genuine-access recency gauge must reach the OTLP body"
         );
     }
 

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -353,10 +353,11 @@ impl<S: Socket> OutboundConnectionHandler<S> {
     /// `GATEWAY_ACK_VERSION_MIN_VERSION`, `None` is production behaviour.
     ///
     /// It takes `bandwidth_limit` too rather than hardcoding `None`. An earlier
-    /// shape had the caller branch between this and `new_test_with_bandwidth`,
-    /// which meant passing a floor override silently discarded any bandwidth
-    /// limit — a trap that would have surfaced as a throughput test which
-    /// mysteriously failed to throttle.
+    /// shape had the caller branch between this and a bandwidth-only
+    /// constructor, which meant passing a floor override silently discarded any
+    /// bandwidth limit — a trap that would have surfaced as a throughput test
+    /// which mysteriously failed to throttle. That second constructor is gone;
+    /// this is the one knob-bearing test constructor.
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn new_test_with_options(
         socket_addr: SocketAddr,
@@ -376,28 +377,6 @@ impl<S: Socket> OutboundConnectionHandler<S> {
             None,
             None,
             ack_version_floor_override,
-        )?;
-        Ok((handler, receiver))
-    }
-
-    #[cfg(any(test, feature = "bench"))]
-    pub(crate) fn new_test_with_bandwidth(
-        socket_addr: SocketAddr,
-        socket: Arc<S>,
-        keypair: TransportKeypair,
-        is_gateway: bool,
-        bandwidth_limit: Option<usize>,
-    ) -> Result<(Self, mpsc::Receiver<PeerConnection<S>>), TransportError> {
-        let (handler, receiver, _listen_handle) = Self::config_listener(
-            socket,
-            keypair,
-            is_gateway,
-            socket_addr,
-            bandwidth_limit,
-            None,
-            None,
-            None,
-            None,
         )?;
         Ok((handler, receiver))
     }

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -3092,6 +3092,28 @@ mod tests {
     // which is exactly the failure mode observed on the live network (16
     // contiguous bytes zeroed inside an otherwise byte-identical contract
     // state).
+    //
+    // SCOPE: `InboundStream` carries large NetMessage sends. It is NOT the
+    // reassembler a contract state travels through - operations-level streams
+    // bypass it entirely (see `process_inbound`'s
+    // `if stream_id.is_operations_stream() { return Ok(None) }`) in favour of
+    // `LockFreeStreamBuffer`. The equivalent coverage for that buffer is the
+    // `streaming_buffer_*` block further down; neither block's result carries
+    // over to the other.
+
+    /// Fragment payload capacities, stated as literals rather than re-derived
+    /// from the sender's own `MAX_DATA_SIZE - (1 + 8 + meta.len())`. An
+    /// expectation computed by the expression under test agrees with that
+    /// expression even when it is wrong, so it cannot fail;
+    /// `fragment_count_literals_are_computed_for_this_max_data_size` is what
+    /// ties these literals to the constants they were computed for.
+    const FULL_FRAGMENT_PAYLOAD: usize = 1130;
+    /// The metadata length every metadata-carrying test below uses.
+    const ROUNDTRIP_METADATA_LEN: usize = 256;
+    /// Fragment #1's payload capacity once `ROUNDTRIP_METADATA_LEN` bytes of
+    /// metadata, a 1-byte `Option` discriminant and an 8-byte length prefix
+    /// have taken their share of `FULL_FRAGMENT_PAYLOAD`.
+    const FIRST_FRAGMENT_PAYLOAD_WITH_METADATA: usize = 865;
 
     /// A multi-fragment stream captured off the simulated wire.
     struct CapturedStream {
@@ -3128,6 +3150,14 @@ mod tests {
         // deadlock the test rather than merely slow it down. Budget the
         // congestion window and the token bucket above the whole transfer so
         // neither can gate a fragment.
+        //
+        // This budget is a belt, not a guarantee: today's default congestion
+        // algorithm is `FixedRate`, whose `current_cwnd()` returns
+        // `usize::MAX / 2`, so the cwnd gate is a no-op and liveness here is
+        // partly accidental. Should the default become BBR or LEDBAT, a
+        // shortfall would park the sender forever on a clock that never
+        // advances. `CAPTURE_TIMEOUT` below turns that into a named failure
+        // instead of a CI run that hangs with no diagnostic.
         let budget = payload.len() + metadata.as_ref().map_or(0, |m| m.len()) + 64 * 1024;
         let congestion_controller =
             crate::transport::congestion_control::CongestionControlConfig::default()
@@ -3204,7 +3234,18 @@ mod tests {
             }
         };
 
-        let (send_result, captured) = tokio::join!(outbound, collect);
+        // Wall-clock bound on a virtual-time transfer: reaching it means the
+        // sender stopped making progress, not that the machine is slow. Every
+        // capture in this module completes in well under a second.
+        const CAPTURE_TIMEOUT: Duration = Duration::from_secs(60);
+        let (send_result, captured) =
+            tokio::time::timeout(CAPTURE_TIMEOUT, async { tokio::join!(outbound, collect) })
+                .await
+                .expect(
+                    "send_stream stalled: it is gated on a cwnd or token-bucket wait that \
+                     VirtualTime will never satisfy, so the budget above no longer covers \
+                     the transfer",
+                );
         send_result
             .expect("send_stream task panicked")
             .expect("send_stream failed");
@@ -3365,8 +3406,15 @@ mod tests {
         // metadata overhead is invisible to a whole-payload check because the
         // sender's total_packets calculation compensates for it.
         let first_fragment_capacity = match &metadata {
-            Some(meta) => MAX_DATA_SIZE - (1 + 8 + meta.len()),
-            None => MAX_DATA_SIZE,
+            Some(meta) => {
+                assert_eq!(
+                    meta.len(),
+                    ROUNDTRIP_METADATA_LEN,
+                    "FIRST_FRAGMENT_PAYLOAD_WITH_METADATA was computed for this metadata length"
+                );
+                FIRST_FRAGMENT_PAYLOAD_WITH_METADATA
+            }
+            None => FULL_FRAGMENT_PAYLOAD,
         };
         assert_eq!(
             captured.fragments[0].1.len(),
@@ -3376,7 +3424,7 @@ mod tests {
         for (number, fragment) in &captured.fragments[1..expected_fragments - 1] {
             assert_eq!(
                 fragment.len(),
-                MAX_DATA_SIZE,
+                FULL_FRAGMENT_PAYLOAD,
                 "{described}: interior fragment #{number} must be full"
             );
         }
@@ -3402,15 +3450,251 @@ mod tests {
         }
     }
 
+    // ------------------------------------------------------------------
+    // The reassembler contract state ACTUALLY uses: LockFreeStreamBuffer
+    // ------------------------------------------------------------------
+    //
+    // `assert_multi_fragment_roundtrip` above exercises `InboundStream`, which
+    // is NOT the reassembler a contract state travels through. Operations-level
+    // streams (`StreamId::next_operations()` - every GET/PUT/broadcast payload)
+    // return from `PeerConnection::process_inbound` BEFORE the legacy
+    // `InboundStream` path is reached, and are reassembled instead by
+    // `LockFreeStreamBuffer` behind `streaming::StreamHandle`, which
+    // `operations/{get,put,update}/op_ctx_task.rs` drain via
+    // `StreamHandle::assemble()`.
+    //
+    // That buffer is a materially different structure - an `AtomicPtr` slot
+    // array with CAS insertion, a contiguous frontier, and a separate consumed
+    // frontier - so a byte-identity result for one says nothing about the
+    // other. These tests run the SAME captured fragments and the SAME delivery
+    // orders through it.
+
+    /// Reassembles `delivery` through the operations-stream path:
+    /// `StreamHandle::push_fragment` into a `LockFreeStreamBuffer`, drained by
+    /// `StreamHandle::assemble()`.
+    ///
+    /// A rejected fragment is surfaced rather than swallowed: the buffer sizes
+    /// its slot array from `total_length_bytes` alone, so a sender that emits
+    /// more fragments than the buffer allocated shows up here as
+    /// `InvalidFragment` instead of as a silently short assembly.
+    async fn reassemble_via_streaming_buffer(
+        total_length_bytes: u64,
+        delivery: Vec<(u32, bytes::Bytes)>,
+    ) -> std::result::Result<Vec<u8>, streaming::StreamError> {
+        let handle = streaming::StreamHandle::new(StreamId::next_operations(), total_length_bytes);
+        for (number, fragment) in delivery {
+            handle.push_fragment(number, fragment)?;
+        }
+        handle.assemble().await
+    }
+
+    /// Asserts a `payload_len`-byte payload survives the real sender's
+    /// fragmentation and `LockFreeStreamBuffer` reassembly byte-identically
+    /// under every delivery order.
+    ///
+    /// Deliberately reuses `capture_stream_fragments`, so the bytes offered to
+    /// the buffer are the same bytes the sender put on the wire, not a
+    /// hand-rolled approximation of them.
+    async fn assert_streaming_buffer_roundtrip(
+        payload_len: usize,
+        metadata: Option<bytes::Bytes>,
+        expected_fragments: usize,
+    ) {
+        assert!(
+            expected_fragments >= 2,
+            "this helper exists to cover MULTI-fragment payloads"
+        );
+
+        let mut payload = vec![0u8; payload_len];
+        crate::config::GlobalRng::fill_bytes(&mut payload);
+
+        let captured = capture_stream_fragments(&payload, metadata.clone()).await;
+        let described = format!(
+            "{payload_len} bytes, metadata={}",
+            metadata.as_ref().map_or(0, |m| m.len())
+        );
+        assert_eq!(
+            captured.fragments.len(),
+            expected_fragments,
+            "{described}: unexpected fragment count"
+        );
+
+        let mut orders: Vec<(&str, Vec<(u32, bytes::Bytes)>)> = vec![
+            ("in order", captured.fragments.clone()),
+            ("reversed", deliver_reversed(&captured)),
+            ("interleaved", deliver_interleaved(&captured)),
+            ("duplicated", deliver_duplicated(&captured)),
+        ];
+        if captured.fragments.len() >= 4 {
+            orders.push(("replay then gap", deliver_replay_then_gap(&captured)));
+        }
+
+        for (order, delivery) in orders {
+            let context = format!("{described}, delivered {order}");
+            let received = reassemble_via_streaming_buffer(captured.total_length_bytes, delivery)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("{context}: LockFreeStreamBuffer reassembly failed: {e}")
+                });
+            assert_bytes_identical(&received, &payload, &context);
+        }
+    }
+
+    /// The 24,832-byte case against the reassembler contract state really uses.
+    #[tokio::test]
+    async fn streaming_buffer_roundtrip_is_byte_identical() {
+        assert_streaming_buffer_roundtrip(24_832, None, 22).await;
+    }
+
+    /// With metadata embedded in fragment #1, the buffer's `+1` overflow slot
+    /// and its `min_complete_fragments` split are both load-bearing: the sender
+    /// emits one more fragment than `ceil(total / MAX_DATA_SIZE)`, and
+    /// `is_complete()` fires one fragment before assembly can succeed.
+    #[tokio::test]
+    async fn streaming_buffer_roundtrip_with_metadata_is_byte_identical() {
+        let mut metadata = vec![0u8; ROUNDTRIP_METADATA_LEN];
+        crate::config::GlobalRng::fill_bytes(&mut metadata);
+        assert_streaming_buffer_roundtrip(24_832, Some(bytes::Bytes::from(metadata)), 23).await;
+    }
+
+    /// 1 MiB over 928 fragments through the CAS slot array.
+    #[tokio::test]
+    async fn large_streaming_buffer_roundtrip_is_byte_identical() {
+        assert_streaming_buffer_roundtrip(1_048_576, None, 928).await;
+    }
+
+    /// Fragment-multiple boundaries, with and without metadata. The
+    /// with-metadata triple is where the buffer's slot allocation
+    /// (`ceil(total / MAX_DATA_SIZE) + 1`) is exactly consumed, so an
+    /// off-by-one there rejects the sender's genuine final fragment.
+    #[tokio::test]
+    async fn streaming_buffer_size_boundaries_are_byte_identical() {
+        assert_streaming_buffer_roundtrip(FULL_FRAGMENT_PAYLOAD * 8, None, 8).await;
+        assert_streaming_buffer_roundtrip(FULL_FRAGMENT_PAYLOAD * 8 - 1, None, 8).await;
+        assert_streaming_buffer_roundtrip(FULL_FRAGMENT_PAYLOAD * 8 + 1, None, 9).await;
+
+        let mut metadata = vec![0u8; ROUNDTRIP_METADATA_LEN];
+        crate::config::GlobalRng::fill_bytes(&mut metadata);
+        let metadata = bytes::Bytes::from(metadata);
+        let exact = FIRST_FRAGMENT_PAYLOAD_WITH_METADATA + FULL_FRAGMENT_PAYLOAD * 7;
+
+        assert_streaming_buffer_roundtrip(exact, Some(metadata.clone()), 8).await;
+        assert_streaming_buffer_roundtrip(exact - 1, Some(metadata.clone()), 8).await;
+        assert_streaming_buffer_roundtrip(exact + 1, Some(metadata), 9).await;
+    }
+
+    /// The incremental consumer (`stream_with_reclaim`, used by piped-stream
+    /// forwarding) reads through `take()`, which empties the slot. Reading and
+    /// inserting interleaved is an ordering `assemble()` never sees, so it gets
+    /// its own byte-identity assertion.
+    #[tokio::test]
+    async fn streaming_buffer_reclaim_consumer_is_byte_identical() {
+        let mut payload = vec![0u8; 24_832];
+        crate::config::GlobalRng::fill_bytes(&mut payload);
+        let captured = capture_stream_fragments(&payload, None).await;
+
+        let handle = streaming::StreamHandle::new(StreamId::next_operations(), 24_832);
+        let mut consumer = handle.stream_with_reclaim();
+        let mut received = Vec::with_capacity(payload.len());
+
+        // Push one fragment, read one fragment, all the way through: the
+        // consumer is always reading a slot the writer touched moments ago.
+        for (number, fragment) in &captured.fragments {
+            handle
+                .push_fragment(*number, fragment.clone())
+                .expect("fragment must be accepted");
+            let chunk = consumer
+                .next()
+                .await
+                .expect("a fragment was just pushed")
+                .expect("stream must not be cancelled");
+            received.extend_from_slice(&chunk);
+        }
+
+        assert_bytes_identical(&received, &payload, "reclaiming consumer");
+    }
+
+    /// `LockFreeStreamBuffer::take()` does not advance `consumed_frontier`, so
+    /// `insert()` still accepts a retransmission of a fragment a reclaiming
+    /// consumer has already read, and refills the emptied slot.
+    ///
+    /// This test pins the CONSEQUENCE, which is the question that matters for
+    /// the #5256 corruption hunt: the refill is a bookkeeping defect (a slot
+    /// that was reclaimed becomes occupied again, and its memory is held until
+    /// the buffer drops), NOT a data defect. The consumer has already advanced
+    /// past that fragment and never re-reads it, and `assemble()` concatenates
+    /// slots strictly in order and stops at the first empty one, so it can
+    /// return `None` but cannot return mis-ordered or holed bytes.
+    ///
+    /// If a future change makes the refilled slot observable in the assembled
+    /// output, this test fails - which is the alarm worth having.
+    #[tokio::test]
+    async fn streaming_buffer_replay_after_reclaim_does_not_corrupt_bytes() {
+        let mut payload = vec![0u8; FULL_FRAGMENT_PAYLOAD * 4];
+        crate::config::GlobalRng::fill_bytes(&mut payload);
+        let captured = capture_stream_fragments(&payload, None).await;
+        assert_eq!(captured.fragments.len(), 4);
+
+        let handle =
+            streaming::StreamHandle::new(StreamId::next_operations(), payload.len() as u64);
+        for (number, fragment) in &captured.fragments {
+            handle.push_fragment(*number, fragment.clone()).unwrap();
+        }
+
+        // A reclaiming consumer takes fragment #1, emptying its slot.
+        let mut consumer = handle.stream_with_reclaim();
+        let first = consumer.next().await.unwrap().unwrap();
+        assert_eq!(first, captured.fragments[0].1);
+
+        // A retransmission of that same fragment arrives afterwards. `take()`
+        // left `consumed_frontier` at 0, so `insert()` treats the emptied slot
+        // as vacant and accepts it.
+        let refilled = handle
+            .push_fragment(1, captured.fragments[0].1.clone())
+            .expect("replay after take is accepted, not rejected as consumed");
+        assert!(
+            refilled,
+            "replay refills the slot a reclaiming consumer already emptied \
+             (see streaming_buffer.rs take(): it does not advance consumed_frontier)"
+        );
+
+        // The consumer never re-reads it: the remaining fragments come back in
+        // order and the concatenation is byte-identical.
+        let mut received = first.to_vec();
+        for _ in 1..captured.fragments.len() {
+            let chunk = consumer.next().await.unwrap().unwrap();
+            received.extend_from_slice(&chunk);
+        }
+        assert_bytes_identical(&received, &payload, "replay after reclaim");
+
+        // And a second consumer assembling the same buffer either sees the
+        // whole payload or nothing - never a corrupted middle.
+        match handle.try_assemble() {
+            Some(assembled) => {
+                assert_bytes_identical(&assembled, &payload, "assemble after reclaim + replay")
+            }
+            None => { /* slots emptied by the consumer: a short read, not a wrong one */ }
+        }
+    }
+
     /// The `expected_fragments` literals in the tests below were computed for
     /// this fragment payload size. Pin it so a change to the fragment overhead
     /// fails loudly here instead of silently re-scoping that coverage.
     #[test]
     fn fragment_count_literals_are_computed_for_this_max_data_size() {
         assert_eq!(
-            MAX_DATA_SIZE, 1130,
+            MAX_DATA_SIZE, FULL_FRAGMENT_PAYLOAD,
             "MAX_DATA_SIZE changed - recompute the expected fragment counts in the \
              multi-fragment roundtrip tests"
+        );
+        // Literal-only arithmetic: the metadata overhead is 1 byte of `Option`
+        // discriminant plus an 8-byte length prefix. Written out here so the
+        // capacity expectations above never have to call the sender's own
+        // expression to know what they expect.
+        assert_eq!(
+            FIRST_FRAGMENT_PAYLOAD_WITH_METADATA + 1 + 8 + ROUNDTRIP_METADATA_LEN,
+            FULL_FRAGMENT_PAYLOAD,
+            "the metadata-reduced first-fragment capacity literal no longer adds up"
         );
     }
 
@@ -3418,10 +3702,14 @@ mod tests {
     /// live network (16 contiguous bytes zeroed inside an otherwise
     /// byte-identical copy). It spans 22 fragments.
     ///
-    /// Byte identity here is what formally closes the fragment path as a
-    /// candidate source of that corruption: reassembly is pure ordered
-    /// concatenation, so a length-preserving hole would have to survive
-    /// fragmentation, AES-128-GCM sealing, and reassembly to reach the caller.
+    /// What this rules out is `InboundStream`: sender-side fragmentation,
+    /// AES-128-GCM sealing, and ordered `InboundStream` reassembly do not
+    /// perforate a payload at this size under any delivery order tested. It
+    /// does NOT clear the path that contract state actually takes - operations
+    /// streams never reach `InboundStream` - so it is not on its own an answer
+    /// to where the observed corruption came from. See
+    /// `streaming_buffer_roundtrip_is_byte_identical` for the same payload
+    /// through the reassembler contract state does use.
     #[tokio::test]
     async fn multi_fragment_roundtrip_is_byte_identical() {
         assert_multi_fragment_roundtrip(24_832, None, 22).await;
@@ -3451,9 +3739,9 @@ mod tests {
     /// single byte).
     #[tokio::test]
     async fn fragment_size_boundaries_are_byte_identical() {
-        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8, None, 8).await;
-        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8 - 1, None, 8).await;
-        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8 + 1, None, 9).await;
+        assert_multi_fragment_roundtrip(FULL_FRAGMENT_PAYLOAD * 8, None, 8).await;
+        assert_multi_fragment_roundtrip(FULL_FRAGMENT_PAYLOAD * 8 - 1, None, 8).await;
+        assert_multi_fragment_roundtrip(FULL_FRAGMENT_PAYLOAD * 8 + 1, None, 9).await;
     }
 
     /// The same boundary triple with metadata embedded, where the exact
@@ -3463,11 +3751,10 @@ mod tests {
     /// mis-stated.
     #[tokio::test]
     async fn metadata_fragment_size_boundaries_are_byte_identical() {
-        let mut metadata = vec![0u8; 256];
+        let mut metadata = vec![0u8; ROUNDTRIP_METADATA_LEN];
         crate::config::GlobalRng::fill_bytes(&mut metadata);
         let metadata = bytes::Bytes::from(metadata);
-        let first_fragment_capacity = MAX_DATA_SIZE - (1 + 8 + metadata.len());
-        let exact = first_fragment_capacity + MAX_DATA_SIZE * 7;
+        let exact = FIRST_FRAGMENT_PAYLOAD_WITH_METADATA + FULL_FRAGMENT_PAYLOAD * 7;
 
         assert_multi_fragment_roundtrip(exact, Some(metadata.clone()), 8).await;
         assert_multi_fragment_roundtrip(exact - 1, Some(metadata.clone()), 8).await;

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -3072,6 +3072,408 @@ mod tests {
         Ok(())
     }
 
+    // ------------------------------------------------------------------
+    // Multi-fragment byte-identity roundtrip coverage (#5256)
+    // ------------------------------------------------------------------
+    //
+    // `test_inbound_outbound_interaction` above sends 1000 bytes, which is a
+    // SINGLE fragment, so nothing in the transport crate exercised
+    // fragmentation plus reassembly end to end. That is the path every large
+    // contract state travels.
+    //
+    // The tests below drive the real `send_stream` fragmentation, capture the
+    // fragments off the simulated wire, and reassemble them through the real
+    // `recv_stream`/`InboundStream`, asserting the received bytes are
+    // BYTE-IDENTICAL to what was sent.
+    //
+    // Byte identity, not length, is the assertion that matters here.
+    // Reassembly already completes only on an exact byte count, so a length
+    // check proves nothing about a length-preserving mid-payload corruption -
+    // which is exactly the failure mode observed on the live network (16
+    // contiguous bytes zeroed inside an otherwise byte-identical contract
+    // state).
+
+    /// A multi-fragment stream captured off the simulated wire.
+    struct CapturedStream {
+        /// `(fragment_number, payload)` in the order the sender emitted them.
+        fragments: Vec<(u32, bytes::Bytes)>,
+        /// Metadata the sender embedded in fragment #1, if any.
+        embedded_metadata: Option<bytes::Bytes>,
+        /// `total_length_bytes` as advertised on the wire.
+        total_length_bytes: u64,
+    }
+
+    /// Runs `payload` through the real outbound fragmentation path and returns
+    /// every fragment the sender put on the wire, decrypted and deserialized.
+    ///
+    /// Uses the in-test `TestSocket` (a channel-backed `Socket` impl) rather
+    /// than a real UDP socket, and `VirtualTime` rather than the wall clock.
+    async fn capture_stream_fragments(
+        payload: &[u8],
+        metadata: Option<bytes::Bytes>,
+    ) -> CapturedStream {
+        let (sender, mut receiver) = mpsc::channel(8);
+        let remote_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
+        let mut key = [0u8; 16];
+        crate::config::GlobalRng::fill_bytes(&mut key);
+        let cipher = Aes128Gcm::new(&key.into());
+
+        let time_source = crate::simulation::VirtualTime::new();
+        let sent_tracker = Arc::new(parking_lot::Mutex::new(
+            SentPacketTracker::new_with_time_source(time_source.clone()),
+        ));
+
+        // Nothing ACKs in this harness, so flightsize only ever grows, and
+        // `VirtualTime` does not advance on its own - a token-bucket wait would
+        // deadlock the test rather than merely slow it down. Budget the
+        // congestion window and the token bucket above the whole transfer so
+        // neither can gate a fragment.
+        let budget = payload.len() + metadata.as_ref().map_or(0, |m| m.len()) + 64 * 1024;
+        let congestion_controller =
+            crate::transport::congestion_control::CongestionControlConfig::default()
+                .with_initial_cwnd(budget)
+                .with_min_cwnd(budget)
+                .with_max_cwnd(budget)
+                .build_arc_with_time_source(time_source.clone());
+        let token_bucket = Arc::new(TokenBucket::new_with_time_source(
+            budget,
+            budget,
+            time_source.clone(),
+        ));
+
+        let stream_id = StreamId::next();
+        let outbound = GlobalExecutor::spawn(send_stream(
+            stream_id,
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(TestSocket::new(sender)),
+            remote_addr,
+            bytes::Bytes::copy_from_slice(payload),
+            cipher.clone(),
+            sent_tracker,
+            token_bucket,
+            congestion_controller,
+            time_source,
+            metadata,
+            None,
+            None,
+        ));
+
+        let collect = async {
+            let mut fragments = Vec::new();
+            let mut embedded_metadata: Option<bytes::Bytes> = None;
+            let mut total_length_bytes: Option<u64> = None;
+            while let Some((_, network_packet)) = receiver.recv().await {
+                let decrypted = PacketData::<_, MAX_PACKET_SIZE>::from_buf(&network_packet)
+                    .try_decrypt_sym(&cipher)
+                    .expect("every emitted fragment must decrypt");
+                let SymmetricMessage {
+                    payload:
+                        SymmetricMessagePayload::StreamFragment {
+                            fragment_number,
+                            payload,
+                            metadata_bytes,
+                            total_length_bytes: advertised,
+                            ..
+                        },
+                    ..
+                } = SymmetricMessage::deser(decrypted.data()).expect("symmetric message")
+                else {
+                    panic!("send_stream must only emit StreamFragment packets");
+                };
+                if let Some(previous) = total_length_bytes {
+                    assert_eq!(
+                        previous, advertised,
+                        "every fragment must advertise the same total_length_bytes"
+                    );
+                }
+                total_length_bytes = Some(advertised);
+                if let Some(meta) = metadata_bytes {
+                    assert_eq!(fragment_number, 1, "metadata may only ride on fragment #1");
+                    assert!(
+                        embedded_metadata.replace(meta).is_none(),
+                        "metadata must be embedded exactly once"
+                    );
+                }
+                fragments.push((fragment_number, payload));
+            }
+            CapturedStream {
+                fragments,
+                embedded_metadata,
+                total_length_bytes: total_length_bytes
+                    .expect("send_stream must emit at least one fragment"),
+            }
+        };
+
+        let (send_result, captured) = tokio::join!(outbound, collect);
+        send_result
+            .expect("send_stream task panicked")
+            .expect("send_stream failed");
+        captured
+    }
+
+    /// Feeds `delivery` through the real `recv_stream`/`InboundStream` path.
+    ///
+    /// Returns the reassembled payload, or `Err(stream_id)` if reassembly never
+    /// completed after every fragment in `delivery` had been offered.
+    async fn reassemble(
+        total_length_bytes: u64,
+        delivery: Vec<(u32, bytes::Bytes)>,
+    ) -> std::result::Result<Vec<u8>, StreamId> {
+        let (tx, rx) = mpsc::channel(delivery.len().max(1));
+        for fragment in delivery {
+            tx.send(fragment).await.expect("receiver is alive");
+        }
+        drop(tx);
+        recv_stream(StreamId::next(), rx, InboundStream::new(total_length_bytes))
+            .await
+            .map(|(_, msg)| msg)
+    }
+
+    /// Strict reverse arrival: fragment #1, the one that may carry metadata and
+    /// is the only one that can start the contiguous run, lands last.
+    fn deliver_reversed(captured: &CapturedStream) -> Vec<(u32, bytes::Bytes)> {
+        let mut delivery = captured.fragments.clone();
+        delivery.reverse();
+        delivery
+    }
+
+    /// Every even-numbered fragment, then every odd-numbered one: a maximally
+    /// interleaved arrival that keeps a gap open until the final fragment.
+    fn deliver_interleaved(captured: &CapturedStream) -> Vec<(u32, bytes::Bytes)> {
+        let (odd, even): (Vec<_>, Vec<_>) = captured
+            .fragments
+            .iter()
+            .cloned()
+            .partition(|(number, _)| number % 2 == 1);
+        even.into_iter().chain(odd).collect()
+    }
+
+    /// Every fragment delivered twice, back to back, in send order.
+    fn deliver_duplicated(captured: &CapturedStream) -> Vec<(u32, bytes::Bytes)> {
+        captured
+            .fragments
+            .iter()
+            .flat_map(|fragment| [fragment.clone(), fragment.clone()])
+            .collect()
+    }
+
+    /// The adversarial replay pattern: deliver a prefix in order, replay a
+    /// fragment the reassembler has ALREADY consumed, then deliver the rest out
+    /// of order.
+    ///
+    /// A reassembler that buffers the replay rather than dropping it wedges its
+    /// own drain loop: the stale key sits at the front of the pending map
+    /// forever, so no later fragment can drain and the stream never completes.
+    fn deliver_replay_then_gap(captured: &CapturedStream) -> Vec<(u32, bytes::Bytes)> {
+        assert!(
+            captured.fragments.len() >= 4,
+            "replay-then-gap needs at least 4 fragments to open a gap behind the replay"
+        );
+        let mut delivery = captured.fragments[..2].to_vec();
+        delivery.push(captured.fragments[0].clone());
+        delivery.extend(captured.fragments[2..].iter().rev().cloned());
+        delivery
+    }
+
+    /// Byte-identity assertion with a compact failure message. A bare
+    /// `assert_eq!` on a megabyte payload would dump both copies.
+    fn assert_bytes_identical(received: &[u8], sent: &[u8], context: &str) {
+        assert_eq!(
+            received.len(),
+            sent.len(),
+            "{context}: reassembled length differs from what was sent"
+        );
+        if let Some(offset) = received.iter().zip(sent).position(|(a, b)| a != b) {
+            let differing = received.iter().zip(sent).filter(|(a, b)| a != b).count();
+            panic!(
+                "{context}: payload CORRUPTED in transit - first differing byte at offset \
+                 {offset} of {}: sent {:#04x}, received {:#04x}; {differing} bytes differ in total",
+                sent.len(),
+                sent[offset],
+                received[offset],
+            );
+        }
+    }
+
+    /// Asserts a `payload_len`-byte payload survives fragmentation and
+    /// reassembly byte-identically under every delivery order.
+    ///
+    /// `expected_fragments` is stated explicitly rather than recomputed from
+    /// the sender's own formula: re-deriving it here would make the assertion
+    /// self-checking and blind to an off-by-one in that formula.
+    /// `fragment_count_literals_are_computed_for_this_max_data_size` pins the
+    /// constant these literals were computed against.
+    async fn assert_multi_fragment_roundtrip(
+        payload_len: usize,
+        metadata: Option<bytes::Bytes>,
+        expected_fragments: usize,
+    ) {
+        assert!(
+            expected_fragments >= 2,
+            "this helper exists to cover MULTI-fragment payloads"
+        );
+
+        let mut payload = vec![0u8; payload_len];
+        crate::config::GlobalRng::fill_bytes(&mut payload);
+
+        let captured = capture_stream_fragments(&payload, metadata.clone()).await;
+        let described = format!(
+            "{payload_len} bytes, metadata={}",
+            metadata.as_ref().map_or(0, |m| m.len())
+        );
+
+        assert_eq!(
+            captured.fragments.len(),
+            expected_fragments,
+            "{described}: unexpected fragment count"
+        );
+        assert_eq!(
+            captured.total_length_bytes, payload_len as u64,
+            "{described}: advertised total_length_bytes must match the payload"
+        );
+        assert_eq!(
+            captured.embedded_metadata, metadata,
+            "{described}: embedded metadata must round-trip byte-identically"
+        );
+
+        // Fragment numbers are 1-indexed, contiguous, and emitted in order.
+        assert_eq!(
+            captured
+                .fragments
+                .iter()
+                .map(|(number, _)| *number)
+                .collect::<Vec<_>>(),
+            (1..=expected_fragments as u32).collect::<Vec<_>>(),
+            "{described}: fragment numbering must be 1-indexed and contiguous"
+        );
+
+        // The sender's own fragmentation must be lossless before reassembly is
+        // even in the picture.
+        let concatenated: Vec<u8> = captured
+            .fragments
+            .iter()
+            .flat_map(|(_, fragment)| fragment.iter().copied())
+            .collect();
+        assert_bytes_identical(
+            &concatenated,
+            &payload,
+            &format!("{described}: fragmentation"),
+        );
+
+        // Fragment #1 is the asymmetric one: embedded metadata steals room from
+        // its payload. Pin that capacity explicitly - an off-by-one in the
+        // metadata overhead is invisible to a whole-payload check because the
+        // sender's total_packets calculation compensates for it.
+        let first_fragment_capacity = match &metadata {
+            Some(meta) => MAX_DATA_SIZE - (1 + 8 + meta.len()),
+            None => MAX_DATA_SIZE,
+        };
+        assert_eq!(
+            captured.fragments[0].1.len(),
+            first_fragment_capacity,
+            "{described}: fragment #1 must be filled to its metadata-reduced capacity"
+        );
+        for (number, fragment) in &captured.fragments[1..expected_fragments - 1] {
+            assert_eq!(
+                fragment.len(),
+                MAX_DATA_SIZE,
+                "{described}: interior fragment #{number} must be full"
+            );
+        }
+
+        let mut orders: Vec<(&str, Vec<(u32, bytes::Bytes)>)> = vec![
+            ("in order", captured.fragments.clone()),
+            ("reversed", deliver_reversed(&captured)),
+            ("interleaved", deliver_interleaved(&captured)),
+            ("duplicated", deliver_duplicated(&captured)),
+        ];
+        if captured.fragments.len() >= 4 {
+            orders.push(("replay then gap", deliver_replay_then_gap(&captured)));
+        }
+
+        for (order, delivery) in orders {
+            let context = format!("{described}, delivered {order}");
+            let received = reassemble(captured.total_length_bytes, delivery)
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("{context}: reassembly never completed despite every byte arriving")
+                });
+            assert_bytes_identical(&received, &payload, &context);
+        }
+    }
+
+    /// The `expected_fragments` literals in the tests below were computed for
+    /// this fragment payload size. Pin it so a change to the fragment overhead
+    /// fails loudly here instead of silently re-scoping that coverage.
+    #[test]
+    fn fragment_count_literals_are_computed_for_this_max_data_size() {
+        assert_eq!(
+            MAX_DATA_SIZE, 1130,
+            "MAX_DATA_SIZE changed - recompute the expected fragment counts in the \
+             multi-fragment roundtrip tests"
+        );
+    }
+
+    /// 24,832 bytes is the size of the corrupt contract state observed on the
+    /// live network (16 contiguous bytes zeroed inside an otherwise
+    /// byte-identical copy). It spans 22 fragments.
+    ///
+    /// Byte identity here is what formally closes the fragment path as a
+    /// candidate source of that corruption: reassembly is pure ordered
+    /// concatenation, so a length-preserving hole would have to survive
+    /// fragmentation, AES-128-GCM sealing, and reassembly to reach the caller.
+    #[tokio::test]
+    async fn multi_fragment_roundtrip_is_byte_identical() {
+        assert_multi_fragment_roundtrip(24_832, None, 22).await;
+    }
+
+    /// Same payload, but with metadata embedded in fragment #1 (fix #2757).
+    /// The first fragment then carries less payload than every other fragment,
+    /// and that asymmetry is exactly where an off-by-one would live.
+    #[tokio::test]
+    async fn multi_fragment_roundtrip_with_metadata_is_byte_identical() {
+        let mut metadata = vec![0u8; 256];
+        crate::config::GlobalRng::fill_bytes(&mut metadata);
+        assert_multi_fragment_roundtrip(24_832, Some(bytes::Bytes::from(metadata)), 23).await;
+    }
+
+    /// A payload far larger than any single-fragment case: 1 MiB over 928
+    /// fragments. Corruption that only shows up deep into a long stream (a
+    /// wrapped counter, an exhausted window, a reused buffer) needs a stream
+    /// long enough to reach it.
+    #[tokio::test]
+    async fn large_multi_fragment_roundtrip_is_byte_identical() {
+        assert_multi_fragment_roundtrip(1_048_576, None, 928).await;
+    }
+
+    /// Boundary triple with no metadata: exactly N full fragments, one byte
+    /// under (still N, last one short), and one byte over (N+1, last one a
+    /// single byte).
+    #[tokio::test]
+    async fn fragment_size_boundaries_are_byte_identical() {
+        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8, None, 8).await;
+        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8 - 1, None, 8).await;
+        assert_multi_fragment_roundtrip(MAX_DATA_SIZE * 8 + 1, None, 9).await;
+    }
+
+    /// The same boundary triple with metadata embedded, where the exact
+    /// multiple is `first_fragment_capacity + 7 * MAX_DATA_SIZE` rather than a
+    /// multiple of `MAX_DATA_SIZE`. This is the boundary the sender's
+    /// `total_packets` calculation gets wrong if the metadata overhead is
+    /// mis-stated.
+    #[tokio::test]
+    async fn metadata_fragment_size_boundaries_are_byte_identical() {
+        let mut metadata = vec![0u8; 256];
+        crate::config::GlobalRng::fill_bytes(&mut metadata);
+        let metadata = bytes::Bytes::from(metadata);
+        let first_fragment_capacity = MAX_DATA_SIZE - (1 + 8 + metadata.len());
+        let exact = first_fragment_capacity + MAX_DATA_SIZE * 7;
+
+        assert_multi_fragment_roundtrip(exact, Some(metadata.clone()), 8).await;
+        assert_multi_fragment_roundtrip(exact - 1, Some(metadata.clone()), 8).await;
+        assert_multi_fragment_roundtrip(exact + 1, Some(metadata), 9).await;
+    }
+
     /// Verify that bincode serialization is fast enough to run on async runtime.
     ///
     /// This test documents the assumption behind removing spawn_blocking from send().

--- a/crates/core/src/transport/peer_connection/inbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/inbound_stream.rs
@@ -55,6 +55,27 @@ impl InboundStream {
         //     "received stream fragment"
         // );
 
+        // Reject an out-of-range fragment number outright. Without this, a
+        // fragment far past the end of the stream is inserted into
+        // `non_contiguous_fragments`, where nothing ever removes it: the drain
+        // loop below only pops keys that reach `frontier + 1`, so the entry -
+        // and this whole `InboundStream`, its spawned `recv_stream` task, its
+        // channel, and the partial payload - lives until the connection
+        // closes. Both sibling reassemblers already bound this
+        // (`streaming_buffer.rs::insert`, `piped_stream.rs::push_fragment`).
+        //
+        // The bound is the largest fragment number the sender could legitimately
+        // emit: one per `MAX_DATA_SIZE` of payload, plus one, because embedded
+        // metadata shortens fragment #1 and can push the tail into an extra
+        // fragment (fix #2757 - the same `+1` `streaming_buffer.rs` allocates
+        // as its overflow slot).
+        let max_fragment_number = (self.total_length_bytes as usize)
+            .div_ceil(super::MAX_DATA_SIZE)
+            .saturating_add(1) as FragmentIdx;
+        if fragment_number == 0 || fragment_number > max_fragment_number {
+            return None;
+        }
+
         // Idempotency guard: a fragment at or below the contiguous frontier has
         // already been appended to `payload`, so a replay of it carries no new
         // bytes. Dropping it is not merely an optimisation: buffering it in
@@ -65,11 +86,24 @@ impl InboundStream {
         // fragment then sits behind the stale key forever and the stream never
         // completes, even once all its bytes have arrived.
         //
-        // Reachability: `PeerConnection::recv` drops same-`packet_id` replays
-        // via `ReceivedPacketTracker` before they get here, so this is
-        // defence-in-depth rather than a live production failure, but
-        // reassembly is documented as order-insensitive and idempotent, and
-        // without this guard it is only the former.
+        // Duplicate semantics differ by side of the frontier, and neither is
+        // "the payload is rebuilt from the newer copy":
+        //   - at or below the frontier: FIRST writer wins, because the bytes
+        //     are already in `payload` and the replay is dropped here;
+        //   - above the frontier: LAST writer wins, because the `insert` below
+        //     overwrites the pending entry.
+        // A replay above the frontier that carries a DIFFERENT length steps
+        // `payload.len()` past `total_length_bytes`, and `get_and_clear`
+        // compares with `==`, so the stream never completes. Only a broken or
+        // hostile sender produces that; an honest retransmit is byte-identical.
+        //
+        // Reachability: `ReceivedPacketTracker` (see
+        // `received_packet_tracker.rs:62`) dedups by `packet_id` only, and an
+        // honest retransmit reuses the original `packet_id`, so loss recovery
+        // never reaches here. A peer that replays the same `fragment_number`
+        // under fresh `packet_id`s does, which makes this a guard against a
+        // hostile or broken peer rather than defence-in-depth against a
+        // condition nothing can produce.
         if fragment_number <= self.last_contiguous_fragment_idx {
             return None;
         }
@@ -106,43 +140,55 @@ impl InboundStream {
 mod tests {
     use super::*;
 
+    /// A full fragment payload, matching what `send_stream` actually emits.
+    ///
+    /// The fixtures below are sized in whole fragments rather than in bytes.
+    /// A 6-byte stream carried in three 2-byte fragments - the shape these
+    /// tests used to assert on - is not a stream any sender produces, and
+    /// `push_fragment`'s out-of-range bound is derived from
+    /// `total_length_bytes`, so an impossible shape now reads as an
+    /// out-of-range fragment number rather than as the ordering case the test
+    /// means to cover.
+    const FRAG: usize = super::super::MAX_DATA_SIZE;
+
+    /// One full fragment of `marker` bytes.
+    fn frag(marker: u8) -> Bytes {
+        Bytes::from(vec![marker; FRAG])
+    }
+
+    /// The payload `markers` reassembles to, in order.
+    fn joined(markers: &[u8]) -> Vec<u8> {
+        markers
+            .iter()
+            .flat_map(|marker| std::iter::repeat_n(*marker, FRAG))
+            .collect()
+    }
+
     #[test]
     fn test_simple_sequence() {
-        let mut stream = InboundStream::new(6);
-        assert_eq!(
-            stream.push_fragment(1, Bytes::from_static(&[1, 2, 3])),
-            None
-        );
-        assert_eq!(
-            stream.push_fragment(2, Bytes::from_static(&[4, 5, 6])),
-            Some(vec![1, 2, 3, 4, 5, 6])
-        );
+        let mut stream = InboundStream::new((2 * FRAG) as u64);
+        assert_eq!(stream.push_fragment(1, frag(1)), None);
+        assert_eq!(stream.push_fragment(2, frag(2)), Some(joined(&[1, 2])));
         assert!(stream.non_contiguous_fragments.is_empty());
         assert!(stream.payload.is_empty());
     }
 
     #[test]
     fn test_out_of_order_fragment_1() {
-        let mut stream = InboundStream::new(6);
-        assert_eq!(stream.push_fragment(1, Bytes::from_static(&[1, 2])), None);
-        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
-        assert_eq!(
-            stream.push_fragment(2, Bytes::from_static(&[3, 4])),
-            Some(vec![1, 2, 3, 4, 5, 6])
-        );
+        let mut stream = InboundStream::new((3 * FRAG) as u64);
+        assert_eq!(stream.push_fragment(1, frag(1)), None);
+        assert_eq!(stream.push_fragment(3, frag(3)), None);
+        assert_eq!(stream.push_fragment(2, frag(2)), Some(joined(&[1, 2, 3])));
         assert!(stream.non_contiguous_fragments.is_empty());
         assert!(stream.payload.is_empty());
     }
 
     #[test]
     fn test_out_of_order_fragment_2() {
-        let mut stream = InboundStream::new(6);
-        assert_eq!(stream.push_fragment(2, Bytes::from_static(&[3, 4])), None);
-        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
-        assert_eq!(
-            stream.push_fragment(1, Bytes::from_static(&[1, 2])),
-            Some(vec![1, 2, 3, 4, 5, 6])
-        );
+        let mut stream = InboundStream::new((3 * FRAG) as u64);
+        assert_eq!(stream.push_fragment(2, frag(2)), None);
+        assert_eq!(stream.push_fragment(3, frag(3)), None);
+        assert_eq!(stream.push_fragment(1, frag(1)), Some(joined(&[1, 2, 3])));
         assert!(stream.non_contiguous_fragments.is_empty());
         assert!(stream.payload.is_empty());
     }
@@ -160,17 +206,17 @@ mod tests {
     /// asserted byte-for-byte, not merely by length.
     #[test]
     fn test_duplicate_fragment_does_not_wedge_reassembly() {
-        let mut stream = InboundStream::new(10);
-        assert_eq!(stream.push_fragment(1, Bytes::from_static(&[1, 1])), None);
-        assert_eq!(stream.push_fragment(2, Bytes::from_static(&[2, 2])), None);
+        let mut stream = InboundStream::new((5 * FRAG) as u64);
+        assert_eq!(stream.push_fragment(1, frag(1)), None);
+        assert_eq!(stream.push_fragment(2, frag(2)), None);
         // Replay of a fragment already folded into `payload`.
-        assert_eq!(stream.push_fragment(1, Bytes::from_static(&[1, 1])), None);
+        assert_eq!(stream.push_fragment(1, frag(1)), None);
         // Remaining fragments arrive out of order behind the replay.
-        assert_eq!(stream.push_fragment(5, Bytes::from_static(&[5, 5])), None);
-        assert_eq!(stream.push_fragment(4, Bytes::from_static(&[4, 4])), None);
+        assert_eq!(stream.push_fragment(5, frag(5)), None);
+        assert_eq!(stream.push_fragment(4, frag(4)), None);
         assert_eq!(
-            stream.push_fragment(3, Bytes::from_static(&[3, 3])),
-            Some(vec![1, 1, 2, 2, 3, 3, 4, 4, 5, 5]),
+            stream.push_fragment(3, frag(3)),
+            Some(joined(&[1, 2, 3, 4, 5])),
             "replayed fragment must not strand the fragments queued behind it"
         );
         assert!(stream.non_contiguous_fragments.is_empty());
@@ -181,13 +227,59 @@ mod tests {
     /// plain overwrite and must leave the reassembled bytes unchanged.
     #[test]
     fn test_duplicate_pending_fragment_is_idempotent() {
-        let mut stream = InboundStream::new(6);
-        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
-        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
-        assert_eq!(stream.push_fragment(2, Bytes::from_static(&[3, 4])), None);
+        let mut stream = InboundStream::new((3 * FRAG) as u64);
+        assert_eq!(stream.push_fragment(3, frag(3)), None);
+        assert_eq!(stream.push_fragment(3, frag(3)), None);
+        assert_eq!(stream.push_fragment(2, frag(2)), None);
+        assert_eq!(stream.push_fragment(1, frag(1)), Some(joined(&[1, 2, 3])));
+        assert!(stream.non_contiguous_fragments.is_empty());
+    }
+
+    /// A fragment number past anything the stream could need must be dropped,
+    /// not parked in `non_contiguous_fragments` for the life of the connection.
+    ///
+    /// `non_contiguous_fragments` is only ever drained by the frontier reaching
+    /// a key, so an entry above the highest reachable fragment number is never
+    /// removed: it pins the `InboundStream`, its `recv_stream` task, its
+    /// channel, and the partial payload until the connection closes. An
+    /// authenticated peer can send fragment 4,000,000,000 as often as it likes,
+    /// because `ReceivedPacketTracker` dedups by `packet_id` rather than by
+    /// fragment number, so a fresh `packet_id` per replay walks straight
+    /// through.
+    #[test]
+    fn test_out_of_range_fragment_is_dropped_not_buffered() {
+        let mut stream = InboundStream::new((2 * FRAG) as u64);
+
+        assert_eq!(stream.push_fragment(u32::MAX, frag(9)), None);
+        assert_eq!(stream.push_fragment(4_000_000_000, frag(9)), None);
+        // One past the highest number a sender could emit for this size:
+        // 2 fragments, plus 1 for a metadata-shortened fragment #1.
+        assert_eq!(stream.push_fragment(4, frag(9)), None);
+        assert_eq!(stream.push_fragment(0, frag(9)), None);
+        assert!(
+            stream.non_contiguous_fragments.is_empty(),
+            "an unreachable fragment number must not occupy the reassembly buffer"
+        );
+
+        // The in-range overflow fragment (#3, used when embedded metadata
+        // shortens fragment #1) is still accepted, and the stream completes.
+        let metadata_overhead = 1 + 8 + 256;
         assert_eq!(
-            stream.push_fragment(1, Bytes::from_static(&[1, 2])),
-            Some(vec![1, 2, 3, 4, 5, 6])
+            stream.push_fragment(1, Bytes::from(vec![1u8; FRAG - metadata_overhead])),
+            None
+        );
+        assert_eq!(stream.push_fragment(2, frag(2)), None);
+        let assembled = stream
+            .push_fragment(3, Bytes::from(vec![3u8; metadata_overhead]))
+            .expect("the metadata-overflow fragment is in range and completes the stream");
+        assert_eq!(assembled.len(), 2 * FRAG);
+        assert_eq!(
+            &assembled[..FRAG - metadata_overhead],
+            &vec![1u8; FRAG - metadata_overhead][..]
+        );
+        assert_eq!(
+            &assembled[2 * FRAG - metadata_overhead..],
+            &vec![3u8; metadata_overhead][..]
         );
         assert!(stream.non_contiguous_fragments.is_empty());
     }

--- a/crates/core/src/transport/peer_connection/inbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/inbound_stream.rs
@@ -54,6 +54,26 @@ impl InboundStream {
         //     non_contig = ?self.non_contiguous_fragments.keys().collect::<Vec<_>>(),
         //     "received stream fragment"
         // );
+
+        // Idempotency guard: a fragment at or below the contiguous frontier has
+        // already been appended to `payload`, so a replay of it carries no new
+        // bytes. Dropping it is not merely an optimisation: buffering it in
+        // `non_contiguous_fragments` WEDGES the drain loop below permanently,
+        // because that loop stops at the first key that is not
+        // `last_contiguous_fragment_idx + 1` and a stale key can never become
+        // that again (the frontier only grows). Every later out-of-order
+        // fragment then sits behind the stale key forever and the stream never
+        // completes, even once all its bytes have arrived.
+        //
+        // Reachability: `PeerConnection::recv` drops same-`packet_id` replays
+        // via `ReceivedPacketTracker` before they get here, so this is
+        // defence-in-depth rather than a live production failure, but
+        // reassembly is documented as order-insensitive and idempotent, and
+        // without this guard it is only the former.
+        if fragment_number <= self.last_contiguous_fragment_idx {
+            return None;
+        }
+
         if fragment_number == self.last_contiguous_fragment_idx + 1 {
             self.last_contiguous_fragment_idx = fragment_number;
             self.payload.extend_from_slice(&fragment);
@@ -125,5 +145,50 @@ mod tests {
         );
         assert!(stream.non_contiguous_fragments.is_empty());
         assert!(stream.payload.is_empty());
+    }
+
+    /// A replay of an already-consumed fragment must not stall the stream.
+    ///
+    /// Without the idempotency guard in `push_fragment`, the replayed fragment
+    /// is buffered under a key at or below the contiguous frontier. The drain
+    /// loop pops the smallest pending key first, sees it is not
+    /// `frontier + 1`, puts it back and breaks, so that stale key blocks every
+    /// later out-of-order fragment forever and the stream never completes even
+    /// though all of its bytes have arrived.
+    ///
+    /// The replay must also not corrupt the payload: the reassembled bytes are
+    /// asserted byte-for-byte, not merely by length.
+    #[test]
+    fn test_duplicate_fragment_does_not_wedge_reassembly() {
+        let mut stream = InboundStream::new(10);
+        assert_eq!(stream.push_fragment(1, Bytes::from_static(&[1, 1])), None);
+        assert_eq!(stream.push_fragment(2, Bytes::from_static(&[2, 2])), None);
+        // Replay of a fragment already folded into `payload`.
+        assert_eq!(stream.push_fragment(1, Bytes::from_static(&[1, 1])), None);
+        // Remaining fragments arrive out of order behind the replay.
+        assert_eq!(stream.push_fragment(5, Bytes::from_static(&[5, 5])), None);
+        assert_eq!(stream.push_fragment(4, Bytes::from_static(&[4, 4])), None);
+        assert_eq!(
+            stream.push_fragment(3, Bytes::from_static(&[3, 3])),
+            Some(vec![1, 1, 2, 2, 3, 3, 4, 4, 5, 5]),
+            "replayed fragment must not strand the fragments queued behind it"
+        );
+        assert!(stream.non_contiguous_fragments.is_empty());
+        assert!(stream.payload.is_empty());
+    }
+
+    /// A replay of a fragment still sitting in the out-of-order buffer is a
+    /// plain overwrite and must leave the reassembled bytes unchanged.
+    #[test]
+    fn test_duplicate_pending_fragment_is_idempotent() {
+        let mut stream = InboundStream::new(6);
+        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
+        assert_eq!(stream.push_fragment(3, Bytes::from_static(&[5, 6])), None);
+        assert_eq!(stream.push_fragment(2, Bytes::from_static(&[3, 4])), None);
+        assert_eq!(
+            stream.push_fragment(1, Bytes::from_static(&[1, 2])),
+            Some(vec![1, 2, 3, 4, 5, 6])
+        );
+        assert!(stream.non_contiguous_fragments.is_empty());
     }
 }

--- a/crates/core/src/transport/peer_connection/piped_stream.rs
+++ b/crates/core/src/transport/peer_connection/piped_stream.rs
@@ -255,8 +255,15 @@ impl<T: TimeSource> PipedStream<T> {
         config: PipedStreamConfig,
         time_source: T,
     ) -> Self {
-        // Calculate total fragments
-        const FRAGMENT_PAYLOAD_SIZE: usize = crate::transport::packet_data::MAX_DATA_SIZE - 40;
+        // Calculate total fragments.
+        //
+        // This MUST be the same payload size the sender actually fragments at,
+        // or `total_fragments` is wrong and `is_complete()` fires at the wrong
+        // point. Take it from the one constant rather than re-deriving the
+        // overhead here: this site said `MAX_DATA_SIZE - 40` while every other
+        // site subtracts 41 (the extra byte is the `Option` discriminant of
+        // `metadata_bytes`; see `peer_connection::MAX_DATA_SIZE`).
+        const FRAGMENT_PAYLOAD_SIZE: usize = super::MAX_DATA_SIZE;
         let total_fragments = if total_bytes == 0 {
             0
         } else {
@@ -788,7 +795,7 @@ mod tests {
 
     #[test]
     fn test_partial_cascade() {
-        // 6 fragments at ~1131 bytes/fragment: ceil(6500/1131) = 6
+        // 6 fragments at 1130 bytes/fragment: ceil(6500/1130) = 6
         let stream = PipedStream::new(make_stream_id(), 6500, 1, PipedStreamConfig::default());
         assert_eq!(stream.total_fragments(), 6);
 

--- a/crates/core/src/transport/peer_connection/piped_stream.rs
+++ b/crates/core/src/transport/peer_connection/piped_stream.rs
@@ -793,6 +793,50 @@ mod tests {
         assert_eq!(stream.buffered_count(), 0);
     }
 
+    /// One byte past a full fragment: the sender emits two fragments, so the
+    /// pipe must expect two.
+    ///
+    /// This is the case that separates the fragment-size fix from the bug it
+    /// replaced. The old `MAX_DATA_SIZE - 40` overstated the payload by one
+    /// byte, so `div_ceil(1131, 1131)` computed `total_fragments = 1`: the pipe
+    /// declared itself complete after fragment #1 and then REJECTED the genuine
+    /// final fragment as out of range. The failure is silent truncation, not a
+    /// visible error, because `is_complete()` has already returned true by the
+    /// time the rejection happens.
+    ///
+    /// `test_partial_cascade` below does not distinguish the two - 6500 bytes
+    /// is 6 fragments under both formulas.
+    #[test]
+    fn test_fragment_count_one_byte_past_a_full_fragment() {
+        let total_bytes = (super::super::MAX_DATA_SIZE + 1) as u64;
+        let stream = PipedStream::new(
+            make_stream_id(),
+            total_bytes,
+            1,
+            PipedStreamConfig::default(),
+        );
+        assert_eq!(
+            stream.total_fragments(),
+            2,
+            "one byte past a full fragment takes two fragments, not one"
+        );
+
+        let forwarded = stream
+            .push_fragment(1, Bytes::from(vec![0u8; super::super::MAX_DATA_SIZE]))
+            .expect("fragment #1 is in range");
+        assert_eq!(forwarded.len(), 1);
+        assert!(
+            !stream.is_complete(),
+            "the stream must not report completion while a fragment is outstanding"
+        );
+
+        let forwarded = stream
+            .push_fragment(2, Bytes::from_static(&[0u8]))
+            .expect("the genuine final fragment must be accepted, not rejected as out of range");
+        assert_eq!(forwarded.len(), 1);
+        assert!(stream.is_complete());
+    }
+
     #[test]
     fn test_partial_cascade() {
         // 6 fragments at 1130 bytes/fragment: ceil(6500/1130) = 6

--- a/crates/core/src/transport/symmetric_message.rs
+++ b/crates/core/src/transport/symmetric_message.rs
@@ -685,14 +685,12 @@ mod test {
         assert_ne!(legacy_plain.data(), versioned_plain.data());
 
         let deser = SymmetricMessage::deser(versioned_plain.data()).unwrap();
-        match deser.payload {
-            SymmetricMessagePayload::AckConnectionV2 { connection } => {
-                assert_eq!(connection.key, sym_key);
-                assert_eq!(connection.remote_addr, addr);
-                assert_eq!(connection.protoc_version, version);
-            }
-            other => panic!("expected AckConnectionV2, got {other}"),
-        }
+        let SymmetricMessagePayload::AckConnectionV2 { connection } = &deser.payload else {
+            panic!("expected AckConnectionV2, got {}", deser.payload);
+        };
+        assert_eq!(connection.key, sym_key);
+        assert_eq!(connection.remote_addr, addr);
+        assert_eq!(connection.protoc_version, version);
         assert_eq!(deser.packet_id, SymmetricMessage::FIRST_PACKET_ID);
     }
 

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -1227,7 +1227,12 @@ mod test {
         store_b.set_after_blob_write_hook(Box::new(move || {
             let mut store_a = store_a_opt.take().expect("hook is invoked exactly once");
             let handle = std::thread::spawn(move || {
-                let _ = store_a.remove_contract(&key1);
+                // Must succeed: a failing remove would leave the blob on disk for
+                // the WRONG reason and the post-condition below would pass
+                // vacuously. `handle.join()` surfaces this panic.
+                store_a
+                    .remove_contract(&key1)
+                    .expect("concurrent remove_contract(X1) must succeed");
             });
             // Real wall-clock sleep: this is a genuine cross-thread race test,
             // so a deterministic TimeSource cannot model the interleaving.

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -1337,7 +1337,10 @@ mod wasmtime_disk_cache_sizing_tests {
     /// *increase* for hosts that are unaffected today.
     #[test]
     fn clamp_bounds_are_ordered_and_ceiling_is_the_historical_default() {
-        assert!(MIN_WASMTIME_CACHE_SIZE_BYTES < MAX_WASMTIME_CACHE_SIZE_BYTES);
+        // Compile-time tripwire: the clamp bounds are consts, so checking their
+        // ordering at compile time catches a regression immediately rather than
+        // only when this test happens to run.
+        const _: () = assert!(MIN_WASMTIME_CACHE_SIZE_BYTES < MAX_WASMTIME_CACHE_SIZE_BYTES);
         assert_eq!(MAX_WASMTIME_CACHE_SIZE_BYTES, LEGACY_FLAT_SOFT_LIMIT_BYTES);
     }
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -12896,12 +12896,12 @@ fn test_placement_migration_at_scale_renewal_load_stays_bounded() {
         // test could pass with migration silently inert (which would defeat its
         // purpose as migration's scale home).
         let mut migrated: Vec<(usize, usize)> = Vec::new();
-        for ci in 0..NUM_CONTRACTS {
+        for (ci, key) in contract_keys.iter().enumerate() {
             // Non-loaded regular nodes are node_no 2..=num_nodes (node 1 is the
             // loaded host; the loaded node hosting its own seeded contract is not
             // a migration).
             for n in 2..=num_nodes {
-                if result.is_node_hosting(&NodeLabel::node(network_name, n), &contract_keys[ci]) {
+                if result.is_node_hosting(&NodeLabel::node(network_name, n), key) {
                     migrated.push((ci, n));
                 }
             }
@@ -13938,12 +13938,6 @@ fn test_subscription_chain_collapses_on_client_leave() {
 struct PieceEGateMetrics {
     // ---- Findability (wire per-tx, the codebase's own GET-reliability metric) ----
     get_attempts: u64,
-    get_successes: u64,
-    get_not_found: u64,
-    get_failures: u64,
-    get_timeouts: u64,
-    /// Successes whose GET traversed the network (hop_count >= 1).
-    network_successes: u64,
     /// wire successes / attempts, in [0, 1].
     findability_rate: f64,
     // ---- Findability (client-visible: requester ended up holding the state) ----
@@ -13970,9 +13964,6 @@ struct PieceEGateMetrics {
     /// Requesters that ended holding a NON-current state (SERVED STALE) — the
     /// direct #4709 signal.
     requesters_stale: usize,
-    /// requesters_stale / (requesters_fresh + requesters_stale), in [0, 1].
-    /// PRIMARY stale-serve number. `None` if no requester obtained any state.
-    stale_serve_rate: Option<f64>,
     /// Mesh subscribers, and how many ended fresh (invariant-1 positive control).
     subscribers_total: usize,
     subscribers_fresh: usize,
@@ -14038,12 +14029,6 @@ fn compute_piece_e_metrics(
     } else {
         requesters_with_state as f64 / requesters_total as f64
     };
-    let served = requesters_fresh + requesters_stale;
-    let stale_serve_rate = if served == 0 {
-        None
-    } else {
-        Some(requesters_stale as f64 / served as f64)
-    };
 
     // --- Subscription-tree formation ---
     let hosting_nodes = result
@@ -14076,11 +14061,6 @@ fn compute_piece_e_metrics(
 
     PieceEGateMetrics {
         get_attempts,
-        get_successes: summary.successes,
-        get_not_found: summary.not_found,
-        get_failures: summary.failures,
-        get_timeouts: summary.timeouts,
-        network_successes: summary.network_successes,
         findability_rate,
         requesters_total,
         requesters_with_state,
@@ -14092,7 +14072,6 @@ fn compute_piece_e_metrics(
         stale_holders,
         requesters_fresh,
         requesters_stale,
-        stale_serve_rate,
         subscribers_total,
         subscribers_fresh,
     }
@@ -16333,14 +16312,14 @@ fn nn_run_put_reach(
     for (label, storage) in result.node_storages.iter() {
         if storage.get_stored_state(&contract_key).is_some() {
             total_holders += 1;
-            for idx in 0..locs.len() {
+            for (idx, &loc) in locs.iter().enumerate() {
                 let matches_label = if idx == 0 {
                     *label == NodeLabel::gateway(&network, 0)
                 } else {
                     *label == NodeLabel::node(&network, idx)
                 };
                 if matches_label {
-                    landing_loc = Some(locs[idx]);
+                    landing_loc = Some(loc);
                 }
             }
         }


### PR DESCRIPTION
## Problem

The measurement regime for #5153 (rule 7) requires that an instrument land at least one
release **ahead** of the mechanism it judges, because an instrument that ships alongside
its subject can only read forward. 0.2.120's regression is permanently unattributable for
exactly that reason.

Several planned changes currently have no instrument to judge them by:

- **No hosting-begin attribution.** Nothing records *why* a peer starts hosting a
  contract, so "why is this peer hosting this?" is unanswerable from telemetry. M12
  cannot be evaluated without it.
- **No futile-repair signal.** The anti-entropy repair path cannot distinguish a heal that
  converged from one re-sending the same bytes indefinitely.
- **A rotted lint surface.** CI gates `cargo clippy --locked -- -D warnings`, which never
  compiles `cfg(test)` code or bench targets. Everything outside that gate had decayed:
  a fresh checkout running clippy the obvious way produced ~16 errors and ~35 warnings.
- **No byte-identity coverage for multi-fragment stream reassembly** (#5256).

## Solution

Four independently-reviewed branches, landed together as the set they were soaked as.

**All four are additive or shadow-only: they add counters, tests, and lint fixes. They
MEASURE. None of them changes network behaviour, and none of them reduces bandwidth.**

1. **Hosting-begin attribution** — `99fa2f4` + `cd3de59`. A `HostingCause` recorded at
   every hosting-begin, computed once in the one place that knows whether an invocation is
   transit at all, and threaded to all five store sites. Review caught an
   originator-loopback GET being filed as transit; since the only thing the enum adds over
   `AccessType` is the own-demand-vs-transit split, that would have left the counter
   reporting plausible numbers while empty of meaning. Also renamed `Relay*` to `Transit*`
   per `.claude/rules/hosting-invariants.md`, with discriminants and `ALL` order unchanged
   so historical series are not relabelled.

2. **Futile-repair detector** — `b66c9a7` + `5fded18`. Shadow mode only;
   `would_quarantine` never acts on anything. Review found two defects that meant the
   detector could not answer its own question: a 30-minute attempt-pairing window against
   an effective revisit period on the order of ten hours for the heavy-summary links it
   exists to hunt (so every attempt there expired unsettled and both counters stayed at
   0), and `unwrap_or(true)` reading probe-budget exhaustion as staleness (so the headline
   would have grown with peer breadth rather than with brokenness).

3. **Transport reassembly tests** — `bcd0fa0` + `6b0fefc`. Byte-identity roundtrip for
   multi-fragment streams, plus coverage of the reassembler contract the state machine
   actually uses. Refs #5256.

4. **Clippy backlog** — `4315e16`. `--all-targets --all-features --locked -- -D warnings`
   is now clean. Fixing that surface corrected real defects rather than cosmetics: a bench
   that had not compiled since `PeerConnection::send` started returning `Result<usize>`,
   and six tests that discarded a `Result` carrying the test's own premise, so they would
   have passed vacuously. Refs #5246.

### Why one PR rather than four

Only the integration was soaked, and the four overlap in `node.rs`, `tracing/telemetry.rs`,
`ring.rs`, `router.rs`, `ring/interest.rs` and `operations/update*`. Landing them
sequentially would ship three intermediate trees that were never built or soaked, and
would re-encounter two conflicts that **git does not report**:

- Both the hosting-begin and futile-repair branches raise `MAX_BUSY_JSON_BYTES` from 5120
  to the *identical* 5376. Git merges two identical changes cleanly and takes one copy,
  but the counter costs are additive. Resolved at 5632 against a **re-measured** 5523 —
  every telemetry constant here was measured, not computed.
- The futile-repair branch adds a `host_contract` test call site that the hosting-begin
  branch's fourth `HostingCause` argument makes stale. They touch different lines, so it
  merges clean and fails at *compile*.

The four branches remain on origin, so per-branch history stays recoverable, and their
commits are preserved in this branch's history.

## Testing

- Soaked as an integrated unit on a real NATed peer for ~30 minutes; results recorded as a
  comment on #5153.
- `cargo fmt --all --check` clean.
- `cargo clippy -p freenet --lib --all-features` clean.
- `cargo clippy -p freenet --all-targets --all-features` clean — the `--all-targets` run is
  the one that catches the compile-level conflict above; `--lib` alone would not, because
  the stale call site is in test code.
- `cargo test -p freenet --lib` green.
- Each branch carries its own pin tests, and each was verified to fail under mutation:
  the hosting-cause pins fail when any store site reverts to a literal or when an
  unattributed third insert is added; the futile-repair outcome rows partition every
  observation; the clippy branch's six de-vacuumed tests now fail loudly instead of
  passing when their premise stops holding.

This branch is `origin/main` merged with the soaked integration branch. The merge required
no conflict resolution, and the resulting diff against `main` is **byte-identical** to the
reviewed and soaked diff, so no prior review is staled by it.

[AI-assisted - Claude]
