### PR TITLE
fix(stores): derive the identity a contract or delegate is filed under

### DIFF
--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -336,10 +336,6 @@ impl ContractStoreBridge for MockWasmRuntime {
     fn remove_contract(&mut self, key: &ContractKey) -> Result<(), anyhow::Error> {
         self.contract_store.remove_contract(key)
     }
-
-    fn ensure_key_indexed(&mut self, key: &ContractKey) -> Result<(), anyhow::Error> {
-        self.contract_store.ensure_key_indexed(key)
-    }
 }
 
 impl crate::wasm_runtime::ContractRuntimeBridge for MockWasmRuntime {}

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -3067,25 +3067,37 @@ mod full_state_version_gate_pins {
              code and parameters first (see ContractStore::verify_contract_identity)"
         );
 
-        let already_stored = body
-            .find("} else if let Some(ref contract_code) = code {")
+        // Slice the branch's OWN region — anchor to its `else if`, and stop at the
+        // `} else {` that closes it. Searching from the anchor to the end of the
+        // function would only prove "a store_contract call exists somewhere at or
+        // after this branch", which an unconditional call hoisted out of the
+        // branch satisfies just as well. That is not the property being pinned.
+        const ANCHOR: &str = "} else if let Some(ref contract_code) = code {";
+        let branch_start = body
+            .find(ANCHOR)
             .expect("the 'code already stored' branch is not where this pin expects it");
-        let store_call = body[already_stored..]
-            .find(".store_contract(contract_code.clone())")
-            .expect(
-                "the already-stored branch must index the new instance by calling \
-                 store_contract — its fast paths do exactly that work once the \
-                 identity is verified",
-            );
+        let after_anchor = branch_start + ANCHOR.len();
+        let branch_end = body[after_anchor..]
+            .find("} else {")
+            .map(|offset| after_anchor + offset)
+            .expect("the already-stored branch must be closed by an else arm");
+        let branch = &body[branch_start..branch_end];
+
+        assert!(
+            branch.contains(".store_contract(contract_code.clone())"),
+            "the already-stored branch must index the new instance by calling \
+             store_contract INSIDE the branch — its fast paths do exactly that \
+             work once the identity is verified"
+        );
         // Both `store_contract` calls in this body are legitimate: the new-code
-        // branch and this one. Two is the expected count; a third needs thought.
+        // branch and this one. A third needs thought, and a call hoisted out of
+        // the branch would push this to three.
         assert_eq!(
             body.matches(".store_contract(").count(),
             2,
             "expected exactly two store_contract calls in the upsert path: the \
              new-code branch and the already-stored branch"
         );
-        assert!(store_call > 0, "unexpected slice offset");
     }
 
     /// The corrupted-state recovery path (the ONE branch that replaces

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -310,21 +310,41 @@ where
                         key: key.into(),
                     }));
                 }
-            } else {
-                // Contract already in store. ensure_key_indexed handles the case of contracts
-                // that reuse the same WASM code with different parameters (e.g., different
-                // River rooms). Without this, lookup_key() fails for the new instance_id.
-                // See issue #2380.
+            } else if let Some(ref contract_code) = code {
+                // Contract code already on disk, but this may be a NEW instance of
+                // it: instances that reuse the same WASM with different parameters
+                // (e.g. different River rooms) each need their own
+                // instance→code row, or `lookup_key()` fails for the new
+                // instance id. See issue #2380.
                 //
-                // We only index when code was provided in this request (code.is_some()).
-                // When code is None, this is a state-only update to an existing contract
-                // that should already be indexed.
-                if code.is_some() {
-                    self.runtime
-                        .ensure_key_indexed(&key)
-                        .map_err(ExecutorError::other)?;
-                }
-                (false, code.is_some(), None)
+                // This goes through `store_contract`, NOT through a bare
+                // index-write helper, and that is the point. `store_contract` is
+                // the store's ONE guarded ingress: it verifies that the key is
+                // derived from the code and parameters in hand (see
+                // `ContractStore::verify_contract_identity`) before it writes
+                // anything, and its own fast paths then do exactly the
+                // "just index this instance" work this branch needs — the blob is
+                // already on disk, so no blob is rewritten and no byte is
+                // re-charged against the disk budget.
+                //
+                // It used to call `ContractStore::ensure_key_indexed` directly,
+                // which wrote the durable instance→code row with no derivation
+                // check at all. That made this — the COMMON path, since any
+                // contract reusing an already-stored binary lands here — an
+                // unverified second ingress to the same index that
+                // `store_contract` guards. Two writers of one durable row, one
+                // guarded and one not, is the structure to avoid; do NOT
+                // reintroduce a direct index write here.
+                //
+                // Only reached when code was provided in this request. With no
+                // code this is a state-only update to a contract that is already
+                // indexed, and there is nothing to verify against.
+                self.runtime
+                    .store_contract(contract_code.clone())
+                    .map_err(ExecutorError::other)?;
+                (false, true, None)
+            } else {
+                (false, false, None)
             };
 
         let is_new_contract = self.state_store.get(&key).await.is_err();
@@ -2963,6 +2983,18 @@ mod full_state_version_gate_pins {
         &after[..end]
     }
 
+    /// `upsert_body` with `//` comment lines removed, so a pin can assert that a
+    /// name does not appear in the CODE without tripping over prose that
+    /// deliberately names it (the removed index writer is discussed in a comment
+    /// right where it used to be called).
+    fn upsert_code_only() -> String {
+        upsert_body()
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// A full state over EXISTING state must reach the contract's
     /// `update_state` (the contract's version acceptance is the ONLY version
     /// oracle core has), and the only WASM-merge bypass writing an initial
@@ -3006,6 +3038,54 @@ mod full_state_version_gate_pins {
             "exactly one direct state_store.store call is allowed in the \
              upsert path (the is_new_contract initial install)"
         );
+    }
+
+    /// The "code already stored" branch must route through `store_contract`,
+    /// the store's one guarded ingress, and must not write the durable
+    /// instance→code index by any other means.
+    ///
+    /// This branch is the COMMON path, not an edge case: any contract reusing an
+    /// already-stored binary lands here, which is every River room after the
+    /// first. It used to call `ContractStore::ensure_key_indexed`, which wrote
+    /// that durable row from a bare `&ContractKey` — no code, no parameters — so
+    /// it could verify neither the identity it was filing nor that the blob it
+    /// pointed at existed. Both gaps were found the same day
+    /// (`verify_contract_identity` for the first, #5280 for the second), which is
+    /// what makes this structural rather than two coincidences.
+    ///
+    /// Reverting the call site alone no longer compiles, since
+    /// `ContractStoreBridge` has no index-writing method any more — this pin
+    /// covers the case where someone restores the trait method too.
+    #[test]
+    fn already_stored_branch_routes_through_the_guarded_store_ingress() {
+        let body = upsert_code_only();
+
+        assert!(
+            !body.contains("ensure_key_indexed"),
+            "the upsert path must not write the instance→code index directly; \
+             route through store_contract, which verifies the key against the \
+             code and parameters first (see ContractStore::verify_contract_identity)"
+        );
+
+        let already_stored = body
+            .find("} else if let Some(ref contract_code) = code {")
+            .expect("the 'code already stored' branch is not where this pin expects it");
+        let store_call = body[already_stored..]
+            .find(".store_contract(contract_code.clone())")
+            .expect(
+                "the already-stored branch must index the new instance by calling \
+                 store_contract — its fast paths do exactly that work once the \
+                 identity is verified",
+            );
+        // Both `store_contract` calls in this body are legitimate: the new-code
+        // branch and this one. Two is the expected count; a third needs thought.
+        assert_eq!(
+            body.matches(".store_contract(").count(),
+            2,
+            "expected exactly two store_contract calls in the upsert path: the \
+             new-code branch and the already-stored branch"
+        );
+        assert!(store_call > 0, "unexpected slice offset");
     }
 
     /// The corrupted-state recovery path (the ONE branch that replaces

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -1225,7 +1225,7 @@ impl ReDb {
     // These replace the legacy KEY_DATA file in contracts directory
 
     /// Store a contract index entry: ContractInstanceId → CodeHash
-    pub fn store_contract_index(
+    pub(crate) fn store_contract_index(
         &self,
         instance_id: &ContractInstanceId,
         code_hash: &CodeHash,
@@ -1309,7 +1309,7 @@ impl ReDb {
 
     /// Store a delegate index entry: DelegateKey → CodeHash
     /// DelegateKey is serialized as 64 bytes (32 byte key + 32 byte code_hash)
-    pub fn store_delegate_index(
+    pub(crate) fn store_delegate_index(
         &self,
         delegate_key: &DelegateKey,
         code_hash: &CodeHash,

--- a/crates/core/src/wasm_runtime/contract.rs
+++ b/crates/core/src/wasm_runtime/contract.rs
@@ -69,11 +69,20 @@ pub(crate) trait ContractStoreBridge {
     /// disk budget. See [`super::ContractStore::code_blob_stored`] (#4218).
     fn code_blob_stored(&self, code_hash: &CodeHash) -> bool;
 
+    /// The store's ONE ingress for the durable instance→code index.
+    ///
+    /// This is deliberately the only index-writing method on this trait. An
+    /// `ensure_key_indexed` sibling used to sit here, which wrote that row with
+    /// none of the preconditions `store_contract` enforces, so the executor's
+    /// "code already on disk, index this new instance" branch was an unguarded
+    /// second ingress to the row the guarded path protects. `store_contract`'s
+    /// own fast paths already do that indexing when the blob is present, so the
+    /// second entry point bought nothing and cost two invariants (see
+    /// `ContractStore::verify_contract_identity` and #5280). Do not add another
+    /// index writer here.
     fn store_contract(&mut self, contract: ContractContainer) -> Result<(), anyhow::Error>;
 
     fn remove_contract(&mut self, key: &ContractKey) -> Result<(), anyhow::Error>;
-
-    fn ensure_key_indexed(&mut self, key: &ContractKey) -> Result<(), anyhow::Error>;
 }
 
 /// Combined trait: WASM execution + contract storage. Implemented by `Runtime`

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -244,6 +244,29 @@ impl ContractStore {
     /// identity. Check 1 alone would still allow a well-formed container to be
     /// filed under an unrelated instance id; check 2 alone is circular.
     ///
+    /// Two distinct `(code, params)` pairs cannot legitimately derive the same
+    /// instance id by a length-shifting trick, only by a genuine BLAKE3
+    /// collision: the first operand of the concatenation is a fixed-length
+    /// 32-byte hash, so `BLAKE3(code_hash ‖ params)` is unambiguously parseable
+    /// and `(code_hash, params)` is uniquely recoverable from the hashed string.
+    /// (Were the first operand variable-length, `a ‖ b` and `a' ‖ b'` could agree
+    /// while the pairs differed, and a cheap preimage would exist without
+    /// breaking the hash.) That is what makes it sound for
+    /// `ensure_key_indexed_locked` to treat an index row disagreeing with a
+    /// verified key as WRONG rather than as an alternative mapping.
+    ///
+    /// # Cost, and where it is paid
+    ///
+    /// One BLAKE3 pass over the WASM per call. Since #5268's follow-up this runs
+    /// on the COMMON path, not just on first store: the executor's "code already
+    /// on disk" branch routes here so that a new instance of an existing binary
+    /// is verified before it is indexed, and on that path there is no module
+    /// compile to be negligible against — the blob is cached and nothing is
+    /// rewritten. It is still small beside the `validate_state` / `update_state`
+    /// WASM call the same PUT performs, which is the honest comparison. Do not
+    /// move the check later to save it: the whole point is that it precedes every
+    /// durable effect.
+    ///
     /// Deriving the id via the stdlib helper rather than re-implementing
     /// `BLAKE3(hash ‖ params)` here is deliberate: a local copy of that formula
     /// would silently diverge if the derivation ever changed.
@@ -309,15 +332,24 @@ impl ContractStore {
                 contract_v1.code().clone(),
                 contract_v1.params().clone(),
             ),
-            ContractContainer::Wasm(_) | _ => unimplemented!(),
+            // Return, don't `unimplemented!()`. Unreachable today (V1 is the only
+            // variant), but `ContractWasmAPIVersion` is `#[non_exhaustive]`, so a
+            // future variant would otherwise panic — and since this function moved
+            // onto the COMMON PUT path (it now handles new instances of
+            // already-stored code, not just first stores), that panic would be
+            // reachable from ordinary traffic rather than from a first store. The
+            // delegate store already answers this case with an error; match it.
+            ContractContainer::Wasm(_) | _ => {
+                return Err(anyhow::anyhow!("unsupported contract container version").into());
+            }
         };
 
         // Verify the identity BEFORE anything durable happens, and before taking
-        // the blob lock: this is pure computation (one BLAKE3 pass over the WASM,
-        // negligible against the compile it precedes), so there is no reason to
-        // hold a process-wide lock across it, and nothing below should run at all
-        // for a container whose key we cannot derive. See
-        // `verify_contract_identity`.
+        // the blob lock: this is pure computation (one BLAKE3 pass over the WASM),
+        // so there is no reason to hold a process-wide lock across it, and nothing
+        // below should run at all for a container whose key we cannot derive.
+        // See `verify_contract_identity`, including what that pass costs on the
+        // already-stored path — where there is no module compile to hide behind.
         if let Err(err) = Self::verify_contract_identity(&key, &code, &params) {
             // WARN, not debug: this is the node declining to file bytes under an
             // identity it did not derive. It should be visible in an operator's
@@ -619,6 +651,18 @@ impl ContractStore {
         match existing {
             Some(recorded) if recorded == *code_hash => return Ok(()),
             Some(recorded) => {
+                // Correcting the row can leave `recorded`'s blob referenced by no
+                // index row at all, if this was its last referent. That is a
+                // bounded disk leak and NOT a correctness problem: `fetch_contract`
+                // resolves code through this index, so an unreferenced blob is
+                // never served, and the disk-budget counter is reconciled against
+                // ground truth by the next `refresh_wasm` walk. It is also strictly
+                // better than the state it replaces, where the wrong row persisted
+                // forever. Deliberately not cleaned up here — orphan reconciliation
+                // in both directions is tracked as #5281, which already covers
+                // orphaned blobs and orphaned state/params rows from other
+                // triggers; a one-off sweep at this call site would be a second,
+                // partial mechanism.
                 tracing::warn!(
                     contract = %key,
                     instance_id = %key.id(),
@@ -1439,7 +1483,7 @@ mod test {
 
         let err = store
             .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged)))
-            .expect_err("an undervied instance must be refused even when the blob is present");
+            .expect_err("an underived instance must be refused even when the blob is present");
         assert!(
             matches!(
                 err.deref(),
@@ -1524,6 +1568,25 @@ mod test {
             Some(hash_a),
             "the fast paths must correct a disagreeing row, not skip it"
         );
+
+        // Everything above reads `code_hash_from_id`, which consults the in-memory
+        // `DashMap` and never the durable ReDb row. So drop the store and rebuild
+        // from the same directory, forcing the index to load from ReDb alone: that
+        // is what proves the correction was made DURABLE rather than only in
+        // memory. Not reachable today, because `ensure_key_indexed_locked` writes
+        // ReDb before updating the map — but it would break silently under a
+        // refactor that reordered them, and an in-memory-only correction would be
+        // undone by the next restart. Same shape as
+        // `test_index_persistence_after_restart`.
+        drop(store);
+        let reopened_db = create_test_db(contract_dir.path()).await;
+        let reopened = ContractStore::new(contract_dir.path().into(), 10_000, reopened_db)?;
+        assert_eq!(
+            reopened.code_hash_from_id(key_a.id()),
+            Some(hash_a),
+            "the correction must be durable: an index rebuilt from ReDb must not \
+             resurrect the disagreeing row"
+        );
         Ok(())
     }
 
@@ -1557,17 +1620,13 @@ mod test {
              it must route through store_contract."
         );
 
-        let gate = production
+        production
             .find("#[cfg(test)]\n    pub fn ensure_key_indexed(")
             .expect(
                 "the bare index writer must stay #[cfg(test)]-gated — it takes only a \
                  &ContractKey, so it can verify neither the identity it files nor that \
                  the blob exists",
             );
-        let locked = production
-            .find("fn ensure_key_indexed_locked(")
-            .expect("ensure_key_indexed_locked not found");
-        assert!(gate < locked, "unexpected ordering of the two helpers");
     }
 
     /// Regression test for the latent shared-WASM deletion bug: removing one

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -164,45 +164,162 @@ impl ContractStore {
         key: &ContractKey,
         params: &Parameters<'_>,
     ) -> Option<ContractContainer> {
-        // Gate on the shared index: an instance that is no longer indexed
-        // (e.g. removed via a sibling executor) must not be served from a stale
-        // per-executor cache entry.
-        if !self.key_to_code_part.contains_key(key.id()) {
+        // Resolve the code hash from the shared INDEX, never from the `code`
+        // field the caller's `ContractKey` carries. Two reasons, and the second
+        // is why this is not merely a tidiness point:
+        //
+        // 1. It gates on the index, so an instance that is no longer indexed
+        //    (e.g. removed via a sibling executor) is not served from a stale
+        //    per-executor cache entry (#4218 problem 2).
+        // 2. That `code` field is an unverified serde field (see
+        //    `verify_contract_identity`), and `ContractKey`'s `Eq`/`Hash` ignore
+        //    it, so it does not have to correspond to this instance at all.
+        //    Keying the cache lookup off it let a caller name an instance it is
+        //    entitled to while choosing WHICH cached code came back for it. The
+        //    index is what this node itself recorded, so resolving through it
+        //    makes the answer a function of the instance alone.
+        let Some(code_hash) = self.key_to_code_part.get(key.id()).map(|e| *e.value()) else {
             return None;
-        }
+        };
 
-        let code_hash = key.code_hash();
-        if let Some(data) = self.contract_cache.get(code_hash) {
+        if let Some(data) = self.contract_cache.get(&code_hash) {
             return Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
                 WrappedContract::new(data, params.clone().into_owned()),
             )));
         }
 
-        self.key_to_code_part.get(key.id()).and_then(|entry| {
-            let code_hash = *entry.value();
-            let path = code_hash.encode();
-            let key_path = self.contracts_dir.join(path).with_extension("wasm");
-            // Load with version prefix stripping (fixes #2924)
-            // Files are stored with to_bytes_versioned() which adds a version prefix.
-            // Must use load_versioned_from_path() to strip it before compilation.
-            let (code, _ver) = ContractCode::load_versioned_from_path(&key_path)
-                .map_err(|err| {
-                    tracing::debug!("contract not found: {err}");
-                    err
-                })
-                .ok()?;
-            let params = params.clone().into_owned();
-            // add back the contract part to the mem store
-            self.contract_cache
-                .insert(code_hash, Arc::new(code.clone()));
-            Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
-                WrappedContract::new(Arc::new(code), params),
-            )))
-        })
+        let key_path = self
+            .contracts_dir
+            .join(code_hash.encode())
+            .with_extension("wasm");
+        // Load with version prefix stripping (fixes #2924)
+        // Files are stored with to_bytes_versioned() which adds a version prefix.
+        // Must use load_versioned_from_path() to strip it before compilation.
+        let (code, _ver) = ContractCode::load_versioned_from_path(&key_path)
+            .map_err(|err| {
+                tracing::debug!("contract not found: {err}");
+                err
+            })
+            .ok()?;
+        let params = params.clone().into_owned();
+        // add back the contract part to the mem store
+        self.contract_cache
+            .insert(code_hash, Arc::new(code.clone()));
+        Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            WrappedContract::new(Arc::new(code), params),
+        )))
+    }
+
+    /// Check that a contract's key is actually derived from the bytes it ships
+    /// with, and refuse it otherwise.
+    ///
+    /// # Why this has to be checked here
+    ///
+    /// A `ContractKey` is two fields, `instance` and `code`, and BOTH are
+    /// ordinary serde fields that survive a wire round-trip exactly as sent:
+    /// nothing recomputes them on deserialization, and `ContractKey`'s `Hash` /
+    /// `Eq` compare `instance` alone, so the `code` half is never even consulted
+    /// for identity. `ContractCode` carries the same shape: `ContractCode::hash()`
+    /// returns a stored field rather than hashing the bytes, and its `PartialEq`
+    /// compares only that field. So a container's claimed identity and its actual
+    /// content are independent until something derives one from the other.
+    ///
+    /// [`ContractStore`] is where that stops being merely untidy: `store_contract`
+    /// uses the claimed code hash as the blob FILENAME and as the value written
+    /// into the instance→code index, both in memory and durably in ReDb, and the
+    /// index is what `fetch_contract` and the compiled-module cache later resolve
+    /// through. An identity the node never derived would therefore decide, durably,
+    /// which bytes it believes are a given contract's code.
+    ///
+    /// # The two checks, and why the order matters
+    ///
+    /// 1. `CodeHash::from_code(code.data())` must equal the code hash the
+    ///    container claims (on the key AND on the code itself). This is the only
+    ///    check that touches the bytes, so it has to come first.
+    /// 2. `instance` must equal `ContractInstanceId::from_params_and_code(params,
+    ///    code)`. That derivation is `BLAKE3(code.hash() ‖ params)` and it reads
+    ///    `code.hash()`, i.e. the stored field, so it is only meaningful ONCE
+    ///    check 1 has established that the field matches the bytes. Doing 2 alone
+    ///    would verify a claim against another claim.
+    ///
+    /// Both together are what bind instance, code hash and bytes into one
+    /// identity. Check 1 alone would still allow a well-formed container to be
+    /// filed under an unrelated instance id; check 2 alone is circular.
+    ///
+    /// Deriving the id via the stdlib helper rather than re-implementing
+    /// `BLAKE3(hash ‖ params)` here is deliberate: a local copy of that formula
+    /// would silently diverge if the derivation ever changed.
+    fn verify_contract_identity(
+        key: &ContractKey,
+        code: &ContractCode<'_>,
+        params: &Parameters<'_>,
+    ) -> RuntimeResult<()> {
+        let actual_code_hash = CodeHash::from_code(code.data());
+
+        // Check 1: the claimed code hash(es) must be the hash of these bytes.
+        // Both the key's copy and the code's own copy are checked, because they
+        // are separate fields and either could be the one a later reader trusts.
+        if actual_code_hash != *key.code_hash() || actual_code_hash != *code.hash() {
+            return Err(crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch {
+                key: Box::new(*key),
+                detail: format!(
+                    "code hashes to {actual_code_hash} but the key claims {} and the code claims {}",
+                    key.code_hash(),
+                    code.hash()
+                ),
+            }
+            .into());
+        }
+
+        // Check 2: sound only now that check 1 passed (see rustdoc).
+        let derived_instance = ContractInstanceId::from_params_and_code(params, code);
+        if derived_instance != *key.id() {
+            return Err(
+                crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch {
+                    key: Box::new(*key),
+                    detail: format!(
+                        "instance {} is not derived from this code and these {} parameter byte(s) \
+                     (derivation gives {derived_instance})",
+                        key.id(),
+                        params.as_ref().len()
+                    ),
+                }
+                .into(),
+            );
+        }
+
+        Ok(())
     }
 
     /// Store a copy of the contract in the local store, in case it hasn't been stored previously.
     pub fn store_contract(&mut self, contract: ContractContainer) -> RuntimeResult<()> {
+        let (key, code, params) = match contract.clone() {
+            ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => (
+                *contract_v1.key(),
+                contract_v1.code().clone(),
+                contract_v1.params().clone(),
+            ),
+            ContractContainer::Wasm(_) | _ => unimplemented!(),
+        };
+
+        // Verify the identity BEFORE anything durable happens, and before taking
+        // the blob lock: this is pure computation (one BLAKE3 pass over the WASM,
+        // negligible against the compile it precedes), so there is no reason to
+        // hold a process-wide lock across it, and nothing below should run at all
+        // for a container whose key we cannot derive. See
+        // `verify_contract_identity`.
+        if let Err(err) = Self::verify_contract_identity(&key, &code, &params) {
+            // WARN, not debug: this is the node declining to file bytes under an
+            // identity it did not derive. It should be visible in an operator's
+            // log without a rebuild (`debug!` compiles out in release builds).
+            tracing::warn!(
+                contract = %key,
+                code_bytes = code.data().len(),
+                "refusing to store contract: {err}"
+            );
+            return Err(err);
+        }
+
         // Serialize against concurrent store/remove on the SAME shared code
         // hash across sibling-executor `ContractStore`s (issue #4216). Without
         // this, a `remove_contract` on another executor can run its
@@ -217,12 +334,6 @@ impl ContractStore {
         let blob_lock = self.db.contract_blob_lock();
         let _blob_guard = blob_lock.lock().unwrap_or_else(|e| e.into_inner());
 
-        let (key, code) = match contract.clone() {
-            ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => {
-                (*contract_v1.key(), contract_v1.code().clone())
-            }
-            ContractContainer::Wasm(_) | _ => unimplemented!(),
-        };
         let code_hash = key.code_hash();
         let key_path = code_hash.encode();
         let key_path = self.contracts_dir.join(key_path).with_extension("wasm");
@@ -870,6 +981,236 @@ mod test {
             "Removed contract must not be served from cache (ghost contract)"
         );
 
+        Ok(())
+    }
+
+    /// A contract whose key IS derived from its own code and parameters stores
+    /// normally. This is the control for the three rejection tests below: without
+    /// it, they would all still pass if `verify_contract_identity` simply rejected
+    /// everything, and a check that cannot come out clean is not evidence.
+    #[tokio::test]
+    async fn store_contract_accepts_a_key_derived_from_its_own_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        // `WrappedContract::new` derives the key from (params, code), so this is
+        // exactly what an honest publisher produces.
+        let contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![1u8, 2, 3, 4])),
+            params.clone(),
+        );
+        let key = *contract.key();
+
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract,
+        )))?;
+        assert!(
+            store.fetch_contract(&key, &params).is_some(),
+            "an honestly-derived contract must still be storable and fetchable"
+        );
+        Ok(())
+    }
+
+    /// The claimed code hash must be the hash of the code actually supplied.
+    ///
+    /// `ContractKey`'s `code` field is an unverified serde field, so a container
+    /// can name a code hash unrelated to its bytes. `store_contract` uses that
+    /// value as the blob filename and as the index value, so accepting it would
+    /// let bytes be filed under a code hash they do not hash to.
+    #[tokio::test]
+    async fn store_contract_rejects_code_hash_that_is_not_the_hash_of_the_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        let mut contract = WrappedContract::new(
+            Arc::new(ContractCode::from(vec![1u8, 2, 3, 4])),
+            params.clone(),
+        );
+        // Keep the instance, claim a code hash that is not this code's hash.
+        let bogus_code_hash = CodeHash::new([7u8; 32]);
+        contract.key = ContractKey::from_id_and_code(*contract.key.id(), bogus_code_hash);
+        let forged_key = contract.key;
+
+        let err = store
+            .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+                contract,
+            )))
+            .expect_err("a code hash that does not match the code must be refused");
+        assert!(
+            matches!(
+                err.deref(),
+                crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch { .. }
+            ),
+            "expected ContractIdentityMismatch, got: {err}"
+        );
+
+        // Nothing durable may have happened: no blob under the claimed hash, and
+        // no index entry for the instance.
+        let claimed_path = contract_dir
+            .path()
+            .join(bogus_code_hash.encode())
+            .with_extension("wasm");
+        assert!(
+            !claimed_path.exists(),
+            "no blob may be written under an unverified code hash"
+        );
+        assert!(
+            store.code_hash_from_id(forged_key.id()).is_none(),
+            "no index entry may be written for a refused contract"
+        );
+        Ok(())
+    }
+
+    /// The instance id must be derived from the code and parameters supplied.
+    ///
+    /// This is the case an internally-consistent container can still forge: the
+    /// code hash genuinely matches the bytes, and only the instance id is
+    /// unrelated to them. Checking the code hash alone would accept this and file
+    /// well-formed code under an arbitrary instance id.
+    #[tokio::test]
+    async fn store_contract_rejects_instance_not_derived_from_code_and_params()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let code = Arc::new(ContractCode::from(vec![1u8, 2, 3, 4]));
+        let params_a: Parameters = [0u8].as_ref().into();
+        let params_b: Parameters = [9u8].as_ref().into();
+
+        let instance_a = *WrappedContract::new(code.clone(), params_a).key().id();
+        let mut forged = WrappedContract::new(code.clone(), params_b);
+        // Correct code hash for these bytes, but another instance's id.
+        forged.key = ContractKey::from_id_and_code(instance_a, *forged.key.code_hash());
+
+        let err = store
+            .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged)))
+            .expect_err("an instance id not derived from this code and params must be refused");
+        assert!(
+            matches!(
+                err.deref(),
+                crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch { .. }
+            ),
+            "expected ContractIdentityMismatch, got: {err}"
+        );
+        assert!(
+            store.code_hash_from_id(&instance_a).is_none(),
+            "a refused contract must not create an index entry"
+        );
+        Ok(())
+    }
+
+    /// A refused contract must not re-point an EXISTING instance's code.
+    ///
+    /// `store_contract`'s slow path overwrites the instance→code index
+    /// unconditionally (both the in-memory mirror and the durable ReDb row), and
+    /// `fetch_contract` plus the compiled-module cache resolve through that index.
+    /// So an accepted forgery would not merely add a bad entry, it would change
+    /// which code an already-stored, legitimate contract resolves to.
+    #[tokio::test]
+    async fn store_contract_refusal_leaves_an_existing_instance_pointing_at_its_own_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        let honest_code = vec![1u8, 2, 3, 4];
+        let honest = WrappedContract::new(
+            Arc::new(ContractCode::from(honest_code.clone())),
+            params.clone(),
+        );
+        let honest_key = *honest.key();
+        let honest_hash = *honest_key.code_hash();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(honest)))?;
+        assert_eq!(store.code_hash_from_id(honest_key.id()), Some(honest_hash));
+
+        // Different code, internally consistent, but claiming the honest
+        // contract's instance id.
+        let other_code = Arc::new(ContractCode::from(vec![9u8, 9, 9, 9, 9]));
+        let mut forged = WrappedContract::new(other_code.clone(), params.clone());
+        let other_hash = *forged.key.code_hash();
+        assert_ne!(
+            other_hash, honest_hash,
+            "fixture must use genuinely different code"
+        );
+        forged.key = ContractKey::from_id_and_code(*honest_key.id(), other_hash);
+
+        store
+            .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged)))
+            .expect_err("a forged instance id must be refused");
+
+        // The honest instance still resolves to its own code, and still serves it.
+        assert_eq!(
+            store.code_hash_from_id(honest_key.id()),
+            Some(honest_hash),
+            "a refused store must not re-point an existing instance's code"
+        );
+        let fetched = store
+            .fetch_contract(&honest_key, &params)
+            .expect("the honest contract must still be served");
+        match fetched {
+            ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) => {
+                assert_eq!(c.code().data(), honest_code.as_slice());
+            }
+            _ => panic!("unexpected container version"),
+        }
+        Ok(())
+    }
+
+    /// `fetch_contract` must resolve code through the node's own index, not
+    /// through the `code` field on the caller's key.
+    ///
+    /// The cache fast path used to look up `key.code_hash()` directly, gated only
+    /// on the instance being indexed at all. Since that field is unverified and
+    /// excluded from `ContractKey`'s `Eq`/`Hash`, a caller could name an instance
+    /// while choosing which cached code came back for it.
+    #[tokio::test]
+    async fn fetch_contract_resolves_code_through_the_index_not_the_callers_key()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        let code_a = vec![1u8, 2, 3, 4];
+        let code_b = vec![9u8, 9, 9, 9, 9];
+
+        let a = WrappedContract::new(Arc::new(ContractCode::from(code_a.clone())), params.clone());
+        let key_a = *a.key();
+        let b = WrappedContract::new(Arc::new(ContractCode::from(code_b.clone())), params.clone());
+        let hash_b = *b.key().code_hash();
+
+        // Store both, so B's code is warm in the per-executor cache.
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(a)))?;
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(b)))?;
+
+        // Name instance A, but claim B's code hash.
+        let mixed_key = ContractKey::from_id_and_code(*key_a.id(), hash_b);
+        let fetched = store
+            .fetch_contract(&mixed_key, &params)
+            .expect("instance A is indexed, so a lookup for it must resolve");
+        match fetched {
+            ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) => {
+                assert_eq!(
+                    c.code().data(),
+                    code_a.as_slice(),
+                    "must serve the code the INDEX records for this instance, not the code hash the caller named"
+                );
+            }
+            _ => panic!("unexpected container version"),
+        }
         Ok(())
     }
 

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -247,6 +247,18 @@ impl ContractStore {
     /// Deriving the id via the stdlib helper rather than re-implementing
     /// `BLAKE3(hash ‖ params)` here is deliberate: a local copy of that formula
     /// would silently diverge if the derivation ever changed.
+    ///
+    /// # Note for a future fuzz or property test
+    ///
+    /// A container built with `Arbitrary` fails check 1 BY CONSTRUCTION and is
+    /// not a bug here: `ContractCode` derives `Arbitrary` with `code_hash` as
+    /// random bytes unrelated to `data`, and `WrappedContract::arbitrary` then
+    /// derives the key from that unrelated hash — so such a container satisfies
+    /// check 2 and fails check 1. Nothing in core or fdev builds contract
+    /// containers that way today, so this is not reachable; but feeding
+    /// `WrappedContract::arbitrary()` to `store_contract` would fail in a way
+    /// that looks like a real defect. Hash the bytes you want the container to
+    /// carry, or go through `WrappedContract::new`.
     fn verify_contract_identity(
         key: &ContractKey,
         code: &ContractCode<'_>,
@@ -541,11 +553,33 @@ impl ContractStore {
         self.key_to_code_part.get(id).map(|r| *r.value())
     }
 
-    /// Ensures the key_to_code_part mapping exists for the given contract key.
-    /// This is needed because when contract code is already cached, store_contract
-    /// may not be called, but we still need to index new ContractInstanceIds that
-    /// use the same code (different parameters = different rooms).
-    /// See issue #2380.
+    /// Index a contract instance from a bare key. **Test fixtures only.**
+    ///
+    /// Indexing a new instance of already-stored code (different parameters =
+    /// different rooms, issue #2380) is real and necessary, but it is
+    /// [`Self::store_contract`]'s job: its fast paths do exactly this work when
+    /// the blob is already present, and they do it AFTER
+    /// [`Self::verify_contract_identity`] has established that the key is
+    /// derived from the code and parameters in hand.
+    ///
+    /// This entry point cannot do that, and that is why it is no longer
+    /// production-reachable. It receives only a `&ContractKey` — no code bytes,
+    /// no parameters — so it can neither derive the identity it is filing nor
+    /// confirm the blob it points at exists. It used to be called directly from
+    /// `bridged_upsert_contract_state_inner` on the common "code already stored"
+    /// path, which made it a second, unguarded writer of the durable
+    /// instance→code row, and it was implicated twice over for two DIFFERENT
+    /// missing preconditions: no derivation check (the hole
+    /// `verify_contract_identity` closes) and no blob-existence check (the
+    /// candidate mechanism for the dangling index entries in #5280). One helper,
+    /// two invariants missed, because a store with real invariants had an ingress
+    /// that could not check them.
+    ///
+    /// It survives `#[cfg(test)]`-gated because several fixtures legitimately
+    /// want "index this key and nothing else". The gate is the enforcement: a
+    /// future production caller does not compile. If you need this from
+    /// production code, you need `store_contract`.
+    #[cfg(test)]
     pub fn ensure_key_indexed(&mut self, key: &ContractKey) -> RuntimeResult<()> {
         // Public entry point: take the shared store/remove lock (issue #4216)
         // so an external caller indexing a new instance is serialized against a
@@ -558,27 +592,59 @@ impl ContractStore {
         self.ensure_key_indexed_locked(key)
     }
 
-    /// Unlocked body of [`ensure_key_indexed`]. The caller MUST hold the shared
-    /// `contract_blob_lock` (issue #4216). Called by `store_contract`, which
-    /// already holds the lock.
+    /// Unlocked body of [`Self::ensure_key_indexed`]. The caller MUST hold the
+    /// shared `contract_blob_lock` (issue #4216). In production this is reached
+    /// only from `store_contract`, which already holds the lock and has already
+    /// verified `key` against the code and parameters it arrived with.
+    ///
+    /// # Why a disagreeing row is corrected rather than left alone
+    ///
+    /// This used to insert only when the instance was ABSENT, which made a wrong
+    /// row STICKY: once `instance -> X` existed, a later honest store of that
+    /// instance could not correct it, because the only unconditional overwrite is
+    /// in `store_contract`'s slow path and that path runs only when the
+    /// instance's own blob is missing. So a row written before the derivation
+    /// check existed would outlive it indefinitely.
+    ///
+    /// An instance id is `BLAKE3(code_hash ‖ params)`, so a verified key's
+    /// instance determines its code hash uniquely: a stored row that disagrees
+    /// with a key the caller has just verified is wrong, not an alternative
+    /// mapping. Overwriting it is therefore both safe and the only self-healing
+    /// path for rows that predate the check. It logs at WARN — not `debug!`,
+    /// which compiles out in release — because a disagreement means the node held
+    /// a mapping it could not have derived, which an operator should see once.
     fn ensure_key_indexed_locked(&mut self, key: &ContractKey) -> RuntimeResult<()> {
         let code_hash = key.code_hash();
-        if !self.key_to_code_part.contains_key(key.id()) {
-            // Store in ReDb
-            self.db
-                .store_contract_index(key.id(), code_hash)
-                .map_err(|e| anyhow::anyhow!("Failed to store contract index: {e}"))?;
-
-            // Update in-memory map
-            self.key_to_code_part.insert(*key.id(), *code_hash);
-
-            tracing::debug!(
-                contract = %key,
-                instance_id = %key.id(),
-                code_hash = %code_hash,
-                "Indexed contract instance (same code, different params)"
-            );
+        let existing = self.key_to_code_part.get(key.id()).map(|e| *e.value());
+        match existing {
+            Some(recorded) if recorded == *code_hash => return Ok(()),
+            Some(recorded) => {
+                tracing::warn!(
+                    contract = %key,
+                    instance_id = %key.id(),
+                    recorded = %recorded,
+                    derived = %code_hash,
+                    "Correcting an instance→code index row that disagrees with the \
+                     contract's own derived identity"
+                );
+            }
+            None => {}
         }
+
+        // Store in ReDb
+        self.db
+            .store_contract_index(key.id(), code_hash)
+            .map_err(|e| anyhow::anyhow!("Failed to store contract index: {e}"))?;
+
+        // Update in-memory map
+        self.key_to_code_part.insert(*key.id(), *code_hash);
+
+        tracing::debug!(
+            contract = %key,
+            instance_id = %key.id(),
+            code_hash = %code_hash,
+            "Indexed contract instance (same code, different params)"
+        );
         Ok(())
     }
 }
@@ -1210,6 +1276,298 @@ mod test {
             _ => panic!("unexpected container version"),
         }
         Ok(())
+    }
+
+    /// Build a `ContractCode` carrying `data` but claiming `claimed_hash` as its
+    /// own stored hash.
+    ///
+    /// `ContractCode::code_hash` is `pub(crate)` to the stdlib, so an in-memory
+    /// value cannot be edited — but it is an ordinary serde field, which is the
+    /// whole reason check 1 tests it. `ContractCode` is `data` then `code_hash`,
+    /// so the hash is the final 32 bytes of the encoding; the assertion pins that
+    /// layout so a stdlib field reorder fails this fixture loudly instead of
+    /// quietly patching the wrong bytes.
+    fn code_claiming_hash(data: Vec<u8>, claimed_hash: CodeHash) -> ContractCode<'static> {
+        let honest = ContractCode::from(data);
+        let mut bytes = bincode::serialize(&honest).expect("code must serialize");
+        let len = bytes.len();
+        assert!(len > 32, "encoding too short to carry a 32-byte hash");
+        assert_eq!(
+            &bytes[len - 32..],
+            honest.hash().as_ref(),
+            "fixture is stale: ContractCode's stored hash is not the final 32 bytes"
+        );
+        bytes[len - 32..].copy_from_slice(claimed_hash.as_ref());
+        bincode::deserialize::<ContractCode>(&bytes)
+            .expect("a patched code must still deserialize")
+            .into_owned()
+    }
+
+    /// `ContractCode`'s OWN stored hash must be checked, not just the key's copy.
+    ///
+    /// Check 1 asserts the recomputed hash against BOTH `key.code_hash()` and
+    /// `code.hash()`. The second clause is the one holding check 2 up, and
+    /// dropping it re-opens the hole on its own: `ContractInstanceId::
+    /// from_params_and_code` derives from `code.hash()`, i.e. the code's STORED
+    /// field (stdlib `key.rs::generate_id`). So a container that claims a correct
+    /// hash on the KEY while carrying a bogus one on the CODE satisfies the
+    /// key-side clause, and then check 2 derives the instance from the bogus
+    /// value and agrees with itself — leaving the instance id arbitrary.
+    ///
+    /// The three fixtures above all forge the key's copy and leave `code.hash()`
+    /// correct, so the key-side clause alone fails them and none of them would
+    /// notice the second clause being deleted. This one fails without it.
+    #[tokio::test]
+    async fn store_contract_rejects_a_code_whose_own_stored_hash_is_not_its_bytes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        let data = vec![1u8, 2, 3, 4];
+        let honest_hash = CodeHash::from_code(&data);
+        let bogus_hash = CodeHash::new([7u8; 32]);
+
+        let forged_code = Arc::new(code_claiming_hash(data.clone(), bogus_hash));
+        assert_eq!(
+            forged_code.data(),
+            data.as_slice(),
+            "the fixture must keep the real bytes"
+        );
+        assert_eq!(
+            *forged_code.hash(),
+            bogus_hash,
+            "the fixture must claim the bogus hash on the CODE"
+        );
+
+        // The instance is derived from the BOGUS hash (that is what
+        // `from_params_and_code` reads), while the key's own code hash is the
+        // CORRECT one — so the key-side clause of check 1 passes, and check 2
+        // agrees with itself.
+        let instance = ContractInstanceId::from_params_and_code(&params, &*forged_code);
+        let key = ContractKey::from_id_and_code(instance, honest_hash);
+        assert_eq!(
+            *key.code_hash(),
+            honest_hash,
+            "the key's copy must be correct, or this tests the wrong clause"
+        );
+        assert_eq!(
+            ContractInstanceId::from_params_and_code(&params, &*forged_code),
+            *key.id(),
+            "check 2 must be satisfiable by this fixture, or it proves nothing \
+             about the clause under test"
+        );
+
+        // `WrappedContract` is `#[non_exhaustive]`, so build it through `new` and
+        // then set the two public fields this fixture needs to control.
+        let mut forged = WrappedContract::new(forged_code.clone(), params.clone().into_owned());
+        forged.data = forged_code;
+        forged.key = key;
+        let err = store
+            .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged)))
+            .expect_err("a code whose own stored hash is not its bytes must be refused");
+        assert!(
+            matches!(
+                err.deref(),
+                crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch { .. }
+            ),
+            "expected ContractIdentityMismatch, got: {err}"
+        );
+        assert!(
+            store.code_hash_from_id(&instance).is_none(),
+            "no index entry may be written for a refused contract"
+        );
+        Ok(())
+    }
+
+    /// Verification must hold on the "code blob already stored" path, because
+    /// that is the path a new instance of existing code takes.
+    ///
+    /// Several instances share one code blob (every River room shares one room
+    /// contract, #2380), so the common case is: blob already on disk, cache warm,
+    /// only a new instance→code row to write. `store_contract` reaches that
+    /// through its fast paths, and the check runs before them — this pins that,
+    /// because a check placed after them would miss the majority of real PUTs.
+    /// The executor's equivalent branch routes here for exactly this reason (see
+    /// `bridged_upsert_contract_state_inner`).
+    #[tokio::test]
+    async fn store_contract_verifies_even_when_the_code_blob_is_already_stored()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let code = Arc::new(ContractCode::from(vec![1u8, 2, 3, 4]));
+        let params_a: Parameters = [0u8].as_ref().into();
+        let params_b: Parameters = [9u8].as_ref().into();
+
+        // First instance: stores the blob, warms the cache.
+        let first = WrappedContract::new(code.clone(), params_a.clone().into_owned());
+        let key_a = *first.key();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(first)))?;
+        assert!(
+            store.code_blob_stored(key_a.code_hash()),
+            "fixture must leave the code blob on disk"
+        );
+
+        // Control: an HONEST second instance of that same blob is still accepted
+        // and indexed. Without this the refusal below would also pass if the fast
+        // paths refused every second instance.
+        let honest_b = WrappedContract::new(code.clone(), params_b.clone().into_owned());
+        let key_b = *honest_b.key();
+        assert_ne!(key_a.id(), key_b.id(), "fixture must be a NEW instance");
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            honest_b,
+        )))?;
+        assert_eq!(
+            store.code_hash_from_id(key_b.id()),
+            Some(*code.hash()),
+            "an honest new instance of already-stored code must be indexed"
+        );
+
+        // Now the same shape with an instance id that is not derived from this
+        // code and these params.
+        let params_c: Parameters = [5u8].as_ref().into();
+        let unrelated_instance = *WrappedContract::new(code.clone(), params_c.into_owned())
+            .key()
+            .id();
+        let mut forged = WrappedContract::new(code.clone(), params_b.clone().into_owned());
+        forged.key = ContractKey::from_id_and_code(unrelated_instance, *code.hash());
+
+        let err = store
+            .store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged)))
+            .expect_err("an undervied instance must be refused even when the blob is present");
+        assert!(
+            matches!(
+                err.deref(),
+                crate::wasm_runtime::RuntimeInnerError::ContractIdentityMismatch { .. }
+            ),
+            "expected ContractIdentityMismatch, got: {err}"
+        );
+        assert!(
+            store.code_hash_from_id(&unrelated_instance).is_none(),
+            "the already-stored fast path must not index an unverified instance"
+        );
+        Ok(())
+    }
+
+    /// An instance→code row that disagrees with a verified key is corrected.
+    ///
+    /// `ensure_key_indexed_locked` used to write only when the instance was
+    /// ABSENT, which made a wrong row permanent: the sole unconditional overwrite
+    /// is `store_contract`'s slow path, reached only when the instance's blob is
+    /// missing, so an honest store of that instance would find the blob present,
+    /// take a fast path, see the instance "already indexed", and leave the wrong
+    /// row in place. Rows written before verification existed would therefore
+    /// outlive it. An instance id is `BLAKE3(code_hash ‖ params)`, so a row that
+    /// disagrees with a verified key is wrong rather than an alternative mapping,
+    /// and correcting it is the self-healing path.
+    #[tokio::test]
+    async fn store_contract_corrects_an_index_row_that_disagrees_with_the_derived_key()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let contract_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(contract_dir.path())?;
+        let db = create_test_db(contract_dir.path()).await;
+        let mut store = ContractStore::new(contract_dir.path().into(), 10_000, db)?;
+
+        let params: Parameters = [0u8, 1].as_ref().into();
+        let code_a = vec![1u8, 2, 3, 4];
+        let honest = WrappedContract::new(
+            Arc::new(ContractCode::from(code_a.clone())),
+            params.clone().into_owned(),
+        );
+        let key_a = *honest.key();
+        let hash_a = *key_a.code_hash();
+
+        // Plant a wrong row for A's instance, the way one written before
+        // verification existed would look. `ensure_key_indexed` is the test-only
+        // bare writer that used to be production-reachable.
+        let hash_b = *WrappedContract::new(
+            Arc::new(ContractCode::from(vec![9u8, 9, 9, 9, 9])),
+            params.clone().into_owned(),
+        )
+        .key()
+        .code_hash();
+        assert_ne!(hash_a, hash_b, "fixture must plant a DIFFERENT code hash");
+        store.ensure_key_indexed(&ContractKey::from_id_and_code(*key_a.id(), hash_b))?;
+        assert_eq!(
+            store.code_hash_from_id(key_a.id()),
+            Some(hash_b),
+            "fixture must leave a disagreeing row in place"
+        );
+
+        // A now stores honestly. Its blob is absent, so this takes the slow path…
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            honest.clone(),
+        )))?;
+        assert_eq!(
+            store.code_hash_from_id(key_a.id()),
+            Some(hash_a),
+            "an honest store must correct a disagreeing row"
+        );
+
+        // …and it is corrected on the already-stored fast paths too, which is
+        // where the stickiness actually bit: re-plant and re-store with the blob
+        // now present.
+        store.ensure_key_indexed(&ContractKey::from_id_and_code(*key_a.id(), hash_b))?;
+        assert_eq!(store.code_hash_from_id(key_a.id()), Some(hash_b));
+        assert!(
+            store.code_blob_stored(&hash_a),
+            "the blob must now be present, so this exercises a fast path"
+        );
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(honest)))?;
+        assert_eq!(
+            store.code_hash_from_id(key_a.id()),
+            Some(hash_a),
+            "the fast paths must correct a disagreeing row, not skip it"
+        );
+        Ok(())
+    }
+
+    /// There must be exactly ONE production ingress to the durable
+    /// instance→code index.
+    ///
+    /// `store_contract_index` has two call sites in this file — `store_contract`'s
+    /// slow path and `ensure_key_indexed_locked` — and that is fine only because
+    /// the second is reachable in production solely THROUGH the first, after
+    /// verification. The bare public wrapper is `#[cfg(test)]`, so a production
+    /// caller does not compile.
+    ///
+    /// This pin exists because that helper was implicated twice, hours apart, for
+    /// two different missing preconditions (no derivation check; no blob-existence
+    /// check, the candidate mechanism for #5280). A third writer appearing
+    /// unnoticed is the failure mode to prevent.
+    #[test]
+    fn the_durable_index_has_one_production_writer() {
+        let src = include_str!("contract_store.rs");
+
+        // Ignore this test module itself: its assertions quote these names.
+        let production = &src[..src
+            .find("#[cfg(test)]\nmod test {")
+            .expect("test module marker not found")];
+
+        assert_eq!(
+            production.matches(".store_contract_index(").count(),
+            2,
+            "exactly two call sites are expected: store_contract's slow path and \
+             ensure_key_indexed_locked. A new one needs its own verification, or \
+             it must route through store_contract."
+        );
+
+        let gate = production
+            .find("#[cfg(test)]\n    pub fn ensure_key_indexed(")
+            .expect(
+                "the bare index writer must stay #[cfg(test)]-gated — it takes only a \
+                 &ContractKey, so it can verify neither the identity it files nor that \
+                 the blob exists",
+            );
+        let locked = production
+            .find("fn ensure_key_indexed_locked(")
+            .expect("ensure_key_indexed_locked not found");
+        assert!(gate < locked, "unexpected ordering of the two helpers");
     }
 
     /// Regression test for the latent shared-WASM deletion bug: removing one

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -178,9 +178,7 @@ impl ContractStore {
         //    entitled to while choosing WHICH cached code came back for it. The
         //    index is what this node itself recorded, so resolving through it
         //    makes the answer a function of the instance alone.
-        let Some(code_hash) = self.key_to_code_part.get(key.id()).map(|e| *e.value()) else {
-            return None;
-        };
+        let code_hash = self.key_to_code_part.get(key.id()).map(|e| *e.value())?;
 
         if let Some(data) = self.contract_cache.get(&code_hash) {
             return Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(

--- a/crates/core/src/wasm_runtime/delegate/interface.rs
+++ b/crates/core/src/wasm_runtime/delegate/interface.rs
@@ -298,9 +298,26 @@ impl DelegateRuntimeInterface for Runtime {
         cipher: XChaCha20Poly1305,
         nonce: XNonce,
     ) -> RuntimeResult<()> {
+        let key = delegate.key().clone();
         self.secret_store
-            .register_delegate(delegate.key().clone(), cipher, nonce)?;
-        self.delegate_store.store_delegate(delegate)
+            .register_delegate(key.clone(), cipher, nonce)?;
+        // Roll the cipher registration back if the store refuses, mirroring
+        // `native_api.rs`'s delegate-creation path. `store_delegate` became
+        // fallible for a NEW reason when it started verifying that a delegate's
+        // key is derived from its own code (see
+        // `DelegateStore::verify_delegate_identity`), so without this a refused
+        // registration leaves an entry in `SecretsStore::ciphers` and nothing
+        // durable to show it: the caller sees an error, the delegate is not
+        // stored, and the map has grown. The content is benign — since #4140 the
+        // DEK is HKDF-derived from the node KEK, so the entry is re-derivable and
+        // holds no secret the node did not already have — but `ciphers` is keyed
+        // by a 64-byte value the requester chooses and is not bounded, so a
+        // rejection path that grows it silently is the wrong shape regardless.
+        if let Err(err) = self.delegate_store.store_delegate(delegate) {
+            self.secret_store.remove_delegate_cipher(&key);
+            return Err(err);
+        }
+        Ok(())
     }
 
     #[inline]

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -80,7 +80,10 @@ async fn setup_runtime(
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -2216,7 +2219,10 @@ async fn test_v1_delegate_detected_as_v1_with_state_store() -> Result<(), Box<dy
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -2349,7 +2355,10 @@ async fn test_v2_delegate_reads_contract_state() -> Result<(), Box<dyn std::erro
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -2446,7 +2455,10 @@ async fn test_v2_delegate_contract_not_found() -> Result<(), Box<dyn std::error:
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -2552,7 +2564,10 @@ async fn setup_v2_runtime_with_contract(
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -3146,7 +3161,10 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
@@ -3393,7 +3411,10 @@ async fn test_notification_application_message_routed_to_registered_app()
             &vec![].into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);
     let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
@@ -3654,7 +3675,10 @@ async fn setup_runtime_with_params(
             &params.into(),
         ))))
     };
-    let _stored = runtime.delegate_store.store_delegate(delegate.clone());
+    runtime
+        .delegate_store
+        .store_delegate(delegate.clone())
+        .expect("fixture delegate must store: Delegate::from derives its key");
 
     let key = XChaCha20Poly1305::generate_key(&mut OsRng);
     let cipher = XChaCha20Poly1305::new(&key);

--- a/crates/core/src/wasm_runtime/delegate_store.rs
+++ b/crates/core/src/wasm_runtime/delegate_store.rs
@@ -161,34 +161,47 @@ impl DelegateStore {
         key: &DelegateKey,
         params: &Parameters<'_>,
     ) -> Option<Delegate<'static>> {
-        if let Some(delegate_code) = self.delegate_cache.get(key.code_hash()) {
+        // Resolve the code hash from the shared INDEX, never from the `code_hash`
+        // field the caller's `DelegateKey` carries, and gate on the index being
+        // populated for this key at all.
+        //
+        // The disk path below was already index-gated; the in-memory cache fast
+        // path was not, and it looked the code up by `key.code_hash()`. Since the
+        // cache is keyed by code hash rather than by delegate key, that served
+        // whatever code was warm under the hash the caller NAMED, for a key this
+        // node had never recorded — so whether an unregistered key resolved at
+        // all depended only on the cache being warm. Resolving through the index
+        // makes the answer a function of what this node itself registered, and
+        // `store_delegate` verifies that identity on the way in (see
+        // `verify_delegate_identity`).
+        let code_hash = *self.key_to_code_part.get(key)?.value();
+
+        if let Some(delegate_code) = self.delegate_cache.get(&code_hash) {
             return Some(Delegate::from((&*delegate_code, params)).into_owned());
         }
-        self.key_to_code_part.get(key).and_then(|code_hash_entry| {
-            let code_hash = *code_hash_entry.value();
-            let delegate_code_path = self
-                .delegates_dir
-                .join(code_hash.encode())
-                .with_extension("wasm");
-            tracing::debug!("loading delegate `{key}` from {delegate_code_path:?}");
-            let DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate {
-                data: delegate_code,
-                ..
-            })) = DelegateContainer::try_from((
-                delegate_code_path.as_path(),
-                params.clone().into_owned(),
-            ))
-            .ok()?
-            else {
-                tracing::warn!("unsupported delegate container version for key `{key}`");
-                return None;
-            };
-            tracing::debug!("loaded `{key}` from path");
-            let delegate = Delegate::from((&delegate_code, &params.clone().into_owned()));
-            self.delegate_cache
-                .insert(*key.code_hash(), Arc::new(delegate_code));
-            Some(delegate)
-        })
+
+        let delegate_code_path = self
+            .delegates_dir
+            .join(code_hash.encode())
+            .with_extension("wasm");
+        tracing::debug!("loading delegate `{key}` from {delegate_code_path:?}");
+        let DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate {
+            data: delegate_code,
+            ..
+        })) = DelegateContainer::try_from((
+            delegate_code_path.as_path(),
+            params.clone().into_owned(),
+        ))
+        .ok()?
+        else {
+            tracing::warn!("unsupported delegate container version for key `{key}`");
+            return None;
+        };
+        tracing::debug!("loaded `{key}` from path");
+        let delegate = Delegate::from((&delegate_code, &params.clone().into_owned()));
+        self.delegate_cache
+            .insert(code_hash, Arc::new(delegate_code));
+        Some(delegate)
     }
 
     /// Ensures the index mapping and .reg backup exist for a key, repairing if missing.
@@ -223,12 +236,134 @@ impl DelegateStore {
         }
     }
 
+    /// Check that a delegate's key is actually derived from the bytes it ships
+    /// with, and refuse it otherwise.
+    ///
+    /// # Why this has to be checked here
+    ///
+    /// A `DelegateKey` is two fields, the 32-byte `key` and a `code_hash`, and
+    /// both are ordinary serde fields that survive a wire round-trip exactly as
+    /// sent: `Delegate` derives `Deserialize`, so its generated impl fills `key`
+    /// in field-by-field and nothing recomputes it. `DelegateCode` has the same
+    /// shape — `DelegateCode::hash()` returns a stored field rather than hashing
+    /// the bytes (it still carries a `// todo: skip serializing and instead
+    /// compute it`), and its `PartialEq` compares only that field. So a
+    /// container's claimed identity and its actual content are independent until
+    /// something derives one from the other.
+    ///
+    /// [`DelegateStore`] is where that stops being merely untidy. `store_delegate`
+    /// uses the claimed code hash as the blob FILENAME, and the delegate
+    /// directory is content-addressed by that name: `fetch_delegate` and the
+    /// `store_delegate` early-return paths both load `<code_hash>.wasm` and hand
+    /// back whatever it contains. An identity the node never derived would
+    /// therefore decide, durably, which bytes it believes are a given delegate's
+    /// code — including for a legitimate delegate registered later whose code
+    /// genuinely does hash to that name, which would pick up the bytes already
+    /// sitting there.
+    ///
+    /// # The two checks, and why the order matters
+    ///
+    /// 1. `CodeHash::from_code(code.data())` must equal the code hash the
+    ///    container claims (on the key AND on the code itself). This is the only
+    ///    check that touches the bytes, so it has to come first.
+    /// 2. The 32-byte key half must be derived from that code hash and these
+    ///    parameters. That derivation is `BLAKE3(code.hash() ‖ params)` and it
+    ///    reads `code.hash()`, i.e. the stored field, so it is only meaningful
+    ///    ONCE check 1 has established that the field matches the bytes. Doing 2
+    ///    alone would verify a claim against another claim.
+    ///
+    /// Both together are what bind key, code hash and bytes into one identity.
+    /// Check 1 alone would still allow well-formed code to be filed under an
+    /// unrelated key; check 2 alone is circular.
+    ///
+    /// Deriving the key via the stdlib's own `Delegate::from((code, params))`
+    /// rather than re-implementing `BLAKE3(hash ‖ params)` here is deliberate: a
+    /// local copy of that formula would silently diverge if the derivation ever
+    /// changed. (`DelegateKey::from_params_and_code`, which that `From` impl
+    /// calls, is private to the stdlib, so the `From` impl is the way to reach
+    /// it.)
+    ///
+    /// # How this differs from the contract-store check
+    ///
+    /// `ContractStore::verify_contract_identity` also protects an instance→code
+    /// INDEX from being re-pointed, because `ContractKey`'s `Hash`/`Eq` compare
+    /// its `instance` alone, so a container claiming an existing instance with
+    /// different code overwrites that instance's index row. `DelegateKey`'s
+    /// derived `Hash`/`Eq` compare BOTH fields, and the ReDb index row key is the
+    /// full 64 bytes, so a container with an unrelated key half addresses a
+    /// different row and cannot re-point an existing one. The index half of that
+    /// problem therefore does not arise here; the content-addressed blob name
+    /// does, and that is what these checks cover.
+    fn verify_delegate_identity(
+        key: &DelegateKey,
+        code: &DelegateCode<'_>,
+        params: &Parameters<'_>,
+    ) -> RuntimeResult<()> {
+        // `DelegateCode::from(&[u8])` hashes the slice it is handed and BORROWS
+        // it, so this is one BLAKE3 pass and no copy of the module. It also
+        // doubles as the input to check 2, which needs a `DelegateCode` whose
+        // stored hash is known-good.
+        let recomputed = DelegateCode::from(code.data());
+        let actual_code_hash = *recomputed.hash();
+
+        // Check 1: the claimed code hash(es) must be the hash of these bytes.
+        // Both the key's copy and the code's own copy are checked, because they
+        // are separate fields and either could be the one a later reader trusts.
+        if actual_code_hash != *key.code_hash() || actual_code_hash != *code.hash() {
+            return Err(super::RuntimeInnerError::DelegateIdentityMismatch {
+                key: Box::new(key.clone()),
+                detail: format!(
+                    "code hashes to {actual_code_hash} but the key claims {} and the code claims {}",
+                    key.code_hash(),
+                    code.hash()
+                ),
+            }
+            .into());
+        }
+
+        // Check 2: sound only now that check 1 passed (see rustdoc).
+        let derived = Delegate::from((&recomputed, params));
+        if derived.key() != key {
+            return Err(super::RuntimeInnerError::DelegateIdentityMismatch {
+                key: Box::new(key.clone()),
+                detail: format!(
+                    "key {key} is not derived from this code and these {} parameter byte(s) \
+                     (derivation gives {})",
+                    params.as_ref().len(),
+                    derived.key()
+                ),
+            }
+            .into());
+        }
+
+        Ok(())
+    }
+
     pub fn store_delegate(&mut self, delegate: DelegateContainer) -> RuntimeResult<()> {
         let code_hash = delegate.code_hash();
         let key = delegate.key();
         let Some(params) = Self::extract_params(&delegate) else {
             return Err(anyhow::anyhow!("unsupported delegate container version").into());
         };
+
+        // Verify the identity BEFORE anything durable happens — before the .reg
+        // write and the ReDb row that the cache/disk early-return paths below
+        // perform via `ensure_index_entry`, and before the blob write further
+        // down. This is pure computation (one BLAKE3 pass over the WASM,
+        // negligible against the compile it precedes), and a refusal therefore
+        // leaves no blob, no .reg record, no index row and no commit, so it is
+        // idempotent under retry. See `verify_delegate_identity`.
+        if let Err(err) = Self::verify_delegate_identity(key, delegate.code(), &params) {
+            // WARN, not debug: this is the node declining to file bytes under an
+            // identity it did not derive. It should be visible in an operator's
+            // log without a rebuild (`debug!` compiles out in release builds).
+            tracing::warn!(
+                delegate = %key,
+                code_bytes = delegate.code().data().len(),
+                "refusing to store delegate: {err}"
+            );
+            return Err(err);
+        }
 
         // Early return if already in cache - but ensure index and .reg are updated
         if self.delegate_cache.get(code_hash).is_some() {
@@ -384,6 +519,355 @@ mod test {
 
     async fn create_test_db(path: &std::path::Path) -> Storage {
         Storage::new(path).await.expect("failed to create test db")
+    }
+
+    /// An honestly-built delegate: `Delegate::from((code, params))` derives the
+    /// key, so this is exactly what a well-behaved publisher produces.
+    fn honest_delegate(code: Vec<u8>, params: Vec<u8>) -> DelegateContainer {
+        let delegate = Delegate::from((&code.into(), &params.into()));
+        DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(delegate))
+    }
+
+    /// Rebuild a `DelegateContainer` with its three CLAIMED identity fields
+    /// replaced, by round-tripping through the same bincode encoding that
+    /// `EncodingProtocol::Native` decodes a `RegisterDelegate` request with.
+    ///
+    /// `Delegate`'s `key` field and `DelegateCode`'s `code_hash` field are both
+    /// private to the stdlib, so an in-memory container cannot be edited — but
+    /// they are ordinary serde fields, which is the entire reason
+    /// `verify_delegate_identity` exists, so a SERIALIZED container can. Going
+    /// through serde is also the more faithful fixture: it is the shape a
+    /// container genuinely arrives in.
+    ///
+    /// The three 32-byte fields are the last bytes of the encoding, in the order
+    /// `code.code_hash`, `key.key`, `key.code_hash` (`Delegate` is
+    /// `parameters, data, key` and `DelegateCode` is `data, code_hash`). The
+    /// assertions pin that layout, so if the stdlib ever reorders these fields
+    /// this fixture fails loudly instead of quietly patching the wrong bytes and
+    /// leaving the tests below asserting nothing.
+    fn with_claimed_identity(
+        delegate: &DelegateContainer,
+        claimed_code_hash_on_code: CodeHash,
+        claimed_key_bytes: [u8; 32],
+        claimed_code_hash_on_key: CodeHash,
+    ) -> DelegateContainer {
+        let mut bytes = bincode::serialize(delegate).expect("container must serialize");
+        let len = bytes.len();
+        assert!(
+            len > 96,
+            "encoding is too short to carry three 32-byte identity fields"
+        );
+        let (code_hash_at, key_at, key_code_hash_at) = (len - 96, len - 64, len - 32);
+        assert_eq!(
+            &bytes[code_hash_at..key_at],
+            delegate.code_hash().as_ref(),
+            "fixture is stale: the code's own code_hash is not where it was"
+        );
+        assert_eq!(
+            &bytes[key_at..key_code_hash_at],
+            delegate.key().bytes(),
+            "fixture is stale: the key's 32-byte half is not where it was"
+        );
+        assert_eq!(
+            &bytes[key_code_hash_at..],
+            delegate.key().code_hash().as_ref(),
+            "fixture is stale: the key's code_hash is not where it was"
+        );
+
+        bytes[code_hash_at..key_at].copy_from_slice(claimed_code_hash_on_code.as_ref());
+        bytes[key_at..key_code_hash_at].copy_from_slice(&claimed_key_bytes);
+        bytes[key_code_hash_at..].copy_from_slice(claimed_code_hash_on_key.as_ref());
+
+        bincode::deserialize(&bytes).expect("a patched container must still deserialize")
+    }
+
+    fn is_identity_mismatch(err: &crate::wasm_runtime::ContractError) -> bool {
+        matches!(
+            err.deref(),
+            crate::wasm_runtime::RuntimeInnerError::DelegateIdentityMismatch { .. }
+        )
+    }
+
+    /// A delegate whose key IS derived from its own code and parameters stores
+    /// normally, and so does one that has been through
+    /// [`with_claimed_identity`] without any of its claims changed.
+    ///
+    /// This is the control for the rejection tests below. Without it they would
+    /// all still pass if `verify_delegate_identity` simply refused everything,
+    /// and a check that cannot come out clean is not evidence. The unchanged
+    /// round-trip is the second half of the control: it shows the fixture's
+    /// re-encoding is not itself what the rejections are detecting.
+    #[tokio::test]
+    async fn store_delegate_accepts_a_key_derived_from_its_own_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let delegate_dir = temp_dir.path().join("delegates-derived-key-test");
+        std::fs::create_dir_all(&delegate_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = DelegateStore::new(delegate_dir.clone(), 10_000, db)?;
+
+        let params = vec![0u8, 1];
+        let delegate = honest_delegate(vec![1u8, 2, 3, 4], params.clone());
+        let key = delegate.key().clone();
+
+        store.store_delegate(delegate.clone())?;
+        assert!(
+            store.fetch_delegate(&key, &params.clone().into()).is_some(),
+            "an honestly-derived delegate must still be storable and fetchable"
+        );
+
+        // Same container, re-encoded but with every claim left as it was.
+        let untouched = with_claimed_identity(
+            &delegate,
+            *delegate.code_hash(),
+            delegate
+                .key()
+                .bytes()
+                .try_into()
+                .expect("a delegate key half is 32 bytes"),
+            *delegate.key().code_hash(),
+        );
+        assert_eq!(
+            untouched.key(),
+            &key,
+            "the round-trip must preserve the key"
+        );
+        store.store_delegate(untouched)?;
+
+        Ok(())
+    }
+
+    /// The claimed code hash must be the hash of the code actually supplied.
+    ///
+    /// The delegate directory is content-addressed by that claimed value:
+    /// `store_delegate` writes `<code_hash>.wasm`, and both `fetch_delegate` and
+    /// `store_delegate`'s own early-return paths read it back by the same name.
+    /// Accepting an unverified claim would file bytes under a name they do not
+    /// hash to.
+    #[tokio::test]
+    async fn store_delegate_rejects_code_hash_that_is_not_the_hash_of_the_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let delegate_dir = temp_dir.path().join("delegates-bad-code-hash-test");
+        std::fs::create_dir_all(&delegate_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = DelegateStore::new(delegate_dir.clone(), 10_000, db)?;
+
+        let params = vec![0u8, 1];
+        let honest = honest_delegate(vec![1u8, 2, 3, 4], params.clone());
+
+        // Claim a code hash, on both copies, that is not this code's hash.
+        let bogus = CodeHash::new([7u8; 32]);
+        let forged = with_claimed_identity(
+            &honest,
+            bogus,
+            honest
+                .key()
+                .bytes()
+                .try_into()
+                .expect("a delegate key half is 32 bytes"),
+            bogus,
+        );
+        let forged_key = forged.key().clone();
+
+        let err = store
+            .store_delegate(forged)
+            .expect_err("a code hash that does not match the code must be refused");
+        assert!(
+            is_identity_mismatch(&err),
+            "expected DelegateIdentityMismatch, got: {err}"
+        );
+
+        // Nothing durable may have happened: no blob under the claimed hash, no
+        // .reg record, and no index entry.
+        assert!(
+            !delegate_dir
+                .join(bogus.encode())
+                .with_extension("wasm")
+                .exists(),
+            "no blob may be written under an unverified code hash"
+        );
+        assert!(
+            !delegate_dir
+                .join(forged_key.encode())
+                .with_extension("reg")
+                .exists(),
+            "no .reg record may be written for a refused delegate"
+        );
+        assert!(
+            store.code_hash_from_key(&forged_key).is_none(),
+            "no index entry may be written for a refused delegate"
+        );
+        Ok(())
+    }
+
+    /// The 32-byte key half must be derived from the code hash and parameters
+    /// supplied.
+    ///
+    /// This is the case an internally-consistent container can still make: the
+    /// code hash genuinely matches the bytes, and only the key half is unrelated
+    /// to them. Checking the code hash alone would accept it and register
+    /// well-formed code under an arbitrary delegate identity — and a delegate's
+    /// identity is what its secret namespace and its context are keyed by.
+    #[tokio::test]
+    async fn store_delegate_rejects_key_not_derived_from_code_and_params()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let delegate_dir = temp_dir.path().join("delegates-bad-key-test");
+        std::fs::create_dir_all(&delegate_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = DelegateStore::new(delegate_dir.clone(), 10_000, db)?;
+
+        let code = vec![1u8, 2, 3, 4];
+        // Two honest delegates over the SAME code but different parameters, so
+        // their key halves differ while their code hashes agree.
+        let victim = honest_delegate(code.clone(), vec![0u8]);
+        let params_b = vec![9u8];
+        let honest_b = honest_delegate(code.clone(), params_b.clone());
+        assert_eq!(
+            victim.code_hash(),
+            honest_b.code_hash(),
+            "fixture must share code so only the key half differs"
+        );
+        assert_ne!(
+            victim.key().bytes(),
+            honest_b.key().bytes(),
+            "fixture must use genuinely different parameters"
+        );
+
+        // Correct code hashes for these bytes, but the OTHER delegate's key half.
+        let forged = with_claimed_identity(
+            &honest_b,
+            *honest_b.code_hash(),
+            victim
+                .key()
+                .bytes()
+                .try_into()
+                .expect("a delegate key half is 32 bytes"),
+            *honest_b.key().code_hash(),
+        );
+        let forged_key = forged.key().clone();
+
+        let err = store
+            .store_delegate(forged)
+            .expect_err("a key half not derived from this code and params must be refused");
+        assert!(
+            is_identity_mismatch(&err),
+            "expected DelegateIdentityMismatch, got: {err}"
+        );
+        assert!(
+            store.code_hash_from_key(&forged_key).is_none(),
+            "a refused delegate must not create an index entry"
+        );
+        assert!(
+            !delegate_dir
+                .join(forged_key.encode())
+                .with_extension("reg")
+                .exists(),
+            "a refused delegate must not create a .reg record"
+        );
+        Ok(())
+    }
+
+    /// A refused delegate must not leave code sitting in the content-addressed
+    /// blob namespace for a LATER, legitimate delegate to pick up.
+    ///
+    /// `store_delegate`'s early-return paths take the blob (or the cache entry)
+    /// at `<code_hash>.wasm` as authoritative for that code hash: a delegate
+    /// whose bytes genuinely hash to it is registered against whatever is already
+    /// there without re-reading its own code. So an accepted mis-hashed container
+    /// would not merely add a bad file, it would decide which code a legitimate
+    /// delegate resolves to.
+    #[tokio::test]
+    async fn store_delegate_refusal_leaves_the_blob_namespace_holding_its_own_code()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let delegate_dir = temp_dir.path().join("delegates-blob-namespace-test");
+        std::fs::create_dir_all(&delegate_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = DelegateStore::new(delegate_dir.clone(), 10_000, db)?;
+
+        let params = vec![0u8, 1];
+        let code_a = vec![1u8, 2, 3, 4];
+        let honest_a = honest_delegate(code_a.clone(), params.clone());
+        let key_a = honest_a.key().clone();
+        let hash_a = *honest_a.code_hash();
+
+        // Different code, claiming A's whole identity. Registered BEFORE A, so
+        // if it were accepted it would be sitting in A's slot when A arrives.
+        let other_code = vec![9u8, 9, 9, 9, 9];
+        let forged = with_claimed_identity(
+            &honest_delegate(other_code, params.clone()),
+            hash_a,
+            key_a
+                .bytes()
+                .try_into()
+                .expect("a delegate key half is 32 bytes"),
+            hash_a,
+        );
+        assert_eq!(
+            forged.key(),
+            &key_a,
+            "the forged container must claim A's key"
+        );
+
+        store
+            .store_delegate(forged)
+            .expect_err("code that does not hash to the claimed name must be refused");
+
+        // A now registers honestly and must resolve to its OWN code.
+        store.store_delegate(honest_a)?;
+        let fetched = store
+            .fetch_delegate(&key_a, &params.clone().into())
+            .expect("the honest delegate must be served");
+        assert_eq!(
+            fetched.code().data(),
+            code_a.as_slice(),
+            "a refused store must not decide which code a legitimate delegate resolves to"
+        );
+        Ok(())
+    }
+
+    /// `fetch_delegate` must resolve code through the node's own index, not
+    /// through the `code_hash` field on the caller's key.
+    ///
+    /// The cache fast path used to look up `key.code_hash()` with no index check
+    /// at all, while the disk path below it was index-gated. Because the cache is
+    /// keyed by code hash and not by delegate key, that served warm code for a
+    /// key this node had never registered — so whether an unregistered key
+    /// resolved depended only on whether some other delegate sharing the code was
+    /// still cached.
+    #[tokio::test]
+    async fn fetch_delegate_resolves_code_through_the_index_not_the_callers_key()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let delegate_dir = temp_dir.path().join("delegates-fetch-index-test");
+        std::fs::create_dir_all(&delegate_dir)?;
+        let db = create_test_db(temp_dir.path()).await;
+        let mut store = DelegateStore::new(delegate_dir.clone(), 10_000, db)?;
+
+        let params = vec![0u8, 1];
+        let honest = honest_delegate(vec![1u8, 2, 3, 4], params.clone());
+        let key = honest.key().clone();
+        let code_hash = *honest.code_hash();
+        store.store_delegate(honest)?;
+
+        // Warm: the registered key still resolves.
+        assert!(
+            store.fetch_delegate(&key, &params.clone().into()).is_some(),
+            "the registered delegate must still be fetchable from the cache"
+        );
+
+        // A key this node never registered, naming the code hash that IS cached.
+        let unregistered = DelegateKey::new([3u8; 32], code_hash);
+        assert_ne!(unregistered, key, "fixture must use a different key");
+        assert!(
+            store
+                .fetch_delegate(&unregistered, &params.clone().into())
+                .is_none(),
+            "a key the node never registered must not be served warm code"
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/wasm_runtime/delegate_store.rs
+++ b/crates/core/src/wasm_runtime/delegate_store.rs
@@ -811,9 +811,12 @@ mod test {
             "the forged container must claim A's key"
         );
 
-        store
-            .store_delegate(forged)
-            .expect_err("code that does not hash to the claimed name must be refused");
+        // The refusal itself is what the two tests above pin, so hold it and
+        // check the CONSEQUENCE first. Otherwise removing the verification makes
+        // this test fail at the `expect_err` and it never reaches the outcome it
+        // exists to describe — a legitimate delegate resolving to code that is
+        // not its own — leaving that half unpinned.
+        let refusal = store.store_delegate(forged);
 
         // A now registers honestly and must resolve to its OWN code.
         store.store_delegate(honest_a)?;
@@ -823,7 +826,12 @@ mod test {
         assert_eq!(
             fetched.code().data(),
             code_a.as_slice(),
-            "a refused store must not decide which code a legitimate delegate resolves to"
+            "a legitimate delegate must resolve to its own code, whatever was \
+             offered for its content-addressed name earlier"
+        );
+        assert!(
+            refusal.is_err_and(|err| is_identity_mismatch(&err)),
+            "code that does not hash to the claimed name must be refused"
         );
         Ok(())
     }

--- a/crates/core/src/wasm_runtime/delegate_store.rs
+++ b/crates/core/src/wasm_runtime/delegate_store.rs
@@ -349,10 +349,10 @@ impl DelegateStore {
         // Verify the identity BEFORE anything durable happens — before the .reg
         // write and the ReDb row that the cache/disk early-return paths below
         // perform via `ensure_index_entry`, and before the blob write further
-        // down. This is pure computation (one BLAKE3 pass over the WASM,
-        // negligible against the compile it precedes), and a refusal therefore
-        // leaves no blob, no .reg record, no index row and no commit, so it is
-        // idempotent under retry. See `verify_delegate_identity`.
+        // down. This is pure computation (one BLAKE3 pass over the WASM) on a path
+        // that only runs at registration, so its cost is not on any hot path. A
+        // refusal therefore leaves no blob, no .reg record, no index row and no
+        // commit, so it is idempotent under retry. See `verify_delegate_identity`.
         if let Err(err) = Self::verify_delegate_identity(key, delegate.code(), &params) {
             // WARN, not debug: this is the node declining to file bytes under an
             // identity it did not derive. It should be visible in an operator's

--- a/crates/core/src/wasm_runtime/error.rs
+++ b/crates/core/src/wasm_runtime/error.rs
@@ -67,6 +67,23 @@ pub(crate) enum RuntimeInnerError {
     #[error("delegate {0} not found in store")]
     DelegateNotFound(DelegateKey),
 
+    /// A delegate offered for storage carries a key that is not derived from
+    /// its own code and parameters, so the node cannot store it under an
+    /// identity it has verified. See `DelegateStore::verify_delegate_identity`.
+    ///
+    /// This is the delegate sibling of [`Self::ContractIdentityMismatch`]. It is
+    /// a separate variant rather than a shared one because the two carry
+    /// different key types, and a caller matching on the error wants to know
+    /// which store refused.
+    #[error(
+        "delegate {key} identity does not match its code: {detail} \
+         (the key a delegate is stored under must be derived from its bytes)"
+    )]
+    DelegateIdentityMismatch {
+        key: Box<DelegateKey>,
+        detail: String,
+    },
+
     #[error(transparent)]
     DelegateExecError(#[from] delegate::DelegateExecError),
 

--- a/crates/core/src/wasm_runtime/error.rs
+++ b/crates/core/src/wasm_runtime/error.rs
@@ -74,6 +74,18 @@ pub(crate) enum RuntimeInnerError {
     #[error("contract {0} not found in store")]
     ContractNotFound(ContractKey),
 
+    /// A contract offered for storage carries a key that is not derived from
+    /// its own code and parameters, so the node cannot store it under an
+    /// identity it has verified. See `ContractStore::verify_contract_identity`.
+    #[error(
+        "contract {key} identity does not match its code: {detail} \
+         (the key a contract is stored under must be derived from its bytes)"
+    )]
+    ContractIdentityMismatch {
+        key: Box<ContractKey>,
+        detail: String,
+    },
+
     #[error(transparent)]
     ContractExecError(#[from] runtime::ContractExecError),
 

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -1096,11 +1096,6 @@ impl super::contract::ContractStoreBridge for Runtime {
         self.contract_store.remove_contract(key)?;
         Ok(())
     }
-
-    fn ensure_key_indexed(&mut self, key: &ContractKey) -> Result<(), anyhow::Error> {
-        self.contract_store.ensure_key_indexed(key)?;
-        Ok(())
-    }
 }
 
 impl super::contract::ContractRuntimeBridge for Runtime {}

--- a/crates/core/src/wasm_runtime/simulation_runtime.rs
+++ b/crates/core/src/wasm_runtime/simulation_runtime.rs
@@ -143,10 +143,19 @@ impl InMemoryContractStore {
 
     // NOTE: there is deliberately no `ensure_key_indexed` here. The executor's
     // "code already stored, index this new instance" branch routes through
-    // `store_contract`, which is the single guarded ingress on both backends —
-    // see `ContractStoreBridge::store_contract`. The removed helper also
-    // recorded EMPTY parameters for the instance, which `store_contract` gets
-    // right, so this backend became more faithful by losing it.
+    // `store_contract` on both backends — see `ContractStoreBridge::store_contract`.
+    // The removed helper also recorded EMPTY parameters for the instance, which
+    // `store_contract` gets right, so this backend became more faithful by
+    // losing it.
+    //
+    // But note what "single ingress" does and does not mean here. It is the
+    // single ingress on both backends; it is only GUARDED on the production one.
+    // The `store_contract` above performs no identity verification at all — the
+    // derivation check lives in `ContractStore::verify_contract_identity`, which
+    // this type does not use. So no simulation test and no mock-executor test can
+    // catch a mis-derived container, and a regression test for that behaviour
+    // cannot live here. It has to be a `ContractStore` unit test or a
+    // `crates/core/tests/` integration test against the real store.
 
     /// Clear all stored contracts (for testing).
     pub fn clear(&self) {

--- a/crates/core/src/wasm_runtime/simulation_runtime.rs
+++ b/crates/core/src/wasm_runtime/simulation_runtime.rs
@@ -141,19 +141,12 @@ impl InMemoryContractStore {
         Ok(())
     }
 
-    /// Ensure a contract key is indexed (instance_id -> code_hash mapping exists).
-    pub fn ensure_key_indexed(&self, key: &ContractKey) -> Result<(), anyhow::Error> {
-        let mut inner = self.inner.lock().unwrap();
-        if !inner.instance_to_code.contains_key(key.id()) {
-            let code_hash = *key.code_hash();
-            // We don't have params here, so use empty. The code hash is the important part
-            // for lookup_key reconstruction.
-            inner
-                .instance_to_code
-                .insert(*key.id(), (code_hash, Parameters::from(Vec::<u8>::new())));
-        }
-        Ok(())
-    }
+    // NOTE: there is deliberately no `ensure_key_indexed` here. The executor's
+    // "code already stored, index this new instance" branch routes through
+    // `store_contract`, which is the single guarded ingress on both backends —
+    // see `ContractStoreBridge::store_contract`. The removed helper also
+    // recorded EMPTY parameters for the instance, which `store_contract` gets
+    // right, so this backend became more faithful by losing it.
 
     /// Clear all stored contracts (for testing).
     pub fn clear(&self) {


### PR DESCRIPTION
Three related changes, all one principle: **a store must derive the identity it files bytes under.**

1. `ContractStore::store_contract` verifies that a contract's key is derived from its own code and parameters.
2. The durable instance→code index gets **one guarded ingress**, closing the common path that skipped (1) entirely.
3. `DelegateStore::store_delegate` gets the same check at the sibling ingress.

---

# 1. Contract store: verify the key against the bytes

## Problem

The contract store used a contract's **claimed** identity to make two durable decisions, without ever checking that identity against the bytes it arrived with.

A `ContractKey` is two fields, `instance` and `code`, and both are ordinary serde fields:

- `WrappedContract` derives `Deserialize` (`freenet-stdlib` `contract_interface/wrapped.rs:116-126`) and its generated impl fills `key` in field-by-field with no recomputation, so a **deserialized** container carries whatever key arrived on the wire.
- `ContractKey`'s `Hash`/`Eq` compare `instance` alone, so the `code` half is never even consulted for identity.
- `ContractCode::hash()` returns a stored field rather than hashing the bytes — it still carries a `// todo: skip serializing and instead compute it` (`contract_interface/code.rs:35-36`).

So a container's claimed identity and its actual content were independent until something derived one from the other, and nothing in the path did.

`ContractStore::store_contract` is where that stopped being merely untidy. It used the claimed code hash as the blob **filename** and as the value written into the instance→code index, both in memory and durably in ReDb, and that index is what `fetch_contract` and the compiled-module cache later resolve through. An identity the node never derived therefore decided, durably, which bytes it believed were a given contract's code. The slow path overwrites the index unconditionally, so this was not limited to adding new entries.

## Solution

Two checks at `store_contract`'s ingress, plus a correction on the read side.

**Check 1 — the code hash must be the hash of the code.** `CodeHash::from_code(code.data())` must equal the code hash claimed on the key *and* the one claimed on the code itself (separate fields; either could be the one a later reader trusts). This is the only check that touches the bytes.

**Check 2 — the instance must derive from that code and these params.** `instance` must equal `ContractInstanceId::from_params_and_code(params, code)`.

**The order matters, and it is not stylistic.** Check 2's derivation is `BLAKE3(code.hash() ‖ params)`, and `code.hash()` reads the *stored* field — the same unverified field that check 1 validates. So check 2 is only meaningful once check 1 has established that the field matches the bytes; **run alone it would verify one claim against another claim**. Both are needed, in this order: check 1 alone would still allow a well-formed container to be filed under an unrelated instance id, and check 2 alone is circular.

Deriving the id through the stdlib helper rather than re-implementing `BLAKE3(hash ‖ params)` locally is deliberate — a local copy of that formula would silently diverge if the derivation ever changed.

Verification runs before the blob lock and before any write, so a refusal leaves no blob, no index row and no commit, and is idempotent under retry.

**Read side.** `fetch_contract`'s cache fast path looked up `key.code_hash()` directly, gated only on the instance being indexed at all. Since that field is unverified and excluded from `Eq`/`Hash`, a caller could name an instance while choosing which cached code came back for it. It now resolves the code hash from the node's own instance→code index, which also preserves the #4218 gate (an instance no longer indexed must not be served from a stale per-executor cache entry).

### What is and is not already safe

Stated precisely, because the distinction is the whole reason the ingress check is needed:

- **Every path that PRODUCES a container derives the key.** There are four: `WrappedContract::new` (`wrapped.rs:135`), `ContractContainer: TryFrom<(&Path, Parameters)>` (`versioning.rs:281`), `TryFrom<(Vec<u8>, P)>` (`versioning.rs:294`), and the `try_decode_fbs` struct literal below. No production site mutates `params` or `key` afterwards, and the one rebuild site, `fetch_contract`, goes through `new` and so recomputes.
- **The majority client path cannot present an inconsistent container at all.** `ContractContainer::try_decode_fbs` (`versioning.rs:423-444`) builds `WrappedContract { data, params, key }` as a struct literal but sets `key = ContractKey::from_params_and_code(&params, &*data)`, **discarding whatever key the client sent**. FlatBuffers is also the default encoding when a client sends no encoding header (`client_events/websocket.rs:904`). So every browser / TypeScript client PUT is re-derived at the decode boundary and cannot be falsely rejected whatever its SDK does.
- **Deserialized containers carry whatever key arrived.** The `EncodingProtocol::Native` client path is a plain `bincode::deserialize::<ClientRequest>` (`client_events/websocket.rs:1789`), and so is every peer-to-peer message. Neither recomputes either field.

The ingress check is what closes that third case, and nothing else in the path does.

### Rollout

- Rejection is **op-scoped** in the sense that it does not touch the connection: the error surfaces through `ExecutorError::other` at both production call sites (`contract_ops.rs:402`, `executor_impl.rs:279`), so the operation fails, with no disconnect and no ban.
- **It is not soft, though.** A rejection anywhere on the route is **terminal for the whole PUT with the retry budget untouched**: `classify_reply` maps `PutMsg::Error` to `ReplyClass::TerminalError` and the comment at `operations/put/op_ctx_task.rs:957-964` says the driver must not retry; the originator converts it to `ErrorKind::OperationError`. No re-route, no retry, and one patched relay mid-route is enough to fail the PUT. This is the same shape as the #4345 row in `bug-prevention-patterns.md`, and it is the accepted consequence — which is why the false-rejection evidence below matters more than anything else in this PR.
- **No wire format change, no version floor, no stdlib or contract WASM change, no re-key, no migration.**

### No kill switch, deliberately

There is no config flag and no log-only mode, so backing out a false positive means revert-and-release. That is a deliberate choice, not an oversight: a flag that disables this check is a flag that re-opens the hole, and the evidence against a false positive is strong on three independent grounds — 6,732/6,732 instances across two production nodes, the derivation unchanged since 0.1.29, and the majority client path re-deriving at the boundary. Recording the trade here so it is on the record rather than discovered later.

### Diagnosis

A dedicated `RuntimeInnerError::ContractIdentityMismatch` variant, logged at **WARN** (not `debug!`, which compiles out in release builds), naming which of the two checks failed and both values. A refusal in the field is attributable rather than appearing as a generic store failure.

## Testing

**Unit (`wasm_runtime::contract_store::test`): 25 tests — 9 new, 16 pre-existing unchanged.**

| Test | Covers |
|---|---|
| `store_contract_accepts_a_key_derived_from_its_own_code` | Control: a legitimately derived contract still stores and serves |
| `store_contract_rejects_code_hash_that_is_not_the_hash_of_the_code` | Check 1, key's copy |
| `store_contract_rejects_a_code_whose_own_stored_hash_is_not_its_bytes` | Check 1, **the code's own copy** — see §2 |
| `store_contract_rejects_instance_not_derived_from_code_and_params` | Check 2 |
| `store_contract_refusal_leaves_an_existing_instance_pointing_at_its_own_code` | A refusal writes nothing |
| `fetch_contract_resolves_code_through_the_index_not_the_callers_key` | Read-side fix |
| `store_contract_verifies_even_when_the_code_blob_is_already_stored` | §2: the check holds on the fast paths |
| `store_contract_corrects_an_index_row_that_disagrees_with_the_derived_key` | §2: a wrong row is correctable |
| `the_durable_index_has_one_production_writer` | §2: no third index writer |

The control matters: without it, the rejection tests would all still pass if verification simply refused everything, and a check that cannot come out clean is not evidence.

**Mutation-verified, each half independently.** Every mutation was applied to committed code and reverted afterwards:

| Mutation | Result |
|---|---|
| Disable `verify_contract_identity` | exactly the 3 original store-side tests fail; control passes |
| Revert the read-side fix | exactly the 1 fetch test fails |
| Delete check 1's `\|\| actual_code_hash != *code.hash()` clause | exactly `..._a_code_whose_own_stored_hash_is_not_its_bytes` fails |
| Restore the absent-only index guard | exactly `..._corrects_an_index_row_that_disagrees...` fails |
| Restore the whole `ensure_key_indexed` structure | exactly the 2 structural pins fail — **and all 24 other store tests pass**, which is precisely why §2 survived the first round of review |

**Evidence that enforcement rejects nothing that already exists.**

*Field state.* Read-only audits of the contract stores on two independent nodes (a gateway and a residential peer), taken from copies — live files were never opened:

| | Derivation (check 2) | Blob hashes (check 1, **key's copy only**) |
|---|---|---|
| Gateway | 5,608 / 5,608 | 211 / 211 |
| Residential peer | 1,124 / 1,124 | 147 / 147 |

Zero mismatches. Both audit pipelines were validated against negative controls before being trusted: hashing the versioned bytes instead of the raw code is distinguishable, and a single bit flip is caught. Note the scope: the blob filename is `key.code_hash()`, so that column validates the **key's** copy. `ContractCode`'s own `code_hash` field is not persisted anywhere, so a divergence between the two could only come from hand-crafted bincode — which is exactly the case §2's new test covers.

*Version stability.* The derivation has not moved. Verified by hashing the function bodies in every locally-cached stdlib — 0.1.29, 0.1.40, 0.3.5, 0.6.0, 0.6.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5 — where `generate_id` (contract), `generate_id` (delegate), `CodeHash::from_code` and `ContractCode::gen_hash` are each **byte-identical across all nine**: same `BLAKE3(code.hash() ‖ params)`, no domain separator, no length prefix. So the check hashes with the same hasher every honest producer has used since 0.1.29, and no older-rule contract can be orphaned. Honest caveat: only locally-cached versions were inspected, and 0.1.29 is the oldest present.

---

# 2. One guarded ingress for the durable index

## Problem

The verification above guarded `store_contract`. The dominant real-world path did not go through it.

`bridged_upsert_contract_state_inner` probes `code_blob_stored(key.code_hash())` to decide whether the code is new. When it is **not** new — every contract reusing an already-stored binary, so every River room after the first — the branch called `ContractStore::ensure_key_indexed(&key)` directly. That wrote `key.id() -> key.code_hash()` into both the durable ReDb index and the shared in-memory index with **no derivation check at all**, and `fetch_contract` plus the compiled-module cache resolve through exactly that index.

The key comes straight off the network: `drive_relay_put` (`operations/put/op_ctx_task.rs:202`) takes `contract.key()` from the `ContractContainer` carried by `PutMsg::Request`, which has no separate key field, so the `{data, params, key}` triple can be internally inconsistent from the moment it deserializes. One PUT, no race, first attempt.

**This was structural, not a one-off.** `ensure_key_indexed` was implicated **twice the same day, by two independent investigations, for two different missing preconditions**: no derivation check (this PR), and no blob-existence check — the candidate mechanism for the dangling index entries found on two production nodes, filed as **#5280**. A cheap index-maintenance helper (added for #2380, shared WASM across instances) had become a second, unguarded ingress to a store with real invariants, and each new invariant had to be remembered in two places with nothing forcing it. This repo's own rules file names that pattern repeatedly.

## Solution: remove the second writer rather than bolt a check onto it

`ensure_key_indexed` receives only a `&ContractKey` — no code bytes, no parameters — so it can verify neither the identity it is filing nor that the blob exists. That is the actual defect in it. So:

- **The executor branch now calls `store_contract`** with the container already in scope. `store_contract`'s own fast paths do exactly the "index this new instance" work the branch needs, and they run **after** `verify_contract_identity`.
- **`ensure_key_indexed` is removed from `ContractStoreBridge`** and from the `Runtime` / `MockWasmRuntime` impls, so reverting the call site alone no longer compiles.
- **`ContractStore::ensure_key_indexed` survives `#[cfg(test)]`-gated**, because several fixtures legitimately want "index this key and nothing else". The gate is the enforcement: a production caller does not compile.
- **`InMemoryContractStore::ensure_key_indexed` is deleted outright.** It also recorded EMPTY parameters for the instance, which `store_contract` gets right, so the simulation backend became more faithful by losing it.

**Side effects checked before adopting this shape.** In this branch the blob is already on disk, so no blob is rewritten and no byte is re-charged: `record_wasm_write` runs only in the new-code branch, and `admit_wasm_write` is a gate, so a refusal charges nothing and needs no rollback. The added cost per already-stored PUT is one BLAKE3 pass over the WASM plus one `exists()` stat, negligible beside the `validate_state` / `update_state` WASM call the same PUT already performs. In the one case where behaviour differs — a sibling executor deleted the blob between the probe and the store — `store_contract` rewrites the blob instead of writing an index row pointing at nothing, which is the #4218 safety behaviour and strictly better than the old outcome.

**The second caller is covered for free.** The delegate-driven `PutContractRequest` path (`contract.rs:715`) takes `req.contract.key()` the same way and calls `upsert_contract_state`, which routes into the same `bridged_upsert_contract_state_inner`. It is the same branch, not a separate site.

## A wrong row is now correctable

`ensure_key_indexed_locked` inserted only when the instance was **absent**, which made a wrong row permanent: the sole unconditional overwrite is `store_contract`'s slow path, reached only when the instance's own blob is missing, so an honest store of that instance would find the blob present, take a fast path, see the instance "already indexed", and leave the wrong row in place. Rows written before the check existed would therefore outlive it indefinitely.

An instance id is `BLAKE3(code_hash ‖ params)`, so a row disagreeing with a key the caller has **just verified** is wrong rather than an alternative mapping. It is now overwritten and logged at WARN.

## The three structural questions, answered

**1. Is there any legitimate reason `ensure_key_indexed` must write a row `store_contract` would refuse?** No, and that is why it is gone rather than guarded. Its one real job — indexing a new instance of already-stored code (#2380) — is work `store_contract`'s fast paths already do, and they do it with the code and parameters in hand. The only thing the separate entry point provided was the ability to do that job *without* those inputs, which is the same thing as the ability to do it without checking. There was no justification for two writers; there was a helper that predated the invariants.

**2. Does #5280 become impossible, or merely less likely?** **Impossible for newly-created rows; #5280 should stay open for the rows that already exist.** Precisely: every production write of that row now happens inside `store_contract` while it holds `contract_blob_lock`, and in each of its three paths the blob is either confirmed present (`key_path.exists()` on the cache fast path, a successful `load_versioned_from_path` on the disk fast path) or written and `sync_all`ed first (slow path). `remove_contract` takes the same lock, so no sibling can delete the blob inside that window. There is no other production writer — the bare one does not compile outside tests. What this does **not** do is repair the dangling rows already on those two nodes; the self-heal above corrects a row that *disagrees* with a verified key, which is a different condition from a row whose blob is missing. So the mechanism is closed, the existing artifacts are not, and #5280 needs its own repair or reconciliation step.

**3. Is the delegate store a third instance of the same pattern?** **No — checked, and it is genuinely separate.** `grep -rn 'store_delegate_index('` gives three call sites, and none is an unguarded parallel ingress: `store_delegate` itself, `ensure_index_entry` (a private helper called only from `store_delegate`'s two early-return paths, i.e. behind the same verification), and `DelegateStore::new`'s startup crash-recovery restore from `.reg` files. So `DelegateStore` already had the shape this change gives `ContractStore`: one public writer, private helpers behind it. Two notes on the startup path, for completeness — it reads `.reg` files from the node's own data directory rather than from any request, so it is a different trust boundary; and it *discards* the parameters it parses (`parse_reg_file` returns them, `DelegateStore::new` binds them to `_params`), so it could not check the derivation even though the data is there. Not changed here: gating startup index recovery on a check with no field evidence risks silently dropping a working delegate's row, which is worse than the condition it would catch.

## Testing

Behavioural coverage is at the store layer (`store_contract_verifies_even_when_the_code_blob_is_already_stored`, `store_contract_corrects_an_index_row_that_disagrees_with_the_derived_key`), and the structural change is pinned at both layers:

- `the_durable_index_has_one_production_writer` (contract_store) pins the two `store_contract_index` call sites and the `#[cfg(test)]` gate, so a third writer cannot appear unnoticed.
- `already_stored_branch_routes_through_the_guarded_store_ingress` (executor_impl) pins that the upsert path contains no direct index write and that the branch delegates to `store_contract`. It scans the body with comment lines stripped, so the comment that *names* the removed helper does not satisfy the assertion it is warning about.

**Why there is no behavioural test driving `bridged_upsert_contract_state_inner` itself**, stated plainly rather than glossed: the only in-crate backend that function can be driven against is `MockWasmRuntime`, whose `InMemoryContractStore::store_contract` is a separate implementation with no verification, so such a test would pass with or without the fix — it would test the wrong layer and look like coverage. The compile-time gate is stronger than a test here (reverting the call site does not build), and the source pins cover the case where someone restores the trait method too. Real end-to-end coverage of this path is `crates/core/tests/operations.rs`, which drives real nodes with the real `ContractStore` under the **Unit & Integration** job.

**Correction to an earlier version of this description:** it credited `simulation_integration` as the gate that would catch a legitimate store being refused in a multi-node flow. That was wrong. That suite runs `MockRuntime` / `MockWasmRuntime` over `InMemoryContractStore`, whose `store_contract` (`wasm_runtime/simulation_runtime.rs:72-98`) this PR does not touch and which performs no verification, so a green Simulation job is not evidence about this change. `crates/core/tests/operations.rs` and its siblings are, because they build containers via `test_utils::load_contract` → `WrappedContract::new` and exercise the real store.

---

# 3. Delegate store: the same check at the sibling ingress

## Problem

The same defect, at `DelegateStore::store_delegate`. A `DelegateKey` is two fields, a 32-byte `key` and a `code_hash`, and both are ordinary serde fields. `Delegate` derives `Deserialize` and its generated impl fills `key` in field-by-field, so a container carries whatever key was sent. `DelegateCode::hash()` likewise returns a stored field rather than hashing the bytes — the same `// todo: skip serializing and instead compute it` — and its `PartialEq` compares only that field.

`store_delegate` used the claimed code hash as the blob **filename**. The delegate directory is content-addressed by that name, and both `fetch_delegate` and `store_delegate`'s own cache/disk early-return paths take whatever sits at `<code_hash>.wasm` as authoritative for that hash without re-reading the bytes — including for a legitimate delegate registered later whose code genuinely does hash to that name.

Reachable from the client API: `DelegateRequest::RegisterDelegate { delegate, .. }` → `register_delegate_and_record_origin` (`contract/executor/runtime/delegates.rs:313`) → `store_delegate`. The other call site (`native_api.rs:717`) builds the container locally via `Delegate::from((&code, &params))` and is self-consistent by construction.

**How the reachable surface compares to the contract case**, since the two are not symmetric:

- Under FlatBuffers — the default encoding — the delegate boundary **does** re-derive, exactly as the contract one does: `DelegateContainer::try_decode_fbs` rebuilds via `Delegate::from((&data, &params))`, discarding the sent key. So the default client path cannot present an inconsistent delegate either.
- Delegates have **no peer-to-peer path at all** (`DelegateContainer` appears in no `NetMessage`), whereas contracts do, and that network path is always bincode. So the contract exposure includes messages between peers, while the delegate exposure needs a client that explicitly selects `EncodingProtocol::Native`. Narrower, same root cause.

## Solution

The same two checks, in the same order, for the same reason (check 2's derivation reads the stored hash field that check 1 validates):

1. `CodeHash::from_code(code.data())` must equal the code hash claimed on the key **and** on the code.
2. The 32-byte key half must be derived from that code hash and these parameters — `BLAKE3(code.hash() ‖ params)`, computed via the stdlib's own `Delegate::from((code, params))` rather than a local copy of the formula. (`DelegateKey::from_params_and_code`, which that `From` impl calls, is private to the stdlib, so the `From` impl is the way to reach it.)

Verification runs before every durable effect — before the `.reg` write and ReDb row that the early-return paths perform via `ensure_index_entry`, and before the blob write — so a refusal leaves no blob, no `.reg` record, no index row and no commit, and is idempotent under retry.

### One half deliberately does not transfer

For contracts, `ContractKey`'s `Hash`/`Eq` compare `instance` alone, so a container claiming an existing instance **re-points that instance's index row**. `DelegateKey`'s derived `Hash`/`Eq` compare **both** fields, and the ReDb row key is the full 64 bytes (`key ‖ code_hash`, `storages/redb.rs:1317-1320`), so a container with an unrelated key half addresses a *different* row and cannot re-point an existing one. The re-pointable namespace here is the content-addressed blob, not the index — so that is what the delegate tests pin instead.

### Read side

Transfers, and is fixed. `fetch_delegate`'s cache fast path looked up `key.code_hash()` with no index check, while the disk path below it was already index-gated. Because the cache is keyed by code hash rather than by delegate key, that served warm code for a key this node had never registered — so whether an unregistered key resolved depended only on whether the cache was warm. It now resolves the code hash from the node's own index.

### Rollout

Same shape as the contract half: rejection is scoped to the request (`register_delegate_and_record_origin` maps the error to `RegisterError`, the connection is untouched), no wire format change, no version floor, no stdlib or WASM change, no re-key, no migration. Its own `RuntimeInnerError::DelegateIdentityMismatch` variant (a sibling of `ContractIdentityMismatch` — the key types differ, so it cannot be reused), logged at **WARN**, naming which check failed with both values.

## Testing

**Unit (`wasm_runtime::delegate_store::test`): 15 tests — 5 new, 10 pre-existing unchanged.**

| Test | Covers |
|---|---|
| `store_delegate_accepts_a_key_derived_from_its_own_code` | Control |
| `store_delegate_rejects_code_hash_that_is_not_the_hash_of_the_code` | Check 1 |
| `store_delegate_rejects_key_not_derived_from_code_and_params` | Check 2 |
| `store_delegate_refusal_leaves_the_blob_namespace_holding_its_own_code` | The outcome a refusal protects |
| `fetch_delegate_resolves_code_through_the_index_not_the_callers_key` | Read-side fix |

The control has two halves, both load-bearing: an honestly-derived delegate stores and fetches, **and** the same container re-encoded through the test fixture with none of its claims changed also stores — so the rejections are not merely detecting the fixture's own round-trip.

The fixture patches the *serialized* container, because the stdlib's `key` and `code_hash` fields are private and an in-memory container cannot be edited. That is also the more faithful shape, since it is how a container genuinely arrives. It asserts the byte offsets it is about to overwrite, so a future stdlib field reorder fails the fixture loudly instead of silently patching the wrong bytes.

**Mutation-verified, both halves independently:**

- Disabling `verify_delegate_identity` fails exactly the 3 store-side tests (control passes, read-side test passes). `store_delegate_refusal_leaves_the_blob_namespace_holding_its_own_code` fails on the **outcome** — the legitimate delegate resolves to `[9, 9, 9, 9, 9]` instead of its own `[1, 2, 3, 4]` — not merely on a return value. An earlier revision asserted the refusal first with `expect_err`, so under mutation it stopped there and never reached the assertion it exists for; a follow-up commit reorders it, which is why that half is now pinned.
- Reverting the read-side fix fails exactly the 1 fetch test.

**Evidence enforcement rejects nothing that already exists — and the limit of it.** A read-only audit of the production gateway's delegate store found 46/46 delegate blobs hash correctly to their filenames, and `delegate_index` held 46 rows with 0 malformed, 0 dangling, and 0 disagreements between the code hash embedded in the 64-byte key and the row's value. **That covers check 1 only.** Check 2 needs the parameters, which the index does not store, so there is no field evidence for the derivation check specifically. What supports it instead is static — every producing path derives the key, and the one production site that builds a container locally goes through `Delegate::from` — plus the version-stability result in §1, which covers the delegate `generate_id` too: byte-identical across all nine cached stdlib versions.

---

## Gates

`cargo fmt --all --check` clean. `cargo clippy --locked -- -D warnings` and `cargo clippy --locked -p freenet --features trace-ot -- -D warnings` both clean (0 warnings, exit 0) — the CI invocations, not a bare `cargo clippy`. `cargo test -p freenet --lib`: 4801 passed, 0 failed, 28 ignored. That includes 25 `contract_store`, 15 `delegate_store`, all 116 `wasm_runtime::delegate*`, and the executor pins. CI is the authority for the integration and simulation jobs.

## Accepted residual: correcting a row can leave a blob unreferenced

Making `ensure_key_indexed_locked` overwrite an index row that disagrees with the just-verified
key means the previously-referenced code hash may end up with no index row pointing at it.
Nothing re-checks the blob's reference count at that point; `remove_contract` is the only place
that refcounts blobs and it runs only on removal.

This is a disk-hygiene residue rather than a correctness problem: `fetch_contract` resolves
through the index, so an unreferenced blob is never served, and `refresh_wasm` is a `du`-walk that
keeps the disk-budget counter accurate about the bytes. But be precise about what that does NOT
mean: **nothing in the tree ever frees an orphaned blob.** `remove_contract` is the only blob GC
and it is driven off live instances, so the residue is permanent absent a future dedicated pass.
An earlier draft of this section said the walk "reconciled" it, which wrongly implied self-healing.
And be precise about the cost, which is not zero: because that walk is a genuine ground-truth
re-measure, the orphan's bytes stay CORRECTLY counted forever, and `admit_wasm_write`
(`disk_usage.rs:603-617`) gates every new code blob on `total_bytes() + blob_len > budget_bytes`.
So an orphan permanently consumes admission headroom. The accounting is honest; the capacity is
genuinely spent.

Frequency is bounded but NOT strictly one-shot, and the earlier "only rows predating this change"
wording was a per-version claim rather than a permanent one. ReDb rows outlive the binary, and this
repo ships crash-loop auto-rollback (#4073), which reinstalls the immediately-previous binary during
probation. A rollback to a pre-check binary can mint fresh disagreeing rows, which the next upgrade
then corrects — so the WARN and the residue can recur across a rollback cycle. It is also strictly better than
the state it replaces, in which a disagreeing row persisted indefinitely. It is reachable only
for rows predating this change, since afterwards no disagreeing row can be created.

Deliberately not cleaned up here, because it is an instance of an existing tracked gap rather
than a new one: **#5281** ("Nothing reconciles state/params rows or WASM blobs against
contract_index, so orphans of both are permanent"), which already documents this residue running
in both directions. Recording it so the accept is a decision rather than an oversight.

Refs #5268, #5280, #5281

[AI-assisted - Claude]



