### PR TITLE
fix: propagate delegate execution failures to the client (2 of 3 bail-outs; third is an open question)

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -465,6 +465,73 @@ where
     }
 }
 
+/// Maps the contract handler's response to a client-driven `DelegateRequest`
+/// into either the values to hand back to the client, or the `Error` to
+/// propagate — logging exactly as the inline match this was extracted from
+/// did. Split out of `process_open_request`'s `DelegateOp` arm so the fix for
+/// #5263 (a genuine delegate execution failure must reach the client as
+/// `Err`, not an empty `Ok`) is unit-testable without constructing an
+/// `OpManager`.
+fn delegate_request_outcome(
+    res: Result<ContractHandlerEvent, crate::contract::ContractError>,
+    client_id: ClientId,
+    request_id: RequestId,
+    delegate_key: &DelegateKey,
+    msg_type: Option<&str>,
+) -> Result<Vec<OutboundDelegateMsg>, Error> {
+    match res {
+        Ok(ContractHandlerEvent::DelegateResponse(Ok(values))) => {
+            if let Some(mt) = msg_type {
+                tracing::info!(
+                    delegate = %delegate_key,
+                    msg_type = %mt,
+                    request_id = %request_id,
+                    outcome = "executed",
+                    "DelegateRequest dispatch"
+                );
+            }
+            Ok(values)
+        }
+        // Genuine delegate execution failure (#5263). Previously this arm
+        // didn't exist: a failure was indistinguishable from
+        // `Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![])))`, so the
+        // client silently received an empty successful response instead of
+        // an error.
+        Ok(ContractHandlerEvent::DelegateResponse(Err(exec_err))) => {
+            tracing::error!(
+                client_id = %client_id,
+                request_id = %request_id,
+                delegate = %delegate_key,
+                error = %exec_err,
+                phase = "error",
+                "Delegate execution failed"
+            );
+            Err(Error::Executor(exec_err))
+        }
+        Err(err) => {
+            tracing::error!(
+                client_id = %client_id,
+                request_id = %request_id,
+                delegate = %delegate_key,
+                error = %err,
+                phase = "error",
+                "Delegate operation failed (contract error)"
+            );
+            Err(Error::Contract(err))
+        }
+        Ok(_) => {
+            tracing::error!(
+                client_id = %client_id,
+                request_id = %request_id,
+                delegate = %delegate_key,
+                phase = "error",
+                "Delegate operation failed (unexpected state)"
+            );
+            Err(Error::Op(OpError::UnexpectedOpState))
+        }
+    }
+}
+
 #[inline]
 async fn process_open_request(
     mut request: OpenRequest<'static>,
@@ -1672,7 +1739,7 @@ async fn process_open_request(
                 // it on a channel the delegate/client cannot reach.
                 let user_context = request.user_context;
 
-                let res = match op_manager
+                let handler_res = op_manager
                     .notify_contract_handler_prioritized(
                         ContractHandlerEvent::DelegateRequest {
                             req,
@@ -1682,58 +1749,14 @@ async fn process_open_request(
                         },
                         crate::contract::Priority::ClientLocal,
                     )
-                    .await
-                {
-                    Ok(ContractHandlerEvent::DelegateResponse(Ok(res))) => {
-                        if let Some(ref mt) = msg_type {
-                            tracing::info!(
-                                delegate = %delegate_key,
-                                msg_type = %mt,
-                                request_id = %request_id,
-                                outcome = "executed",
-                                "DelegateRequest dispatch"
-                            );
-                        }
-                        res
-                    }
-                    // Genuine delegate execution failure (#5263). Previously
-                    // this arm didn't exist: a failure was indistinguishable
-                    // from `Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![])))`,
-                    // so the client silently received an empty successful
-                    // response instead of an error.
-                    Ok(ContractHandlerEvent::DelegateResponse(Err(exec_err))) => {
-                        tracing::error!(
-                            client_id = %client_id,
-                            request_id = %request_id,
-                            delegate = %delegate_key,
-                            error = %exec_err,
-                            phase = "error",
-                            "Delegate execution failed"
-                        );
-                        return Err(Error::Executor(exec_err));
-                    }
-                    Err(err) => {
-                        tracing::error!(
-                            client_id = %client_id,
-                            request_id = %request_id,
-                            delegate = %delegate_key,
-                            error = %err,
-                            phase = "error",
-                            "Delegate operation failed (contract error)"
-                        );
-                        return Err(Error::Contract(err));
-                    }
-                    Ok(_) => {
-                        tracing::error!(
-                            client_id = %client_id,
-                            request_id = %request_id,
-                            delegate = %delegate_key,
-                            phase = "error",
-                            "Delegate operation failed (unexpected state)"
-                        );
-                        return Err(Error::Op(OpError::UnexpectedOpState));
-                    }
-                };
+                    .await;
+                let res = delegate_request_outcome(
+                    handler_res,
+                    client_id,
+                    request_id,
+                    &delegate_key,
+                    msg_type.as_deref(),
+                )?;
 
                 let host_response = Ok(HostResponse::DelegateResponse {
                     key: delegate_key.clone(),
@@ -2454,6 +2477,89 @@ mod unsupported_request_tests {
              client, not merely log and fall through to `Ok(None)` — a \
              client whose request lands here would wait forever with no \
              response. Arm content: {arm:?}"
+        );
+    }
+}
+
+/// Unit tests for `delegate_request_outcome`, the mapping `process_open_request`
+/// uses to turn the contract handler's response to a client `DelegateRequest`
+/// into either the values to return or the `Error` to propagate. These drive
+/// the function directly — no `OpManager` needed — so the #5263 fix (a
+/// genuine delegate execution failure reaches the client as `Err`, not an
+/// empty `Ok`) is covered at the exact layer the client actually sees.
+#[cfg(test)]
+mod delegate_request_outcome_tests {
+    use super::*;
+
+    fn key() -> DelegateKey {
+        DelegateKey::new([3u8; 32], CodeHash::new([0u8; 32]))
+    }
+
+    #[test]
+    fn genuine_execution_failure_becomes_executor_error() {
+        let exec_err = crate::contract::ExecutorError::other(anyhow::anyhow!(
+            "missing message origin for message type: \"application message\""
+        ));
+        let res = delegate_request_outcome(
+            Ok(ContractHandlerEvent::DelegateResponse(Err(exec_err))),
+            ClientId::next(),
+            RequestId::new(),
+            &key(),
+            None,
+        );
+        assert!(
+            matches!(res, Err(Error::Executor(_))),
+            "a genuine delegate execution failure must reach the client as \
+             Err(Error::Executor(_)), not a fake success (#5263); got {res:?}"
+        );
+    }
+
+    #[test]
+    fn successful_execution_returns_the_values() {
+        let res = delegate_request_outcome(
+            Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![]))),
+            ClientId::next(),
+            RequestId::new(),
+            &key(),
+            Some("ApplicationMessages"),
+        );
+        assert!(
+            res.expect("a successful response must not be an error")
+                .is_empty(),
+            "an empty Vec on a genuinely successful response is still correct — \
+             only a genuine failure should become Err"
+        );
+    }
+
+    #[test]
+    fn channel_level_contract_error_propagates_as_contract_error() {
+        let res = delegate_request_outcome(
+            Err(crate::contract::ContractError::NoEvHandlerResponse),
+            ClientId::next(),
+            RequestId::new(),
+            &key(),
+            None,
+        );
+        assert!(
+            matches!(res, Err(Error::Contract(_))),
+            "a channel-level failure (handler dropped, no response) must \
+             surface as Error::Contract; got {res:?}"
+        );
+    }
+
+    #[test]
+    fn unexpected_response_variant_is_reported_as_unexpected_op_state() {
+        let res = delegate_request_outcome(
+            Ok(ContractHandlerEvent::ExportUserSecretsResponse(Ok(vec![]))),
+            ClientId::next(),
+            RequestId::new(),
+            &key(),
+            None,
+        );
+        assert!(
+            matches!(res, Err(Error::Op(OpError::UnexpectedOpState))),
+            "a response of the wrong ContractHandlerEvent variant must be \
+             reported, not silently accepted; got {res:?}"
         );
     }
 }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1684,7 +1684,7 @@ async fn process_open_request(
                     )
                     .await
                 {
-                    Ok(ContractHandlerEvent::DelegateResponse(res)) => {
+                    Ok(ContractHandlerEvent::DelegateResponse(Ok(res))) => {
                         if let Some(ref mt) = msg_type {
                             tracing::info!(
                                 delegate = %delegate_key,
@@ -1695,6 +1695,22 @@ async fn process_open_request(
                             );
                         }
                         res
+                    }
+                    // Genuine delegate execution failure (#5263). Previously
+                    // this arm didn't exist: a failure was indistinguishable
+                    // from `Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![])))`,
+                    // so the client silently received an empty successful
+                    // response instead of an error.
+                    Ok(ContractHandlerEvent::DelegateResponse(Err(exec_err))) => {
+                        tracing::error!(
+                            client_id = %client_id,
+                            request_id = %request_id,
+                            delegate = %delegate_key,
+                            error = %exec_err,
+                            phase = "error",
+                            "Delegate execution failed"
+                        );
+                        return Err(Error::Executor(exec_err));
                     }
                     Err(err) => {
                         tracing::error!(

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -2490,6 +2490,7 @@ mod unsupported_request_tests {
 #[cfg(test)]
 mod delegate_request_outcome_tests {
     use super::*;
+    use freenet_stdlib::prelude::ApplicationMessage;
 
     fn key() -> DelegateKey {
         DelegateKey::new([3u8; 32], CodeHash::new([0u8; 32]))
@@ -2514,8 +2515,53 @@ mod delegate_request_outcome_tests {
         );
     }
 
+    /// The success arm must return the delegate's OWN values, not merely
+    /// something that is not an error.
+    ///
+    /// Passing only `vec![]` here would be vacuous: a mutation to
+    /// `Ok(_) => Ok(vec![])` discards every outbound message the delegate
+    /// produced and an emptiness-only assertion still passes. So this drives a
+    /// non-empty payload and asserts it arrives verbatim. `OutboundDelegateMsg`
+    /// is not `PartialEq`, hence the match on the payload rather than
+    /// `assert_eq!` on the Vec.
     #[test]
     fn successful_execution_returns_the_values() {
+        let payload = vec![7u8, 8, 9];
+        let res = delegate_request_outcome(
+            Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![
+                OutboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(payload.clone())),
+            ]))),
+            ClientId::next(),
+            RequestId::new(),
+            &key(),
+            Some("ApplicationMessages"),
+        );
+        let values = res.expect("a successful response must not be an error");
+        assert_eq!(
+            values.len(),
+            1,
+            "the delegate's outbound messages must be returned, not dropped"
+        );
+        // `let ... else` rather than a `match` with a catch-all: this crate
+        // denies `clippy::wildcard_enum_match_arm`, and spelling out all seven
+        // sibling variants here would need editing every time one is added,
+        // for no gain -- the test only cares about the one it asked for.
+        let OutboundDelegateMsg::ApplicationMessage(msg) = &values[0] else {
+            panic!("expected the ApplicationMessage back, got {:?}", &values[0]);
+        };
+        assert_eq!(
+            msg.payload, payload,
+            "the payload must arrive verbatim; a success arm that substitutes \
+             its own value is the mutation this pins"
+        );
+    }
+
+    /// The companion to the above, and the one closest to #5263: a delegate
+    /// that legitimately produces NO outbound messages is still a SUCCESS.
+    /// This is the regression this PR could most plausibly cause — turning a
+    /// legitimate no-op response into a client-visible error.
+    #[test]
+    fn genuinely_empty_success_stays_ok() {
         let res = delegate_request_outcome(
             Ok(ContractHandlerEvent::DelegateResponse(Ok(vec![]))),
             ClientId::next(),
@@ -2524,7 +2570,7 @@ mod delegate_request_outcome_tests {
             Some("ApplicationMessages"),
         );
         assert!(
-            res.expect("a successful response must not be an error")
+            res.expect("an empty but successful response must not be an error")
                 .is_empty(),
             "an empty Vec on a genuinely successful response is still correct — \
              only a genuine failure should become Err"

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -596,7 +596,14 @@ where
                 iterations = iterations,
                 "Exceeded maximum contract request iterations, possible infinite loop"
             );
-            // Return whatever we accumulated so far
+            // Stays `Ok` DELIBERATELY, and this is an OPEN QUESTION, not a
+            // settled decision. Exhausting the iteration budget may be a
+            // legitimate outcome for a delegate that simply has more work than
+            // the cap allows, in which case converting it to `Err` would turn
+            // working delegates into client-visible failures. Nobody has
+            // established which it is, so #5263 deliberately did not touch it.
+            // Confirm the intent before changing this -- see the tracking
+            // issue linked from the PR.
             return Ok(accumulated_messages);
         }
 
@@ -622,8 +629,16 @@ where
                     phase = "unexpected_response",
                     "Unexpected response type from delegate request"
                 );
-                // Return whatever we accumulated so far
-                return Ok(accumulated_messages);
+                // An internal invariant violation, not a delegate outcome: the
+                // executor answered a delegate request with a variant that is
+                // not a delegate response at all. Reporting it as an empty
+                // success is the same lie #5263 removes from the failure arm
+                // below -- the client cannot tell "the delegate said nothing"
+                // from "this node is confused". Nothing legitimate reaches
+                // here, so there is no working behaviour to regress.
+                return Err(ExecutorError::other(anyhow::anyhow!(
+                    "unexpected response variant for a delegate request on {delegate_key}"
+                )));
             }
             Err(err) => {
                 // Downgrade "not found" to warn — expected during legacy
@@ -3094,6 +3109,57 @@ mod tests {
     ///  2. the notification path — which has no connection and therefore
     ///     hardcodes `Local` — is `InterDelegateDispatch::Suppressed`, so that
     ///     hardcoded value can never reach the hop.
+    /// Pin: the unexpected-response arm must return `Err`, not a fake success.
+    ///
+    /// The executor answering a delegate request with a variant that is not a
+    /// delegate response is an internal invariant violation. Returning
+    /// `Ok(accumulated_messages)` there is the same lie #5263 removes from the
+    /// execution-failure arm: the client cannot distinguish "the delegate said
+    /// nothing" from "this node is confused".
+    ///
+    /// Pinned from source rather than behaviourally because both mock
+    /// executors (`MockWasmRuntime`, `MockRuntime`) return `Err`
+    /// unconditionally, so no fixture can drive the executor to hand back a
+    /// wrong-variant `Ok`. Truncated at the test module first -- the needles
+    /// occur in this function's own text (see #5450).
+    #[test]
+    fn unexpected_response_variant_does_not_become_a_fake_success() {
+        let full = include_str!("contract.rs");
+        let cutoff = full
+            .find("\nmod tests {")
+            .expect("contract.rs must have a top-level `mod tests`");
+        let src = &full[..cutoff];
+
+        let start = src
+            .find("async fn handle_delegate_with_contract_requests")
+            .expect("handle_delegate_with_contract_requests must exist");
+        let body = &src[start..];
+        let end = body[1..]
+            .find("\nasync fn ")
+            .map(|i| i + 1)
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let arm = body
+            .find("phase = \"unexpected_response\"")
+            .expect("the unexpected-response arm must exist");
+        let after = &body[arm..];
+        // Bound to this arm: stop at the next match arm's opening.
+        let arm_end = after.find("Err(err) => {").unwrap_or(after.len());
+        let arm = &after[..arm_end];
+
+        assert!(
+            arm.contains("return Err("),
+            "the unexpected-response arm must return an error; returning \
+             Ok(accumulated_messages) reports an internal invariant violation \
+             to the client as an empty SUCCESS (#5263). Arm: {arm:?}"
+        );
+        assert!(
+            !arm.contains("return Ok(accumulated_messages)"),
+            "the unexpected-response arm must not fall back to a fake success"
+        );
+    }
+
     /// Pin: the delegate->apps TTL sweep must run BEFORE the early return on
     /// an execution failure.
     ///

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -602,8 +602,7 @@ where
             // the cap allows, in which case converting it to `Err` would turn
             // working delegates into client-visible failures. Nobody has
             // established which it is, so #5263 deliberately did not touch it.
-            // Confirm the intent before changing this -- see the tracking
-            // issue linked from the PR.
+            // Confirm the intent before changing this -- tracked as #5454.
             return Ok(accumulated_messages);
         }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -543,7 +543,7 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     user_context: Option<&UserSecretContext>,
     delegate_key: &DelegateKey,
     prompter: &P,
-) -> Vec<OutboundDelegateMsg>
+) -> Result<Vec<OutboundDelegateMsg>, ExecutorError>
 where
     CH: ContractHandler + Send + 'static,
     P: UserInputPrompter,
@@ -597,7 +597,7 @@ where
                 "Exceeded maximum contract request iterations, possible infinite loop"
             );
             // Return whatever we accumulated so far
-            return accumulated_messages;
+            return Ok(accumulated_messages);
         }
 
         // Execute the delegate request
@@ -623,26 +623,30 @@ where
                     "Unexpected response type from delegate request"
                 );
                 // Return whatever we accumulated so far
-                return accumulated_messages;
+                return Ok(accumulated_messages);
             }
             Err(err) => {
                 // Downgrade "not found" to warn — expected during legacy
-                // migration probes when old delegate WASM isn't on this node
+                // migration probes when old delegate WASM isn't on this node.
+                // A missing-delegate probe stays a benign empty response
+                // rather than a client-visible error; only genuine execution
+                // failures propagate as Err below (#5263 — previously EVERY
+                // failure here, including real ones, silently became an
+                // empty successful DelegateResponse to the client).
                 if err.is_missing_delegate() {
                     tracing::warn!(
                         delegate_key = %delegate_key,
                         "Delegate not found in store (expected for migration probes)"
                     );
-                } else {
-                    tracing::error!(
-                        delegate_key = %delegate_key,
-                        error = %err,
-                        phase = "execution_failed",
-                        "Failed executing delegate request"
-                    );
+                    return Ok(accumulated_messages);
                 }
-                // Return whatever we accumulated so far
-                return accumulated_messages;
+                tracing::error!(
+                    delegate_key = %delegate_key,
+                    error = %err,
+                    phase = "execution_failed",
+                    "Failed executing delegate request"
+                );
+                return Err(err);
             }
         };
 
@@ -691,7 +695,7 @@ where
             && delegate_messages.is_empty()
             && user_input_requests.is_empty()
         {
-            return accumulated_messages;
+            return Ok(accumulated_messages);
         }
 
         let mut inbound_responses: Vec<InboundDelegateMsg<'static>> = Vec::new();
@@ -2135,6 +2139,15 @@ async fn handle_delegate_notification<CH, P>(
         prompter,
     )
     .await;
+
+    // Notification-driven: there is no client waiting to answer, so an
+    // execution failure has nothing to propagate to. Already logged inside
+    // `handle_delegate_with_contract_requests`; just stop here, matching the
+    // pre-existing behavior of falling through with nothing to route (#5263
+    // only changes what happens on the CLIENT-driven path below).
+    let Ok(outbound) = outbound else {
+        return;
+    };
 
     // Route outbound ApplicationMessages to the apps registered with this
     // delegate (#3275). handle_delegate_with_contract_requests already
@@ -5168,6 +5181,64 @@ mod hol_4391_tests {
                 );
             }
             other => panic!("expected RegisterSubscriberListenerResponse, got {other}"),
+        }
+    }
+
+    /// Regression for #5263: when a delegate's execution fails, the client
+    /// driving `ContractHandlerEvent::DelegateRequest` through
+    /// `handle_contract_event` MUST see the failure ride back as
+    /// `DelegateResponse(Err(_))`, not a fake empty successful response.
+    ///
+    /// `MockWasmRuntime::execute_delegate_request` unconditionally returns a
+    /// generic `ExecutorError::other(...)` for any delegate request — not the
+    /// `is_missing_delegate()` case, which stays a benign empty response for
+    /// legacy migration probes (see `handle_delegate_with_contract_requests`)
+    /// — so no delegate needs to be registered to exercise the genuine
+    /// execution-failure branch this test targets.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_request_surfaces_execution_failure_5263() {
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(rcv_halve, None, "del_fail_5263").await;
+
+        let delegate_key = DelegateKey::new([7u8; 32], CodeHash::new([0u8; 32]));
+        let req = DelegateRequest::ApplicationMessages {
+            key: delegate_key,
+            params: Parameters::from(vec![]),
+            inbound: vec![],
+        };
+        let event = ContractHandlerEvent::DelegateRequest {
+            req,
+            origin_contract: None,
+            connection_scope: crate::client_events::ConnectionScope::Local,
+            user_context: None,
+        };
+        let send_fut = send_halve.send_to_handler(event);
+        let recv_fut = async {
+            let (id, received, _priority) = handler
+                .channel()
+                .recv_from_sender()
+                .await
+                .expect("handler channel should be open");
+            handle_contract_event(
+                &mut handler,
+                id,
+                received,
+                &user_input::AutoApprovePrompter,
+                None,
+            )
+            .await
+            .expect("dispatch must not error");
+        };
+        let (send_res, ()) = tokio::join!(send_fut, recv_fut);
+        match send_res.expect("must receive a response") {
+            ContractHandlerEvent::DelegateResponse(result) => {
+                assert!(
+                    result.is_err(),
+                    "a delegate execution failure must surface an error to the \
+                     client, not a fake empty success (#5263)"
+                );
+            }
+            other => panic!("expected DelegateResponse, got {other}"),
         }
     }
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -3094,20 +3094,6 @@ mod tests {
         ContractKey::from_params_and_code(&params, &code)
     }
 
-    /// H2 — the control that REPLACED the deleted registration-record gate.
-    ///
-    /// Removing a control is only safe if the thing standing in for it is
-    /// itself pinned. The inter-delegate hop is safe because it forwards the
-    /// ORIGINATING connection scope, so a non-local caller cannot launder its
-    /// lack of attestation through a delegate. Nothing enforced that: passing a
-    /// literal `ConnectionScope::Local` at the hop compiled and broke nothing.
-    ///
-    /// Two properties, because the hop has two callers with different scope
-    /// provenance:
-    ///  1. the hop forwards the `connection_scope` VARIABLE, never a literal; and
-    ///  2. the notification path — which has no connection and therefore
-    ///     hardcodes `Local` — is `InterDelegateDispatch::Suppressed`, so that
-    ///     hardcoded value can never reach the hop.
     /// Pin: the unexpected-response arm must return `Err`, not a fake success.
     ///
     /// The executor answering a delegate request with a variant that is not a
@@ -3208,6 +3194,20 @@ mod tests {
         );
     }
 
+    /// H2 — the control that REPLACED the deleted registration-record gate.
+    ///
+    /// Removing a control is only safe if the thing standing in for it is
+    /// itself pinned. The inter-delegate hop is safe because it forwards the
+    /// ORIGINATING connection scope, so a non-local caller cannot launder its
+    /// lack of attestation through a delegate. Nothing enforced that: passing a
+    /// literal `ConnectionScope::Local` at the hop compiled and broke nothing.
+    ///
+    /// Two properties, because the hop has two callers with different scope
+    /// provenance:
+    ///  1. the hop forwards the `connection_scope` VARIABLE, never a literal; and
+    ///  2. the notification path — which has no connection and therefore
+    ///     hardcodes `Local` — is `InterDelegateDispatch::Suppressed`, so that
+    ///     hardcoded value can never reach the hop.
     #[test]
     fn inter_delegate_hop_forwards_the_originating_scope() {
         let src = include_str!("contract.rs");

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2142,9 +2142,20 @@ async fn handle_delegate_notification<CH, P>(
 
     // Notification-driven: there is no client waiting to answer, so an
     // execution failure has nothing to propagate to. Already logged inside
-    // `handle_delegate_with_contract_requests`; just stop here, matching the
-    // pre-existing behavior of falling through with nothing to route (#5263
-    // only changes what happens on the CLIENT-driven path below).
+    // `handle_delegate_with_contract_requests`; there is nothing to route.
+    //
+    // The TTL sweep runs BEFORE this return, not after. It is the registry's
+    // only production caller, and it is what time-bounds the delegate->apps
+    // map per the AGENTS.md GC-exemption rule. Returning above it would make
+    // the sweep conditional on the delegate SUCCEEDING -- and the failure that
+    // motivated #5263 is one a delegate repeats on every single invocation
+    // (rejecting `origin: None`), so on a node whose delegates are all failing
+    // that way the backstop would never run at all. Registrations for apps
+    // that vanished without a clean disconnect would then pin their slots
+    // against MAX_APPS_PER_DELEGATE until the process restarted. Sweeping is
+    // independent of whether this particular execution produced anything.
+    delegate_app_registry::sweep_expired();
+
     let Ok(outbound) = outbound else {
         return;
     };
@@ -2177,12 +2188,6 @@ async fn handle_delegate_notification<CH, P>(
             }
         })
         .collect();
-
-    // Opportunistic TTL sweep of the delegate->apps registry, mirroring how
-    // prune_expired_contexts sweeps on delegate activity rather than via a
-    // background task. Bounds stale registrations for apps that vanished
-    // without a clean disconnect (AGENTS.md GC-exemption rule).
-    delegate_app_registry::sweep_expired();
 
     if app_messages.is_empty() {
         return;
@@ -3089,6 +3094,55 @@ mod tests {
     ///  2. the notification path — which has no connection and therefore
     ///     hardcodes `Local` — is `InterDelegateDispatch::Suppressed`, so that
     ///     hardcoded value can never reach the hop.
+    /// Pin: the delegate->apps TTL sweep must run BEFORE the early return on
+    /// an execution failure.
+    ///
+    /// `sweep_expired` is the registry's ONLY production caller, and it is what
+    /// time-bounds the map per the AGENTS.md GC-exemption rule. #5263 added an
+    /// early `return` on a failed execution; putting the sweep after it makes
+    /// the backstop conditional on the delegate SUCCEEDING. The failure that
+    /// motivated #5263 is one a delegate repeats on EVERY invocation (rejecting
+    /// `origin: None`), so on a node whose delegates all fail that way the
+    /// sweep would never run and stale registrations would pin their slots
+    /// against `MAX_APPS_PER_DELEGATE` until restart.
+    ///
+    /// The source is truncated at the test module BEFORE scraping: both needles
+    /// below also occur in this function's own text, which `include_str!` pulls
+    /// in, so without the cut a rename would silently widen the region instead
+    /// of panicking (see #5450).
+    #[test]
+    fn ttl_sweep_precedes_the_execution_failure_return() {
+        let full = include_str!("contract.rs");
+        let cutoff = full
+            .find("\nmod tests {")
+            .expect("contract.rs must have a top-level `mod tests`");
+        let src = &full[..cutoff];
+
+        let start = src
+            .find("async fn handle_delegate_notification")
+            .expect("handle_delegate_notification must exist");
+        let body = &src[start..];
+        let end = body[1..]
+            .find("\nasync fn ")
+            .map(|i| i + 1)
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let sweep = body
+            .find("delegate_app_registry::sweep_expired()")
+            .expect("the TTL sweep must live in handle_delegate_notification");
+        let bail = body
+            .find("let Ok(outbound) = outbound else")
+            .expect("the execution-failure early return must exist");
+
+        assert!(
+            sweep < bail,
+            "the TTL sweep ({sweep}) must run BEFORE the execution-failure \
+             return ({bail}); after it, the registry's only production sweep \
+             becomes conditional on the delegate succeeding"
+        );
+    }
+
     #[test]
     fn inter_delegate_hop_forwards_the_originating_scope() {
         let src = include_str!("contract.rs");

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -1302,7 +1302,7 @@ mod tests {
             ),
             (
                 "DelegateResponse",
-                ContractHandlerEvent::DelegateResponse(vec![]),
+                ContractHandlerEvent::DelegateResponse(Ok(vec![])),
             ),
             (
                 "ClientDisconnect",

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -818,7 +818,11 @@ pub(crate) enum ContractHandlerEvent {
         /// `Debug` impl redacts the secret, so logging this event is safe.
         user_context: Option<UserSecretContext>,
     },
-    DelegateResponse(Vec<OutboundDelegateMsg>),
+    /// `Err` on a genuine delegate execution failure (#5263 — previously
+    /// every failure here silently became an empty successful
+    /// `DelegateResponse`, so the client had no way to distinguish
+    /// "the delegate answered nothing" from "the delegate failed").
+    DelegateResponse(Result<Vec<OutboundDelegateMsg>, ExecutorError>),
     /// Export a hosted user's per-user delegate secrets into an encrypted
     /// bundle (hosted-mode export, P3-live of #4381). Carries the
     /// connection-derived `user_context` (the forge-proof per-user namespace,


### PR DESCRIPTION
## Problem

A delegate execution failure reached the client as an **empty successful** `DelegateResponse`. `handle_delegate_with_contract_requests` logged `phase = "execution_failed"` and then returned the messages it had accumulated so far; `process_open_request` mapped that straight to `HostResponse::DelegateResponse`. An app could not distinguish "the delegate answered nothing" from "the delegate failed", so it sat on a loading screen indefinitely.

## Scope — read this before assuming the class is closed

`handle_delegate_with_contract_requests` has **three** `return Ok(accumulated_messages)` bail-outs. This PR closes **two** of them, deliberately, and the third is left with a documented open question rather than a guess.

| site | disposition |
|---|---|
| execution failure (`Err` from `execute_delegate_request`) | **fixed** — now returns `Err`, the original #5263 case |
| unexpected response variant (`Ok(_other)`) | **fixed** — an internal invariant violation, nothing legitimate reaches it |
| iteration limit exceeded | **left as `Ok`** — see below |

**The iteration-limit arm is an open question, not deferred work.** Exhausting the budget may be a legitimate outcome for a delegate with more contract requests than the cap allows, in which case converting it to `Err` would turn working delegates into client-visible failures — a regression, not a fix. Whether the cap exists to bound work or to detect misbehaviour is author intent and is not recoverable from the code. Tracked as **#5454**; @iduartgomez is the likeliest person to know which was meant. The arm now carries a comment saying exactly this, marked open, so a future reader does not mistake the absence of a change for a considered "no".

One more deliberate carve-out, unchanged by this PR: `is_missing_delegate()` still returns an empty success for a delegate that is not installed on this node, so migration probes stay benign. It is a typed match on `RequestError::DelegateError(Missing(_))`, not a string sniff, so it cannot swallow genuine failures — but nothing pins it, and it is the one branch separating a true positive from a false positive here. Also in #5454.

## Solution

`ContractHandlerEvent::DelegateResponse` now carries `Result<Vec<OutboundDelegateMsg>, ExecutorError>`, and `client_events.rs` maps it through a new `delegate_request_outcome` so the classification lives in one place with its own tests rather than inline in `process_open_request`.

A genuine execution failure becomes `Err(Error::Executor(..))` and reaches the client as a `ClientError`. A delegate that legitimately produces no outbound messages still returns SUCCESS with an empty `values` — that path is unchanged and pinned by `successful_execution_returns_the_values`.

## Also fixed here: a regression this PR introduced

The early return added to `handle_delegate_notification` originally sat **above** `delegate_app_registry::sweep_expired()`, which is the registry's only production caller and the thing that time-bounds the delegate→apps map under the AGENTS.md GC-exemption rule. That made the TTL sweep conditional on the delegate having *succeeded*.

Not theoretical: the failure #5263 exists to fix is one a delegate repeats on **every** invocation (rejecting `origin: None`), so on an affected node the backstop would never run at all, and registrations for apps that vanished without a clean disconnect would pin their slots against `MAX_APPS_PER_DELEGATE` until restart. The bug fix would have created the exact condition the TTL was introduced to prevent. The sweep now runs before the return, pinned by `ttl_sweep_precedes_the_execution_failure_return`.

## Testing

- `delegate_request_surfaces_execution_failure_5263` — drives `handle_contract_event` over a real channel with a mock executor; verified red before the fix, green after.
- `delegate_request_outcome_tests` (4) — each asserts a specific `Error` variant against a specific input, not merely "is an error". `genuine_execution_failure_becomes_executor_error` is the one that pins #5263; the other three are the success guard and refactor-safety pins for the extraction.
- `ttl_sweep_precedes_the_execution_failure_return` and `unexpected_response_variant_does_not_become_a_fake_success` — source pins. Both mock executors return `Err` unconditionally, so neither class can be driven behaviourally today. Both truncate at the test module before scraping, because their needles occur in their own text (the vacuous-pin shape surveyed in **#5450**).

**Known gap, stated rather than papered over:** no test exercises a *real* WASM delegate failing end-to-end to a real WebSocket client. Coverage is two unit layers joined by a compiler-checked shared type, which is a reasonable argument that this PR does not need it — but it is not the same thing as having it.

Rebased onto current main over ~92 commits. The only conflict was in `client_events.rs`, where main's `unsupported_request_tests` (from merged #5392) and this branch's `delegate_request_outcome_tests` both append at end-of-file; both kept, verified by hunk enumeration (4 hunks, the last a pure append) with zero deletions touching #5392 content.

Closes #5263

[AI-assisted - Claude]
