### PR TITLE
fix(canary): isolate TMPDIR so Gate A stops blocking healthy releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,9 +421,17 @@ jobs:
             # test-exempt. Without this, a genuine shell regression test scores
             # zero against TEST_ATTR_RE (Rust-only) and the fix is wrongly
             # rejected — the gap that hid the announce-to-river fix's own test.
+            # `check` is one of several assertion helpers in this repo's shell
+            # self-tests; `auto-update-canary_lifecycle_test.sh` reports through
+            # `ok`/`bad` instead. Matching only `check` made this rule miss a
+            # genuine behavioural regression test (#5290 added a lifecycle case
+            # that reproduces the fault and goes red without the fix) and demand
+            # `test-exempt` for a PR that had exactly the test the rule wants —
+            # the same "gate cannot see its subject" shape the comment above
+            # describes. Match the helpers actually in use.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*check[[:space:]]' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok)[[:space:]]' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -633,6 +633,14 @@ a tag that no longer exists is worse than the draft.
    (`build_info::GIT_DIRTY`), so the canary will report *auto-update is
    DISABLED* rather than reproducing the parse failure. Commit or stash first.
 
+   A clean run here is **not** evidence that the harness is sound. CI stages
+   the binary differently — `cross-compile.yml` puts it at `/tmp/freenet`,
+   which used to collide with a directory the node creates under `$TMPDIR` and
+   blocked v0.2.124 on a healthy binary. Running from `./target/release/` is
+   precisely the environment where that class of fault cannot occur, which is
+   why local validation went 4/4 green while CI blocked. If local reproduces
+   nothing, suspect the staging environment before the binary.
+
 ### If Gate B fails
 
 The release is already public and the fleet will **not** converge onto it on

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -527,7 +527,18 @@ assert_detection_healthy() {
 NODE_EXIT=""
 run_node_until_check() {
   local binary="$1" work="$2"
-  mkdir -p "$work/home/.local/state/freenet" "$work/cfg" "$work/data" "$work/logs"
+  # `$work/tmp` is created HERE, with the rest of the tree, rather than inside
+  # the subshell next to the `export TMPDIR` that uses it. Gate A would not
+  # care -- the node's own `create_dir_all` builds its parents -- but Gate B
+  # does: the real updater stages through `tempfile::tempdir()` (`update.rs`),
+  # which requires TMPDIR to EXIST and will not create it. A `mkdir` inside the
+  # backgrounded subshell also fails invisibly (no `set -e`, and its output
+  # goes to `node.out`), so a broken workdir would surface as a mystery
+  # update-path failure rather than as itself.
+  if ! mkdir -p "$work/home/.local/state/freenet" "$work/cfg" "$work/data" \
+                "$work/logs" "$work/tmp"; then
+    fail "could not create the canary workdir under $work -- this is a harness/disk problem, not an auto-update fault."
+  fi
 
   # An isolated HOME matters for more than tidiness: the node keeps its GitHub
   # poll token-bucket under $HOME/.local/state/freenet, so a shared HOME would
@@ -593,10 +604,21 @@ run_node_until_check() {
     #      directory that is always empty and never read. PORTS are the shared
     #      resource that actually collides; see the header.
     #
-    # Relocating the staged binary would only address (1). Isolating TMPDIR
-    # addresses both, and is scoped to this subshell so only the canary's
-    # throwaway node is affected.
-    mkdir -p "$work/tmp"
+    # Relocating the staged binary in `cross-compile.yml` WOULD have unblocked
+    # v0.2.124 -- tested: pre-fix script, a scratch TMPDIR with no `freenet`
+    # entry in it, binary staged outside it, and the gate returns rc=0 "the node
+    # compared against '0.2.123'". An earlier version of this comment claimed
+    # relocation was "NOT sufficient"; that was wrong, and it was wrong for an
+    # instructive reason -- the run behind it was on a host where
+    # `/tmp/freenet` already existed as another user's directory, i.e. case (2),
+    # generalised into a claim about case (1).
+    #
+    # Isolation is still the better fix, for (2) rather than (1): relocation
+    # leaves the canary sharing the caller's temp dir, so on a machine already
+    # running a node under another user the gate can still panic on a
+    # `/tmp/freenet` it does not own -- an auto-update verdict decided by who
+    # owns a directory. Scoped to this subshell, so only the canary's throwaway
+    # node is affected.
     # shellcheck disable=SC2030  # subshell-local is the point, same as HOME
     # above: the caller's TMPDIR must not move on a machine already running a
     # node. Gate B's `freenet update` sets its own (see `cmd_selfupdate`),
@@ -979,8 +1001,8 @@ cmd_selfupdate() {
     # a release tarball into the ambient system temp dir. Safe for the swap --
     # `replace_binary` copies to a `.freenet.new.tmp` beside the DESTINATION
     # and renames there, so the atomic same-filesystem rename never involves
-    # TMPDIR.
-    mkdir -p "$work/tmp"
+    # TMPDIR. The directory itself is created with the rest of the workdir in
+    # `run_node_until_check`, which Gate B always runs before reaching here.
     # shellcheck disable=SC2031  # deliberate, as for HOME above: this subshell
     # sets its own copy; nothing outside it reads the change.
     export TMPDIR="$work/tmp"

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -55,16 +55,20 @@
 #                 and a draft release does not appear there.
 #
 # Run either locally. Both keep their FILES to their own temp directory
-# (isolated HOME, config, data, log dirs and TMPDIR), so nothing outside it is
-# touched.
+# (isolated HOME, TMPDIR, webapp cache, and config/data/log dirs), so nothing
+# outside it is touched.
 #
-# TMPDIR is in that list for a reason and must stay there: the node's contract
-# web directory is `std::env::temp_dir()/freenet/webs`, hardwired, and does NOT
-# follow `--data-dir`. Until v0.2.124 this file did not set TMPDIR, so the claim
-# above was false -- and worse, `cross-compile.yml` stages the binary under test
-# at `/tmp/freenet`, the exact path the node then tries to create a directory
-# under. The node panicked on ENOTDIR before reaching the update task, and Gate A
-# blocked a release whose binary was perfectly healthy. See `run_node_until_check`.
+# TMPDIR is in that list for a reason and must stay there, and the reason is not
+# the one it looks like. `client_api.rs` unconditionally `create_dir_all`s
+# `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it builds
+# the router. That directory is VESTIGIAL: nothing in the tree reads or writes
+# it, and web contracts are unpacked elsewhere (`default_webapp_cache_dir`). Its
+# one surviving effect is the panic when the mkdir FAILS -- `$TMPDIR/freenet`
+# being a FILE, or a directory owned by another user. Through v0.2.124 this file
+# did not set TMPDIR, and `cross-compile.yml` stages the binary under test at
+# `/tmp/freenet`, which is exactly that path: ENOTDIR, panic (exit 101) before
+# the update task spawned, and Gate A blocked a release whose binary was
+# perfectly healthy. See `run_node_until_check`.
 #
 # PORTS are the exception, and an earlier version of this header overstated it
 # by calling the runs "safe to run on a machine already running a node". They
@@ -563,29 +567,53 @@ run_node_until_check() {
     # var removes the class outright for the cost of one line. Only the
     # canary's own throwaway node is affected.
     export FREENET_DISABLE_LOG_RATE_LIMIT=1
-    # The node's contract web directory is `std::env::temp_dir()/freenet/webs`
-    # (client_api.rs), hardwired -- it does NOT follow `--data-dir`. Two
-    # consequences, and the first one blocked a healthy release:
+    # `client_api.rs` unconditionally `create_dir_all`s
+    # `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it
+    # builds the router, and that path does NOT follow `--data-dir`. The
+    # directory itself is VESTIGIAL -- nothing reads or writes it (`"webs"` has
+    # exactly one occurrence in `crates/`, the mkdir), and unpacked web
+    # contracts live under `default_webapp_cache_dir` instead. So the only thing
+    # it can still do is PANIC when the mkdir fails, which it does two ways:
     #
-    #   1. `cross-compile.yml` stages the binary it is about to gate at
-    #      `/tmp/freenet`, which is exactly the path the node then tries to
-    #      `mkdir` under. `create_dir_all` hits ENOTDIR against the binary FILE
-    #      and the node panics (exit 101) before the update task ever spawns, so
-    #      Gate A reports "the startup update check never ran" and blocks. That
-    #      is what happened to v0.2.124: the shipping binary was fine, and the
-    #      gate's own harness was not. Verified on the released artifact --
-    #      UNVERIFIED with the default TMPDIR, `rc=0` and
-    #      "compared against '0.2.123'" with TMPDIR isolated. Relocating the
-    #      binary alone is NOT sufficient; the isolation is the fix.
-    #   2. Without this the canary is not self-contained, contradicting this
-    #      file's own header: two nodes on one machine share
-    #      `/tmp/freenet/webs`. The header's "safe to run on a machine already
-    #      running a node" claim was corrected for PORTS earlier; this is the
-    #      other half of the same claim.
+    #   1. `$TMPDIR/freenet` is a FILE. `cross-compile.yml` stages the binary it
+    #      is about to gate at `/tmp/freenet`, exactly that path, so
+    #      `create_dir_all` hits ENOTDIR against the binary and the node panics
+    #      (exit 101) before the update task ever spawns. Gate A then reports
+    #      "the startup update check never ran" and blocks. That is what
+    #      happened to v0.2.124: the shipping binary was fine, the gate's own
+    #      harness was not. Measured on the SHIPPED v0.2.124 artifact staged at
+    #      that path, this fix against a reverted-fix control:
+    #          fixed    rc=0, "compared against '0.2.123'"
+    #          control  rc=1, node exited 101, panicked in `client_api.rs`
+    #                   ("Not a directory (os error 20)")
+    #   2. `$TMPDIR/freenet` is a directory owned by ANOTHER USER and has no
+    #      `webs` child yet -- EACCES, same panic, which is what the panic's own
+    #      "may happen if ... was created by another user" text is about. Two
+    #      canary runs on one host do NOT collide here: they would share a
+    #      directory that is always empty and never read. PORTS are the shared
+    #      resource that actually collides; see the header.
     #
-    # Scoped to the subshell, so only the canary's throwaway node is affected.
+    # Relocating the staged binary would only address (1). Isolating TMPDIR
+    # addresses both, and is scoped to this subshell so only the canary's
+    # throwaway node is affected.
     mkdir -p "$work/tmp"
+    # shellcheck disable=SC2030  # subshell-local is the point, same as HOME
+    # above: the caller's TMPDIR must not move on a machine already running a
+    # node. Gate B's `freenet update` sets its own (see `cmd_selfupdate`),
+    # which is what makes shellcheck notice this one at all.
     export TMPDIR="$work/tmp"
+    # The webapp cache does not follow TMPDIR or --data-dir either: it resolves
+    # through `directories::ProjectDirs` (`default_webapp_cache_dir`), which
+    # reads XDG_CACHE_HOME AHEAD of HOME, and `FREENET_WEBAPP_CACHE_DIR`
+    # overrides both. `WebappCache::with_root` create_dir_all's it on every
+    # boot, so on a host with XDG_CACHE_HOME set the canary would write outside
+    # its workdir. Unlike the vestigial mkdir above this one fails SOFT (a warn,
+    # the node carries on), so it never blocked a release -- it is here to make
+    # the header's isolation claim true rather than nearly true. Setting the
+    # explicit override is what closes it; XDG_CACHE_HOME is scoped too so any
+    # other cache-dir consumer lands in the workdir as well.
+    export XDG_CACHE_HOME="$work/cache"
+    export FREENET_WEBAPP_CACHE_DIR="$work/cache/freenet-webapp"
     exec timeout "$CANARY_TIMEOUT_SECS" "$binary" network \
       --config-dir "$work/cfg" \
       --data-dir "$work/data" \
@@ -944,6 +972,18 @@ cmd_selfupdate() {
     # shellcheck disable=SC2031  # deliberate: `freenet update` must read the
     # same isolated state dir the node wrote, and nothing outside it.
     export HOME="$work/home"
+    # `download_and_install` stages the downloaded tarball in
+    # `tempfile::tempdir()` (`update.rs`, and the macOS DMG path likewise),
+    # which follows TMPDIR. Without this the header's "both runs keep their
+    # FILES to their own temp directory" was true of Gate A only: Gate B wrote
+    # a release tarball into the ambient system temp dir. Safe for the swap --
+    # `replace_binary` copies to a `.freenet.new.tmp` beside the DESTINATION
+    # and renames there, so the atomic same-filesystem rename never involves
+    # TMPDIR.
+    mkdir -p "$work/tmp"
+    # shellcheck disable=SC2031  # deliberate, as for HOME above: this subshell
+    # sets its own copy; nothing outside it reads the change.
+    export TMPDIR="$work/tmp"
     "$work/bin/freenet" update --quiet
   ); then
     fail "\`freenet update\` failed -- the node asked for an update and the installer could not apply it."

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -55,7 +55,16 @@
 #                 and a draft release does not appear there.
 #
 # Run either locally. Both keep their FILES to their own temp directory
-# (isolated HOME, config, data and log dirs), so nothing outside it is touched.
+# (isolated HOME, config, data, log dirs and TMPDIR), so nothing outside it is
+# touched.
+#
+# TMPDIR is in that list for a reason and must stay there: the node's contract
+# web directory is `std::env::temp_dir()/freenet/webs`, hardwired, and does NOT
+# follow `--data-dir`. Until v0.2.124 this file did not set TMPDIR, so the claim
+# above was false -- and worse, `cross-compile.yml` stages the binary under test
+# at `/tmp/freenet`, the exact path the node then tries to create a directory
+# under. The node panicked on ENOTDIR before reaching the update task, and Gate A
+# blocked a release whose binary was perfectly healthy. See `run_node_until_check`.
 #
 # PORTS are the exception, and an earlier version of this header overstated it
 # by calling the runs "safe to run on a machine already running a node". They
@@ -554,6 +563,29 @@ run_node_until_check() {
     # var removes the class outright for the cost of one line. Only the
     # canary's own throwaway node is affected.
     export FREENET_DISABLE_LOG_RATE_LIMIT=1
+    # The node's contract web directory is `std::env::temp_dir()/freenet/webs`
+    # (client_api.rs), hardwired -- it does NOT follow `--data-dir`. Two
+    # consequences, and the first one blocked a healthy release:
+    #
+    #   1. `cross-compile.yml` stages the binary it is about to gate at
+    #      `/tmp/freenet`, which is exactly the path the node then tries to
+    #      `mkdir` under. `create_dir_all` hits ENOTDIR against the binary FILE
+    #      and the node panics (exit 101) before the update task ever spawns, so
+    #      Gate A reports "the startup update check never ran" and blocks. That
+    #      is what happened to v0.2.124: the shipping binary was fine, and the
+    #      gate's own harness was not. Verified on the released artifact --
+    #      UNVERIFIED with the default TMPDIR, `rc=0` and
+    #      "compared against '0.2.123'" with TMPDIR isolated. Relocating the
+    #      binary alone is NOT sufficient; the isolation is the fix.
+    #   2. Without this the canary is not self-contained, contradicting this
+    #      file's own header: two nodes on one machine share
+    #      `/tmp/freenet/webs`. The header's "safe to run on a machine already
+    #      running a node" claim was corrected for PORTS earlier; this is the
+    #      other half of the same claim.
+    #
+    # Scoped to the subshell, so only the canary's throwaway node is affected.
+    mkdir -p "$work/tmp"
+    export TMPDIR="$work/tmp"
     exec timeout "$CANARY_TIMEOUT_SECS" "$binary" network \
       --config-dir "$work/cfg" \
       --data-dir "$work/data" \

--- a/scripts/auto-update-canary_lifecycle_test.sh
+++ b/scripts/auto-update-canary_lifecycle_test.sh
@@ -412,10 +412,18 @@ fi
 #    comes from the kernel refusing to mkdir under a file, not from a fixture
 #    that prints a panic message on cue.
 #
+#    This case catches the isolation being ABSENT; case 10 catches it being
+#    WRONG. Not a redundant pair, and mutation testing is what separated them:
+#    rewriting the export to `TMPDIR=/tmp` leaves THIS case green on any host
+#    where `/tmp/freenet` happens to be a usable directory (it is one on nova),
+#    because the node's mkdir then succeeds somewhere useless rather than
+#    failing. Case 10 reads the value the node actually got, so it fails on
+#    that mutation unconditionally. Deleting the export fails both.
+#
 #    A source scrape in auto-update-canary_test.sh also pins `export TMPDIR`,
-#    and that pin is worth keeping for the ordering it checks (before `exec`,
-#    before `freenet update`) -- but it asserts TEXT. It cannot tell a working
-#    `export TMPDIR="$work/tmp"` from `export TMPDIR=/tmp`. This case can.
+#    kept for the ordering it checks (before `exec`, before `freenet update`)
+#    and for the Gate B half. It asserts TEXT, so it is green on BOTH mutations
+#    above -- verified, not assumed.
 # ---------------------------------------------------------------------------
 CITMP="$TMPROOT/citmp"
 mkdir -p "$CITMP"
@@ -486,7 +494,10 @@ fi
 #     "no supervisor" error instead of taking the exit-42 path Gate B asserts).
 #
 #     The fake dumps its own environment, so this asserts what the node
-#     actually receives rather than what the script appears to set.
+#     actually receives rather than what the script appears to set -- which is
+#     also what makes it the case that survives a WRONG value rather than only
+#     a missing one (see case 9). Mutation-checked: deleting
+#     `export FREENET_SUPERVISED=1` fails here and nowhere else.
 # ---------------------------------------------------------------------------
 ENVDUMP="$TMPROOT/node-env.txt"
 FAKE_ENVDUMP="$TMPROOT/fake-envdump"

--- a/scripts/auto-update-canary_lifecycle_test.sh
+++ b/scripts/auto-update-canary_lifecycle_test.sh
@@ -396,6 +396,155 @@ else
     ok "a blocking gate dumps the node's own log before the workdir is deleted"
 fi
 
+# ---------------------------------------------------------------------------
+# 9. The canary must not let its own TMPDIR reach the node.
+#
+#    This is the #5290 fault, and it blocked v0.2.124 on a binary that was
+#    perfectly healthy. `client_api.rs` unconditionally `create_dir_all`s
+#    `std::env::temp_dir()/freenet/webs` when it builds the router and PANICS
+#    (exit 101) if it cannot -- and `cross-compile.yml` stages the binary it is
+#    about to gate at `/tmp/freenet`, which is exactly the path that mkdir
+#    needs to be a directory. ENOTDIR, dead node, and Gate A reports "the
+#    startup update check never ran" of a product that was fine.
+#
+#    The fake node here IS the regular file staged at `$TMPDIR/freenet`, which
+#    is what makes this a real test rather than a story about one: the ENOTDIR
+#    comes from the kernel refusing to mkdir under a file, not from a fixture
+#    that prints a panic message on cue.
+#
+#    A source scrape in auto-update-canary_test.sh also pins `export TMPDIR`,
+#    and that pin is worth keeping for the ordering it checks (before `exec`,
+#    before `freenet update`) -- but it asserts TEXT. It cannot tell a working
+#    `export TMPDIR="$work/tmp"` from `export TMPDIR=/tmp`. This case can.
+# ---------------------------------------------------------------------------
+CITMP="$TMPROOT/citmp"
+mkdir -p "$CITMP"
+FAKE_STAGED="$CITMP/freenet"
+cat > "$FAKE_STAGED" <<FAKESTAGED
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo "Freenet version: 0.2.122 (deadbeefcafe)"
+    exit 0
+fi
+logdir=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --log-dir) logdir="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+mkdir -p "\$logdir"
+# Models client_api.rs: hardwired to temp_dir(), does NOT follow --data-dir,
+# and panics rather than degrading when the directory cannot be created.
+webdir="\${TMPDIR:-/tmp}/freenet/webs"
+if ! mkdir -p "\$webdir" 2>/dev/null; then
+    echo "thread 'main' panicked at crates/core/src/server/client_api.rs:256:13:" >&2
+    echo "Failed to create contract web directory at \$webdir: Not a directory (os error 20)" >&2
+    exit 101
+fi
+sleep 1
+echo "2026-08-08T02:00:00.000000Z  $CHECK_LINE" >> "\$logdir/freenet.2026-08-08-02.log"
+echo "2026-08-08T02:00:00.100000Z  $LATEST_SEEN_LINE" >> "\$logdir/freenet.2026-08-08-02.log"
+echo "2026-08-08T02:00:00.200000Z  $COMPLETE_LINE" >> "\$logdir/freenet.2026-08-08-02.log"
+exit 0
+FAKESTAGED
+chmod +x "$FAKE_STAGED"
+
+# Save and restore rather than running in a subshell: `cmd_preflight` sets
+# NODE_EXIT and the workdir trap in THIS shell, and a subshell would discard
+# both. `${TMPDIR+x}` distinguishes unset from empty, which matters under
+# `set -u`.
+STAGED_OUTER_SET=0
+STAGED_OUTER_WAS=""
+# shellcheck disable=SC2031  # the sourced canary sets TMPDIR inside its node
+# subshell; THIS one is the caller's, which is exactly what the case has to
+# manipulate to model a CI runner whose /tmp holds the staged binary.
+if [ -n "${TMPDIR+x}" ]; then STAGED_OUTER_SET=1; STAGED_OUTER_WAS="$TMPDIR"; fi
+# shellcheck disable=SC2031
+export TMPDIR="$CITMP"
+STAGED_OUT="$(cmd_preflight "$FAKE_STAGED" 2>&1)"
+STAGED_RC=$?
+if [ "$STAGED_OUTER_SET" -eq 1 ]; then export TMPDIR="$STAGED_OUTER_WAS"; else unset TMPDIR; fi
+
+if [ "$STAGED_RC" -eq 0 ]; then
+    ok "the gate passes a HEALTHY binary staged at \$TMPDIR/freenet (the canary isolates TMPDIR)"
+elif [[ "$STAGED_OUT" == *"client_api.rs"* || "$STAGED_OUT" == *"contract web directory"* ]]; then
+    bad "the canary let its own TMPDIR reach the node: the node died creating \$TMPDIR/freenet/webs against the binary under test, and a HEALTHY release was blocked (exit $STAGED_RC). This is #5290 -- CI stages the gated binary at /tmp/freenet."
+else
+    bad "the gate failed a healthy binary for some other reason (exit $STAGED_RC): $STAGED_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. The ENVIRONMENT handed to the node, asserted behaviourally.
+#
+#     Case 9 covers TMPDIR because TMPDIR is the one that broke a release. The
+#     other three exports are in the same position it was: nothing observes
+#     them, so deleting `export HOME=` or `export FREENET_SUPERVISED=1` leaves
+#     every suite green while the canary quietly stops being isolated (HOME:
+#     the node's GitHub poll bucket lands in the caller's home) or stops
+#     testing the real fleet transition (FREENET_SUPERVISED: the node logs a
+#     "no supervisor" error instead of taking the exit-42 path Gate B asserts).
+#
+#     The fake dumps its own environment, so this asserts what the node
+#     actually receives rather than what the script appears to set.
+# ---------------------------------------------------------------------------
+ENVDUMP="$TMPROOT/node-env.txt"
+FAKE_ENVDUMP="$TMPROOT/fake-envdump"
+cat > "$FAKE_ENVDUMP" <<FAKEENV
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo "Freenet version: 0.2.122 (deadbeefcafe)"
+    exit 0
+fi
+logdir=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --log-dir) logdir="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+mkdir -p "\$logdir"
+{
+  echo "HOME=\${HOME:-<unset>}"
+  echo "TMPDIR=\${TMPDIR:-<unset>}"
+  echo "FREENET_SUPERVISED=\${FREENET_SUPERVISED:-<unset>}"
+  echo "FREENET_DISABLE_LOG_RATE_LIMIT=\${FREENET_DISABLE_LOG_RATE_LIMIT:-<unset>}"
+} > "$ENVDUMP"
+sleep 1
+echo "2026-08-08T02:00:00.000000Z  $CHECK_LINE" >> "\$logdir/freenet.2026-08-08-02.log"
+exit 0
+FAKEENV
+chmod +x "$FAKE_ENVDUMP"
+
+ENVWORK="$TMPROOT/envwork"
+mkdir -p "$ENVWORK"
+run_node_until_check "$FAKE_ENVDUMP" "$ENVWORK" >/dev/null 2>&1
+
+if [ ! -f "$ENVDUMP" ]; then
+    bad "the env-dump fake node never ran, so the canary's exports are unverified"
+else
+    if grep -qaF "HOME=$ENVWORK/home" "$ENVDUMP"; then
+        ok "the node's HOME is inside the canary workdir"
+    else
+        bad "the node's HOME is not isolated to the workdir -- its GitHub poll bucket lands in the caller's home, so one gate's budget throttles the other's check"
+    fi
+    if grep -qaF "TMPDIR=$ENVWORK/tmp" "$ENVDUMP"; then
+        ok "the node's TMPDIR is inside the canary workdir"
+    else
+        bad "the node's TMPDIR is NOT isolated to the workdir: its \$TMPDIR/freenet/webs mkdir escapes into the caller's temp dir, and in CI collides with the binary under test (#5290)"
+    fi
+    if grep -qaF "FREENET_SUPERVISED=1" "$ENVDUMP"; then
+        ok "the node runs with FREENET_SUPERVISED=1 (the exit-42 path Gate B asserts)"
+    else
+        bad "FREENET_SUPERVISED is not set, so the node logs a 'no supervisor' error and stays put instead of taking the exit-42 path Gate B asserts"
+    fi
+    if grep -qaF "FREENET_DISABLE_LOG_RATE_LIMIT=1" "$ENVDUMP"; then
+        ok "the node runs with log rate limiting disabled (a dropped WARN cannot fake a green gate)"
+    else
+        bad "FREENET_DISABLE_LOG_RATE_LIMIT is not set: a dropped parse-failure WARN leaves every negative assertion satisfied, which is a false GREEN on a binary carrying the #5221 bug"
+    fi
+fi
+
 echo
 if [[ "$FAILURES" -eq 0 ]]; then
     echo "All auto-update-canary lifecycle assertions passed."

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -566,6 +566,66 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# --- TMPDIR must be scoped before either process starts ---------------------
+# `client_api.rs` unconditionally `create_dir_all`s
+# `std::env::temp_dir()/freenet/webs` at router construction. The directory is
+# vestigial (nothing reads it), but the mkdir can FAIL -- `$TMPDIR/freenet`
+# being a file, or another user's directory -- and it panics when it does, exit
+# 101, before the update task spawns. `cross-compile.yml` stages the binary it
+# is about to gate at exactly `/tmp/freenet`, so with an unisolated TMPDIR that
+# is not a hypothetical: it blocked v0.2.124, a release whose binary was fine.
+#
+# The reason this is a pin and not just a fix: deleting `export TMPDIR` leaves
+# all four suites green. The fault reappears only at the next release, in CI,
+# as a blocked release with a diagnosis ("the startup update check never ran")
+# that points at the product rather than the harness. There is no behavioural
+# test that can see it -- reproducing it means staging a real binary at the
+# colliding path -- so a source scrape of the launch sites is the check.
+#
+# ORDER is asserted, not just presence: an export that lands after `exec` never
+# runs at all (exec replaces the shell), and one that lands after the `freenet
+# update` call is equally decorative. Cross-file (this scrapes CANARY_SH), so
+# it cannot be satisfied by its own assertion text.
+tmpdir_first_export="$(grep -n '^[[:space:]]*export TMPDIR=' "$CANARY_SH" | head -1 | cut -d: -f1)"
+tmpdir_exports="$(grep -c '^[[:space:]]*export TMPDIR=' "$CANARY_SH")"
+node_exec_line="$(grep -n '^[[:space:]]*exec timeout' "$CANARY_SH" | head -1 | cut -d: -f1)"
+update_call_line="$(grep -n 'freenet" update' "$CANARY_SH" | head -1 | cut -d: -f1)"
+# The anchors themselves must resolve, or the pin quietly stops auditing.
+if [[ -z "$node_exec_line" || -z "$update_call_line" ]]; then
+    echo "FAIL - TMPDIR pin: cannot locate the canary's launch sites (exec timeout: '${node_exec_line:-none}', freenet update: '${update_call_line:-none}')." >&2
+    echo "       The pin scrapes for those two anchors; if they were renamed, update this pin rather than dropping it." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ -z "$tmpdir_first_export" ]]; then
+    echo "FAIL - TMPDIR pin: auto-update-canary.sh no longer exports TMPDIR at all." >&2
+    echo "       The node create_dir_all's \$TMPDIR/freenet/webs and PANICS (exit 101) if that path" >&2
+    echo "       is a file or another user's directory. cross-compile.yml stages the gated binary at" >&2
+    echo "       /tmp/freenet, which is that path -- this is what blocked v0.2.124 on a healthy binary." >&2
+    FAILURES=$((FAILURES + 1))
+elif (( tmpdir_first_export >= node_exec_line )); then
+    echo "FAIL - TMPDIR pin: the node's 'exec timeout' (line $node_exec_line) is not preceded by an" >&2
+    echo "       'export TMPDIR=' (first one at line $tmpdir_first_export). exec REPLACES the shell, so an" >&2
+    echo "       export below it never runs and the node inherits the ambient temp dir." >&2
+    FAILURES=$((FAILURES + 1))
+elif (( tmpdir_exports < 2 )); then
+    echo "FAIL - TMPDIR pin: only $tmpdir_exports 'export TMPDIR=' in auto-update-canary.sh; Gate B's" >&2
+    echo "       'freenet update' subshell (line $update_call_line) needs its own. download_and_install stages" >&2
+    echo "       the release tarball in tempfile::tempdir(), which follows TMPDIR, so without it Gate B" >&2
+    echo "       writes outside the workdir and the header's isolation claim is true of Gate A only." >&2
+    FAILURES=$((FAILURES + 1))
+else
+    # The Gate B export must be inside that subshell: after the node's exec,
+    # before the update call. A second export anywhere else does not isolate it.
+    tmpdir_gate_b="$(grep -n '^[[:space:]]*export TMPDIR=' "$CANARY_SH" | awk -F: -v lo="$node_exec_line" -v hi="$update_call_line" '$1 > lo && $1 < hi {print $1; exit}')"
+    if [[ -z "$tmpdir_gate_b" ]]; then
+        echo "FAIL - TMPDIR pin: no 'export TMPDIR=' between the node's exec (line $node_exec_line) and the" >&2
+        echo "       'freenet update' call (line $update_call_line), so Gate B's installer runs with the ambient" >&2
+        echo "       temp dir and stages a release tarball outside the canary's workdir." >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   - source pin: TMPDIR is scoped before the node exec (line $tmpdir_first_export < $node_exec_line) and before \`freenet update\` (line $tmpdir_gate_b < $update_call_line)"
+    fi
+fi
+
 # --- markers must still exist in the Rust source ----------------------------
 # Without this the fixtures above are a self-consistent copy of strings that
 # may no longer be emitted: the canary would go quietly blind while its own

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -575,17 +575,22 @@ fi
 # is about to gate at exactly `/tmp/freenet`, so with an unisolated TMPDIR that
 # is not a hypothetical: it blocked v0.2.124, a release whose binary was fine.
 #
-# The reason this is a pin and not just a fix: deleting `export TMPDIR` leaves
-# all four suites green. The fault reappears only at the next release, in CI,
-# as a blocked release with a diagnosis ("the startup update check never ran")
-# that points at the product rather than the harness. There is no behavioural
-# test that can see it -- reproducing it means staging a real binary at the
-# colliding path -- so a source scrape of the launch sites is the check.
+# This is the WEAKER of the two checks on this fix, and it should be read that
+# way. `auto-update-canary_lifecycle_test.sh` case 9 covers the Gate A half
+# BEHAVIOURALLY: its fake node IS the regular file staged at `$TMPDIR/freenet`,
+# so a missing isolation blocks a healthy binary on a real kernel ENOTDIR. That
+# is the one that matters. A source scrape asserts TEXT and cannot tell a
+# working `export TMPDIR="$work/tmp"` from `export TMPDIR=/tmp`.
 #
-# ORDER is asserted, not just presence: an export that lands after `exec` never
-# runs at all (exec replaces the shell), and one that lands after the `freenet
-# update` call is equally decorative. Cross-file (this scrapes CANARY_SH), so
-# it cannot be satisfied by its own assertion text.
+# Two things it still adds, which is why it stays:
+#   - the GATE B half. Isolating the `freenet update` subshell cannot be
+#     exercised without downloading and installing a real release, so for that
+#     one a scrape is what there is.
+#   - ORDER. An export that lands after `exec` never runs at all (exec replaces
+#     the shell), and one after the `freenet update` call is equally
+#     decorative.
+# Cross-file (it scrapes CANARY_SH), so it cannot be satisfied by its own
+# assertion text.
 tmpdir_first_export="$(grep -n '^[[:space:]]*export TMPDIR=' "$CANARY_SH" | head -1 | cut -d: -f1)"
 tmpdir_exports="$(grep -c '^[[:space:]]*export TMPDIR=' "$CANARY_SH")"
 node_exec_line="$(grep -n '^[[:space:]]*exec timeout' "$CANARY_SH" | head -1 | cut -d: -f1)"


### PR DESCRIPTION
## Problem

**Gate A blocked release v0.2.124 on a binary that was perfectly healthy.** The gate was right to block on what it saw; what it saw was its own harness failing.

When it builds the client-API router, the node unconditionally `create_dir_all`s `std::env::temp_dir()/freenet/webs` (`crates/core/src/server/client_api.rs`, `let contract_web_path =`) and **panics if that fails**. `temp_dir()` reads only `TMPDIR`, so the path does not follow `--data-dir`, and the canary isolated HOME, config, data and log dirs but not `TMPDIR` — so it escaped the sandbox.

That directory is **vestigial**: `grep -rn '"webs"' crates/` returns exactly one hit, the creation site. Nothing reads or writes it; web contracts are unpacked elsewhere (`default_webapp_cache_dir`). Its one surviving effect is the ability to abort startup. Filed separately as #5291 — this PR fixes the canary, not the node.

`cross-compile.yml:638` stages the binary it is about to gate at `/tmp/freenet`. That is exactly the path the node then tries to create a directory under, so `create_dir_all` hit `ENOTDIR` against the binary **file**:

```
thread 'main' panicked at crates/core/src/server/client_api.rs:256:13:
Failed to create contract web directory at /tmp/freenet/webs: Not a directory (os error 20)
```

The node died (exit 101) before the update task spawned, so Gate A reported *"the startup update check never ran"* and refused to publish. Correct behaviour on the evidence available to it — the release stayed a draft, the fleet stayed on 0.2.123, and the dev-room alarm fired. But the shipping binary was fine.

Two things made this land at the worst moment: the harness had never run in real CI before it gated a real release, and local validation (4/4 green pre-merge) ran the binary from `target/release/freenet`, where the collision cannot occur.

## Approach

Set `TMPDIR` to a directory inside the canary's own workdir, scoped to the subshell that launches the node, so only the throwaway node is affected.

**Correction to an earlier revision of this description.** It claimed "relocating the binary alone is not sufficient." That was wrong, and review disproved it by testing: with the pre-fix script, a clean scratch `TMPDIR` containing no `freenet` entry, and the binary staged outside it, the same artifact returns `rc=0`. **Relocating the binary in `cross-compile.yml` alone would have unblocked v0.2.124.** The contrary evidence came from a host-specific condition over-generalised — `/tmp/freenet` on the test host is a directory owned by another user, so that run hit EACCES rather than the file collision.

Isolation is still the better fix, for the narrower and true reason: relocation cures the CI symptom while leaving the canary non-self-contained, so on any machine where `$TMPDIR/freenet` is owned by someone else — a shared host, or one already running a node under a service account — the node still panics. Isolation removes the dependency on what happens to be in the ambient temp dir.

It also closes the second half of this file's own isolation claim. The **ports** half was corrected earlier (the runs bind real ports and collide with a running node); this is the other half — until now two nodes on one machine shared `/tmp/freenet/webs`, so the header's "keeps its files to its own temp directory" was false.

## Testing

Verified against the **shipped v0.2.124 artifact**, downloaded from the draft release (`0.2.124 (6d39f89b9207)`), staged at `$TMPDIR/freenet` to reproduce the exact collision. CI staged it at `/tmp/freenet` literally; that path is an unwritable directory on the test host, so `TMPDIR` was pointed at a scratch dir with the binary inside it — same mechanism, reproducible without root.

| Case | Result |
|---|---|
| **Fixed** | `rc=0` — `OK: the node compared against '0.2.123', which matches GitHub's latest release.` and `OK: startup update check ran to completion and parsed GitHub's response.` |
| **Control** (fix reverted, same collision) | `rc=1`, `node exited with code 101`, `panicked at client_api.rs:256`, `Failed to create contract web directory at …/freenet/webs: Not a directory (os error 20)` |

The control reproduces the production failure exactly, so this is a before/after with a working negative case rather than an assertion that it should help.

A separate run — same artifact, non-colliding binary path, default `TMPDIR`, on a host where `/tmp/freenet` is another user's directory — also failed. That is the EACCES case, not the ENOTDIR one, and it is host-specific; see the correction above. Both are startup panics reported by Gate A as "the startup update check never ran", which is the hard-fail branch, **not** the INDETERMINATE/UNVERIFIED branch the script keeps carefully distinct.

**Regression coverage.** The four suites were all green while this bug shipped, because they drive a bash fake node with no web directory. Added: a behavioural lifecycle case in which the fake node **is** the regular file staged at `$TMPDIR/freenet`, so the ENOTDIR comes from the kernel rather than being simulated — red before the fix, green after. A source-scrape pin is included too, but the behavioural case is the load-bearing one: a pin cannot distinguish `export TMPDIR="$work/tmp"` from `export TMPDIR=/tmp`. A companion case asserts the full env handed to the node, closing a sibling gap where deleting `export HOME=` also left every suite green.

## Not fixed here, deliberately

- **The node hardwiring its web dir to `$TMPDIR/freenet/webs` regardless of `--data-dir`.** That is arguably a product bug — a node's files escaping its configured data dir — but changing it affects every node, not just the canary, and belongs in its own PR with its own review. Filed separately.
- **Gate A runs downstream of `cargo publish`.** v0.2.124's crates are on crates.io while its GitHub release is still an unpublished draft, because the gate sits after the one irreversible step. A Gate A block should cost a re-run, not a version number. Filed separately; it needs an ordering change in `release.yml`/`cross-compile.yml`, not a one-line patch.
- **The canary has never run outside a release.** Its first live exercise was the release it was gating. A continuous run on `main` — with *mechanically identical* staging, or it proves nothing — would surface harness faults where they are cheap. Filed separately.

Refs #5222, #5236.

[AI-assisted - Claude]

