### PR TITLE
ci(clippy): bring cfg(test) and bench targets under the clippy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,13 @@ jobs:
   clippy_check:
     name: Clippy
     runs-on: ubicloud-standard-8
-    timeout-minutes: 15
+    # Raised from 15 for the two added all-targets steps, which compile the test
+    # and bench targets the other steps skip. Measured on a warm
+    # `Swatinem/rust-cache` hit: 46s + 41s + 2m09s = 4m26s for the job with one
+    # all-targets step, so the headroom is not for the warm case -- it is for a
+    # cold cache, where the first step absorbs the full dependency build and the
+    # later steps each add an incremental pass on top.
+    timeout-minutes: 30
     # No dependencies - runs immediately in parallel with fmt_check
 
     env:
@@ -473,11 +479,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # `--all-targets` (= --lib --bins --tests --benches --examples) is a strict
+      # superset of the lib+bins this used to check, and it is what brings
+      # `cfg(test)` code under the gate. See the block below the trace-ot step for
+      # why that matters and what it still does not reach.
       - name: clippy
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
-        run: cargo clippy --locked -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       # Guards the opt-in `trace-ot` OpenTelemetry feature against silent
       # rot: it is excluded from the default build, so a refactor can break
@@ -488,6 +498,51 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
         run: cargo clippy --locked -p freenet --features trace-ot -- -D warnings
+
+      # Until #5292 the clippy gate compiled neither `cfg(test)` code nor the
+      # bench targets, so every lint in a `mod tests` or a `benches/` file was
+      # unguarded. That was not hypothetical: the surface had rotted badly,
+      # including a bench that had not compiled since `PeerConnection::send`
+      # started returning `Result<usize>`, and several tests that discarded a
+      # `Result` carrying the test's own premise and so passed vacuously. #5279
+      # (643ee5d35) is the cleanup and records the measured counts; not repeated
+      # here, because this file outlives those numbers.
+      #
+      # A cleanup only holds if something can turn red when it regresses. Within
+      # one commit of that cleanup landing, #5269 reintroduced a denied lint in
+      # test code and every CI job stayed green.
+      #
+      # BOTH feature positions are needed, and this is the counterintuitive part:
+      # `--all-features` is NOT a maximal build. It does not subsume default
+      # features -- it CONTRADICTS them wherever code is
+      # `cfg(not(feature = ...))`, because turning a feature ON deletes its
+      # negated block. `broadcast_queue.rs` puts `mod queue` behind
+      # `cfg(not(feature = "simulation_tests"))`, so the all-features run
+      # cfg-deletes that module including the ~1,690 lines of `#[cfg(test)]`
+      # inside it -- which is where six discards of this very lint class were
+      # found. The default-features run above is the only thing that reaches
+      # them. Every negation-gated feature except `redb` is default-OFF, so that
+      # one run covers all of their negations at once (`simulation_tests`,
+      # `trace-ot`, `bench`).
+      #
+      # Conversely this step is the ONLY gate on the bench targets, which declare
+      # `required-features = ["bench"]` and so build under no other invocation,
+      # and on non-default-feature code (`sqlite`, `console-subscriber`,
+      # `test-network`, `jemalloc-prof`, `nightly_tests`). Do not "simplify" the
+      # two into one; neither subsumes the other.
+      #
+      # KNOWN GAP, not closed here: `redb` is default-ON, so the ~16
+      # `cfg(not(feature = "redb"))` / `cfg(all(feature = "sqlite",
+      # not(feature = "redb")))` sites are compiled by NO invocation in this
+      # workflow. Closing that needs `--no-default-features --features sqlite`,
+      # which does not build today (see the note at hosting.rs:5469, a
+      # pre-existing gap unrelated to this change).
+      #
+      - name: clippy (all targets, all features)
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
   # Windows compile check - catches missing imports, feature flags, and
   # platform-specific errors that Linux CI misses. Added after #3685 where

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -267,6 +267,23 @@ unsafe_op_in_unsafe_fn = "deny"
 [lints.clippy]
 # Disallow `let _ = expr` when `expr` is #[must_use].
 # Forces explicit handling or an intentional `drop()` call.
+#
+# CAVEAT, learned the hard way (#5292): the suggested `drop()` escape hatch is
+# NOT always available, and then the two lints forbid opposite spellings of the
+# same statement. If the discarded value is `#[must_use]` AND `Copy` (e.g. a
+# `Result<(), SendError<T>>` where `T: Copy`), `let _ = x` is denied here while
+# `drop(x)` is denied by rustc's `dropping_copy_types` -- the drop genuinely
+# does nothing, so the lint is right. The same applies to a `#[must_use]` type
+# with no `Drop` glue, via `clippy::drop_non_drop`.
+#
+# When that happens, the resolution is a PER-SITE
+# `#[allow(clippy::let_underscore_must_use)]` with a comment saying why the
+# value is ignorable -- see `broadcast_queue.rs` in `mod observation_tests`.
+# Do NOT widen this to a module-level allow (it un-gates every future discard in
+# that module) and do NOT disable `dropping_copy_types`/`drop_non_drop`
+# crate-wide to make `drop()` work everywhere: both catch real mistakes, and
+# suppressing a lint to make a fix convenient is what produced the test-code
+# blind spot #5292 had to close.
 let_underscore_must_use = "deny"
 
 # Flag `_ =>` catch-all arms on non-exhaustive enums.

--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -1814,6 +1814,15 @@ mod queue {
                                 // Hold the scheduling bundle (and therefore the
                                 // lane permit) for the lifetime of the "send".
                                 let _scheduling = scheduling;
+                                // Observation channel; a dropped receiver is
+                                // expected. Neither spelling is lint-clean here:
+                                // `let _ =` trips the crate-wide deny on
+                                // `let_underscore_must_use`, and `drop(...)`
+                                // trips `dropping_copy_types` because this
+                                // `Result` is `Copy`, so the drop does nothing.
+                                // Allow the former per-site; see the note beside
+                                // the lint declarations in crates/core/Cargo.toml.
+                                #[allow(clippy::let_underscore_must_use)]
                                 let _ = tx.send((lane, entry.key));
                                 // Never completes: the permit stays held, so the
                                 // test can saturate a lane deterministically.
@@ -1941,7 +1950,7 @@ mod queue {
                     let tx = tx.clone();
                     async move {
                         let _scheduling = scheduling;
-                        let _ = tx.send(entry.fanout);
+                        drop(tx.send(entry.fanout));
                     }
                 },
             ));
@@ -2110,6 +2119,15 @@ mod queue {
                         move |entry: BroadcastEntry, _s: QueueScheduling| {
                             let tx = tx.clone();
                             async move {
+                                // Observation channel; a dropped receiver is
+                                // expected. Neither spelling is lint-clean here:
+                                // `let _ =` trips the crate-wide deny on
+                                // `let_underscore_must_use`, and `drop(...)`
+                                // trips `dropping_copy_types` because this
+                                // `Result` is `Copy`, so the drop does nothing.
+                                // Allow the former per-site; see the note beside
+                                // the lint declarations in crates/core/Cargo.toml.
+                                #[allow(clippy::let_underscore_must_use)]
                                 let _ = tx.send((lane, entry.key));
                             }
                         },
@@ -2139,7 +2157,7 @@ mod queue {
             );
 
             large.abort();
-            let _ = large.await;
+            drop(large.await);
 
             assert!(
                 small_permits.is_closed(),
@@ -2215,9 +2233,26 @@ mod queue {
                             let tx = tx.clone();
                             let release = release.clone();
                             async move {
+                                // Observation channel; a dropped receiver is
+                                // expected. Neither spelling is lint-clean here:
+                                // `let _ =` trips the crate-wide deny on
+                                // `let_underscore_must_use`, and `drop(...)`
+                                // trips `dropping_copy_types` because this
+                                // `Result` is `Copy`, so the drop does nothing.
+                                // Allow the former per-site; see the note beside
+                                // the lint declarations in crates/core/Cargo.toml.
+                                #[allow(clippy::let_underscore_must_use)]
                                 let _ = tx.send((lane, entry.key));
                                 if matches!(lane, QueuedPayloadClass::Large) {
-                                    let _ = release.acquire_owned().await;
+                                    // A BARRIER, not a held permit: wait until
+                                    // capacity exists, then release immediately.
+                                    // `drop(...)` preserves that exactly, since
+                                    // `let _ = x` also drops at end of statement.
+                                    // Do NOT "fix" this to `let _permit = ...` --
+                                    // binding it holds the permit for the rest of
+                                    // the block and changes when the large lane
+                                    // unblocks.
+                                    drop(release.acquire_owned().await);
                                 } else {
                                     scheduling.permit.ensure_capacity_for(BIG).await;
                                 }

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -4268,7 +4268,14 @@ mod tests {
         // free, so the next test can observe a non-zero baseline that then
         // drops mid-assertion.
         pump.abort();
-        let _ = pump.await;
+        // `drop(...)` rather than `let _ = ...`, because
+        // `let_underscore_must_use` is denied crate-wide. Not asserted because
+        // the `JoinResult` carries nothing this test is about: a pump panic
+        // before the frame is already surfaced by the `out.next()` expectation
+        // above, and after the frame the pump is parked (empty `initial`,
+        // `pending()` inbound, live `tx`), so there is nothing else to report.
+        // The await itself is the point -- see the comment above.
+        drop(pump.await);
     }
 
     /// Wait for the shared subscriber counter to quiesce, then return it.

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -1267,12 +1267,10 @@ mod test {
         let fetched = store
             .fetch_contract(&honest_key, &params)
             .expect("the honest contract must still be served");
-        match fetched {
-            ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) => {
-                assert_eq!(c.code().data(), honest_code.as_slice());
-            }
-            _ => panic!("unexpected container version"),
-        }
+        let ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) = fetched else {
+            panic!("unexpected container version");
+        };
+        assert_eq!(c.code().data(), honest_code.as_slice());
         Ok(())
     }
 
@@ -1309,16 +1307,14 @@ mod test {
         let fetched = store
             .fetch_contract(&mixed_key, &params)
             .expect("instance A is indexed, so a lookup for it must resolve");
-        match fetched {
-            ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) => {
-                assert_eq!(
-                    c.code().data(),
-                    code_a.as_slice(),
-                    "must serve the code the INDEX records for this instance, not the code hash the caller named"
-                );
-            }
-            _ => panic!("unexpected container version"),
-        }
+        let ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) = fetched else {
+            panic!("unexpected container version");
+        };
+        assert_eq!(
+            c.code().data(),
+            code_a.as_slice(),
+            "must serve the code the INDEX records for this instance, not the code hash the caller named"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

CI gated clippy as `cargo clippy --locked -- -D warnings`. That compiles neither
`cfg(test)` code nor the bench targets, so every lint in a `mod tests` or a `benches/` file
was unguarded. `--all-targets` appeared nowhere in `ci.yml`.

That surface had rotted, and #5279 (`643ee5d35`) cleaned it up. But a cleanup only holds if
something can turn red when it regresses — and this one has now regressed **twice in a
single day**, both times green:

- **#5269** added a `let _ = pump.await;` to `permission_prompts.rs`, denied crate-wide by
  `let_underscore_must_use = "deny"` in `crates/core/Cargo.toml`.
- **#5285** (merged today) added two `wildcard_enum_match_arm` errors in `contract_store.rs`
  test code. This gate caught them on its **first run against a base that included it** —
  a violation that had landed hours earlier through the very hole being closed here.

Both passed CI because CI never compiled test code. That is the argument for this change:
not that the surface *might* rot, but that it is rotting at a measurable rate right now.

## Solution

**1. `--all-targets` on the existing clippy step.** One flag.
`--all-targets` = `--lib --bins --tests --benches --examples`, a strict superset of the
lib+bins it checked before, so nothing that was gated becomes ungated.

**2. Fix the nine lints that flag makes visible.** One in `permission_prompts.rs` (#5269),
six in `broadcast_queue.rs`, two in `contract_store.rs` (#5285).

The `contract_store.rs` pair are rewritten as `let ... else` rather than suppressed, which
removes the lint instead of allowing it:

```rust
let ContractContainer::Wasm(ContractWasmAPIVersion::V1(c)) = fetched else {
    panic!("unexpected container version");
};
```

That is the treatment #5279 applied to 14 of its 23 sites, reserving `#[allow]` for the 9
whose wildcard covered a large or external enum. These two are two-arm matches on a local
enum where the wildcard exists only to panic, so the `let ... else` shape applies.

Both feature positions are kept, and this is the counterintuitive part: **`--all-features`
is not a maximal build.** It does not subsume default features — it *contradicts* them
wherever code is `cfg(not(feature = ...))`, because turning a feature on deletes its negated
block. `broadcast_queue.rs` puts `mod queue` behind `cfg(not(feature = "simulation_tests"))`,
so the all-features run cfg-deletes that module including the ~1,690 lines of `#[cfg(test)]`
inside it — which is exactly where the six live. Every negation-gated feature except `redb`
is default-**off**, so the single default-features run reaches all of their negations at once
(`simulation_tests`, `trace-ot`, `bench`).

Conversely the all-features step is the only gate on the bench targets, which declare
`required-features = ["bench"]` and build under no other invocation — bench rot was one of
the two concrete defects #5279 found — and on non-default-feature code. Neither invocation
subsumes the other; they should not be merged into one.

`timeout-minutes` 15 → 30. Measured on this PR's own earlier run: 46s + 41s + 2m09s = 4m26s,
against a historical max of 4m57s. The headroom is for a cold cache, not the warm case.

### Why the `broadcast_queue.rs` fixes are not uniform

Three use `drop(...)`; three use a per-site `#[allow(clippy::let_underscore_must_use)]`.
**That split is determined by payload type, not by author preference — verified, not
inferred:** all four sites use the same `tokio::sync::mpsc::unbounded_channel()` constructor
(`:1795`, `:1944`, `:2110`, `:2206`), so the sender type is identical and the payload is the
only thing that can differ.

Two lints forbid opposite spellings of the same statement. `let_underscore_must_use` (denied
crate-wide) rejects `let _ = <must_use>`. But if the discarded value is also `Copy`, rustc's
`dropping_copy_types` rejects `drop(x)` — correctly, since the drop does nothing. For a value
that is both, **neither spelling is clean and there is no `drop()`-shaped fix.**

`:1817`, `:2113` and `:2218` are that case: identical `tx.send((lane, entry.key))` calls
whose `Result` is `Copy`. They take a per-site `#[allow]` with a comment naming both lints.
`:1944` is the same `tx.send` *shape* but its payload is not `Copy`, so `drop()` works there
— which is why the treatment differs between lines that look alike.

A note on how that was established, because it is the kind of thing worth not guessing at:
the first attempt fixed all six with `drop(...)`, which is idiomatic and was wrong for three
of them. The compiler said `implements Copy` in output that had been truncated by a `tail -6`,
so the diagnosis was available before it was theorised. **A fix is not verified because it is
idiomatic; the watched-it-fail-watched-it-pass standard applies to the remedy, not only to the
gate.**

Per-site rather than a module-level `#[allow]`: a module-wide allow would un-gate every
future discard in that module, the same defect this PR exists to close. And **not** a
crate-wide allow of the drop lints, for three reasons: it would not fix these sites anyway
(the blocker is a rustc lint, not the clippy one); both lints catch real mistakes; and
suppressing a lint to make a fix convenient is precisely what produced this blind spot —
see below. The conflict is documented beside the lint declarations in
`crates/core/Cargo.toml`, which is the copy that survives in-tree.

`:2142` is the only byte-identical `JoinHandle` shape. `:2220` is
`let _ = release.acquire_owned().await;`, where the permit is semantically load-bearing:
it is a **barrier**, waiting for capacity and releasing immediately. `drop(...)` preserves
that exactly, because `let _ = x` also drops at end of statement. The rewrite that *would*
break it is `let _permit = ...`, which holds the permit for the rest of the block and changes
when the large lane unblocks. The comment at that site names the wrong fix explicitly.

### How the blind spot was manufactured

Worth recording, because the causal chain is not obvious. `broadcast_queue.rs:640-644` says
the module is cfg-deleted "to keep `cargo clippy --features simulation_tests -- -D warnings`
clean" — a production module was hidden to silence dead-code under a feature, and that is
what made its ~1,690 lines of tests unlintable. The deeper fix is to stop cfg-deleting the
module and `#[allow]` the dead code instead. **Separate change, not this PR.**

### What this does NOT cover

A gate oversold is a gate misread, so: this does not make the backlog unable to re-rot.
`redb` is default-**on**, so the ~16 `cfg(not(feature = "redb"))` and
`cfg(all(feature = "sqlite", not(feature = "redb")))` sites are compiled by **no** invocation
in this workflow. Closing that needs `--no-default-features --features sqlite`, which does
not build today — see the in-tree note at `hosting.rs:5469`, a pre-existing gap unrelated to
this change. Feature combinations narrower than "all default" / "all features" are also
unreached.

## Testing

**The gate was verified to FAIL before being trusted.** A gate nobody has watched fail is not
a gate. With the `ci.yml` change in place and the `permission_prompts.rs` fix reverted:

```
crates/core/src/server/client_api/permission_prompts.rs:4271:9: error: non-binding `let` on an expression with `#[must_use]` type
error: could not compile `freenet` (lib test) due to 1 previous error
```

Restoring it returns that invocation to green.

**Counts are a property of the invocation, not of the tree.** Under
`--all-targets --all-features` exactly one error existed on main; under `--all-targets` with
default features there were **seven** — the same one plus the six in `broadcast_queue.rs`
invisible to the first for the feature reason above. Three independent routes agreed on that
figure: a read-only lens predicted six in `broadcast_queue.rs` (explicitly labelled a
prediction), a separate agent measured seven on a branch without this PR's fix, and the
measurement here.

Local verification on the final shape, both positions green:

- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Run with `--keep-going`, so no compilation unit could mask another, and `--manifest-path`
pinned, so the tree under test is named in the invocation rather than inferred from a working
directory.

One further note on method, because the first CI run of this gate went red for a reason worth
recording. Local verification was against this branch alone; CI for a `pull_request` builds
the **merge** of head into current base, and #5285 landed in between. So CI compiled test
code that did not exist in anything verified locally, and the tree that had been verified no
longer existed on CI's side. The fix is procedural: **rebase onto current main before
verifying, so the local tree equals CI's merge tree.** Both invocations above were re-run
that way.

## Note for a future maintainer

The risk on this step is memory, not time. `clippy_check` runs on `ubicloud-standard-8`
(8 vCPU / 16 GB) and now compiles the largest unit set in the workflow, with
`RUST_MIN_STACK: 268435456`. If an intermittent OOM or SIGSEGV appears on this required
check, the fix is moving the job to `ubicloud-standard-16` (which `test_unit` already uses),
**not** raising the timeout again.

Closes #5246 — that issue reports `cargo clippy --all-features` failing on
`new_test_with_bandwidth` dead code. It is stale: the function was deleted by `643ee5d35`
and has zero references in the tree. It also illustrates this PR's rationale, having been
`#[cfg(any(test, feature = "bench"))]` and so invisible to the default gate.

Refs #5279

[AI-assisted - Claude]
