### PR TITLE
feat(obs): measure the notification leg's summary agreement rate (R4b instrument)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4506,13 +4506,22 @@ std::thread_local! {
     // always decodes as `Other` — the receiver, which is the only side that can
     // judge agreement, cannot know which send site produced it. Entry count is
     // the best available proxy and needs no wire change: the notification and
-    // rejection emitters are single-entry BY CONSTRUCTION while both reply
-    // emitters are multi-entry (see `outbound_message_mix::SummariesDetail`).
+    // rejection emitters are single-entry BY CONSTRUCTION, and only
+    // `InterestsReply` — the ~5-min heartbeat — is genuinely multi-entry (see
+    // `outbound_message_mix::SummariesDetail`).
     //
-    // Known ambiguity, stated so the number is not over-read: a heartbeat reply
-    // for a peer pair sharing exactly ONE contract is also single-entry, so the
-    // single bucket is "state-change-driven sites PLUS narrow heartbeats", not
-    // a clean partition. It is directional evidence, not attribution.
+    // Known contamination, stated so the number is not over-read, and it is
+    // larger than a heartbeat edge case: `ChangeInterestsReply` is single-entry
+    // 100% of the time (measured mean exactly 1.000, `max_entries` 1, over
+    // 418,476 messages on 1,284 peers), because `broadcast_change_interests`
+    // gossips one contract per message. Corrected 2026-08-12 (#5153 review F1) —
+    // this said "both reply emitters are multi-entry", which is what made the
+    // proxy look clean. A narrow heartbeat (a peer pair sharing exactly ONE
+    // contract) contaminates too, but is the smaller term. So the single bucket
+    // is "state-change-driven sites PLUS interest-churn replies PLUS narrow
+    // heartbeats": directional evidence, not attribution, and the send-side
+    // per-emitter census in `outbound_message_mix` is what makes the
+    // contamination subtractable rather than assumed.
     /// Peak size of the digest arm's per-hash local-summary cache (#4965).
     /// The observable for the RETENTION bound: the cache holds owned summary
     /// clones, so its peak entry count is what decides whether a hostile

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -599,10 +599,19 @@ pub enum SummariesEmitter {
     /// every ~5-min heartbeat received.
     InterestsReply,
     /// `node::handle_interest_sync_message`, replying to a `ChangeInterests`
-    /// delta — also multi-entry, but driven by interest churn rather than by
-    /// the heartbeat clock. Kept apart from [`Self::InterestsReply`] so the
-    /// residual arm below stays a pure residual; folding the two would repeat,
-    /// one level down, exactly the conflation this tag exists to undo.
+    /// delta — driven by interest churn rather than by the heartbeat clock. Kept
+    /// apart from [`Self::InterestsReply`] so the residual arm below stays a pure
+    /// residual; folding the two would repeat, one level down, exactly the
+    /// conflation this tag exists to undo.
+    ///
+    /// **SINGLE-entry, essentially always** — corrected 2026-08-12 (#5153 review
+    /// F1); this said "also multi-entry" and that was measurably false.
+    /// `operations::broadcast_change_interests` is called with one contract per
+    /// gossip, so the reply built for it carries one entry: mean **1.000**
+    /// entries/msg with `max_entries` **1** across 418,476 messages on 1,284
+    /// peers in one window. Load-bearing, not trivia — it is why message LENGTH
+    /// is not a clean proxy for "this is a notification", which the R4b
+    /// agreement-rate instrument depends on.
     ChangeInterestsReply,
     /// `operations::update::send_summary_back_on_rejection` — one entry, only
     /// when a rejected broadcast's summary already matched ours.

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -604,7 +604,20 @@ pub enum SummariesEmitter {
     /// residual; folding the two would repeat, one level down, exactly the
     /// conflation this tag exists to undo.
     ///
-    /// **SINGLE-entry, essentially always** — corrected 2026-08-12 (#5153 review
+    /// **SINGLE-entry, essentially always — but by CALLER convention, not by
+    /// construction.** `broadcast_change_interests` takes `added: Vec<ContractKey>`
+    /// and every caller today passes at most one, yet nothing pins that; and the
+    /// reply loop's hash-collision path can yield 2+ entries on a u32 FNV-1a
+    /// collision. So this is an empirical property of the current call sites, and
+    /// it is deliberately left unpinned: the R4b instrument is robust either way
+    /// (a multi-entry reply simply classifies as `MultiEntry` and leaves the
+    /// single-entry population). Contrast the NOTIFICATION leg, whose identical
+    /// structural property IS pinned, by
+    /// `notification_leg_is_always_full_bytes_and_single_entry` — because `p` is
+    /// read off that leg, so drift there corrupts the measurement rather than
+    /// merely shrinking its denominator.
+    ///
+    /// Corrected 2026-08-12 (#5153 review
     /// F1); this said "also multi-entry" and that was measurably false.
     /// `operations::broadcast_change_interests` is called with one contract per
     /// gossip, so the reply built for it carries one entry: mean **1.000**

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -4116,6 +4116,21 @@ async fn handle_interest_sync_message(
                                 // per requested hash, so a single-entry digest
                                 // mismatch produces a single-entry reply and
                                 // classifies the same way on arrival.
+                                //
+                                // ACCEPTED BIAS, and it runs in the dangerous
+                                // direction: if the `SummaryRequest` or its
+                                // reply is DROPPED, this divergence is never
+                                // recorded anywhere. The numerator is untouched
+                                // and the denominator is short, so `p` reads
+                                // HIGH — it is a CEILING, not a floor, by the
+                                // loss rate on one round trip. Double-counting
+                                // would have erred the safe way (declining a
+                                // mechanism worth building); this errs toward
+                                // building on an agreement rate better than
+                                // reality. Correct arithmetic with a
+                                // known-direction bias still beats a wrong
+                                // number, so this stays — see
+                                // `OutboundMix::record_summary_comparison`.
                                 // #4965 review S2: separate "we hold nothing,
                                 // they do" from a genuine digest disagreement.
                                 // Only the former sat outside the 98.1%

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3501,6 +3501,21 @@ async fn handle_interest_sync_message(
                 // never both in one message, and sharing one set would let the
                 // first kind silence the second.
                 let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
+                // R4b instrument (#5153). THIS is the arm that reads `p`
+                // BACKWARD: a proactive summary notification lands here today as
+                // a single-entry FULL-BYTES `Summaries`, and the loop below
+                // already performs exactly the comparison a 21-byte digest would
+                // have made. So classifying by message shape measures the
+                // notification leg's agreement rate on real production traffic
+                // before R4b ships anything — no wire change, no new variant, no
+                // version gate. See `OutboundMix::record_summary_comparison` for
+                // why shape is the only available discriminator (the emitter tag
+                // is `#[serde(skip)]`) and for the measured contamination.
+                //
+                // Computed BEFORE the loop consumes `entries`, on the length of
+                // the message the peer actually sent. Same expression as the
+                // `SummaryDigests` arm's, so the two legs stay comparable.
+                let single_entry = entries.len() == 1;
                 for entry in entries {
                     for contract in op_manager.interest_manager.lookup_by_hash(entry.hash) {
                         if !op_manager.interest_manager.has_local_interest(&contract) {
@@ -3569,6 +3584,7 @@ async fn handle_interest_sync_message(
                                     contract.id(),
                                     ours.as_ref(),
                                     theirs.as_ref(),
+                                    single_entry,
                                     &mut compared_contracts,
                                 );
                                 let delta_verdict = if identical {
@@ -3648,6 +3664,7 @@ async fn handle_interest_sync_message(
                             (None, Some(_)) => {
                                 op_manager.outbound_mix.record_summary_one_sided(
                                     contract.id(),
+                                    single_entry,
                                     &mut one_sided_counted,
                                 );
                                 false
@@ -4016,6 +4033,7 @@ async fn handle_interest_sync_message(
                                     contract.id(),
                                     ours.as_ref(),
                                     ours.as_ref(),
+                                    single_entry,
                                     &mut compared_contracts,
                                 );
                                 crate::config::GlobalTestMetrics::record_summary_digest_agreement(
@@ -4084,6 +4102,20 @@ async fn handle_interest_sync_message(
                                 crate::config::GlobalTestMetrics::record_summary_digest_mismatch(
                                     single_entry,
                                 );
+                                // R4b instrument (#5153): a genuine digest
+                                // disagreement deliberately does NOT record a
+                                // `summary_entries_differing` here, on either the
+                                // total or the single-entry bucket. It defers to
+                                // the full-bytes `Summaries` reply that the
+                                // `SummaryRequest` below provokes, which observes
+                                // it in the other arm — recording here as well
+                                // would count one divergence twice and inflate
+                                // exactly the denominator `p` is computed
+                                // against. Continuity across R4b is preserved
+                                // rather than lost: the reply carries one entry
+                                // per requested hash, so a single-entry digest
+                                // mismatch produces a single-entry reply and
+                                // classifies the same way on arrival.
                                 // #4965 review S2: separate "we hold nothing,
                                 // they do" from a genuine digest disagreement.
                                 // Only the former sat outside the 98.1%
@@ -4094,6 +4126,7 @@ async fn handle_interest_sync_message(
                                 if our_summary.is_none() {
                                     op_manager.outbound_mix.record_summary_one_sided(
                                         contract.id(),
+                                        single_entry,
                                         &mut one_sided_counted,
                                     );
                                 }
@@ -11068,6 +11101,247 @@ mod tests {
                  identical/differing comparison, or the telemetry that \
                  justifies this change stops being able to measure it"
             );
+        }
+
+        /// The R4b agreement-rate instrument (#5153), driven through the REAL
+        /// receive arm.
+        ///
+        /// R4b would swap the proactive summary notification's full summary
+        /// bytes for a 21-byte digest, and that trade wins or loses entirely on
+        /// `p`, the agreement rate ON THAT LEG. The fleet-wide rate cannot
+        /// answer it: comparisons are per ENTRY, and a notification carries
+        /// 1.000 entries/message against the heartbeat's 222.97, so a 99.73%
+        /// aggregate is essentially the heartbeat's population.
+        ///
+        /// The measurement is possible today only because a notification
+        /// already arrives here as a single-entry FULL-BYTES `Summaries` and
+        /// this arm already performs the comparison a digest would have made.
+        /// These tests live at the handler level rather than on `OutboundMix`
+        /// because a unit test on the counter cannot tell a live discriminator
+        /// from a constant: only driving the real arm can, and what it asserts
+        /// on is the rollup body production telemetry would actually ship.
+        mod r4b_single_entry_instrument {
+            use super::*;
+
+            /// Feed one full-bytes `Summaries` message and return the rollup
+            /// body the node would emit for the window.
+            async fn report(
+                h: &Harness,
+                peer: SocketAddr,
+                entries: Vec<SummaryEntry>,
+            ) -> serde_json::Value {
+                handle_interest_sync_message(
+                    &h.op_manager,
+                    peer,
+                    InterestMessage::Summaries {
+                        emitter: crate::message::SummariesEmitter::Other,
+                        entries,
+                    },
+                )
+                .await;
+                h.op_manager.outbound_mix.rollup_body_for_test()
+            }
+
+            fn count(body: &serde_json::Value, key: &str) -> u64 {
+                body.get(key)
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| panic!("rollup body must carry `{key}`"))
+            }
+
+            /// A summary entry for `key` carrying `summary`.
+            fn entry_for(key: &ContractKey, summary: &[u8]) -> SummaryEntry {
+                SummaryEntry {
+                    hash: contract_hash(key),
+                    summary_bytes: Some(summary.to_vec()),
+                }
+            }
+
+            /// A SINGLE-entry message's comparison lands in both the total and
+            /// the single-entry bucket; a MULTI-entry one lands in the total
+            /// only.
+            ///
+            /// The two halves are the whole instrument. Only the second can
+            /// fail if the discriminator is replaced by a constant `true`, and
+            /// only the first if it is replaced by `false` — the realistic
+            /// mutations, since either is one token. Asserting the multi-entry
+            /// message adds EXACTLY nothing to the single bucket (rather than
+            /// merely less) is what stops that bucket from quietly measuring
+            /// something other than message shape.
+            #[tokio::test]
+            async fn message_shape_decides_which_bucket_an_agreement_lands_in() {
+                let ours = vec![4u8; 64];
+                let h = build_harness("r4b-shape", 17300, ours.clone()).await;
+                // A second locally-hosted, summarizable contract, so the
+                // multi-entry message is genuinely multi-CONTRACT rather than a
+                // repeat the per-message dedup would collapse.
+                let second = host_many(&h, 1);
+                let hashes = distinct_hashes(&[h.key, second[0]]);
+                assert_eq!(hashes.len(), 2, "premise: two distinct advertised hashes");
+
+                // SINGLE entry, agreeing.
+                let body = report(&h, h.new_peer, vec![entry_for(&h.key, &ours)]).await;
+                assert_eq!(
+                    count(&body, "summary_entries_identical"),
+                    1,
+                    "premise: the fixture must produce a real two-sided \
+                     agreement, or neither bucket is under test"
+                );
+                assert_eq!(
+                    count(&body, "summary_entries_identical_single"),
+                    1,
+                    "a single-entry `Summaries` IS the notification leg's shape \
+                     — its agreement must reach the single-entry bucket, or \
+                     `p` reads as zero and R4b looks unbuildable"
+                );
+
+                // MULTI entry, both agreeing. Counters are cumulative over the
+                // window, so the deltas are what matter.
+                let body = report(
+                    &h,
+                    h.new_peer,
+                    vec![entry_for(&h.key, &ours), entry_for(&second[0], &ours)],
+                )
+                .await;
+                assert_eq!(
+                    count(&body, "summary_entries_identical"),
+                    3,
+                    "premise: both entries of the multi-entry message must \
+                     resolve to a locally-interested, summarizable contract, \
+                     or the multi-entry case is not actually exercised"
+                );
+                assert_eq!(
+                    count(&body, "summary_entries_identical_single"),
+                    1,
+                    "a MULTI-entry message is heartbeat-shaped and must add \
+                     nothing to the single-entry bucket — a bucket that grows \
+                     here is counting comparisons, not message shape, and `p` \
+                     silently becomes the fleet-wide rate the instrument \
+                     exists because it cannot use"
+                );
+            }
+
+            /// The same split applies to DISAGREEMENT, which is `p`'s
+            /// denominator.
+            ///
+            /// Without it a low single-entry agreement COUNT and a low
+            /// single-entry comparison VOLUME are indistinguishable — the ratio
+            /// would have a numerator and no denominator.
+            #[tokio::test]
+            async fn message_shape_decides_which_bucket_a_disagreement_lands_in() {
+                let ours = vec![4u8; 64];
+                let theirs = vec![9u8; 64];
+                let h = build_harness("r4b-shape-diff", 17310, ours.clone()).await;
+                let second = host_many(&h, 1);
+
+                let body = report(&h, h.new_peer, vec![entry_for(&h.key, &theirs)]).await;
+                assert_eq!(count(&body, "summary_entries_differing"), 1);
+                assert_eq!(
+                    count(&body, "summary_entries_differing_single"),
+                    1,
+                    "the notification leg's disagreements are `p`'s denominator"
+                );
+
+                let body = report(
+                    &h,
+                    h.new_peer,
+                    vec![entry_for(&h.key, &theirs), entry_for(&second[0], &theirs)],
+                )
+                .await;
+                assert_eq!(count(&body, "summary_entries_differing"), 3);
+                assert_eq!(
+                    count(&body, "summary_entries_differing_single"),
+                    1,
+                    "a multi-entry message must add nothing to the \
+                     single-entry denominator"
+                );
+
+                // The per-contract attribution carries the subset too, which is
+                // what separates "a few non-converging contracts" (structural
+                // `p` = 0) from "the leg disagrees in general".
+                let listed = body
+                    .get("summary_differing_contracts")
+                    .and_then(|v| v.as_array())
+                    .expect("summary_differing_contracts must be an array");
+                let mine = listed
+                    .iter()
+                    .find(|e| {
+                        e.get("contract").and_then(|v| v.as_str())
+                            == Some(h.key.id().to_string().as_str())
+                    })
+                    .expect("the diverging contract must be named");
+                assert_eq!(mine.get("count").and_then(|v| v.as_u64()), Some(2));
+                assert_eq!(
+                    mine.get("single_count").and_then(|v| v.as_u64()),
+                    Some(1),
+                    "per-contract attribution must carry the notification-leg \
+                     subset, not just the total"
+                );
+            }
+
+            /// Every `OutboundMix` summary-observation call in this file passes
+            /// the message-shape discriminator, and there are exactly as many
+            /// such call sites as this pin knows about.
+            ///
+            /// The behavioural tests above cover the two-sided sites. They
+            /// cannot reach the ONE-SIDED sites, which need a contract this node
+            /// is interested in but cannot summarize — so a future edit could
+            /// hard-code `false` there and stay green. This pin closes that gap,
+            /// and fails on a NEW call site too, which is the case that would
+            /// otherwise silently under-count.
+            ///
+            /// Two scoping rules make it non-vacuous, and both were needed:
+            ///
+            /// * Comments are stripped (`code_only`) — the prose around these
+            ///   call sites names `single_entry` repeatedly, so a
+            ///   comment-inclusive scan would pass with the argument deleted.
+            /// * The scan stops at the test module — otherwise the needles below
+            ///   match THEMSELVES (string literals survive `code_only`), which
+            ///   is how a self-matching pin comes to count its own text as
+            ///   evidence. Confirmed by observation: the unscoped version found
+            ///   6 sites, not 4.
+            #[test]
+            fn every_summary_observation_passes_the_message_shape() {
+                const TEST_MOD: &str = "\n#[cfg(test)]\nmod tests {";
+                let whole = include_str!("node.rs");
+                let production_end = whole
+                    .find(TEST_MOD)
+                    .expect("the test module anchor must still exist — update this pin");
+                let src = code_only(&whole[..production_end]);
+                let sites: Vec<usize> = [
+                    "outbound_mix.record_summary_comparison(",
+                    "outbound_mix.record_summary_one_sided(",
+                ]
+                .iter()
+                .flat_map(|needle| {
+                    src.match_indices(needle)
+                        .map(|(i, m)| i + m.len())
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+                assert_eq!(
+                    sites.len(),
+                    4,
+                    "expected 4 summary-observation call sites (two per \
+                     InterestSync receive arm); found {}. A new site must pass \
+                     the message-shape discriminator too, or its observations \
+                     silently miss the single-entry buckets",
+                    sites.len()
+                );
+                for start in sites {
+                    // Bound the window at the call's closing `);` so a match
+                    // cannot come from the NEXT call site's arguments.
+                    let end = src[start..]
+                        .find(");")
+                        .map(|off| start + off)
+                        .expect("a call site must have a closing `);`");
+                    let args = &src[start..end];
+                    assert!(
+                        args.contains("single_entry"),
+                        "a summary-observation call site does not pass the \
+                         message-shape discriminator; its args were: {args}"
+                    );
+                }
+            }
         }
 
         /// End-to-end wiring for the SHADOW-MODE futile-repair detector

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2894,7 +2894,7 @@ fn classify_summary_digest(
 /// every peer does today, so the cost of guessing wrong is bandwidth, never
 /// convergence.
 ///
-/// # Only the MULTI-ENTRY reply legs use this (#4965 review §2)
+/// # Only the REPLY legs use this (#4965 review §2)
 ///
 /// `ChangeInterestsReply` routes through here. `InterestsReply` no longer
 /// does: #5155 needs the form BEFORE it builds entries, so that it can bound
@@ -2903,8 +2903,20 @@ fn classify_summary_digest(
 /// twice. The encoding decision is identical; only the point at which it is
 /// taken moved.
 ///
-/// The two single-entry legs — `Notification` and `Rejection` — call
-/// [`full_summaries_message`] directly and ship full bytes this release.
+/// The heading said "MULTI-ENTRY reply legs" until 2026-08-12; corrected per
+/// #5153 review F1, because **`ChangeInterestsReply` is single-entry** (one
+/// contract per `broadcast_change_interests` gossip; measured mean 1.000
+/// entries/msg, `max_entries` 1, over 418,476 messages on 1,284 peers). Only
+/// `InterestsReply` is genuinely multi-entry. The distinction is load-bearing
+/// for the R4b agreement-rate instrument, which cannot read the emitter tag and
+/// so uses message length as its proxy: `ChangeInterestsReply` is that proxy's
+/// largest contaminant, and calling it multi-entry is what made the proxy look
+/// clean. See `network_bridge::outbound_message_mix`.
+///
+/// `Notification` and `Rejection` are also single-entry, but call
+/// [`full_summaries_message`] directly and ship full bytes this release — which
+/// is why a single-entry observation on the DIGEST leg cannot be a notification
+/// today.
 ///
 /// The reason is evidential, not technical: the 98.1% agreement rate that
 /// justifies hash-first was measured on a heartbeat-dominated population, and
@@ -3584,7 +3596,8 @@ async fn handle_interest_sync_message(
                                     contract.id(),
                                     ours.as_ref(),
                                     theirs.as_ref(),
-                                    single_entry,
+                                    crate::node::network_bridge::outbound_message_mix::
+                                        SummaryObservation::full_bytes(single_entry),
                                     &mut compared_contracts,
                                 );
                                 let delta_verdict = if identical {
@@ -3664,7 +3677,8 @@ async fn handle_interest_sync_message(
                             (None, Some(_)) => {
                                 op_manager.outbound_mix.record_summary_one_sided(
                                     contract.id(),
-                                    single_entry,
+                                    crate::node::network_bridge::outbound_message_mix::
+                                        SummaryObservation::full_bytes(single_entry),
                                     &mut one_sided_counted,
                                 );
                                 false
@@ -3912,8 +3926,13 @@ async fn handle_interest_sync_message(
                 > = std::collections::HashMap::new();
                 let mut cached_for_hash: Option<u32> = None;
                 let mut compared_contracts: HashSet<ContractInstanceId> = HashSet::new();
-                // See the sibling set in the `Summaries` arm.
-                let mut one_sided_counted: HashSet<ContractInstanceId> = HashSet::new();
+                // No `one_sided_counted` set here, unlike the `Summaries` arm:
+                // this arm no longer records one-sided observations at all
+                // (#5153 review F2 — it double-counted against the full-bytes
+                // reply that follows). Its absence is the compiler-checked half
+                // of that fix: re-adding a recording here fails to build until
+                // someone also re-adds the set, which is a prompt to re-read why
+                // it went away.
                 // WIRE-ORDER INDEPENDENCE — the invariant this grouping exists
                 // to establish.
                 //
@@ -4033,7 +4052,15 @@ async fn handle_interest_sync_message(
                                     contract.id(),
                                     ours.as_ref(),
                                     ours.as_ref(),
-                                    single_entry,
+                                    // DIGEST leg, deliberately a separate bucket
+                                    // from the full-bytes one: a notification
+                                    // ships full bytes unconditionally today, so
+                                    // a single-entry observation arriving here is
+                                    // churn-leg by construction and is NOT part
+                                    // of the population R4b's `p` is about
+                                    // (#5153 review F1).
+                                    crate::node::network_bridge::outbound_message_mix::
+                                        SummaryObservation::digest(single_entry),
                                     &mut compared_contracts,
                                 );
                                 crate::config::GlobalTestMetrics::record_summary_digest_agreement(
@@ -4131,20 +4158,28 @@ async fn handle_interest_sync_message(
                                 // known-direction bias still beats a wrong
                                 // number, so this stays — see
                                 // `OutboundMix::record_summary_comparison`.
-                                // #4965 review S2: separate "we hold nothing,
-                                // they do" from a genuine digest disagreement.
-                                // Only the former sat outside the 98.1%
-                                // denominator, and it is the one costing +2
-                                // messages for bytes the full-bytes path
-                                // shipped immediately (and used to seed our
-                                // peer-summary cache).
-                                if our_summary.is_none() {
-                                    op_manager.outbound_mix.record_summary_one_sided(
-                                        contract.id(),
-                                        single_entry,
-                                        &mut one_sided_counted,
-                                    );
-                                }
+                                // #5153 review F2 — the one-sided recording that
+                                // used to live here is REMOVED, not moved.
+                                //
+                                // It fired when `our_summary.is_none()` and then
+                                // set `needs_bytes`, so the bytes were requested
+                                // and the full-bytes `Summaries` arm observed the
+                                // SAME contract again on its `(None, Some(_))`
+                                // branch. Two different messages with two
+                                // different per-message dedup sets, so nothing
+                                // suppressed the repeat: one divergence, counted
+                                // twice. That directly contradicted the
+                                // no-double-count property this arm's `differing`
+                                // deferral is built on, and it inflated
+                                // `summary_entries_one_sided_single`, which is
+                                // presented as an R4b cost input.
+                                //
+                                // The full-bytes arm still records it, so nothing
+                                // is lost: `our_summary` is None there too, so
+                                // the reply takes `(None, Some(_))` and counts
+                                // exactly once. One-sided now defers exactly as
+                                // `differing` already did — consistently, rather
+                                // than one of the two.
                                 needs_bytes = true;
                             }
                         }
@@ -11333,15 +11368,23 @@ mod tests {
                         .collect::<Vec<_>>()
                 })
                 .collect();
+                // THREE, not four: the `Summaries` arm's two (comparison +
+                // one-sided) and the `SummaryDigests` arm's one (comparison
+                // only). The digest arm's one-sided recording was REMOVED as a
+                // double count (#5153 review F2), and this count is what will
+                // notice if it comes back — it did notice when the fix landed.
                 assert_eq!(
                     sites.len(),
-                    4,
-                    "expected 4 summary-observation call sites (two per \
-                     InterestSync receive arm); found {}. A new site must pass \
-                     the message-shape discriminator too, or its observations \
-                     silently miss the single-entry buckets",
+                    3,
+                    "expected 3 summary-observation call sites (two on the \
+                     full-bytes `Summaries` arm, one on `SummaryDigests`); found \
+                     {}. A NEW site must pass the message-shape discriminator \
+                     too, and a new one-sided recording on the digest arm is the \
+                     #5153 F2 double count returning",
                     sites.len()
                 );
+                let mut full_bytes_legs = 0;
+                let mut digest_legs = 0;
                 for start in sites {
                     // Bound the window at the call's closing `);` so a match
                     // cannot come from the NEXT call site's arguments.
@@ -11355,7 +11398,99 @@ mod tests {
                         "a summary-observation call site does not pass the \
                          message-shape discriminator; its args were: {args}"
                     );
+                    // The LEG matters as much as the shape: a digest-leg
+                    // observation labelled full-bytes silently merges churn
+                    // traffic into the R4b population (#5153 review F1), and
+                    // both spellings contain `single_entry`, so the assertion
+                    // above cannot tell them apart.
+                    if args.contains("SummaryObservation::full_bytes(") {
+                        full_bytes_legs += 1;
+                    } else if args.contains("SummaryObservation::digest(") {
+                        digest_legs += 1;
+                    } else {
+                        panic!(
+                            "a summary-observation call site names neither leg \
+                             constructor, so which population it lands in is \
+                             unpinned; its args were: {args}"
+                        );
+                    }
                 }
+                assert_eq!(
+                    (full_bytes_legs, digest_legs),
+                    (2, 1),
+                    "expected 2 full-bytes-leg sites and 1 digest-leg site; a \
+                     digest observation recorded as full-bytes would fold \
+                     churn-leg traffic into the notification population `p` is \
+                     computed over"
+                );
+            }
+
+            /// The `SummaryDigests` arm must NOT record a one-sided observation
+            /// (#5153 review F2 — it double-counted).
+            ///
+            /// It used to: on a digest mismatch with no local summary it recorded
+            /// one-sided AND set `needs_bytes`, so the full-bytes reply observed
+            /// the same contract again on its `(None, Some(_))` branch. Two
+            /// messages, two per-message dedup sets, nothing suppressing the
+            /// repeat — one divergence counted twice, inflating a field that is
+            /// presented as an R4b cost input.
+            ///
+            /// Pinned at the source because the property is an ABSENCE, and the
+            /// behavioural fixture for it would need a contract this node is
+            /// interested in but cannot summarize. The complementary behavioural
+            /// half lives in `outbound_message_mix`:
+            /// `digest_leg_single_entry_observations_stay_out_of_the_full_bytes_bucket`
+            /// asserts a digest-leg observation reaches no single bucket even if
+            /// one did arrive.
+            ///
+            /// Scoped to production code and comment-stripped for the same two
+            /// reasons as the pin above; the count assertion is what makes it
+            /// non-vacuous, since a needle that matched nothing at all would
+            /// otherwise look like a pass.
+            #[test]
+            fn digest_arm_records_no_one_sided_observation() {
+                const TEST_MOD: &str = "\n#[cfg(test)]\nmod tests {";
+                let whole = include_str!("node.rs");
+                let production_end = whole
+                    .find(TEST_MOD)
+                    .expect("the test module anchor must still exist — update this pin");
+                let src = code_only(&whole[..production_end]);
+
+                let digest_arm = src
+                    .find("InterestMessage::SummaryDigests { entries, .. } => {")
+                    .expect("SummaryDigests arm not found — update this pin");
+                let arm_end = src[digest_arm..]
+                    .find("InterestMessage::SummaryRequest { hashes } => {")
+                    .map(|off| digest_arm + off)
+                    .expect("end of SummaryDigests arm not found — update this pin");
+                let arm = &src[digest_arm..arm_end];
+
+                assert!(
+                    !arm.contains("record_summary_one_sided"),
+                    "the SummaryDigests arm records a one-sided observation \
+                     again. The full-bytes `Summaries` arm ALSO records it once \
+                     the requested bytes arrive, so this counts one divergence \
+                     twice and inflates summary_entries_one_sided(_single) \
+                     (#5153 review F2)"
+                );
+                // Non-vacuity: the arm must still be the arm, and must still
+                // contain the sibling observation the instrument depends on.
+                assert!(
+                    arm.contains("record_summary_comparison"),
+                    "window no longer covers the digest arm's observation site — \
+                     this pin would pass against unrelated text"
+                );
+                // And the full-bytes arm must still be the one that records it,
+                // or the deferral loses the observation entirely.
+                let full_bytes_arm = src
+                    .find("InterestMessage::Summaries { entries, .. } => {")
+                    .expect("Summaries arm not found — update this pin");
+                let full_bytes = &src[full_bytes_arm..digest_arm];
+                assert!(
+                    full_bytes.contains("record_summary_one_sided"),
+                    "nothing records one-sided any more: the digest arm defers to \
+                     the full-bytes arm, so the full-bytes arm must still count it"
+                );
             }
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3929,10 +3929,11 @@ async fn handle_interest_sync_message(
                 // No `one_sided_counted` set here, unlike the `Summaries` arm:
                 // this arm no longer records one-sided observations at all
                 // (#5153 review F2 — it double-counted against the full-bytes
-                // reply that follows). Its absence is the compiler-checked half
-                // of that fix: re-adding a recording here fails to build until
-                // someone also re-adds the set, which is a prompt to re-read why
-                // it went away.
+                // reply that follows). Its absence is a nudge, NOT a guard: a
+                // re-added recording could pass `&mut HashSet::new()` as a
+                // temporary and compile fine. The actual guard is the test
+                // `digest_arm_records_no_one_sided_observation`, which fails if
+                // this arm regains a one-sided call.
                 // WIRE-ORDER INDEPENDENCE — the invariant this grouping exists
                 // to establish.
                 //
@@ -4144,20 +4145,31 @@ async fn handle_interest_sync_message(
                                 // mismatch produces a single-entry reply and
                                 // classifies the same way on arrival.
                                 //
-                                // ACCEPTED BIAS, and it runs in the dangerous
-                                // direction: if the `SummaryRequest` or its
+                                // ACCEPTED BIAS: if the `SummaryRequest` or its
                                 // reply is DROPPED, this divergence is never
-                                // recorded anywhere. The numerator is untouched
-                                // and the denominator is short, so `p` reads
-                                // HIGH — it is a CEILING, not a floor, by the
+                                // recorded anywhere, so it pushes `p` UP by the
                                 // loss rate on one round trip. Double-counting
-                                // would have erred the safe way (declining a
-                                // mechanism worth building); this errs toward
-                                // building on an agreement rate better than
-                                // reality. Correct arithmetic with a
-                                // known-direction bias still beats a wrong
-                                // number, so this stays — see
-                                // `OutboundMix::record_summary_comparison`.
+                                // would be plain wrong arithmetic, so the
+                                // deferral stays.
+                                //
+                                // This is NOT the only bias and `p` is NOT a
+                                // ceiling — an earlier revision of this comment
+                                // said it was. The contamination term runs the
+                                // other way and is larger: a single-entry
+                                // `SummaryRequestReply` is differing by
+                                // construction, so it inflates the denominator.
+                                // See `OutboundMix::record_summary_comparison`
+                                // and `notification_share_bounds` for both terms
+                                // and why `p` must be quoted as an interval.
+                                //
+                                // Also not shape-preserving under hash collision:
+                                // if two locally-known contracts share one 32-bit
+                                // FNV-1a hash, the reply carries TWO entries and
+                                // classifies as `MultiEntry`, so the deferred
+                                // observation reaches no single-entry bucket at
+                                // all. Rare, and it removes rather than
+                                // fabricates, but it is a third small downward
+                                // path on the single-entry counters.
                                 // #5153 review F2 — the one-sided recording that
                                 // used to live here is REMOVED, not moved.
                                 //

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -11437,6 +11437,91 @@ mod tests {
                 );
             }
 
+            /// THE TWO PROPERTIES THIS WHOLE INSTRUMENT RESTS ON (#5153 review F4).
+            ///
+            /// `p` is read off single-entry FULL-BYTES `Summaries`, and that is a
+            /// proxy for "this is a notification" only while both of these hold:
+            ///
+            /// 1. A notification ships **full bytes unconditionally** — it must
+            ///    not consult the hash-first version gate. If it did, the
+            ///    pre-R4b full-bytes buckets would silently go quiet AND the
+            ///    claim "a digest single is provably not a notification" would
+            ///    INVERT, with every test still green.
+            /// 2. A notification is **single-entry** — one contract per send. If
+            ///    notifications were ever batched (plausible: coalescing work is
+            ///    already in this tree), they would leave the single-entry
+            ///    population entirely and `p` would silently become the
+            ///    agreement rate of whatever failed to batch.
+            ///
+            /// Both are true today, verified from code and field: the emitter
+            /// calls `full_summaries_message(vec![...], Notification)` with no
+            /// reference to the gate, and the field shows mean 41,642 B/msg with
+            /// entries exactly equal to msgs and **no rollup anywhere reporting
+            /// `max_entries > 1`**. So multi-entry false negatives are impossible
+            /// today rather than merely unobserved.
+            ///
+            /// Neither was pinned. This mirrors
+            /// `summary_request_reply_is_always_full_bytes`, which pins exactly
+            /// this shape for the request-reply arm — and note that
+            /// `no_uninstrumented_full_summaries_construction` does NOT cover it:
+            /// that forces `Summaries` through the instrumented constructor but
+            /// says nothing about a site switching to the digest gate.
+            #[test]
+            fn notification_leg_is_always_full_bytes_and_single_entry() {
+                let src = include_str!("operations/update.rs");
+                let f = src
+                    .find("pub(crate) async fn send_proactive_summary_notification(")
+                    .expect("notification emitter not found — update this pin");
+                // Bound at the next top-level `pub(crate)` item so a sibling's
+                // gate usage cannot satisfy or trip the assertions below.
+                let end = src[f..]
+                    .find("\npub(crate) ")
+                    .map(|off| f + off)
+                    .unwrap_or(src.len());
+                let body = code_only(&src[f..end]);
+
+                assert!(
+                    body.contains("full_summaries_message("),
+                    "the notification leg must build its message through \
+                     full_summaries_message — the instrumented FULL-BYTES \
+                     constructor. Window extraction may also be off; check that \
+                     first."
+                );
+                assert!(
+                    body.contains("SummariesEmitter::Notification"),
+                    "window extraction is off — the notification emitter body \
+                     should tag its own emitter"
+                );
+                // Property 1. Every entry point to the encoding CHOICE, matching
+                // the sibling pin: #5155 split `summaries_reply_for_peer` into
+                // two names, neither a substring of the old one.
+                for banned in [
+                    "summaries_reply_for_peer",
+                    "summary_reply_form",
+                    "summaries_reply_in_form",
+                ] {
+                    assert!(
+                        !body.contains(banned),
+                        "the notification leg now consults `{banned}`, i.e. the \
+                         hash-first version gate. That moves notifications onto \
+                         the digest leg, so the R4b full-bytes single-entry \
+                         buckets go quiet AND `SummaryObservation::SingleEntryDigest`'s \
+                         'not a notification' premise inverts — silently, with \
+                         every other test green (#5153 review F4)"
+                    );
+                }
+                // Property 2. One contract per send. `vec![` with a single
+                // element is the shape; a batched send would collect or extend.
+                assert!(
+                    body.contains("vec![full_entry.clone()]"),
+                    "the notification leg no longer sends exactly one entry. If \
+                     notifications are now batched they leave the single-entry \
+                     population, and `p` becomes the agreement rate of whatever \
+                     failed to batch (#5153 review F4). Re-derive the proxy \
+                     before changing this."
+                );
+            }
+
             /// The `SummaryDigests` arm must NOT record a one-sided observation
             /// (#5153 review F2 — it double-counted).
             ///

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3852,16 +3852,34 @@ async fn handle_interest_sync_message(
                     let start = crate::config::GlobalRng::random_range(0..entries.len());
                     entries.rotate_left(start);
                 }
-                // #4965 agreement-rate proxy: single-entry messages come
-                // from the state-change-driven send sites (proactive
-                // notification, rejection summary-back) by construction, while
-                // the heartbeat / interest-churn replies are multi-entry. The
-                // emitter tag is non-wire so the receiver cannot read it; this
-                // is the closest available discriminator. Reads `entries.len()`
-                // — the length of the message the peer actually SENT. The
-                // rotation above reorders but never shortens, and the cap
-                // applies to the processing window rather than to this count,
-                // so a capped message is still classified by its true size.
+                // #4965 agreement-rate proxy: the state-change-driven send
+                // sites (proactive notification, rejection summary-back) are
+                // single-entry by construction, and only `InterestsReply` (the
+                // ~5-min heartbeat) is genuinely multi-entry. The emitter tag
+                // is non-wire so the receiver cannot read it; this is the
+                // closest available discriminator.
+                //
+                // It is a CONTAMINATED discriminator, and on THIS arm — the
+                // digest leg — the contamination is the whole population.
+                // `ChangeInterestsReply` is single-entry 100% of the time
+                // (measured mean exactly 1.000, `max_entries` 1, over 418,476
+                // messages on 1,284 peers; corroborated in two further
+                // windows), because `broadcast_change_interests` gossips one
+                // contract per message. It is ALSO version-gated to digests and
+                // the fleet is past the floor, so 95-99% of its sends arrive
+                // here. Meanwhile a notification ships full bytes
+                // unconditionally (`send_proactive_summary_notification`), so a
+                // single-entry observation on the digest leg is churn-leg BY
+                // CONSTRUCTION and is not the R4b population at all — which is
+                // why `SummaryObservation::digest` keeps it in separate buckets
+                // rather than folding it into `*_single`. Do not read this flag
+                // here as "this was a notification"; it is not, today.
+                //
+                // Reads `entries.len()` — the length of the message the peer
+                // actually SENT. The rotation above reorders but never shortens,
+                // and the cap applies to the processing window rather than to
+                // this count, so a capped message is still classified by its
+                // true size.
                 let single_entry = entries.len() == 1;
                 // Dedup on the (hash, digest) PAIR, not on the hash alone.
                 //
@@ -4426,11 +4444,20 @@ async fn handle_interest_sync_message(
             if entries.is_empty() {
                 None
             } else {
-                // #5052: also multi-entry and also built by
-                // `summary_if_hosted_or_in_use`, but driven by interest CHURN
-                // rather than the heartbeat clock — a peer joining or dropping
-                // interest, not a periodic tick. Same bytes, a different thing
-                // to fix if it is the large one.
+                // #5052: also built by `summary_if_hosted_or_in_use`, but driven
+                // by interest CHURN rather than the heartbeat clock — a peer
+                // joining or dropping interest, not a periodic tick. A different
+                // thing to fix if it is the large one.
+                //
+                // SINGLE-entry, unlike the `InterestsReply` above — corrected
+                // 2026-08-12 (#5153 review F1), where this said "also
+                // multi-entry". `broadcast_change_interests` gossips one contract
+                // per message, so the `entries` built above carries exactly one:
+                // measured mean 1.000, `max_entries` 1, over 418,476 messages on
+                // 1,284 peers. Load-bearing rather than trivia — the R4b
+                // agreement-rate instrument cannot read the emitter tag and uses
+                // message LENGTH as its proxy for "this was a notification", so
+                // this arm is that proxy's largest contaminant.
                 Some(summaries_reply_for_peer(
                     op_manager,
                     source,

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -91,6 +91,62 @@ const MAX_TRACKED_CONTRACTS: usize = 256;
 /// which the top few answer, and the aggregate counts above carry the rest.
 const TOP_DIFFERING_CONTRACTS_REPORTED: usize = 10;
 
+/// What a summary comparison's message was shaped like, and which receive arm
+/// saw it — the R4b (#5153) discriminator.
+///
+/// One enum rather than a `bool` because the two facts are not independent and
+/// the illegal pairing must be unrepresentable: a single-entry observation on
+/// the DIGEST leg is, today, provably **not** notification traffic (a
+/// notification ships full bytes unconditionally,
+/// `operations/update.rs::send_summary_notification`), so folding it in with the
+/// full-bytes leg would mix two populations under one name. A caller holding a
+/// `bool` cannot express that difference; this type forces it to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SummaryObservation {
+    /// Multi-entry message: heartbeat or interest-churn shaped, and not the
+    /// population R4b's `p` is about.
+    MultiEntry,
+    /// Single-entry FULL-BYTES `Summaries`. The R4b population — but see
+    /// [`OutboundMix::record_summary_comparison`]: it is ~15% not-notification,
+    /// and the per-arm census is what makes that subtractable.
+    SingleEntryFullBytes,
+    /// Single-entry `SummaryDigests`. Counted SEPARATELY and deliberately: it
+    /// cannot be notification traffic while notifications ship full bytes, so it
+    /// is churn-leg, and merging it into the full-bytes bucket would buy
+    /// post-R4b series continuity by corrupting the pre-R4b measurement.
+    SingleEntryDigest,
+}
+
+impl SummaryObservation {
+    /// The full-bytes-leg classification for a message of `entries` length.
+    pub(crate) fn full_bytes(single_entry: bool) -> Self {
+        if single_entry {
+            Self::SingleEntryFullBytes
+        } else {
+            Self::MultiEntry
+        }
+    }
+
+    /// The digest-leg classification for a message of `entries` length.
+    pub(crate) fn digest(single_entry: bool) -> Self {
+        if single_entry {
+            Self::SingleEntryDigest
+        } else {
+            Self::MultiEntry
+        }
+    }
+
+    /// Does this land in the full-bytes single-entry bucket (the R4b population)?
+    fn is_single_full_bytes(self) -> bool {
+        matches!(self, Self::SingleEntryFullBytes)
+    }
+
+    /// Does this land in the digest-leg single-entry bucket?
+    fn is_single_digest(self) -> bool {
+        matches!(self, Self::SingleEntryDigest)
+    }
+}
+
 /// Per-contract differing-comparison counts: the total, and the single-entry
 /// subset.
 ///
@@ -112,9 +168,14 @@ struct DifferingCount {
 impl DifferingCount {
     /// Count one differing comparison, saturating for the same reason every
     /// other counter here does.
-    fn add(&mut self, single_entry: bool) {
+    ///
+    /// `single` tracks the FULL-BYTES leg only, matching
+    /// [`Window::summary_entries_differing_single`]: the digest leg is a
+    /// different population (see [`SummaryObservation`]) and must not be folded
+    /// in here either.
+    fn add(&mut self, obs: SummaryObservation) {
         self.total = self.total.saturating_add(1);
-        if single_entry {
+        if obs.is_single_full_bytes() {
             self.single = self.single.saturating_add(1);
         }
     }
@@ -265,12 +326,23 @@ pub(crate) struct SummariesDetail {
     /// `entries.len()` — how many `SummaryEntry` this one message carried.
     ///
     /// The independent check on the attribution, and the reason it is worth
-    /// recording: the notification and rejection emitters are single-entry by
-    /// construction while both reply emitters are multi-entry, so a mean of
-    /// entries-per-message far from 1 on a single-entry arm (or exactly 1 on a
-    /// reply arm) means a call site is mislabelled. Byte totals alone cannot
-    /// show that — they look plausible either way, which is precisely how the
-    /// combined arm misled for as long as it did.
+    /// recording: a mean of entries-per-message far from 1 on an arm that should
+    /// be single-entry means a call site is mislabelled. Byte totals alone
+    /// cannot show that — they look plausible either way, which is precisely how
+    /// the combined arm misled for as long as it did.
+    ///
+    /// CORRECTED 2026-08-12 (#5153 review F1), because the earlier claim here
+    /// was measurably false and three sites in this tree repeated it: it said
+    /// "both reply emitters are multi-entry". **`ChangeInterestsReply` is
+    /// single-entry, essentially always.** `broadcast_change_interests` is
+    /// called with one contract per gossip, so the reply built for it carries
+    /// exactly one entry, and the field agrees — mean **1.000** entries/msg with
+    /// `max_entries` **1** over 418,476 messages on 1,284 peers in one window.
+    /// Only `InterestsReply` is genuinely multi-entry (mean ~224, max 2,401).
+    ///
+    /// That matters far beyond a doc nit: it is why `entries.len() == 1` is NOT
+    /// a clean proxy for "this is a notification", and why the per-arm
+    /// [`Window::summaries_single_entry_msgs`] census exists.
     entries: u64,
 }
 
@@ -441,6 +513,30 @@ struct Window {
     /// reply is moderately wide" from "one peer shares 400 contracts with us",
     /// which the mean cannot.
     summaries_max_entries: [u64; SUMMARIES_ARMS.len()],
+    /// How many messages this arm SENT carrying exactly one entry — the R4b
+    /// (#5153) contamination census, and the thing that turns the receive-side
+    /// proxy from an assumption into arithmetic.
+    ///
+    /// The receive side cannot know which emitter a `Summaries` came from: the
+    /// tag is `#[serde(skip)]`, so an inbound message always decodes as
+    /// [`SummariesEmitter::Other`] and `entries.len() == 1` is the only
+    /// discriminator available there. The SEND side has both facts at once, in
+    /// [`SummariesDetail`], at a single choke point. Counting single-entry
+    /// messages per emitter here therefore measures exactly what the receive-side
+    /// proxy is unable to separate.
+    ///
+    /// Why it is needed, in numbers (one window, 2026-08-12): `notification`
+    /// 3,194,108 single-entry messages, but `change_interests_reply` 418,476
+    /// (mean 1.000, max 1) and `request_reply` at least 131,153 — so **~15% of
+    /// single-entry `Summaries` are not notifications.** An earlier version of
+    /// this instrument documented only `rejection` (669 messages, 0.015%) as the
+    /// contamination, which was the smallest of three by three orders of
+    /// magnitude and left the largest unnamed.
+    ///
+    /// With this census the analysis can bound `p` instead of asserting it:
+    /// notification's share of the single-entry population is measured per node
+    /// per minute rather than assumed to be ~1.
+    summaries_single_entry_msgs: [u64; SUMMARIES_ARMS.len()],
     /// InterestSync summary comparisons where both sides held a summary and
     /// the bytes were IDENTICAL. See [`OutboundMix::record_summary_comparison`].
     summary_entries_identical: u64,
@@ -466,13 +562,43 @@ struct Window {
     /// instrument land a release ahead of the mechanism it judges (regime rule
     /// 7; 0.2.120 is permanently unattributable for want of exactly this).
     ///
-    /// See [`OutboundMix::record_summary_comparison`] for the discriminator's
-    /// limits, including the measured `Rejection` contamination.
+    /// **This bucket is the FULL-BYTES leg only, and it is ~15%
+    /// not-notification.** Read
+    /// [`OutboundMix::record_summary_comparison`] before quoting a number off
+    /// it — the contamination is measurable but NOT negligible, and it biases
+    /// `p` in BOTH directions. Subtract it using
+    /// [`Window::summaries_single_entry_msgs`].
     summary_entries_identical_single: u64,
-    /// The SINGLE-ENTRY subset of [`Window::summary_entries_differing`]. The
-    /// denominator half of `p` — without it a low single-entry agreement COUNT
-    /// and a low single-entry VOLUME look the same.
+    /// The SINGLE-ENTRY subset of [`Window::summary_entries_differing`], full-bytes
+    /// leg. The denominator half of `p` — without it a low single-entry agreement
+    /// COUNT and a low single-entry VOLUME look the same.
+    ///
+    /// **This is the bucket the contamination hurts most.** A single-entry
+    /// `SummaryRequestReply` is differing BY CONSTRUCTION (bytes are only
+    /// requested after a digest mismatch, so they cannot then compare equal),
+    /// and there were >=131,153 such messages in one window against a fleet
+    /// `summary_entries_differing` of 559,992. So a large part of this counter is
+    /// digest-mismatch reply traffic rather than notification disagreement, which
+    /// inflates `p`'s denominator and makes `p` read LOW.
     summary_entries_differing_single: u64,
+    /// Single-entry observations seen on the `SummaryDigests` leg, kept apart
+    /// from the full-bytes buckets above.
+    ///
+    /// NOT notification traffic, and that is the point of separating them: a
+    /// notification ships full bytes unconditionally today
+    /// (`operations/update.rs::send_summary_notification`), while
+    /// `ChangeInterestsReply` does route through the version gate — so a
+    /// single-entry observation arriving on the digest leg is churn-leg by
+    /// construction. Folding these into `*_single` would have bought post-R4b
+    /// series continuity by corrupting the pre-R4b measurement, which is the one
+    /// the build/no-build decision rests on.
+    ///
+    /// After R4b ships, notifications move onto this leg and these become the
+    /// interesting counters. Both are emitted throughout so the transition is
+    /// visible rather than inferred.
+    summary_entries_identical_single_digest: u64,
+    /// Digest-leg sibling of [`Window::summary_entries_differing_single`].
+    summary_entries_differing_single_digest: u64,
     /// Comparisons where exactly ONE side held a summary (#4965 review S2).
     ///
     /// The 98.1% identical figure has a structural hole:
@@ -486,12 +612,20 @@ struct Window {
     /// Counted so the post-deploy data can size it rather than leaving the
     /// headline extrapolated over a population it never observed.
     summary_entries_one_sided: u64,
-    /// The SINGLE-ENTRY subset of [`Window::summary_entries_one_sided`].
+    /// The SINGLE-ENTRY subset of [`Window::summary_entries_one_sided`],
+    /// full-bytes leg.
     ///
     /// Carried for the same reason the one-sided total is: under a digest-first
     /// notification this population classifies as `NeedBytes`, so it is a COST
     /// on the R4b leg rather than a neutral case, and `p` computed without it
     /// would be extrapolated over a population it never observed.
+    ///
+    /// No digest-leg sibling, and that is deliberate rather than an omission:
+    /// the digest arm no longer records one-sided at all. It used to, and the
+    /// same contract was then counted a SECOND time when the requested bytes
+    /// arrived at the full-bytes arm — different messages, different per-message
+    /// dedup sets, so nothing suppressed it (#5153 review F2). The digest arm now
+    /// defers one-sided accounting exactly as it already deferred `differing`.
     summary_entries_one_sided_single: u64,
     /// Which contracts the differing comparisons belonged to, bounded at
     /// [`MAX_TRACKED_CONTRACTS`].
@@ -591,6 +725,15 @@ impl OutboundMix {
             w.summaries_max_bytes[s] = w.summaries_max_bytes[s].max(b);
             w.summaries_entries[s] = w.summaries_entries[s].saturating_add(detail.entries);
             w.summaries_max_entries[s] = w.summaries_max_entries[s].max(detail.entries);
+            // R4b contamination census (#5153 review F1). Recorded HERE because
+            // this is the only place that holds the true emitter and the entry
+            // count together — the receive side has just the count, which is
+            // exactly why its proxy needs this to be interpretable. Same branch
+            // as the parent update, so it cannot disagree about a message.
+            if detail.entries == 1 {
+                w.summaries_single_entry_msgs[s] =
+                    w.summaries_single_entry_msgs[s].saturating_add(1);
+            }
         }
     }
 
@@ -627,26 +770,59 @@ impl OutboundMix {
     /// emitter. Plumbing it through would be a wire change, which is precisely
     /// what this instrument exists to avoid needing.
     ///
-    /// The proxy holds because the state-change-driven send sites are
-    /// single-entry by construction while the heartbeat and interest-churn
-    /// replies are multi-entry: notifications measured 1.000 entries/message
-    /// against the heartbeat's 222.97.
+    /// The SIGNAL half of the proxy is exact and field-confirmed: a notification
+    /// is single-entry by construction, measuring mean **1.000** entries/message
+    /// with `max_entries` 1 in every window checked.
     ///
-    /// KNOWN CONTAMINATION, stated rather than designed around:
-    /// `entries.len() == 1` also matches [`SummariesEmitter::Rejection`], the
-    /// summary-back on a rejected update. Measured at **535 messages against
-    /// 3,579,282 notifications (0.015%)** — four orders of magnitude below the
-    /// signal, so it cannot move `p`. It is named here so a future reader does
-    /// not rediscover it and mistake the bucket for pure notification traffic.
+    /// # CONTAMINATION IS ~15%, AND IT BIASES `p` BOTH WAYS
+    ///
+    /// Corrected 2026-08-12 (#5153 review F1). An earlier version of this doc
+    /// named [`SummariesEmitter::Rejection`] as the contamination and put it at
+    /// 0.015%. Rejection is real but is the SMALLEST of three contaminants by
+    /// three orders of magnitude (669 messages in one window). The two that
+    /// matter were unnamed:
+    ///
+    /// | single-entry `Summaries` sender | msgs, one window | effect on `p` |
+    /// |---|---|---|
+    /// | `Notification` (the signal) | 3,194,108 | — |
+    /// | `ChangeInterestsReply` | 418,476 (mean 1.000, max 1, 1,284 peers) | either |
+    /// | `SummaryRequestReply` | >=131,153 | **downward** |
+    /// | `Rejection` | 669 | either |
+    ///
+    /// So **~15% of single-entry observations are not notifications.**
+    ///
+    /// `ChangeInterestsReply` is single-entry because
+    /// `broadcast_change_interests` is called with one contract per gossip, so
+    /// the reply carries exactly one entry. Three places in this tree asserted
+    /// it was multi-entry; all are corrected, because that claim is what made
+    /// `entries.len() == 1` look clean.
+    ///
+    /// **The `SummaryRequestReply` term is the dangerous one, and it runs
+    /// DOWNWARD.** Bytes are requested only after a digest mismatch, so when
+    /// they arrive they cannot compare equal — such a reply lands in
+    /// `differing` by construction. Single-entry ones therefore inflate `p`'s
+    /// DENOMINATOR only, and at real scale: >=131,153 such messages against a
+    /// fleet `summary_entries_differing` of 559,992 in the same window. A true
+    /// notification-leg `p` of 99% would measure around **95%**.
+    ///
+    /// So `p` off this counter is NOT a clean ceiling. It has an upward term
+    /// (divergences lost to a dropped round trip, below) and a larger downward
+    /// term (request-reply denominator inflation). **Do not quote a point
+    /// estimate.** Use [`Window::summaries_single_entry_msgs`] — the send-side
+    /// per-emitter census — to bound the notification share and report an
+    /// interval.
     ///
     /// Recording it here rather than deriving it downstream is deliberate:
     /// only the receive arm knows the shape of the message the entry came in,
     /// and a rate re-derived later from arithmetic over separately-reported
     /// totals would silently absorb every other filter between them.
     ///
-    /// # `p` AS MEASURED IS A CEILING, NOT A FLOOR
+    /// # THE UPWARD TERM: divergences lost to a dropped round trip
     ///
-    /// State this to anyone sizing R4b from these counters. On the
+    /// This was previously documented as making `p` a pure CEILING. That was
+    /// wrong — it is only one of two biases, and the contamination term above
+    /// pushes the other way and is larger today. Both are stated so neither is
+    /// mistaken for the whole story. On the
     /// `SummaryDigests` leg a genuine digest disagreement is recorded not at
     /// the mismatch itself but when the requested bytes arrive back here — see
     /// the `DigestVerdict::NeedBytes` branch in `node.rs`, which deliberately
@@ -656,21 +832,26 @@ impl OutboundMix {
     /// one, so `p` comes out HIGHER than reality, by the loss rate on one
     /// request/reply round trip.
     ///
-    /// The direction is the point. Double-counting would have biased `p`
-    /// DOWNWARD — conservative, costing at worst a mechanism worth building.
-    /// This biases it UPWARD, which risks building R4b on an agreement rate
-    /// better than the network actually achieves, and that is the more
-    /// expensive mistake. Correct arithmetic with a known-direction bias still
-    /// beats a wrong number, so the deferral stays; the bias is documented
-    /// instead of removed. It is also the same lost-deferred-round-trip
-    /// fragility R4b's own design work flagged separately, so it is a coherent
-    /// known limitation rather than a surprise.
+    /// Double-counting instead would have biased `p` downward, so the deferral
+    /// is still the right call — recording one divergence twice is simply wrong
+    /// arithmetic. It is also the same lost-deferred-round-trip fragility R4b's
+    /// own design work flagged separately, so it is a coherent known limitation
+    /// rather than a surprise. It is expected to be SMALL (it needs a lost
+    /// message) next to the contamination term above, which is structural and
+    /// ~15%.
+    ///
+    /// # NET: bound it, do not point-estimate it
+    ///
+    /// Two biases, opposite signs, the larger one downward. The honest reading
+    /// of these counters is an interval computed with the send-side census, not
+    /// a single number — and a build/no-build call for R4b should be made on
+    /// that interval.
     pub(crate) fn record_summary_comparison(
         &self,
         contract: &ContractInstanceId,
         ours: &[u8],
         theirs: &[u8],
-        single_entry: bool,
+        obs: SummaryObservation,
         counted_this_message: &mut HashSet<ContractInstanceId>,
     ) {
         // The per-message dedup lives HERE, not at the call site, for the same
@@ -693,16 +874,24 @@ impl OutboundMix {
         let mut w = self.window.lock();
         if identical {
             w.summary_entries_identical = w.summary_entries_identical.saturating_add(1);
-            if single_entry {
+            if obs.is_single_full_bytes() {
                 w.summary_entries_identical_single =
                     w.summary_entries_identical_single.saturating_add(1);
+            }
+            if obs.is_single_digest() {
+                w.summary_entries_identical_single_digest =
+                    w.summary_entries_identical_single_digest.saturating_add(1);
             }
             return;
         }
         w.summary_entries_differing = w.summary_entries_differing.saturating_add(1);
-        if single_entry {
+        if obs.is_single_full_bytes() {
             w.summary_entries_differing_single =
                 w.summary_entries_differing_single.saturating_add(1);
+        }
+        if obs.is_single_digest() {
+            w.summary_entries_differing_single_digest =
+                w.summary_entries_differing_single_digest.saturating_add(1);
         }
         let mut dropped = false;
         // Bounded for the same reason the payload mix bounds its attribution:
@@ -725,11 +914,11 @@ impl OutboundMix {
         let len = w.differing_by_contract.len();
         match w.differing_by_contract.entry(*contract) {
             std::collections::hash_map::Entry::Occupied(mut e) => {
-                e.get_mut().add(single_entry);
+                e.get_mut().add(obs);
             }
             std::collections::hash_map::Entry::Vacant(e) => {
                 if len < MAX_TRACKED_CONTRACTS {
-                    e.insert(DifferingCount::default()).add(single_entry);
+                    e.insert(DifferingCount::default()).add(obs);
                 } else {
                     dropped = true;
                 }
@@ -761,12 +950,20 @@ impl OutboundMix {
     /// two-sided counter does: `entries` is peer-supplied and may repeat a
     /// hash, so without it a peer could inflate this bucket at will.
     ///
-    /// `single_entry` carries the same meaning, and the same known limits, as
-    /// in [`Self::record_summary_comparison`] — read that doc for both.
+    /// `obs` carries the same meaning, and the same known limits, as in
+    /// [`Self::record_summary_comparison`] — read that doc for both.
+    ///
+    /// **Only the FULL-BYTES arm may call this.** The digest arm used to, and
+    /// because the same contract was then observed again when the requested
+    /// bytes arrived, one divergence was counted twice (#5153 review F2). A
+    /// [`SummaryObservation::SingleEntryDigest`] reaching here is therefore a
+    /// bug, and is counted in the total but deliberately in no single bucket —
+    /// dropping it silently would hide the regression, while giving it a bucket
+    /// would re-open the double count.
     pub(crate) fn record_summary_one_sided(
         &self,
         contract: &ContractInstanceId,
-        single_entry: bool,
+        obs: SummaryObservation,
         counted_this_message: &mut HashSet<ContractInstanceId>,
     ) {
         if !counted_this_message.insert(*contract) {
@@ -774,7 +971,7 @@ impl OutboundMix {
         }
         let mut w = self.window.lock();
         w.summary_entries_one_sided = w.summary_entries_one_sided.saturating_add(1);
-        if single_entry {
+        if obs.is_single_full_bytes() {
             w.summary_entries_one_sided_single =
                 w.summary_entries_one_sided_single.saturating_add(1);
         }
@@ -885,6 +1082,14 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
             format!("{stem}_max_entries"),
             w.summaries_max_entries[s].into(),
         );
+        // R4b contamination census (#5153 review F1). Seven more integers on a
+        // rollup that already carries five per arm — the same cost argument, and
+        // it is what makes the receive-side single-entry buckets interpretable
+        // rather than merely present.
+        body.insert(
+            format!("{stem}_single_entry_msgs"),
+            w.summaries_single_entry_msgs[s].into(),
+        );
     }
 
     // #4965 falsifier. Emitted unconditionally (including as a pair of zeros)
@@ -926,6 +1131,19 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     body.insert(
         "summary_entries_one_sided_single".into(),
         w.summary_entries_one_sided_single.into(),
+    );
+    // Digest-leg siblings, kept as separate keys rather than merged: today they
+    // are churn-leg traffic and NOT notifications, and after R4b ships the
+    // notification population moves onto this leg. Emitting both makes that
+    // migration visible in the data instead of something an analyst has to
+    // assume happened.
+    body.insert(
+        "summary_entries_identical_single_digest".into(),
+        w.summary_entries_identical_single_digest.into(),
+    );
+    body.insert(
+        "summary_entries_differing_single_digest".into(),
+        w.summary_entries_differing_single_digest.into(),
     );
 
     // #4965 co-host exclusion, measured in the release build. Emitted
@@ -1179,10 +1397,34 @@ mod tests {
         let a = test_instance_id(1);
         let b = test_instance_id(2);
 
-        mix.record_summary_comparison(&a, b"same", b"same", false, &mut HashSet::new());
-        mix.record_summary_comparison(&a, b"ours", b"theirs", false, &mut HashSet::new());
-        mix.record_summary_comparison(&b, b"ours", b"theirs", false, &mut HashSet::new());
-        mix.record_summary_comparison(&a, b"same", b"same", false, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &a,
+            b"same",
+            b"same",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_comparison(
+            &a,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_comparison(
+            &b,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_comparison(
+            &a,
+            b"same",
+            b"same",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
 
         let w = mix.take_window();
         assert_eq!(w.summary_entries_identical, 2);
@@ -1204,7 +1446,13 @@ mod tests {
     fn differing_attribution_is_bounded_but_keeps_accruing_known_contracts() {
         let mix = OutboundMix::new();
         let tracked = test_instance_id(0);
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &tracked,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
 
         // Fill well past the cap with distinct ids.
         for i in 1..(MAX_TRACKED_CONTRACTS as u32 + 300) {
@@ -1212,12 +1460,18 @@ mod tests {
                 &test_instance_id(i),
                 b"ours",
                 b"theirs",
-                false,
+                SummaryObservation::MultiEntry,
                 &mut HashSet::new(),
             );
         }
         // ...then hit the already-tracked one again.
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &tracked,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
 
         let w = mix.take_window();
         assert!(
@@ -1256,7 +1510,7 @@ mod tests {
                     &test_instance_id(i),
                     b"ours",
                     b"theirs",
-                    false,
+                    SummaryObservation::MultiEntry,
                     &mut HashSet::new(),
                 );
             }
@@ -1306,10 +1560,22 @@ mod tests {
         let mix = OutboundMix::new();
         let c = test_instance_id(1);
         for _ in 0..3 {
-            mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"same",
+                b"same",
+                SummaryObservation::MultiEntry,
+                &mut HashSet::new(),
+            );
         }
         for _ in 0..5 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"ours",
+                b"theirs",
+                SummaryObservation::MultiEntry,
+                &mut HashSet::new(),
+            );
         }
         let body = outbound_mix_json(&mix.take_window(), 60);
         assert_eq!(
@@ -1349,22 +1615,50 @@ mod tests {
 
         // identical: 2 single, 3 multi.
         for _ in 0..2 {
-            mix.record_summary_comparison(&c, b"same", b"same", true, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"same",
+                b"same",
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
         for _ in 0..3 {
-            mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"same",
+                b"same",
+                SummaryObservation::MultiEntry,
+                &mut HashSet::new(),
+            );
         }
         // differing: 4 single, 1 multi.
         for _ in 0..4 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", true, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"ours",
+                b"theirs",
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
-        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &c,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
         // one-sided: 5 single, 2 multi.
         for _ in 0..5 {
-            mix.record_summary_one_sided(&c, true, &mut HashSet::new());
+            mix.record_summary_one_sided(
+                &c,
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
         for _ in 0..2 {
-            mix.record_summary_one_sided(&c, false, &mut HashSet::new());
+            mix.record_summary_one_sided(&c, SummaryObservation::MultiEntry, &mut HashSet::new());
         }
 
         let w = mix.take_window();
@@ -1416,9 +1710,21 @@ mod tests {
     fn single_entry_buckets_are_exactly_zero_when_the_discriminator_is_false() {
         let mix = OutboundMix::new();
         let c = test_instance_id(1);
-        mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
-        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
-        mix.record_summary_one_sided(&c, false, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &c,
+            b"same",
+            b"same",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_comparison(
+            &c,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_one_sided(&c, SummaryObservation::MultiEntry, &mut HashSet::new());
 
         let w = mix.take_window();
         assert_eq!(
@@ -1458,13 +1764,29 @@ mod tests {
         let mix = OutboundMix::new();
         let c = test_instance_id(1);
         for _ in 0..2 {
-            mix.record_summary_comparison(&c, b"same", b"same", true, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"same",
+                b"same",
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
         for _ in 0..4 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", true, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &c,
+                b"ours",
+                b"theirs",
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
         for _ in 0..6 {
-            mix.record_summary_one_sided(&c, true, &mut HashSet::new());
+            mix.record_summary_one_sided(
+                &c,
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
         let body = outbound_mix_json(&mix.take_window(), 60);
         assert_eq!(
@@ -1517,11 +1839,29 @@ mod tests {
         let busy = test_instance_id(1);
         let noisy = test_instance_id(2);
         for _ in 0..5 {
-            mix.record_summary_comparison(&busy, b"ours", b"theirs", false, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &busy,
+                b"ours",
+                b"theirs",
+                SummaryObservation::MultiEntry,
+                &mut HashSet::new(),
+            );
         }
-        mix.record_summary_comparison(&busy, b"ours", b"theirs", true, &mut HashSet::new());
+        mix.record_summary_comparison(
+            &busy,
+            b"ours",
+            b"theirs",
+            SummaryObservation::SingleEntryFullBytes,
+            &mut HashSet::new(),
+        );
         for _ in 0..3 {
-            mix.record_summary_comparison(&noisy, b"ours", b"theirs", true, &mut HashSet::new());
+            mix.record_summary_comparison(
+                &noisy,
+                b"ours",
+                b"theirs",
+                SummaryObservation::SingleEntryFullBytes,
+                &mut HashSet::new(),
+            );
         }
 
         let body = outbound_mix_json(&mix.take_window(), 60);
@@ -1627,13 +1967,31 @@ mod tests {
         // One message that repeats `c` five times and names `other` once.
         let mut first_message = HashSet::new();
         for _ in 0..5 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut first_message);
+            mix.record_summary_comparison(
+                &c,
+                b"ours",
+                b"theirs",
+                SummaryObservation::MultiEntry,
+                &mut first_message,
+            );
         }
-        mix.record_summary_comparison(&other, b"same", b"same", false, &mut first_message);
+        mix.record_summary_comparison(
+            &other,
+            b"same",
+            b"same",
+            SummaryObservation::MultiEntry,
+            &mut first_message,
+        );
 
         // A second message names `c` again — a genuinely new observation.
         let mut second_message = HashSet::new();
-        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut second_message);
+        mix.record_summary_comparison(
+            &c,
+            b"ours",
+            b"theirs",
+            SummaryObservation::MultiEntry,
+            &mut second_message,
+        );
 
         let w = mix.take_window();
         assert_eq!(
@@ -1698,7 +2056,7 @@ mod tests {
                 &test_instance_id(i),
                 b"ours",
                 b"theirs",
-                false,
+                SummaryObservation::MultiEntry,
                 &mut HashSet::new(),
             );
         }
@@ -1827,6 +2185,143 @@ mod tests {
                 w.summaries_msgs[summaries_index(emitter)],
                 1,
                 "each emitter sent exactly one message: {emitter:?}"
+            );
+        }
+    }
+
+    /// The per-arm single-entry census counts single-entry messages PER EMITTER,
+    /// which is the whole point of it (#5153 review F1).
+    ///
+    /// The receive side sees only `entries.len()`, so it cannot tell a
+    /// notification from a `ChangeInterestsReply` — and field data says ~15% of
+    /// single-entry `Summaries` are NOT notifications. This census is the only
+    /// place both facts exist together, so it is what converts that
+    /// contamination from an unstated assumption into a subtractable number.
+    ///
+    /// The fixture mirrors the measured shape deliberately: notification and
+    /// change-interests-reply single-entry, interests-reply wide. If the census
+    /// counted messages rather than SINGLE-ENTRY messages, the wide arm would be
+    /// non-zero and this fails.
+    #[test]
+    fn single_entry_census_is_per_emitter_and_excludes_wide_messages() {
+        let mix = OutboundMix::new();
+        // Notification: single-entry by construction (field: mean 1.000).
+        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
+        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
+        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
+        // ChangeInterestsReply: ALSO single-entry (field: mean 1.000, max 1) —
+        // the contaminant an earlier version of this instrument missed.
+        record_summaries(&mix, SummariesEmitter::ChangeInterestsReply, 1, 400);
+        // InterestsReply: genuinely wide (field: mean ~224). Must NOT be counted.
+        record_summaries(&mix, SummariesEmitter::InterestsReply, 224, 200);
+        // A request reply can be either; a single-entry one is differing by
+        // construction, which is the downward-bias term.
+        record_summaries(&mix, SummariesEmitter::SummaryRequestReply, 1, 1600);
+        record_summaries(&mix, SummariesEmitter::SummaryRequestReply, 7, 1600);
+
+        let w = mix.take_window();
+        let census = |e| w.summaries_single_entry_msgs[summaries_index(e)];
+        assert_eq!(census(SummariesEmitter::Notification), 3);
+        assert_eq!(
+            census(SummariesEmitter::ChangeInterestsReply),
+            1,
+            "the largest contaminant must be counted, not assumed away"
+        );
+        assert_eq!(
+            census(SummariesEmitter::InterestsReply),
+            0,
+            "a 224-entry message is not single-entry; counting it would make the \
+             census meaningless"
+        );
+        assert_eq!(
+            census(SummariesEmitter::SummaryRequestReply),
+            1,
+            "one of the two request replies was single-entry"
+        );
+
+        // The decision this feeds: notification's share of the single-entry
+        // population. Computable from the census alone, which is the property
+        // that lets the analysis bound `p` instead of asserting it.
+        let total_single: u64 = SUMMARIES_ARMS.iter().map(|e| census(*e)).sum();
+        assert_eq!(total_single, 5);
+        assert_eq!(census(SummariesEmitter::Notification), 3);
+
+        let body = outbound_mix_json(&w, 60);
+        assert_eq!(
+            body.get("interest_sync_summaries_notification_single_entry_msgs")
+                .and_then(|v| v.as_u64()),
+            Some(3),
+            "the census must reach the rollup under a per-arm key"
+        );
+        assert_eq!(
+            body.get("interest_sync_summaries_change_interests_reply_single_entry_msgs")
+                .and_then(|v| v.as_u64()),
+            Some(1)
+        );
+        assert_eq!(
+            body.get("interest_sync_summaries_interests_reply_single_entry_msgs")
+                .and_then(|v| v.as_u64()),
+            Some(0),
+            "emitted as an explicit zero, like every other field here"
+        );
+    }
+
+    /// A DIGEST-leg single-entry observation must not land in the full-bytes
+    /// bucket (#5153 review F1).
+    ///
+    /// Today a notification ships full bytes unconditionally, so a single-entry
+    /// observation on the digest leg is churn-leg traffic by construction —
+    /// merging the two would buy post-R4b series continuity by corrupting the
+    /// pre-R4b measurement that the build/no-build decision rests on. Asserting
+    /// the full-bytes bucket is EXACTLY 0 is what makes that separation real
+    /// rather than nominal.
+    #[test]
+    fn digest_leg_single_entry_observations_stay_out_of_the_full_bytes_bucket() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+        mix.record_summary_comparison(
+            &c,
+            b"same",
+            b"same",
+            SummaryObservation::SingleEntryDigest,
+            &mut HashSet::new(),
+        );
+        mix.record_summary_comparison(
+            &c,
+            b"ours",
+            b"theirs",
+            SummaryObservation::SingleEntryDigest,
+            &mut HashSet::new(),
+        );
+
+        let w = mix.take_window();
+        assert_eq!(w.summary_entries_identical, 1, "totals still count it");
+        assert_eq!(w.summary_entries_differing, 1, "totals still count it");
+        assert_eq!(
+            w.summary_entries_identical_single, 0,
+            "a digest-leg observation is NOT the R4b full-bytes population"
+        );
+        assert_eq!(w.summary_entries_differing_single, 0);
+        assert_eq!(w.summary_entries_identical_single_digest, 1);
+        assert_eq!(w.summary_entries_differing_single_digest, 1);
+        assert_eq!(
+            w.differing_by_contract.get(&c).map(|d| d.single),
+            Some(0),
+            "per-contract attribution must follow the same split, or the \
+             notification-leg share of a contract's divergence is overstated"
+        );
+
+        let body = outbound_mix_json(&w, 60);
+        for (key, want) in [
+            ("summary_entries_identical_single", 0),
+            ("summary_entries_differing_single", 0),
+            ("summary_entries_identical_single_digest", 1),
+            ("summary_entries_differing_single_digest", 1),
+        ] {
+            assert_eq!(
+                body.get(key).and_then(|v| v.as_u64()),
+                Some(want),
+                "{key} must reach the rollup with the leg split intact"
             );
         }
     }

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -383,6 +383,12 @@ const SUMMARIES_WIRE_FORMS: [SummariesWireForm; 2] =
 /// "everyone's sends" and "everyone's receives" are the same traffic counted
 /// twice.
 ///
+/// The field measurement makes this concrete rather than merely structural:
+/// **48.7% of node-minutes send ZERO notifications** (77,327 of 158,708 rollups)
+/// while still receiving them from peers' fan-out, and 41.7% send zero
+/// `change_interests_reply`. So for roughly half the sample a per-node
+/// correction is not merely wrong, it is undefined or zero.
+///
 /// The name is the guard: `FleetSingleEntryTotals` cannot be read as a per-node
 /// quantity. It does not physically stop someone summing one node's records into
 /// it — the collection-taking signature that would needs a rollup-parsing
@@ -752,8 +758,11 @@ struct Window {
     /// instrument land a release ahead of the mechanism it judges (regime rule
     /// 7; 0.2.120 is permanently unattributable for want of exactly this).
     ///
-    /// **This bucket is the FULL-BYTES leg only, and it is ~15%
-    /// not-notification.** Read
+    /// **This bucket is the FULL-BYTES leg only, and it is ~4.6%
+    /// not-notification** — NOT the ~15% merged figure, because
+    /// `ChangeInterestsReply` is 95.3% digest today and so mostly never reaches
+    /// this bucket. Two independent derivations agree on ~4-5% (per-arm census
+    /// projection, and classifying rollups by mean bytes/msg). Read
     /// [`OutboundMix::record_summary_comparison`] before quoting a number off
     /// it — the contamination is measurable but NOT negligible, and it biases
     /// `p` in BOTH directions. Subtract it using
@@ -998,11 +1007,35 @@ impl OutboundMix {
     /// | single-entry `Summaries` sender | msgs, one window | effect on `p` |
     /// |---|---|---|
     /// | `Notification` (the signal) | 3,194,108 | — |
-    /// | `ChangeInterestsReply` | 418,476 (mean 1.000, max 1, 1,284 peers) | either |
-    /// | `SummaryRequestReply` | >=131,153 | **downward** |
-    /// | `Rejection` | 669 | either |
+    /// | `ChangeInterestsReply` | 418,476 (mean 1.000, max 1, 1,284 peers) | either; 95.3% digest so mostly off the full-bytes leg |
+    /// | `SummaryRequestReply` | >=131,153 | **downward** (mostly, not all — see below) |
+    /// | `Rejection` | 669 | **UPWARD** — identical by construction |
     ///
-    /// So **~15% of single-entry observations are not notifications.**
+    /// The signs matter and the census cannot supply them; they come from what
+    /// each emitter means. `Rejection` fires only when a rejected broadcast's
+    /// summary ALREADY matched ours, so it is identical by construction and
+    /// pushes `p` up — it is the one arm whose sign is actually knowable, and at
+    /// 669 messages it is harmless, but it is not "either".
+    ///
+    /// So **~15% of single-entry MESSAGES SENT are not notifications** — note the
+    /// unit: messages, on the send side. Saying "observations" there would import
+    /// the receive-side unit and is the category error this whole section exists
+    /// to prevent.
+    ///
+    /// **Per LEG, which is what actually matters:** `ChangeInterestsReply` is
+    /// **95.3% digest / 4.7% full-bytes**, so the FULL-BYTES leg — the one `p` is
+    /// computed over today — is only **~4.6%** contaminated, essentially
+    /// `request_reply + rejection`. The ~15% is the merged number and applying it
+    /// to the full-bytes leg over-subtracts by roughly 11 points. Two independent
+    /// derivations agree on the ~4-5% figure: projecting the per-arm census, and
+    /// classifying rollups by mean bytes/msg (digest singles ~41 B against
+    /// full-bytes ~9-10 KB).
+    ///
+    /// Scale of what the split buys: **without it the instrument cannot tell a
+    /// true `p` of 99% from 95%** (worst-case bracket ~17 points wide against a
+    /// 4-point decision gap); with it, residual uncertainty is **≈±0.6 points**.
+    /// The leg split is therefore not tidiness — it is the difference between an
+    /// instrument that answers its question and one that does not.
     ///
     /// `ChangeInterestsReply` is single-entry because
     /// `broadcast_change_interests` is called with one contract per gossip, so
@@ -1012,11 +1045,18 @@ impl OutboundMix {
     ///
     /// **The `SummaryRequestReply` term is the dangerous one, and it runs
     /// DOWNWARD.** Bytes are requested only after a digest mismatch, so when
-    /// they arrive they cannot compare equal — such a reply lands in
-    /// `differing` by construction. Single-entry ones therefore inflate `p`'s
-    /// DENOMINATOR only, and at real scale: >=131,153 such messages against a
-    /// fleet `summary_entries_differing` of 559,992 in the same window. A true
-    /// notification-leg `p` of 99% would measure around **95%**.
+    /// they arrive they *almost always* compare unequal — such a reply lands in
+    /// `differing`. Not airtight, and worth stating precisely rather than as a
+    /// law: state can converge between the digest mismatch and the bytes
+    /// arriving, in which case the reply compares equal after all. Single-entry
+    /// ones therefore inflate `p`'s DENOMINATOR predominantly, at real scale: at
+    /// least 131,153 such messages against a fleet `summary_entries_differing`
+    /// of 559,992 in the same window.
+    ///
+    /// (An earlier revision put a figure here — "a true 99% would measure around
+    /// 95%". Removed: that arithmetic silently assumes one comparison per
+    /// message, which is the very conversion the expansion factor makes unknown
+    /// until deployment. It was a point estimate dressed as a consequence.)
     ///
     /// So `p` off this counter is NOT a clean ceiling. It has an upward term
     /// (divergences lost to a dropped round trip, below) and a larger downward
@@ -1059,6 +1099,25 @@ impl OutboundMix {
     /// of these counters is an interval computed with the send-side census, not
     /// a single number — and a build/no-build call for R4b should be made on
     /// that interval.
+    ///
+    /// **The two are NOT independent, so do not add their uncertainties.** The
+    /// dropped-round-trip term above and the request-reply contamination are the
+    /// same phenomenon viewed from opposite ends: the sender counts a reply it
+    /// sent, the receiver never observes it, so a census subtraction
+    /// over-subtracts by exactly that loss rate. Treating them as two separate
+    /// biases overstates the uncertainty structure.
+    ///
+    /// # ROLLOUT: version skew makes the first data the least trustworthy
+    ///
+    /// Only nodes on this build emit either counter. During adoption the
+    /// receive-side singles therefore come largely from senders that are ABSENT
+    /// from the census, so the fleet-closure assumption the whole correction
+    /// rests on is weakest exactly when the first numbers arrive. And the send
+    /// mix genuinely differs by version — #4965 added the digest legs, #5155
+    /// changed `InterestsReply` shape, #5003 changed notification recipients — so
+    /// this is not merely a smaller sample, it is a differently-composed one.
+    /// Compounds the two-release-lag: wait for adoption before trusting the
+    /// share, even though expansion calibrates early.
     pub(crate) fn record_summary_comparison(
         &self,
         contract: &ContractInstanceId,

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -2808,18 +2808,34 @@ mod tests {
     /// that a call site is labelled correctly.
     ///
     /// Byte totals alone cannot catch a mislabelled emitter — they look
-    /// plausible under any labelling. Mean entries per message can: the
-    /// notification and rejection emitters are single-entry by construction,
-    /// both reply emitters are multi-entry, so a reply arm reporting a mean of
-    /// 1.0 (or a notification arm reporting 12) says the attribution is wrong
-    /// even though every byte reconciles.
+    /// plausible under any labelling. Mean entries per message can, but ONLY
+    /// per arm, and the per-arm expectation is not uniform:
+    ///
+    /// | arm | expected mean entries/msg | a wrong reading |
+    /// |---|---|---|
+    /// | `Notification` | exactly 1 | anything above 1 |
+    /// | `Rejection` | exactly 1 | anything above 1 |
+    /// | `ChangeInterestsReply` | **exactly 1** (measured 1.000, max 1) | anything above 1 |
+    /// | `InterestsReply` | ~224, max 2,401 | a mean of 1.0 |
+    ///
+    /// **`ChangeInterestsReply` reporting a mean of 1.0 is CORRECT and says
+    /// nothing is wrong** — corrected 2026-08-12 (#5153 review F1), because the
+    /// rule stated here previously ("both reply emitters are multi-entry, so a
+    /// reply arm reporting a mean of 1.0 says the attribution is wrong") was
+    /// false and would send an operator hunting a mis-attribution that does not
+    /// exist. `broadcast_change_interests` gossips one contract per message, so
+    /// one entry per reply is the design. Only `InterestsReply` at a mean of 1.0,
+    /// or `Notification`/`Rejection`/`ChangeInterestsReply` above 1, is evidence
+    /// of a mislabelled call site.
     #[test]
     fn entry_counts_are_recorded_per_sub_arm() {
         let mix = OutboundMix::new();
         // Two single-entry notifications.
         record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
         record_summaries(&mix, SummariesEmitter::Notification, 1, 110);
-        // Two multi-entry heartbeat replies, 12 and 4 entries.
+        // Two multi-entry HEARTBEAT replies, 12 and 4 entries — `InterestsReply`
+        // is the one genuinely-wide arm. `ChangeInterestsReply` would be
+        // single-entry here, which is why the wide fixture uses this arm.
         record_summaries(&mix, SummariesEmitter::InterestsReply, 12, 12_000);
         record_summaries(&mix, SummariesEmitter::InterestsReply, 4, 4_000);
 

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -94,11 +94,19 @@ const TOP_DIFFERING_CONTRACTS_REPORTED: usize = 10;
 /// What a summary comparison's message was shaped like, and which receive arm
 /// saw it — the R4b (#5153) discriminator.
 ///
-/// One enum rather than a `bool` because the two facts are not independent and
-/// the illegal pairing must be unrepresentable: a single-entry observation on
-/// the DIGEST leg is, today, provably **not** notification traffic (a
+/// One enum rather than a `bool` because the two facts are not independent, and
+/// a named variant makes the wrong pairing hard to write by accident rather than
+/// impossible: all three variants are `pub(crate)`, so a call site can still name
+/// `SingleEntryFullBytes` directly on the digest leg. The actual guard against
+/// that is the call-site pin `every_summary_observation_passes_the_message_shape`,
+/// which asserts the leg split (2 full-bytes sites, 1 digest) and goes red on a
+/// directly-named variant. The enum's job is to stop the mistake being invisible;
+/// the pin's job is to stop it shipping.
+///
+/// Why the pairing matters: a single-entry observation on the DIGEST leg is,
+/// today, provably **not** notification traffic (a
 /// notification ships full bytes unconditionally,
-/// `operations/update.rs::send_summary_notification`), so folding it in with the
+/// `operations/update.rs::send_proactive_summary_notification`), so folding it in with the
 /// full-bytes leg would mix two populations under one name. A caller holding a
 /// `bool` cannot express that difference; this type forces it to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -320,9 +328,173 @@ impl OutboundKind {
 /// today's call sites (the tag is mandatory), but the recorder counts such a
 /// message in the residual rather than dropping it, so the sub-arms sum to the
 /// parent by construction rather than by everyone remembering to.
+/// Which wire form carried a `Summaries`-family message.
+///
+/// The census MUST split on this, not just on emitter and length (#5153 review
+/// round 2). `OutboundClass::classify` folds `InterestMessage::Summaries` and
+/// `InterestMessage::SummaryDigests` into one arm with the same emitter tag,
+/// while the RECEIVE side counts them into separate single-entry buckets. A
+/// leg-blind census therefore charges digest-form sends against the full-bytes
+/// leg — and since `summary_reply_form` returns `Digests` for every peer at or
+/// above the `(0, 2, 116)` floor and the fleet is past it, MOST
+/// `ChangeInterestsReply` traffic is digests and never enters the full-bytes
+/// receive population at all. Correcting the full-bytes leg with a merged
+/// number over-subtracts by roughly 11 points.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum SummariesWireForm {
+    /// `InterestMessage::Summaries` — full summary bytes per entry.
+    #[default]
+    FullBytes,
+    /// `InterestMessage::SummaryDigests` — 21-byte digests (#4965).
+    Digests,
+}
+
+impl SummariesWireForm {
+    fn index(self) -> usize {
+        match self {
+            Self::FullBytes => 0,
+            Self::Digests => 1,
+        }
+    }
+
+    /// Telemetry key infix. `full_bytes` is spelled out rather than left
+    /// implicit so neither leg reads as the default in a dashboard query.
+    fn stem(self) -> &'static str {
+        match self {
+            Self::FullBytes => "full_bytes",
+            Self::Digests => "digests",
+        }
+    }
+}
+
+const SUMMARIES_WIRE_FORMS: [SummariesWireForm; 2] =
+    [SummariesWireForm::FullBytes, SummariesWireForm::Digests];
+
+/// FLEET-WIDE single-entry totals for one window, and the only supported input
+/// to [`notification_share_bounds`].
+///
+/// This type exists to make one specific mistake impossible to write down. An
+/// earlier revision instructed an analyst, in prose, to measure notification's
+/// share "per node per minute". **That computation is invalid**: the census is
+/// recorded on the SENDER and the comparison buckets on the RECEIVER, so a
+/// node's census describes its own outbound while its buckets describe its
+/// neighbours' outbound. They are disjoint traffic. The correction is only
+/// meaningful summed across the reporting fleet for the same window, where
+/// "everyone's sends" and "everyone's receives" are the same traffic counted
+/// twice.
+///
+/// The name is the guard: `FleetSingleEntryTotals` cannot be read as a per-node
+/// quantity. It does not physically stop someone summing one node's records into
+/// it — the collection-taking signature that would needs a rollup-parsing
+/// harness this crate has no other use for — so that residual is named here
+/// rather than left implicit.
+///
+/// # `request_leg` is EXCLUDED, deliberately
+///
+/// `SummaryRequest` carries bare 32-bit hashes and no summary entries, so it is
+/// never observed as a comparison. Summing all seven census arms would put a
+/// population in the denominator that the numerator structurally cannot contain,
+/// inflating it and understating notification's share. [`Self::from_census`]
+/// drops it; asserted by `census_denominator_excludes_the_request_leg`.
+// DELIBERATELY has no production caller: the node never reads its own rollups
+// back, so this is an executable REFERENCE for the offline analysis, which lives
+// in Python outside this repo. Shipping it as tested code rather than as a
+// rustdoc recipe is the point — an earlier revision expressed the recipe only in
+// prose, got the aggregation level wrong there while the tests beside it computed
+// the right thing, and nothing compared the two. Residual, stated: the divergence
+// risk moves from prose-vs-code to Rust-vs-Python. A named implementation with
+// worked numbers is at least something the Python can be checked against, which
+// prose never was.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FleetSingleEntryTotals {
+    /// Single-entry messages the fleet SENT on the leg being corrected,
+    /// attributed to `Notification`.
+    notification_msgs: u64,
+    /// Same leg, every OTHER summary-bearing emitter — the contamination.
+    other_msgs: u64,
+}
+
+impl FleetSingleEntryTotals {
+    /// Sum one wire form's census across the fleet, excluding the request leg.
+    ///
+    /// `per_arm` is indexed by [`summaries_index`], i.e. the shape of
+    /// `Window::summaries_single_entry_msgs[..][form]` summed over records.
+    #[allow(dead_code)] // see the type-level note: reference impl, no in-tree caller
+    fn from_census(per_arm: [u64; SUMMARIES_ARMS.len()]) -> Self {
+        let mut notification_msgs = 0u64;
+        let mut other_msgs = 0u64;
+        for emitter in SUMMARIES_ARMS {
+            let n = per_arm[summaries_index(emitter)];
+            // Exhaustive on purpose: a new emitter must be classified here
+            // rather than defaulting into either bucket.
+            match emitter {
+                SummariesEmitter::Notification => {
+                    notification_msgs = notification_msgs.saturating_add(n);
+                }
+                // Carries no summary entries, so never a comparison.
+                SummariesEmitter::SummaryRequest => {}
+                SummariesEmitter::InterestsReply
+                | SummariesEmitter::ChangeInterestsReply
+                | SummariesEmitter::Rejection
+                | SummariesEmitter::SummaryRequestReply
+                | SummariesEmitter::Other => {
+                    other_msgs = other_msgs.saturating_add(n);
+                }
+            }
+        }
+        Self {
+            notification_msgs,
+            other_msgs,
+        }
+    }
+}
+
+/// Notification's share of the fleet's single-entry sends on one leg, as an
+/// interval.
+///
+/// Returns `(lower, upper)`. `upper` is the raw share; `lower` charges the whole
+/// contamination against notifications, the worst case for `p`. Quote `p` across
+/// the gap rather than at a point.
+///
+/// **This is not the full correction.** The share is over MESSAGES; the buckets
+/// it corrects count COMPARISONS, and the expansion between them is
+/// emitter-DEPENDENT. A `SummaryRequestReply` exists only because a digest
+/// mismatched, which presupposes the receiver had local interest AND a summary,
+/// so it expands to >= 1 by construction — while a notification can arrive for a
+/// contract the receiver holds no interest in and expand to 0. Notifications
+/// therefore expand to fewer comparisons on average, so applying this share to
+/// the comparison population OVER-subtracts them. That is the same
+/// "differing by construction" property that inflated the denominator, biting a
+/// second time by another mechanism: fixing one does not fix the other.
+///
+/// The expansion factor is **not measurable until this ships** — both sides of
+/// the ratio are counters added here. The first analysis after deployment must
+/// compute `(single-entry comparisons) / (single-entry census messages)`
+/// fleet-wide, record it with its window, and only then quote a bounded `p`. It
+/// calibrates early: both counters come from the same record on the same node,
+/// so any adoption level yields a valid expansion estimate well before `p`
+/// itself is representative.
+#[allow(dead_code)] // see `FleetSingleEntryTotals`: reference impl, no in-tree caller
+fn notification_share_bounds(t: FleetSingleEntryTotals) -> (f64, f64) {
+    let total = t.notification_msgs.saturating_add(t.other_msgs);
+    if total == 0 {
+        // No traffic is not 0% notification, it is no information. (0.0, 1.0)
+        // makes an empty window read as maximally uncertain rather than as
+        // evidence that notifications are absent.
+        return (0.0, 1.0);
+    }
+    let upper = t.notification_msgs as f64 / total as f64;
+    let lower = t.notification_msgs.saturating_sub(t.other_msgs) as f64 / total as f64;
+    (lower, upper)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct SummariesDetail {
     emitter: SummariesEmitter,
+    /// Which wire form carried it — see [`SummariesWireForm`] for why the
+    /// census cannot be read without this.
+    wire_form: SummariesWireForm,
     /// `entries.len()` — how many `SummaryEntry` this one message carried.
     ///
     /// The independent check on the attribution, and the reason it is worth
@@ -439,6 +611,7 @@ impl OutboundClass {
                         kind: OutboundKind::InterestSyncSummaries,
                         summaries: Some(SummariesDetail {
                             emitter: *emitter,
+                            wire_form: SummariesWireForm::FullBytes,
                             entries: entries.len() as u64,
                         }),
                     },
@@ -450,6 +623,7 @@ impl OutboundClass {
                         kind: OutboundKind::InterestSyncSummaries,
                         summaries: Some(SummariesDetail {
                             emitter: *emitter,
+                            wire_form: SummariesWireForm::Digests,
                             entries: entries.len() as u64,
                         }),
                     },
@@ -461,6 +635,12 @@ impl OutboundClass {
                         kind: OutboundKind::InterestSyncSummaries,
                         summaries: Some(SummariesDetail {
                             emitter: SummariesEmitter::SummaryRequest,
+                            // The request leg exists only in the hash-first
+                            // exchange, so `Digests` is the honest label — but it
+                            // carries no summary entries either way and
+                            // `FleetSingleEntryTotals::from_census` excludes it
+                            // from every denominator.
+                            wire_form: SummariesWireForm::Digests,
                             entries: hashes.len() as u64,
                         }),
                     },
@@ -525,18 +705,28 @@ struct Window {
     /// messages per emitter here therefore measures exactly what the receive-side
     /// proxy is unable to separate.
     ///
-    /// Why it is needed, in numbers (one window, 2026-08-12): `notification`
-    /// 3,194,108 single-entry messages, but `change_interests_reply` 418,476
-    /// (mean 1.000, max 1) and `request_reply` at least 131,153 — so **~15% of
-    /// single-entry `Summaries` are not notifications.** An earlier version of
-    /// this instrument documented only `rejection` (669 messages, 0.015%) as the
-    /// contamination, which was the smallest of three by three orders of
-    /// magnitude and left the largest unnamed.
+    /// **Indexed by `[arm][wire form]`, and the wire form is load-bearing.**
+    /// See [`SummariesWireForm`]: a leg-blind census over-subtracts the
+    /// full-bytes leg by roughly 11 points, because most `ChangeInterestsReply`
+    /// goes out as digests today and never reaches the full-bytes receive
+    /// population that `*_single` counts.
     ///
-    /// With this census the analysis can bound `p` instead of asserting it:
-    /// notification's share of the single-entry population is measured per node
-    /// per minute rather than assumed to be ~1.
-    summaries_single_entry_msgs: [u64; SUMMARIES_ARMS.len()],
+    /// Why it is needed, in numbers (one window, 2026-08-12): `notification`
+    /// 3,194,108 single-entry messages, `change_interests_reply` 418,476 (mean
+    /// 1.000, max 1), `request_reply` at least 131,153, `rejection` 669. Merged
+    /// across wire forms that is ~15% not-notification — but the FULL-BYTES leg,
+    /// which is the one `p` is computed over, is contaminated mainly by
+    /// `request_reply` and `rejection`, nearer **4%**. An even earlier version
+    /// documented only `rejection` (0.015%), the smallest of the three.
+    ///
+    /// Those figures come from pre-split telemetry and are therefore themselves
+    /// merged; the whole point of this field is that the deployed version
+    /// measures the split directly instead of estimating it.
+    ///
+    /// How to use it: see
+    /// [`FleetSingleEntryTotals`] — fleet-wide only, as a ratio, and never
+    /// joined per node.
+    summaries_single_entry_msgs: [[u64; SUMMARIES_WIRE_FORMS.len()]; SUMMARIES_ARMS.len()],
     /// InterestSync summary comparisons where both sides held a summary and
     /// the bytes were IDENTICAL. See [`OutboundMix::record_summary_comparison`].
     summary_entries_identical: u64,
@@ -586,7 +776,7 @@ struct Window {
     ///
     /// NOT notification traffic, and that is the point of separating them: a
     /// notification ships full bytes unconditionally today
-    /// (`operations/update.rs::send_summary_notification`), while
+    /// (`operations/update.rs::send_proactive_summary_notification`), while
     /// `ChangeInterestsReply` does route through the version gate — so a
     /// single-entry observation arriving on the digest leg is churn-leg by
     /// construction. Folding these into `*_single` would have bought post-R4b
@@ -598,6 +788,28 @@ struct Window {
     /// visible rather than inferred.
     summary_entries_identical_single_digest: u64,
     /// Digest-leg sibling of [`Window::summary_entries_differing_single`].
+    ///
+    /// # STRUCTURALLY ZERO IN PRODUCTION TODAY — do not compute a rate from it
+    ///
+    /// The digest arm records a comparison in exactly one place, the
+    /// `DigestVerdict::Agree` branch, and it passes byte-identical operands by
+    /// construction; `NeedBytes` deliberately records nothing (the F2 deferral).
+    /// So this counter cannot be incremented by any production path, and
+    /// `identical_single_digest / (identical + differing)_single_digest` reads
+    /// **1.000 forever**. That is not a 100% agreement rate — it is an artefact
+    /// of where the recording sites are, and quoting it as evidence would be the
+    /// overstated-saving failure this instrument exists to avoid.
+    ///
+    /// A NON-ZERO value would mean something specific and worth knowing: either
+    /// the digest arm gained a recording on a disagreeing path, or
+    /// `classify_summary_digest` returned `Agree` for operands that then compared
+    /// unequal — i.e. a digest collision or a summary that changed mid-handler.
+    /// It is emitted for that reason, and because the `NeedBytes` decision is
+    /// revisited at R4b, when notifications move onto this leg and both digest
+    /// counters become the interesting pair.
+    ///
+    /// Only the unit tests drive it, deliberately, by constructing a state
+    /// production cannot reach.
     summary_entries_differing_single_digest: u64,
     /// Comparisons where exactly ONE side held a summary (#4965 review S2).
     ///
@@ -731,8 +943,9 @@ impl OutboundMix {
             // exactly why its proxy needs this to be interpretable. Same branch
             // as the parent update, so it cannot disagree about a message.
             if detail.entries == 1 {
-                w.summaries_single_entry_msgs[s] =
-                    w.summaries_single_entry_msgs[s].saturating_add(1);
+                let f = detail.wire_form.index();
+                w.summaries_single_entry_msgs[s][f] =
+                    w.summaries_single_entry_msgs[s][f].saturating_add(1);
             }
         }
     }
@@ -1082,14 +1295,21 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
             format!("{stem}_max_entries"),
             w.summaries_max_entries[s].into(),
         );
-        // R4b contamination census (#5153 review F1). Seven more integers on a
-        // rollup that already carries five per arm — the same cost argument, and
-        // it is what makes the receive-side single-entry buckets interpretable
-        // rather than merely present.
-        body.insert(
-            format!("{stem}_single_entry_msgs"),
-            w.summaries_single_entry_msgs[s].into(),
-        );
+        // R4b contamination census (#5153 review F1), split by WIRE FORM (review
+        // round 2). 14 integers on a rollup that already carries five per arm —
+        // the same cost argument, and it is what makes the receive-side
+        // single-entry buckets interpretable rather than merely present.
+        //
+        // The wire-form split is not optional: the receive side counts full-bytes
+        // and digest observations into SEPARATE buckets, so a census merged
+        // across forms cannot correct either one. See `SummariesWireForm`.
+        for form in SUMMARIES_WIRE_FORMS {
+            let f = form.index();
+            body.insert(
+                format!("{stem}_{}_single_entry_msgs", form.stem()),
+                w.summaries_single_entry_msgs[s][f].into(),
+            );
+        }
     }
 
     // #4965 falsifier. Emitted unconditionally (including as a pair of zeros)
@@ -1277,6 +1497,37 @@ mod tests {
             OutboundClass::classify(&summaries_msg(emitter, n, 1)),
             bytes,
         );
+    }
+
+    /// Send `n` entries as the DIGEST wire form under `emitter`.
+    ///
+    /// Needed because `record_summaries` only ever produces
+    /// `InterestMessage::Summaries`, so a census test built on it alone cannot
+    /// distinguish the two legs — which is exactly the gap that let a leg-blind
+    /// census look correct (#5153 review round 2).
+    fn record_digests(mix: &OutboundMix, emitter: SummariesEmitter, n: usize) {
+        let msg = NetMessage::V1(NetMessageV1::InterestSync {
+            message: InterestMessage::SummaryDigests {
+                entries: (0..n)
+                    .map(|i| crate::message::SummaryDigestEntry {
+                        hash: i as u32,
+                        summary_digest: None,
+                    })
+                    .collect(),
+                emitter,
+            },
+        });
+        mix.record_sent(OutboundClass::classify(&msg), 21 * n);
+    }
+
+    /// Send a `SummaryRequest` carrying `n` bare hashes and no summary entries.
+    fn record_request_leg(mix: &OutboundMix, n: usize) {
+        let msg = NetMessage::V1(NetMessageV1::InterestSync {
+            message: InterestMessage::SummaryRequest {
+                hashes: (0..n).map(|i| i as u32).collect(),
+            },
+        });
+        mix.record_sent(OutboundClass::classify(&msg), 4 * n);
     }
 
     /// Taking the window leaves the accumulator empty, so consecutive rollups
@@ -2203,66 +2454,165 @@ mod tests {
     /// counted messages rather than SINGLE-ENTRY messages, the wide arm would be
     /// non-zero and this fails.
     #[test]
-    fn single_entry_census_is_per_emitter_and_excludes_wide_messages() {
+    fn single_entry_census_is_per_emitter_leg_split_and_excludes_wide_messages() {
         let mix = OutboundMix::new();
-        // Notification: single-entry by construction (field: mean 1.000).
-        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
-        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
-        record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
-        // ChangeInterestsReply: ALSO single-entry (field: mean 1.000, max 1) —
-        // the contaminant an earlier version of this instrument missed.
+        // Full-bytes leg. Notification is single-entry by construction (field:
+        // mean 1.000) and ships full bytes unconditionally this release.
+        for _ in 0..3 {
+            record_summaries(&mix, SummariesEmitter::Notification, 1, 100);
+        }
+        // ChangeInterestsReply is ALSO single-entry (field: mean 1.000, max 1) —
+        // the contaminant an earlier revision missed. One send on each leg,
+        // because in production it is version-gated to DIGESTS and so mostly does
+        // NOT reach the full-bytes receive population.
         record_summaries(&mix, SummariesEmitter::ChangeInterestsReply, 1, 400);
-        // InterestsReply: genuinely wide (field: mean ~224). Must NOT be counted.
+        record_digests(&mix, SummariesEmitter::ChangeInterestsReply, 1);
+        // InterestsReply is genuinely wide (field: mean ~224). Never counted.
         record_summaries(&mix, SummariesEmitter::InterestsReply, 224, 200);
-        // A request reply can be either; a single-entry one is differing by
-        // construction, which is the downward-bias term.
+        // Rejection: tiny but real, asserted explicitly rather than left to
+        // "structurally covered" — that phrase is what preceded the F1 miss.
+        record_summaries(&mix, SummariesEmitter::Rejection, 1, 800);
+        // Request reply: single-entry ones are differing by construction.
         record_summaries(&mix, SummariesEmitter::SummaryRequestReply, 1, 1600);
         record_summaries(&mix, SummariesEmitter::SummaryRequestReply, 7, 1600);
+        // The REQUEST leg carries bare hashes and no summary entries, so it must
+        // never enter a denominator. Without this send the exclusion asserted by
+        // `census_denominator_excludes_the_request_leg` would be untested here.
+        record_request_leg(&mix, 1);
 
         let w = mix.take_window();
-        let census = |e| w.summaries_single_entry_msgs[summaries_index(e)];
-        assert_eq!(census(SummariesEmitter::Notification), 3);
+        let full = |e| {
+            w.summaries_single_entry_msgs[summaries_index(e)][SummariesWireForm::FullBytes.index()]
+        };
+        let dig = |e| {
+            w.summaries_single_entry_msgs[summaries_index(e)][SummariesWireForm::Digests.index()]
+        };
+
+        assert_eq!(full(SummariesEmitter::Notification), 3);
         assert_eq!(
-            census(SummariesEmitter::ChangeInterestsReply),
+            full(SummariesEmitter::ChangeInterestsReply),
             1,
             "the largest contaminant must be counted, not assumed away"
         );
         assert_eq!(
-            census(SummariesEmitter::InterestsReply),
+            dig(SummariesEmitter::ChangeInterestsReply),
+            1,
+            "its DIGEST sends must land on the digest leg, not folded into \
+             full-bytes — that fold over-subtracts the leg `p` is computed on"
+        );
+        assert_eq!(
+            full(SummariesEmitter::InterestsReply),
             0,
             "a 224-entry message is not single-entry; counting it would make the \
              census meaningless"
         );
-        assert_eq!(
-            census(SummariesEmitter::SummaryRequestReply),
-            1,
-            "one of the two request replies was single-entry"
-        );
-
-        // The decision this feeds: notification's share of the single-entry
-        // population. Computable from the census alone, which is the property
-        // that lets the analysis bound `p` instead of asserting it.
-        let total_single: u64 = SUMMARIES_ARMS.iter().map(|e| census(*e)).sum();
-        assert_eq!(total_single, 5);
-        assert_eq!(census(SummariesEmitter::Notification), 3);
+        assert_eq!(full(SummariesEmitter::Rejection), 1);
+        assert_eq!(full(SummariesEmitter::SummaryRequestReply), 1);
+        assert_eq!(dig(SummariesEmitter::SummaryRequest), 1);
 
         let body = outbound_mix_json(&w, 60);
+        for (key, want) in [
+            (
+                "interest_sync_summaries_notification_full_bytes_single_entry_msgs",
+                3,
+            ),
+            (
+                "interest_sync_summaries_change_interests_reply_full_bytes_single_entry_msgs",
+                1,
+            ),
+            (
+                "interest_sync_summaries_change_interests_reply_digests_single_entry_msgs",
+                1,
+            ),
+            (
+                "interest_sync_summaries_interests_reply_full_bytes_single_entry_msgs",
+                0,
+            ),
+            (
+                "interest_sync_summaries_rejection_full_bytes_single_entry_msgs",
+                1,
+            ),
+        ] {
+            assert_eq!(
+                body.get(key).and_then(|v| v.as_u64()),
+                Some(want),
+                "{key} must reach the rollup with the leg split intact"
+            );
+        }
+    }
+
+    /// The census denominator EXCLUDES the request leg (#5153 review round 2).
+    ///
+    /// `SummaryRequest` carries bare 32-bit hashes and no summary entries, so it
+    /// is never observed as a comparison. Summing all seven arms would put a
+    /// population in the denominator the numerator structurally cannot contain,
+    /// understating notification's share. The fixture deliberately CONTAINS a
+    /// large request-leg count, because an earlier version of the census test
+    /// summed all seven arms while its fixture happened to have none — so it
+    /// could not have exposed the trap it was meant to catch.
+    #[test]
+    fn census_denominator_excludes_the_request_leg() {
+        let mut per_arm = [0u64; SUMMARIES_ARMS.len()];
+        per_arm[summaries_index(SummariesEmitter::Notification)] = 90;
+        per_arm[summaries_index(SummariesEmitter::ChangeInterestsReply)] = 10;
+        per_arm[summaries_index(SummariesEmitter::SummaryRequest)] = 900;
+
+        let totals = FleetSingleEntryTotals::from_census(per_arm);
+        assert_eq!(totals.notification_msgs, 90);
         assert_eq!(
-            body.get("interest_sync_summaries_notification_single_entry_msgs")
-                .and_then(|v| v.as_u64()),
-            Some(3),
-            "the census must reach the rollup under a per-arm key"
+            totals.other_msgs, 10,
+            "the request leg is not contamination either — it is not a \
+             comparison at all"
         );
-        assert_eq!(
-            body.get("interest_sync_summaries_change_interests_reply_single_entry_msgs")
-                .and_then(|v| v.as_u64()),
-            Some(1)
+
+        let (lower, upper) = notification_share_bounds(totals);
+        assert!(
+            (upper - 0.9).abs() < 1e-9,
+            "share must be 90/100, not 90/1000: got {upper}"
         );
-        assert_eq!(
-            body.get("interest_sync_summaries_interests_reply_single_entry_msgs")
-                .and_then(|v| v.as_u64()),
-            Some(0),
-            "emitted as an explicit zero, like every other field here"
+        assert!(
+            (lower - 0.8).abs() < 1e-9,
+            "lower bound charges the contamination to notifications: got {lower}"
+        );
+    }
+
+    /// An empty window is NO INFORMATION, not 0% notification.
+    ///
+    /// A point estimate of 0.0 for an idle window would let a quiet node read as
+    /// evidence that notifications are absent.
+    #[test]
+    fn empty_census_reads_as_maximally_uncertain() {
+        let totals = FleetSingleEntryTotals::from_census([0u64; SUMMARIES_ARMS.len()]);
+        assert_eq!(notification_share_bounds(totals), (0.0, 1.0));
+    }
+
+    /// Worked example on the real measured window (2026-08-12), so the recipe is
+    /// exercised against the numbers it was derived from rather than toy inputs.
+    ///
+    /// These are the MERGED pre-split figures — the deployed census reports the
+    /// legs separately, which is the point — so this pins the arithmetic, not the
+    /// eventual answer.
+    #[test]
+    fn notification_share_worked_example_on_measured_window() {
+        let mut per_arm = [0u64; SUMMARIES_ARMS.len()];
+        per_arm[summaries_index(SummariesEmitter::Notification)] = 3_194_108;
+        per_arm[summaries_index(SummariesEmitter::ChangeInterestsReply)] = 418_476;
+        per_arm[summaries_index(SummariesEmitter::SummaryRequestReply)] = 131_153;
+        per_arm[summaries_index(SummariesEmitter::Rejection)] = 669;
+        // Present in the window and correctly ignored.
+        per_arm[summaries_index(SummariesEmitter::SummaryRequest)] = 130_834;
+
+        let totals = FleetSingleEntryTotals::from_census(per_arm);
+        let (lower, upper) = notification_share_bounds(totals);
+        // ~85.3% of merged single-entry sends are notifications, i.e. ~14.7%
+        // contamination — reproducing the review figure from raw counters.
+        assert!(
+            (0.852..0.854).contains(&upper),
+            "expected ~0.853 notification share, got {upper}"
+        );
+        assert!(
+            (0.705..0.707).contains(&lower),
+            "expected ~0.706 worst case, got {lower}"
         );
     }
 

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -758,15 +758,21 @@ struct Window {
     /// instrument land a release ahead of the mechanism it judges (regime rule
     /// 7; 0.2.120 is permanently unattributable for want of exactly this).
     ///
-    /// **This bucket is the FULL-BYTES leg only, and it is ~4.6%
-    /// not-notification** — NOT the ~15% merged figure, because
-    /// `ChangeInterestsReply` is 95.3% digest today and so mostly never reaches
-    /// this bucket. Two independent derivations agree on ~4-5% (per-arm census
-    /// projection, and classifying rollups by mean bytes/msg). Read
+    /// **This bucket is the FULL-BYTES leg only, and its contamination is
+    /// BRACKETED at 0.07%-12.4% — it is not the ~15% merged figure, and it is
+    /// not a point estimate either.** `ChangeInterestsReply` is 95-99% digest
+    /// today, so it mostly never reaches this bucket. What is established is the
+    /// BOUND, and the bound is what the correction needs: even the pathological
+    /// upper end stays below the merged ~15%, so correcting this bucket with the
+    /// merged number over-subtracts. A central value near ~5% follows only under
+    /// assumptions this counter cannot check, so do not quote one — quoting a
+    /// point estimate where only an interval is supported is the same error class
+    /// this instrument was itself corrected for. Read
     /// [`OutboundMix::record_summary_comparison`] before quoting a number off
     /// it — the contamination is measurable but NOT negligible, and it biases
     /// `p` in BOTH directions. Subtract it using
-    /// [`Window::summaries_single_entry_msgs`].
+    /// [`Window::summaries_single_entry_msgs`], which is the only thing that can
+    /// narrow the bracket.
     summary_entries_identical_single: u64,
     /// The SINGLE-ENTRY subset of [`Window::summary_entries_differing`], full-bytes
     /// leg. The denominator half of `p` — without it a low single-entry agreement
@@ -1023,13 +1029,25 @@ impl OutboundMix {
     /// to prevent.
     ///
     /// **Per LEG, which is what actually matters:** `ChangeInterestsReply` is
-    /// **95.3% digest / 4.7% full-bytes**, so the FULL-BYTES leg — the one `p` is
-    /// computed over today — is only **~4.6%** contaminated, essentially
-    /// `request_reply + rejection`. The ~15% is the merged number and applying it
-    /// to the full-bytes leg over-subtracts by roughly 11 points. Two independent
-    /// derivations agree on the ~4-5% figure: projecting the per-arm census, and
-    /// classifying rollups by mean bytes/msg (digest singles ~41 B against
-    /// full-bytes ~9-10 KB).
+    /// 95-99% digest, so the FULL-BYTES leg — the one `p` is computed over today
+    /// — carries only the residue of it, essentially `request_reply + rejection`.
+    ///
+    /// **That residue is a BRACKET, 0.07%-12.4%, not a point estimate.** Three
+    /// independent measurements agree on the bracket (per-arm census projection;
+    /// classifying rollups by mean bytes/msg, digest singles ~41 B against
+    /// full-bytes ~9-10 KB; and a 6,214-node-minute / 1,132-peer window), and a
+    /// central value lands near ~5% under one window's assumptions — but only
+    /// under those assumptions, so **do not quote the central value.** The claim
+    /// that survives without them is the one the correction actually needs: even
+    /// 12.4% is below the merged ~15%, so applying the merged number to the
+    /// full-bytes leg over-subtracts.
+    ///
+    /// The bracket is wide for a structural reason, and that reason is the
+    /// argument for the census rather than an excuse: **the `request_reply`
+    /// single-entry SHARE that the exact figure depends on is not derivable from
+    /// today's keys at all.** `summaries_single_entry_msgs` is precisely the key
+    /// that makes it derivable, which is why the census exists — a narrower prior
+    /// measurement would not have removed the need for it.
     ///
     /// Scale of what the split buys: **without it the instrument cannot tell a
     /// true `p` of 99% from 95%** (worst-case bracket ~17 points wide against a
@@ -1337,7 +1355,8 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     // per-node budget is 10 events/s (`tracing/telemetry.rs`), 3.11% of records
     // already collide with it, and the collector runs at ~88.8 GB/day, so a
     // per-event stream is what got #4940 closed. Five extra integers per
-    // node-minute costs nothing measurable.
+    // node-minute cost nothing measurable — seven now, with the two census keys
+    // added below.
     //
     // Emitted unconditionally including as zeros, same rule as the arms above:
     // "this emitter sent nothing" and "this build does not report it" must not
@@ -1355,7 +1374,8 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
             w.summaries_max_entries[s].into(),
         );
         // R4b contamination census (#5153 review F1), split by WIRE FORM (review
-        // round 2). 14 integers on a rollup that already carries five per arm —
+        // round 2). 14 integers on a rollup for the five per arm it already
+        // carried, taking each arm to seven —
         // the same cost argument, and it is what makes the receive-side
         // single-entry buckets interpretable rather than merely present.
         //
@@ -2340,6 +2360,28 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(0)
         );
+        // The eight scalars this test did NOT cover (#5153 review round 2). Six are
+        // the R4b counters the build/no-build decision reads, and two
+        // (`summary_entries_one_sided`, the notification pair) were unpinned from
+        // the start. The convention this file states everywhere — a field that
+        // vanishes when zero is invisible to the analysis — was unenforced for
+        // exactly the fields that matter most.
+        for key in [
+            "summary_entries_one_sided",
+            "summary_entries_identical_single",
+            "summary_entries_differing_single",
+            "summary_entries_one_sided_single",
+            "summary_entries_identical_single_digest",
+            "summary_entries_differing_single_digest",
+            "notification_targets_sent",
+            "notification_cohosts_skipped",
+        ] {
+            assert_eq!(
+                body.get(key).and_then(|v| v.as_u64()),
+                Some(0),
+                "an idle window must emit {key} as an explicit zero"
+            );
+        }
         assert_eq!(
             body.get("summary_differing_contracts")
                 .and_then(|v| v.as_array())
@@ -2525,6 +2567,12 @@ mod tests {
         // because in production it is version-gated to DIGESTS and so mostly does
         // NOT reach the full-bytes receive population.
         record_summaries(&mix, SummariesEmitter::ChangeInterestsReply, 1, 400);
+        // TWO digest sends against ONE full-bytes send, deliberately unequal.
+        // With both at 1 the assertions below pass even if the `full_bytes` and
+        // `digests` keys are swapped in `SummariesWireForm::stem`, which is the
+        // exact mistake this leg split exists to prevent — an equal-valued
+        // fixture cannot detect a transposition.
+        record_digests(&mix, SummariesEmitter::ChangeInterestsReply, 1);
         record_digests(&mix, SummariesEmitter::ChangeInterestsReply, 1);
         // InterestsReply is genuinely wide (field: mean ~224). Never counted.
         record_summaries(&mix, SummariesEmitter::InterestsReply, 224, 200);
@@ -2555,9 +2603,10 @@ mod tests {
         );
         assert_eq!(
             dig(SummariesEmitter::ChangeInterestsReply),
-            1,
+            2,
             "its DIGEST sends must land on the digest leg, not folded into \
-             full-bytes — that fold over-subtracts the leg `p` is computed on"
+             full-bytes — that fold over-subtracts the leg `p` is computed on. \
+             Two here against one full-bytes so a key transposition is visible"
         );
         assert_eq!(
             full(SummariesEmitter::InterestsReply),
@@ -2581,7 +2630,7 @@ mod tests {
             ),
             (
                 "interest_sync_summaries_change_interests_reply_digests_single_entry_msgs",
-                1,
+                2,
             ),
             (
                 "interest_sync_summaries_interests_reply_full_bytes_single_entry_msgs",
@@ -2919,7 +2968,7 @@ mod tests {
         }
     }
 
-    /// Every sub-arm's five counters reach the emitted body under their own
+    /// Every sub-arm's seven counters reach the emitted body under their own
     /// keys, and an idle window emits them as explicit zeros.
     ///
     /// The counters were only ever checked on the `Window` struct. A swapped
@@ -2987,7 +3036,20 @@ mod tests {
         let idle = outbound_mix_json(&Window::default(), 60);
         for emitter in SUMMARIES_ARMS {
             let stem = summaries_stem(emitter);
-            for suffix in ["msgs", "bytes", "max_bytes", "entries", "max_entries"] {
+            // SEVEN suffixes, not five: the two R4b census keys are part of every
+            // arm's emitted set (#5153 review round 2). They were absent from both
+            // this loop and the value loop above, so the keys the instrument's
+            // whole correction depends on were the only per-arm keys with no
+            // presence guarantee at all.
+            for suffix in [
+                "msgs",
+                "bytes",
+                "max_bytes",
+                "entries",
+                "max_entries",
+                "full_bytes_single_entry_msgs",
+                "digests_single_entry_msgs",
+            ] {
                 let key = format!("{stem}_{suffix}");
                 assert_eq!(
                     idle.get(&key).and_then(|v| v.as_u64()),
@@ -2996,6 +3058,11 @@ mod tests {
                 );
             }
         }
+        // Presence is all an idle window can check: with every census key at zero,
+        // a `full_bytes`/`digests` transposition is invisible here AND harmless
+        // here. The transposition is caught by
+        // `single_entry_census_is_per_emitter_leg_split_and_excludes_wide_messages`,
+        // whose fixture deliberately sends unequal counts per leg.
     }
 
     /// Emitter-completeness pin: which production files touch

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -643,6 +643,28 @@ impl OutboundMix {
     /// only the receive arm knows the shape of the message the entry came in,
     /// and a rate re-derived later from arithmetic over separately-reported
     /// totals would silently absorb every other filter between them.
+    ///
+    /// # `p` AS MEASURED IS A CEILING, NOT A FLOOR
+    ///
+    /// State this to anyone sizing R4b from these counters. On the
+    /// `SummaryDigests` leg a genuine digest disagreement is recorded not at
+    /// the mismatch itself but when the requested bytes arrive back here — see
+    /// the `DigestVerdict::NeedBytes` branch in `node.rs`, which deliberately
+    /// records nothing so one divergence is not counted twice. **If the
+    /// `SummaryRequest` or its reply is lost, that divergence is never recorded
+    /// at all.** The numerator is untouched and the denominator is short by
+    /// one, so `p` comes out HIGHER than reality, by the loss rate on one
+    /// request/reply round trip.
+    ///
+    /// The direction is the point. Double-counting would have biased `p`
+    /// DOWNWARD — conservative, costing at worst a mechanism worth building.
+    /// This biases it UPWARD, which risks building R4b on an agreement rate
+    /// better than the network actually achieves, and that is the more
+    /// expensive mistake. Correct arithmetic with a known-direction bias still
+    /// beats a wrong number, so the deferral stays; the bias is documented
+    /// instead of removed. It is also the same lost-deferred-round-trip
+    /// fragility R4b's own design work flagged separately, so it is a coherent
+    /// known limitation rather than a surprise.
     pub(crate) fn record_summary_comparison(
         &self,
         contract: &ContractInstanceId,

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -91,6 +91,35 @@ const MAX_TRACKED_CONTRACTS: usize = 256;
 /// which the top few answer, and the aggregate counts above carry the rest.
 const TOP_DIFFERING_CONTRACTS_REPORTED: usize = 10;
 
+/// Per-contract differing-comparison counts: the total, and the single-entry
+/// subset.
+///
+/// One struct rather than a second map keyed the same way. The key is
+/// contract-controlled, so a parallel `HashMap` would double the amplification
+/// surface [`MAX_TRACKED_CONTRACTS`] exists to bound, and would let the two
+/// views disagree about which contracts were tracked when the cap binds on one
+/// and not the other. Widening the value keeps one bound, one admission
+/// decision, and `single <= total` true per contract by construction.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+struct DifferingCount {
+    /// Every differing comparison attributed to this contract.
+    total: u64,
+    /// Of those, the ones that arrived in a SINGLE-entry message — the
+    /// notification-leg proxy. See [`OutboundMix::record_summary_comparison`].
+    single: u64,
+}
+
+impl DifferingCount {
+    /// Count one differing comparison, saturating for the same reason every
+    /// other counter here does.
+    fn add(&mut self, single_entry: bool) {
+        self.total = self.total.saturating_add(1);
+        if single_entry {
+            self.single = self.single.saturating_add(1);
+        }
+    }
+}
+
 /// Rollup cadence, matching [`super::broadcast_payload_mix`] so the two
 /// rollups can be joined per node-minute without interpolation.
 const ROLLUP_WINDOW: Duration = Duration::from_secs(60);
@@ -417,6 +446,33 @@ struct Window {
     summary_entries_identical: u64,
     /// Same, but the summary bytes DIFFERED.
     summary_entries_differing: u64,
+    /// The SINGLE-ENTRY subset of [`Window::summary_entries_identical`] — the
+    /// R4b (#5153) instrument.
+    ///
+    /// R4b would replace the proactive summary NOTIFICATION's full summary
+    /// bytes (mean 41.6 KB, 18.7-24.4% of all outbound across three measured
+    /// windows) with a 21-byte digest, falling back to bytes on mismatch. That
+    /// trade wins or loses entirely on `p`, the agreement rate **on that leg**
+    /// — and the fleet-wide rate is inadmissible for it, because comparisons
+    /// are recorded per ENTRY and a notification carries 1.000 entries/message
+    /// against the heartbeat's 222.97. A 99.73% aggregate is therefore almost
+    /// entirely the heartbeat's population.
+    ///
+    /// A notification today already IS a single-entry full-bytes `Summaries`
+    /// message, and its receiver already performs exactly the comparison a
+    /// digest would have made. So splitting the counters above by
+    /// `entries.len() == 1` reads `p` BACKWARD off real production traffic,
+    /// with no wire change and no behaviour change — which is what lets the
+    /// instrument land a release ahead of the mechanism it judges (regime rule
+    /// 7; 0.2.120 is permanently unattributable for want of exactly this).
+    ///
+    /// See [`OutboundMix::record_summary_comparison`] for the discriminator's
+    /// limits, including the measured `Rejection` contamination.
+    summary_entries_identical_single: u64,
+    /// The SINGLE-ENTRY subset of [`Window::summary_entries_differing`]. The
+    /// denominator half of `p` — without it a low single-entry agreement COUNT
+    /// and a low single-entry VOLUME look the same.
+    summary_entries_differing_single: u64,
     /// Comparisons where exactly ONE side held a summary (#4965 review S2).
     ///
     /// The 98.1% identical figure has a structural hole:
@@ -430,6 +486,13 @@ struct Window {
     /// Counted so the post-deploy data can size it rather than leaving the
     /// headline extrapolated over a population it never observed.
     summary_entries_one_sided: u64,
+    /// The SINGLE-ENTRY subset of [`Window::summary_entries_one_sided`].
+    ///
+    /// Carried for the same reason the one-sided total is: under a digest-first
+    /// notification this population classifies as `NeedBytes`, so it is a COST
+    /// on the R4b leg rather than a neutral case, and `p` computed without it
+    /// would be extrapolated over a population it never observed.
+    summary_entries_one_sided_single: u64,
     /// Which contracts the differing comparisons belonged to, bounded at
     /// [`MAX_TRACKED_CONTRACTS`].
     ///
@@ -439,7 +502,16 @@ struct Window {
     /// `contract-summary-determinism.md`). Only the DIFFERING side is
     /// attributed — the identical side needs no diagnosis, and tracking it
     /// would double the map for no decision.
-    differing_by_contract: HashMap<ContractInstanceId, u64>,
+    ///
+    /// Split by single-entry (see [`DifferingCount`]) because an AGGREGATE `p`
+    /// would hide the population that decides R4b. A contract whose merge does
+    /// not converge has `p` structurally 0 — no digest can ever agree — and
+    /// non-converging merges are 32.7% of all update applies (#5153). Two such
+    /// contracts were measured at 9.64% and 2.67% of ALL differing comparisons,
+    /// so "is the notification leg's disagreement a handful of broken contracts
+    /// or the whole population" is a question the per-contract single count
+    /// answers and the ratio alone cannot.
+    differing_by_contract: HashMap<ContractInstanceId, DifferingCount>,
     /// Recipients the proactive summary notification actually sent to, summed
     /// over the window's notifications. See
     /// [`OutboundMix::record_notification_recipients`].
@@ -543,11 +615,40 @@ impl OutboundMix {
     /// interpolation), and the telemetry budget has room for exactly one more
     /// aligned rollup stream (`telemetry.rs`, `MAX_SHADOW_EVENTS_PER_SECOND`),
     /// which this measurement does not deserve to consume.
+    ///
+    /// # The `single_entry` split (R4b instrument, #5153)
+    ///
+    /// `single_entry` is `entries.len() == 1` for the message this comparison
+    /// arrived in, and it is a PROXY for "this comparison happened on the
+    /// proactive-notification leg". It is a proxy rather than the fact because
+    /// the fact is not on the wire: `InterestMessage::Summaries::emitter` is
+    /// `#[serde(skip)]` (`message.rs`), so an inbound message always decodes as
+    /// [`SummariesEmitter::Other`] and the receiver cannot read the true
+    /// emitter. Plumbing it through would be a wire change, which is precisely
+    /// what this instrument exists to avoid needing.
+    ///
+    /// The proxy holds because the state-change-driven send sites are
+    /// single-entry by construction while the heartbeat and interest-churn
+    /// replies are multi-entry: notifications measured 1.000 entries/message
+    /// against the heartbeat's 222.97.
+    ///
+    /// KNOWN CONTAMINATION, stated rather than designed around:
+    /// `entries.len() == 1` also matches [`SummariesEmitter::Rejection`], the
+    /// summary-back on a rejected update. Measured at **535 messages against
+    /// 3,579,282 notifications (0.015%)** — four orders of magnitude below the
+    /// signal, so it cannot move `p`. It is named here so a future reader does
+    /// not rediscover it and mistake the bucket for pure notification traffic.
+    ///
+    /// Recording it here rather than deriving it downstream is deliberate:
+    /// only the receive arm knows the shape of the message the entry came in,
+    /// and a rate re-derived later from arithmetic over separately-reported
+    /// totals would silently absorb every other filter between them.
     pub(crate) fn record_summary_comparison(
         &self,
         contract: &ContractInstanceId,
         ours: &[u8],
         theirs: &[u8],
+        single_entry: bool,
         counted_this_message: &mut HashSet<ContractInstanceId>,
     ) {
         // The per-message dedup lives HERE, not at the call site, for the same
@@ -570,9 +671,17 @@ impl OutboundMix {
         let mut w = self.window.lock();
         if identical {
             w.summary_entries_identical = w.summary_entries_identical.saturating_add(1);
+            if single_entry {
+                w.summary_entries_identical_single =
+                    w.summary_entries_identical_single.saturating_add(1);
+            }
             return;
         }
         w.summary_entries_differing = w.summary_entries_differing.saturating_add(1);
+        if single_entry {
+            w.summary_entries_differing_single =
+                w.summary_entries_differing_single.saturating_add(1);
+        }
         let mut dropped = false;
         // Bounded for the same reason the payload mix bounds its attribution:
         // the key is contract-controlled, so an unbounded map here would be an
@@ -594,11 +703,11 @@ impl OutboundMix {
         let len = w.differing_by_contract.len();
         match w.differing_by_contract.entry(*contract) {
             std::collections::hash_map::Entry::Occupied(mut e) => {
-                *e.get_mut() = e.get().saturating_add(1);
+                e.get_mut().add(single_entry);
             }
             std::collections::hash_map::Entry::Vacant(e) => {
                 if len < MAX_TRACKED_CONTRACTS {
-                    e.insert(1);
+                    e.insert(DifferingCount::default()).add(single_entry);
                 } else {
                     dropped = true;
                 }
@@ -629,9 +738,13 @@ impl OutboundMix {
     /// Shares the caller's per-message dedup set for the same reason the
     /// two-sided counter does: `entries` is peer-supplied and may repeat a
     /// hash, so without it a peer could inflate this bucket at will.
+    ///
+    /// `single_entry` carries the same meaning, and the same known limits, as
+    /// in [`Self::record_summary_comparison`] — read that doc for both.
     pub(crate) fn record_summary_one_sided(
         &self,
         contract: &ContractInstanceId,
+        single_entry: bool,
         counted_this_message: &mut HashSet<ContractInstanceId>,
     ) {
         if !counted_this_message.insert(*contract) {
@@ -639,6 +752,10 @@ impl OutboundMix {
         }
         let mut w = self.window.lock();
         w.summary_entries_one_sided = w.summary_entries_one_sided.saturating_add(1);
+        if single_entry {
+            w.summary_entries_one_sided_single =
+                w.summary_entries_one_sided_single.saturating_add(1);
+        }
     }
 
     /// Record one proactive summary notification's recipient split (#4965).
@@ -670,6 +787,20 @@ impl OutboundMix {
     /// Atomically take the current window, leaving a fresh empty one.
     fn take_window(&self) -> Window {
         std::mem::take(&mut *self.window.lock())
+    }
+
+    /// The rollup body this node would emit right now, WITHOUT draining the
+    /// window.
+    ///
+    /// Exists so a handler test can assert on what production telemetry would
+    /// actually carry, rather than on a counter the test also computed. The
+    /// discriminator that decides the R4b instrument's buckets is chosen in
+    /// `node.rs`'s receive arms, so a unit test on this type alone cannot tell
+    /// a live discriminator from a constant `false` — only a test that drives
+    /// the real handler can, and it needs a way to read the result.
+    #[cfg(test)]
+    pub(crate) fn rollup_body_for_test(&self) -> serde_json::Value {
+        outbound_mix_json(&self.window.lock(), 60)
     }
 }
 
@@ -754,6 +885,27 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
         w.differing_attribution_dropped.into(),
     );
 
+    // R4b instrument (#5153): the SINGLE-ENTRY subset of the three counters
+    // above, which is the notification leg's own agreement rate `p`. Emitted
+    // unconditionally INCLUDING as zeros, same rule as everything else on this
+    // rollup — a field that disappears when zero is invisible to the analysis,
+    // and "this node saw no single-entry comparisons" is a data point, not an
+    // absence. Each of these is a SUBSET of its total by construction (both are
+    // written under one lock in the same branch), so `single <= total` holds per
+    // window and is asserted rather than assumed.
+    body.insert(
+        "summary_entries_identical_single".into(),
+        w.summary_entries_identical_single.into(),
+    );
+    body.insert(
+        "summary_entries_differing_single".into(),
+        w.summary_entries_differing_single.into(),
+    );
+    body.insert(
+        "summary_entries_one_sided_single".into(),
+        w.summary_entries_one_sided_single.into(),
+    );
+
     // #4965 co-host exclusion, measured in the release build. Emitted
     // unconditionally as a PAIR: `skipped` alone cannot be read (100 of 100 and
     // 100 of 10,000 are different findings), and a dropped field must not look
@@ -771,12 +923,12 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
     // "specific contracts are non-deterministic" vs "the design is wrong".
     // Capped in the emitted body as well as in the map: the map bound stops
     // unbounded GROWTH, this bound stops an unbounded RECORD.
-    let mut differing: Vec<(String, u64)> = w
+    let mut differing: Vec<(String, DifferingCount)> = w
         .differing_by_contract
         .iter()
         .map(|(k, v)| (k.to_string(), *v))
         .collect();
-    differing.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    differing.sort_unstable_by(|a, b| b.1.total.cmp(&a.1.total).then_with(|| a.0.cmp(&b.0)));
     differing.truncate(TOP_DIFFERING_CONTRACTS_REPORTED);
     body.insert(
         "summary_differing_contracts".into(),
@@ -786,7 +938,13 @@ fn outbound_mix_json(w: &Window, window_secs: u64) -> serde_json::Value {
                 .map(|(key, count)| {
                     let mut o = serde_json::Map::new();
                     o.insert("contract".into(), key.into());
-                    o.insert("count".into(), count.into());
+                    o.insert("count".into(), count.total.into());
+                    // R4b (#5153): the notification-leg share of THIS
+                    // contract's divergence. Ranking stays by `count` — the
+                    // question this list answers is which contracts diverge, and
+                    // re-ranking by the subset would change what the top-N means
+                    // for every existing reader of the field.
+                    o.insert("single_count".into(), count.single.into());
                     serde_json::Value::Object(o)
                 })
                 .collect(),
@@ -999,17 +1157,17 @@ mod tests {
         let a = test_instance_id(1);
         let b = test_instance_id(2);
 
-        mix.record_summary_comparison(&a, b"same", b"same", &mut HashSet::new());
-        mix.record_summary_comparison(&a, b"ours", b"theirs", &mut HashSet::new());
-        mix.record_summary_comparison(&b, b"ours", b"theirs", &mut HashSet::new());
-        mix.record_summary_comparison(&a, b"same", b"same", &mut HashSet::new());
+        mix.record_summary_comparison(&a, b"same", b"same", false, &mut HashSet::new());
+        mix.record_summary_comparison(&a, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_comparison(&b, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_comparison(&a, b"same", b"same", false, &mut HashSet::new());
 
         let w = mix.take_window();
         assert_eq!(w.summary_entries_identical, 2);
         assert_eq!(w.summary_entries_differing, 2);
         // Only the differing side is attributed per contract.
-        assert_eq!(w.differing_by_contract.get(&a).copied(), Some(1));
-        assert_eq!(w.differing_by_contract.get(&b).copied(), Some(1));
+        assert_eq!(w.differing_by_contract.get(&a).map(|c| c.total), Some(1));
+        assert_eq!(w.differing_by_contract.get(&b).map(|c| c.total), Some(1));
     }
 
     /// The per-contract map is bounded, and an ALREADY-TRACKED contract keeps
@@ -1024,7 +1182,7 @@ mod tests {
     fn differing_attribution_is_bounded_but_keeps_accruing_known_contracts() {
         let mix = OutboundMix::new();
         let tracked = test_instance_id(0);
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs", &mut HashSet::new());
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs", false, &mut HashSet::new());
 
         // Fill well past the cap with distinct ids.
         for i in 1..(MAX_TRACKED_CONTRACTS as u32 + 300) {
@@ -1032,11 +1190,12 @@ mod tests {
                 &test_instance_id(i),
                 b"ours",
                 b"theirs",
+                false,
                 &mut HashSet::new(),
             );
         }
         // ...then hit the already-tracked one again.
-        mix.record_summary_comparison(&tracked, b"ours", b"theirs", &mut HashSet::new());
+        mix.record_summary_comparison(&tracked, b"ours", b"theirs", false, &mut HashSet::new());
 
         let w = mix.take_window();
         assert!(
@@ -1045,7 +1204,7 @@ mod tests {
             w.differing_by_contract.len()
         );
         assert_eq!(
-            w.differing_by_contract.get(&tracked).copied(),
+            w.differing_by_contract.get(&tracked).map(|c| c.total),
             Some(2),
             "an already-tracked contract must keep accruing past the cap"
         );
@@ -1075,6 +1234,7 @@ mod tests {
                     &test_instance_id(i),
                     b"ours",
                     b"theirs",
+                    false,
                     &mut HashSet::new(),
                 );
             }
@@ -1124,10 +1284,10 @@ mod tests {
         let mix = OutboundMix::new();
         let c = test_instance_id(1);
         for _ in 0..3 {
-            mix.record_summary_comparison(&c, b"same", b"same", &mut HashSet::new());
+            mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
         }
         for _ in 0..5 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", &mut HashSet::new());
+            mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
         }
         let body = outbound_mix_json(&mix.take_window(), 60);
         assert_eq!(
@@ -1142,6 +1302,240 @@ mod tests {
             Some(5),
             "differing count must reach the body under its own key"
         );
+    }
+
+    // ===== R4b instrument (#5153): the single-entry split =====
+
+    /// Each single-entry bucket counts ONLY single-entry observations, and is a
+    /// subset of its total.
+    ///
+    /// The `single <= total` half is what makes the emitted pair readable as a
+    /// rate at all: `p` is `identical_single / (identical_single +
+    /// differing_single)`, and a bucket that could exceed its total would mean
+    /// the two were counting different populations. The "only single-entry"
+    /// half is the discriminator itself — if the flag were ignored and every
+    /// observation landed in the single bucket, `p` would silently become the
+    /// fleet-wide rate again, which is the exact number this instrument exists
+    /// because it CANNOT use.
+    ///
+    /// Distinguishable counts per bucket so a copy-paste between the three
+    /// pairs cannot pass.
+    #[test]
+    fn single_entry_buckets_count_only_single_entry_observations() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+
+        // identical: 2 single, 3 multi.
+        for _ in 0..2 {
+            mix.record_summary_comparison(&c, b"same", b"same", true, &mut HashSet::new());
+        }
+        for _ in 0..3 {
+            mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
+        }
+        // differing: 4 single, 1 multi.
+        for _ in 0..4 {
+            mix.record_summary_comparison(&c, b"ours", b"theirs", true, &mut HashSet::new());
+        }
+        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
+        // one-sided: 5 single, 2 multi.
+        for _ in 0..5 {
+            mix.record_summary_one_sided(&c, true, &mut HashSet::new());
+        }
+        for _ in 0..2 {
+            mix.record_summary_one_sided(&c, false, &mut HashSet::new());
+        }
+
+        let w = mix.take_window();
+        assert_eq!(w.summary_entries_identical, 5);
+        assert_eq!(w.summary_entries_identical_single, 2);
+        assert_eq!(w.summary_entries_differing, 5);
+        assert_eq!(w.summary_entries_differing_single, 4);
+        assert_eq!(w.summary_entries_one_sided, 7);
+        assert_eq!(w.summary_entries_one_sided_single, 5);
+
+        for (single, total, label) in [
+            (
+                w.summary_entries_identical_single,
+                w.summary_entries_identical,
+                "identical",
+            ),
+            (
+                w.summary_entries_differing_single,
+                w.summary_entries_differing,
+                "differing",
+            ),
+            (
+                w.summary_entries_one_sided_single,
+                w.summary_entries_one_sided,
+                "one_sided",
+            ),
+        ] {
+            assert!(
+                single <= total,
+                "{label}: single-entry bucket ({single}) must be a SUBSET of \
+                 its total ({total}) — otherwise the two count different \
+                 populations and their ratio is not a rate"
+            );
+        }
+    }
+
+    /// Passing `single_entry: false` everywhere drives every single bucket to
+    /// EXACTLY zero while leaving the totals untouched.
+    ///
+    /// This is the mutation this instrument's whole value rests on. If the
+    /// discriminator in `node.rs` were replaced by a constant `false` — the
+    /// realistic edit, since it is one token — the totals would still look
+    /// perfectly healthy and only these three fields would go quiet. Asserting
+    /// "exactly 0" rather than "smaller" is the point: a bucket that stayed
+    /// non-zero under the mutation would be measuring something other than the
+    /// flag, which is the failure mode that produced three wrong counts in a
+    /// row for the #4965 co-host filter.
+    #[test]
+    fn single_entry_buckets_are_exactly_zero_when_the_discriminator_is_false() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+        mix.record_summary_comparison(&c, b"same", b"same", false, &mut HashSet::new());
+        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut HashSet::new());
+        mix.record_summary_one_sided(&c, false, &mut HashSet::new());
+
+        let w = mix.take_window();
+        assert_eq!(
+            w.summary_entries_identical, 1,
+            "the total must be unchanged"
+        );
+        assert_eq!(
+            w.summary_entries_differing, 1,
+            "the total must be unchanged"
+        );
+        assert_eq!(
+            w.summary_entries_one_sided, 1,
+            "the total must be unchanged"
+        );
+        assert_eq!(w.summary_entries_identical_single, 0);
+        assert_eq!(w.summary_entries_differing_single, 0);
+        assert_eq!(w.summary_entries_one_sided_single, 0);
+        assert_eq!(
+            w.differing_by_contract.get(&c).map(|d| d.single),
+            Some(0),
+            "the per-contract single count must go to zero too, or a deleted \
+             discriminator would still look attributed"
+        );
+    }
+
+    /// The three single-entry counters reach the emitted body under their own
+    /// keys, and an idle window emits them as explicit zeros.
+    ///
+    /// Distinguishable counts (2/4/6) so a swapped key cannot pass: emitting
+    /// the differing subset under the identical key would invert `p` and send
+    /// the R4b decision the wrong way with every other test green. The idle
+    /// half matters because a field that vanishes when zero is invisible to the
+    /// analysis — "this node saw no notification-leg comparisons" is a data
+    /// point, not an absence.
+    #[test]
+    fn single_entry_counters_reach_the_rollup_body_under_the_right_keys() {
+        let mix = OutboundMix::new();
+        let c = test_instance_id(1);
+        for _ in 0..2 {
+            mix.record_summary_comparison(&c, b"same", b"same", true, &mut HashSet::new());
+        }
+        for _ in 0..4 {
+            mix.record_summary_comparison(&c, b"ours", b"theirs", true, &mut HashSet::new());
+        }
+        for _ in 0..6 {
+            mix.record_summary_one_sided(&c, true, &mut HashSet::new());
+        }
+        let body = outbound_mix_json(&mix.take_window(), 60);
+        assert_eq!(
+            body.get("summary_entries_identical_single")
+                .and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            body.get("summary_entries_differing_single")
+                .and_then(|v| v.as_u64()),
+            Some(4)
+        );
+        assert_eq!(
+            body.get("summary_entries_one_sided_single")
+                .and_then(|v| v.as_u64()),
+            Some(6)
+        );
+
+        let idle = outbound_mix_json(&Window::default(), 60);
+        for key in [
+            "summary_entries_identical_single",
+            "summary_entries_differing_single",
+            "summary_entries_one_sided_single",
+        ] {
+            assert_eq!(
+                idle.get(key).and_then(|v| v.as_u64()),
+                Some(0),
+                "{key} must be emitted as an explicit zero on an idle window"
+            );
+        }
+    }
+
+    /// The per-contract list carries the single-entry subset alongside the
+    /// total, and keeps ranking by the total.
+    ///
+    /// Not decoration. A contract whose merge does not converge has `p`
+    /// structurally 0 — no digest can agree — and those are 32.7% of all update
+    /// applies (#5153), with two measured at 9.64% and 2.67% of ALL differing
+    /// comparisons. An aggregate `p` would hide them, so the per-contract
+    /// single count is what separates "a handful of broken contracts" from "the
+    /// notification leg disagrees in general". Ranking must stay on the total,
+    /// because re-ranking by the subset would silently change what the existing
+    /// `summary_differing_contracts` field means to its current readers.
+    #[test]
+    fn per_contract_attribution_carries_the_single_entry_subset() {
+        let mix = OutboundMix::new();
+        // `busy` diverges more overall; `noisy` diverges ONLY on the
+        // notification leg. Ranking must follow `busy`, and the subset must
+        // still expose `noisy` as the notification-leg offender.
+        let busy = test_instance_id(1);
+        let noisy = test_instance_id(2);
+        for _ in 0..5 {
+            mix.record_summary_comparison(&busy, b"ours", b"theirs", false, &mut HashSet::new());
+        }
+        mix.record_summary_comparison(&busy, b"ours", b"theirs", true, &mut HashSet::new());
+        for _ in 0..3 {
+            mix.record_summary_comparison(&noisy, b"ours", b"theirs", true, &mut HashSet::new());
+        }
+
+        let body = outbound_mix_json(&mix.take_window(), 60);
+        let listed = body
+            .get("summary_differing_contracts")
+            .and_then(|v| v.as_array())
+            .expect("summary_differing_contracts must be an array")
+            .clone();
+        let read = |i: usize, field: &str| {
+            listed[i]
+                .get(field)
+                .and_then(|v| v.as_u64())
+                .unwrap_or_else(|| panic!("entry {i} must carry {field}"))
+        };
+        assert_eq!(listed.len(), 2);
+        assert_eq!(
+            listed[0].get("contract").and_then(|v| v.as_str()),
+            Some(busy.to_string().as_str()),
+            "ranking must stay on the TOTAL, not the single-entry subset"
+        );
+        assert_eq!(read(0, "count"), 6);
+        assert_eq!(read(0, "single_count"), 1);
+        assert_eq!(read(1, "count"), 3);
+        assert_eq!(
+            read(1, "single_count"),
+            3,
+            "a contract that diverges only on the notification leg must be \
+             visible as such"
+        );
+        for i in 0..listed.len() {
+            assert!(
+                read(i, "single_count") <= read(i, "count"),
+                "entry {i}: the per-contract single count must be a subset of \
+                 its total"
+            );
+        }
     }
 
     /// The #4965 notification split accumulates and reaches the body under
@@ -1211,13 +1605,13 @@ mod tests {
         // One message that repeats `c` five times and names `other` once.
         let mut first_message = HashSet::new();
         for _ in 0..5 {
-            mix.record_summary_comparison(&c, b"ours", b"theirs", &mut first_message);
+            mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut first_message);
         }
-        mix.record_summary_comparison(&other, b"same", b"same", &mut first_message);
+        mix.record_summary_comparison(&other, b"same", b"same", false, &mut first_message);
 
         // A second message names `c` again — a genuinely new observation.
         let mut second_message = HashSet::new();
-        mix.record_summary_comparison(&c, b"ours", b"theirs", &mut second_message);
+        mix.record_summary_comparison(&c, b"ours", b"theirs", false, &mut second_message);
 
         let w = mix.take_window();
         assert_eq!(
@@ -1226,7 +1620,7 @@ mod tests {
         );
         assert_eq!(w.summary_entries_identical, 1);
         assert_eq!(
-            w.differing_by_contract.get(&c).copied(),
+            w.differing_by_contract.get(&c).map(|c| c.total),
             Some(2),
             "per-contract attribution must dedup the same way as the aggregate"
         );
@@ -1282,6 +1676,7 @@ mod tests {
                 &test_instance_id(i),
                 b"ours",
                 b"theirs",
+                false,
                 &mut HashSet::new(),
             );
         }

--- a/crates/core/src/node/network_bridge/outbound_message_mix.rs
+++ b/crates/core/src/node/network_bridge/outbound_message_mix.rs
@@ -115,8 +115,11 @@ pub(crate) enum SummaryObservation {
     /// population R4b's `p` is about.
     MultiEntry,
     /// Single-entry FULL-BYTES `Summaries`. The R4b population — but see
-    /// [`OutboundMix::record_summary_comparison`]: it is ~15% not-notification,
-    /// and the per-arm census is what makes that subtractable.
+    /// [`OutboundMix::record_summary_comparison`]: it is NOT pure notification
+    /// traffic, its contamination is a BRACKET (0.07%-12.4%) rather than a point
+    /// estimate, and the per-arm census is what makes that subtractable. The
+    /// merged ~15% figure describes a different population and must not be
+    /// applied to this one.
     SingleEntryFullBytes,
     /// Single-entry `SummaryDigests`. Counted SEPARATELY and deliberately: it
     /// cannot be notification traffic while notifications ship full bytes, so it
@@ -338,8 +341,10 @@ impl OutboundKind {
 /// leg — and since `summary_reply_form` returns `Digests` for every peer at or
 /// above the `(0, 2, 116)` floor and the fleet is past it, MOST
 /// `ChangeInterestsReply` traffic is digests and never enters the full-bytes
-/// receive population at all. Correcting the full-bytes leg with a merged
-/// number over-subtracts by roughly 11 points.
+/// receive population at all. Correcting the full-bytes leg with the merged
+/// number therefore over-subtracts — by how much is a bracket, not a figure,
+/// since the merged rate is ~15% while the full-bytes leg's own contamination is
+/// only bounded at 0.07%-12.4%.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum SummariesWireForm {
     /// `InterestMessage::Summaries` — full summary bytes per entry.
@@ -713,16 +718,20 @@ struct Window {
     ///
     /// **Indexed by `[arm][wire form]`, and the wire form is load-bearing.**
     /// See [`SummariesWireForm`]: a leg-blind census over-subtracts the
-    /// full-bytes leg by roughly 11 points, because most `ChangeInterestsReply`
-    /// goes out as digests today and never reaches the full-bytes receive
-    /// population that `*_single` counts.
+    /// full-bytes leg, because most `ChangeInterestsReply` goes out as digests
+    /// today and never reaches the full-bytes receive population that `*_single`
+    /// counts. The size of that error is a bracket rather than a figure — see
+    /// below.
     ///
     /// Why it is needed, in numbers (one window, 2026-08-12): `notification`
     /// 3,194,108 single-entry messages, `change_interests_reply` 418,476 (mean
     /// 1.000, max 1), `request_reply` at least 131,153, `rejection` 669. Merged
     /// across wire forms that is ~15% not-notification — but the FULL-BYTES leg,
     /// which is the one `p` is computed over, is contaminated mainly by
-    /// `request_reply` and `rejection`, nearer **4%**. An even earlier version
+    /// `request_reply` and `rejection`, and its rate is only **bounded at
+    /// 0.07%-12.4%**, not measured. Do not quote a central value: the
+    /// `request_reply` single-entry share it would rest on is not derivable from
+    /// today's keys, which is why this census exists. An even earlier version
     /// documented only `rejection` (0.015%), the smallest of the three.
     ///
     /// Those figures come from pre-split telemetry and are therefore themselves
@@ -1108,8 +1117,9 @@ impl OutboundMix {
     /// arithmetic. It is also the same lost-deferred-round-trip fragility R4b's
     /// own design work flagged separately, so it is a coherent known limitation
     /// rather than a surprise. It is expected to be SMALL (it needs a lost
-    /// message) next to the contamination term above, which is structural and
-    /// ~15%.
+    /// message) next to the contamination term above, which is structural rather
+    /// than loss-dependent — merged ~15%, and on this leg bounded at
+    /// 0.07%-12.4%.
     ///
     /// # NET: bound it, do not point-estimate it
     ///
@@ -2118,7 +2128,23 @@ mod tests {
                 &mut HashSet::new(),
             );
         }
+        // One MULTI-entry one-sided record, so the TOTAL (7) differs from the
+        // single-entry SUBSET (6). Without it both keys read 6 and a
+        // `summary_entries_one_sided` / `_one_sided_single` transposition in
+        // `outbound_mix_json` satisfies every assertion here — and this is the
+        // only body-level assertion either key has, so nothing else would catch
+        // it (#5153 review round 5). The identical/differing pairs are already
+        // distinguished by `headline_counters_reach_the_rollup_body_under_the_right_keys`,
+        // whose fixture leaves their single buckets at 0.
+        mix.record_summary_one_sided(&c, SummaryObservation::MultiEntry, &mut HashSet::new());
         let body = outbound_mix_json(&mix.take_window(), 60);
+        assert_eq!(
+            body.get("summary_entries_one_sided")
+                .and_then(|v| v.as_u64()),
+            Some(7),
+            "the one-sided TOTAL must be distinguishable from its single-entry \
+             subset, or the two keys can be transposed undetected"
+        );
         assert_eq!(
             body.get("summary_entries_identical_single")
                 .and_then(|v| v.as_u64()),
@@ -2360,12 +2386,19 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(0)
         );
-        // The eight scalars this test did NOT cover (#5153 review round 2). Six are
-        // the R4b counters the build/no-build decision reads, and two
-        // (`summary_entries_one_sided`, the notification pair) were unpinned from
-        // the start. The convention this file states everywhere — a field that
-        // vanishes when zero is invisible to the analysis — was unenforced for
-        // exactly the fields that matter most.
+        // Eight scalars this test did not previously list. Of these, exactly ONE
+        // — `summary_entries_one_sided` — had no coverage anywhere; the
+        // notification pair is value-asserted by
+        // `notification_recipient_split_is_emitted_even_when_idle`, and the six
+        // R4b counters by `single_entry_counters_reach_the_rollup_body_...`.
+        // The other seven entries here are therefore belt-and-braces, not new
+        // coverage.
+        //
+        // Stated precisely because an earlier version of this comment claimed all
+        // eight were uncovered and that "two were unpinned from the start", which
+        // was false about this file's own history (#5153 review round 5). A
+        // comment about coverage is exactly what the next reviewer trusts instead
+        // of re-deriving, so an overstatement here is worse than no comment.
         for key in [
             "summary_entries_one_sided",
             "summary_entries_identical_single",
@@ -2744,24 +2777,33 @@ mod tests {
             SummaryObservation::SingleEntryDigest,
             &mut HashSet::new(),
         );
-        mix.record_summary_comparison(
-            &c,
-            b"ours",
-            b"theirs",
-            SummaryObservation::SingleEntryDigest,
-            &mut HashSet::new(),
-        );
+        // TWO differing against ONE identical, deliberately unequal. With both
+        // at 1 every assertion below passes even if the two `*_single_digest`
+        // keys are transposed in `outbound_mix_json`, or if the recorder
+        // increments the wrong one — and these are precisely the keys the
+        // notification population MOVES to when R4b ships, so a transposition
+        // would invert `p` on the post-R4b reading with the whole suite green.
+        // An equal-valued fixture cannot see a swap (#5153 review round 5).
+        for _ in 0..2 {
+            mix.record_summary_comparison(
+                &c,
+                b"ours",
+                b"theirs",
+                SummaryObservation::SingleEntryDigest,
+                &mut HashSet::new(),
+            );
+        }
 
         let w = mix.take_window();
         assert_eq!(w.summary_entries_identical, 1, "totals still count it");
-        assert_eq!(w.summary_entries_differing, 1, "totals still count it");
+        assert_eq!(w.summary_entries_differing, 2, "totals still count it");
         assert_eq!(
             w.summary_entries_identical_single, 0,
             "a digest-leg observation is NOT the R4b full-bytes population"
         );
         assert_eq!(w.summary_entries_differing_single, 0);
         assert_eq!(w.summary_entries_identical_single_digest, 1);
-        assert_eq!(w.summary_entries_differing_single_digest, 1);
+        assert_eq!(w.summary_entries_differing_single_digest, 2);
         assert_eq!(
             w.differing_by_contract.get(&c).map(|d| d.single),
             Some(0),
@@ -2774,7 +2816,7 @@ mod tests {
             ("summary_entries_identical_single", 0),
             ("summary_entries_differing_single", 0),
             ("summary_entries_identical_single_digest", 1),
-            ("summary_entries_differing_single_digest", 1),
+            ("summary_entries_differing_single_digest", 2),
         ] {
             assert_eq!(
                 body.get(key).and_then(|v| v.as_u64()),
@@ -3038,9 +3080,21 @@ mod tests {
             let stem = summaries_stem(emitter);
             // SEVEN suffixes, not five: the two R4b census keys are part of every
             // arm's emitted set (#5153 review round 2). They were absent from both
-            // this loop and the value loop above, so the keys the instrument's
-            // whole correction depends on were the only per-arm keys with no
-            // presence guarantee at all.
+            // this loop and the value loop above.
+            //
+            // Precisely: 9 of the 14 census keys had no assertion anywhere; the
+            // other 5 were already value-pinned by
+            // `single_entry_census_is_per_emitter_leg_split_...`. An earlier
+            // version of this comment implied all 14 were unguarded (#5153 review
+            // round 5) — overstating a coverage gap misleads the next reader
+            // exactly as much as understating one.
+            //
+            // NOTE the scope of what this loop guarantees: CENSUS keys and the
+            // five original per-arm keys. It says nothing about `window_secs`,
+            // `total_msgs`, `total_bytes`, or 29 of the 30 per-`OutboundKind`
+            // body keys, none of which have a body-key assertion. That gap is
+            // pre-existing and out of scope here, but do not read this loop as
+            // "every emitted key is pinned".
             for suffix in [
                 "msgs",
                 "bytes",

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1121,11 +1121,22 @@ pub(crate) async fn send_proactive_summary_notification(
     // is nothing per-peer to compute.
     //
     // This leg ships FULL BYTES this release. Hash-first (#4965) does NOT
-    // apply here: digest-first rides the two multi-entry reply legs
-    // (`InterestsReply` / `ChangeInterestsReply`) only, and the send site 40
-    // lines below carries the evidential reasoning for why this one was left
-    // out. There is no per-peer encoding choice on this path, and no version
-    // gate is consulted.
+    // apply here: digest-first rides the two REPLY legs (`InterestsReply` /
+    // `ChangeInterestsReply`) only, and the send site 40 lines below carries the
+    // evidential reasoning for why this one was left out. There is no per-peer
+    // encoding choice on this path, and no version gate is consulted.
+    //
+    // The reply legs are not both multi-entry — corrected 2026-08-12 (#5153
+    // review F1). Only `InterestsReply` (the ~5-min heartbeat) is;
+    // `ChangeInterestsReply` is single-entry 100% of the time (measured mean
+    // 1.000, `max_entries` 1, over 418,476 messages on 1,284 peers), because
+    // `broadcast_change_interests` gossips one contract per message. That
+    // matters here because it means message length does NOT separate this
+    // notification leg from the churn reply, which is the proxy the R4b
+    // agreement-rate instrument rests on. See the send site below, whose own
+    // multi-entry claim is tracked separately in #5306 — it is the stated
+    // justification for an already-shipped decision, so it is corrected there
+    // rather than silently here.
     //
     // Worth stating because the opposite is the intuitive guess: this is the
     // send site that fires on every state change to every interested peer, so

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -15531,8 +15531,13 @@ fn test_summary_first_put_reverse_delta_converges_originator() {
 // vacuous.
 //
 // NOTE ON WHICH LEG IS EXERCISED: after the #4965 review, digest-first ships on
-// the two MULTI-ENTRY reply legs only (`InterestsReply`, `ChangeInterestsReply`)
-// — `Notification` and `Rejection` stay full-bytes. So the digests observed here
+// the two REPLY legs only (`InterestsReply`, `ChangeInterestsReply`) —
+// `Notification` and `Rejection` stay full-bytes. Only `InterestsReply` is
+// genuinely multi-entry; this comment said "the two MULTI-ENTRY reply legs"
+// until 2026-08-12, corrected per #5153 review F1, because
+// `ChangeInterestsReply` is single-entry 100% of the time (one contract per
+// `broadcast_change_interests` gossip; measured mean 1.000, `max_entries` 1,
+// over 418,476 messages on 1,284 peers). So the digests observed here
 // necessarily come from the connection-time `Interests` -> reply exchange, which
 // is the leg that matters, and NOT from the per-state-change notification.
 // `summaries_reply_for_peer` is the only path that can emit a digest, and only


### PR DESCRIPTION
## Problem

R4b would replace the proactive notification's full summary bytes (mean 41.6 KB, 18.7-24.4%
of all outbound across three measured windows) with a 21-byte digest, falling back to bytes
on mismatch. The trade wins or loses entirely on `p`, the agreement rate **on that leg** —
and `p` has never been measured.

The fleet-wide 99.73% is inadmissible for it. Comparisons are recorded per ENTRY, and a
notification carries 1.000 entries/message against the heartbeat's 222.97, so the aggregate
is almost entirely the heartbeat's population.

## Solution

No wire change, no new variant, no behaviour change. A notification today already IS a
single-entry full-bytes `Summaries` message, and its receiver already performs exactly the
comparison a digest would have made — so splitting the existing counters by
`entries.len() == 1` reads `p` backward off real production traffic. That is what lets the
instrument land a release ahead of the mechanism it judges (0.2.120 is permanently
unattributable for want of exactly this).

**Three new receive-side fields**, emitted unconditionally including as zeros:
`summary_entries_identical_single`, `summary_entries_differing_single`,
`summary_entries_one_sided_single`, plus digest-leg siblings
`summary_entries_{identical,differing}_single_digest`.

**A send-side per-emitter census**, `{stem}_{full_bytes,digests}_single_entry_msgs`, taken
at the classification choke point — the one place the true emitter and `entries.len()` exist
together. This is what converts the contamination below from an assumption into a
subtractable number.

**`differing_by_contract` widened** with the single-entry subset per contract, so a
non-converging contract stays visible instead of being averaged away.

## The proxy is contaminated, and the contamination is why the census exists

`entries.len() == 1` is a proxy for "this was a notification", not a partition of it.

| single-entry `Summaries` sender | msgs, one window | effect on `p` |
|---|---|---|
| `Notification` (the signal) | 3,194,108 (mean 1.000) | — |
| `ChangeInterestsReply` | 418,476 (mean 1.000, max 1, 1,284 peers) | either; 95-99% digest, so mostly off the full-bytes leg |
| `SummaryRequestReply` | >=131,153 single-entry | **downward** (mostly, not always) |
| `Rejection` | 669 | **upward** — identical by construction |

Merged, ~15% of single-entry messages SENT are not notifications. Per leg — which is what
matters, since `p` is computed on the full-bytes leg — the residue there is
**bracketed at 0.07%-12.4%**.

**That is a bracket and not a point estimate, deliberately.** An earlier revision of this
PR quoted ~4.6%. Three independent measurements agree on the bracket, and a central value
lands near ~5% under one window's assumptions — but only under those assumptions. The claim
that survives without them is the one the correction actually needs: **even 12.4% is below
the merged ~15%**, so applying the merged number to the full-bytes leg over-subtracts.

The bracket is wide for a structural reason, and that reason is the argument for the census
rather than an excuse for the width: **the `request_reply` single-entry share that the exact
figure depends on is not derivable from today's keys at all.** The census is precisely the
key that makes it derivable. A narrower prior measurement would not have removed the need
for it — which is a stronger case for shipping the census than "we measured 4.6%" was.

Quoting a point estimate where only an interval is supported is the same error class this
PR was itself correcting. It should not survive into the artifact that documents the fix.

### Bias direction

The measured value is **not a ceiling**. It has an upward term (divergences lost to a
dropped `SummaryRequest` round trip) and a larger downward term (request-reply denominator
inflation). The two are **not independent** — they are one phenomenon seen from opposite
ends — so their uncertainties must not be added. Report an interval, not a point.

## Why the leg split, specifically

A notification ships full bytes unconditionally (no version gate consulted), while
`ChangeInterestsReply` does route through the gate and the fleet is past its floor. So a
single-entry observation arriving on the `SummaryDigests` leg is churn-leg **by
construction** and is not the R4b population. Folding the legs together would have bought
post-R4b series continuity by corrupting the pre-R4b measurement the build/no-build
decision rests on.

Scale of what the split buys: **without it the instrument cannot tell a true `p` of 99%
from 95%** (~17-point bracket against a 4-point decision gap); with it, residual
uncertainty is ~±0.6 points.

## Known design limitation: this subtracts where it could filter (#5307)

The instrument corrects for request-reply contamination by SUBTRACTING a fleet-wide
send-side share. The receiver could instead FILTER locally: it already knows, with no wire
change, whether an arriving `Summaries` answers its own outstanding `SummaryRequest`, and
could simply exclude it from the comparison. That is the better design and it is tracked as
**#5307**.

It was not taken here, for two reasons stated rather than left implicit:

1. **It is robustness, not sufficiency.** The leg split alone brings residual uncertainty
   to ~±0.6 points against a 4-point decision gap, so the instrument answers its question
   without the filter. The filter would narrow an interval that is already narrow enough to
   decide on.
2. **It is a second reviewable surface.** Filtering is a behavioural change to the receive
   arm, not an added counter — and per this repo's own rule a filter must count its own
   drops (TTL expiry and cap eviction produce false negatives that would otherwise be
   silently absorbed), so it needs its own `..._suppressed` counter and its own tests.
   Bundling that into a pure-instrumentation PR would put a behaviour change and its
   measurement in one review.

## Correction completeness


`ChangeInterestsReply` is single-entry because `broadcast_change_interests` gossips one
contract per message: measured mean exactly **1.000**, `max_entries` **1**, over 418,476
messages on 1,284 peers, and confirmed in two further independent windows. Calling it
multi-entry is what made `entries.len() == 1` look clean.

Every site in the tree that asserted otherwise is now corrected, in `node.rs` (both the
digest-arm discriminator and the reply build site), `config.rs`, `operations/update.rs`,
`outbound_message_mix.rs`, `message.rs`, and `tests/simulation_integration.rs`. One is
deliberately left: `operations/update.rs:1206`, where the false claim is the stated
evidential justification for an already-shipped digest-first scope decision rather than a
description of the code. Correcting the sentence there without re-examining the decision it
justifies would launder the error, so it is tracked as **#5306**.

The correction included a diagnostic rule that had been written into a test rustdoc — "a
reply arm reporting a mean of 1.0 says the attribution is wrong". An operator applying it
would have concluded the census was broken precisely when it was correct. It now states the
per-arm expectation, which is not uniform.

## Test coverage

Behavioural tests drive the real `handle_interest_sync_message` and assert on the emitted
rollup body, not just on the `Window` struct. Mutation-verified:

- disabling the single-entry gate drops both single buckets to zero while the totals hold;
- the multi-entry assertions are not vacuous;
- a wire-form misclassification is caught;
- the census excludes the request leg (`SummaryRequest` carries bare hashes and no summary
  entries, so it is never a comparison — the fixture deliberately contains a request-leg
  send, because an earlier version of the test summed all seven arms while its fixture
  happened to have none, and so could not have exposed the trap it existed to catch).

Two properties the proxy rests on are now pinned, both mutation-verified
(`notification_leg_is_always_full_bytes_and_single_entry`):

1. notifications ship full bytes unconditionally — they must not consult the hash-first
   version gate. If they did, the pre-R4b full-bytes buckets would go quiet AND
   `SingleEntryDigest`'s "provably not a notification" premise would INVERT, with every
   test green.
2. notifications are single-entry. Batching them (plausible — coalescing work is already in
   this tree) would move them out of the single-entry population, and `p` would silently
   become the agreement rate of whatever failed to batch.

The rollup's "every field emits unconditionally, including zeros" convention is now pinned
for every key this PR adds — a field that vanishes when zero is invisible to the analysis,
so a future switch to conditional insertion would otherwise have passed CI. That closed a
gap of **22 emitted keys** with no presence guarantee: the 14 per-arm census keys, the six
new R4b counters, and two (`summary_entries_one_sided` and the notification pair) that had
been unpinned since they were added.

**The pin was verified by mutation, not assumed.** With every digest-form census key at
zero, an equality assertion passes even if the `full_bytes` and `digests` key names are
transposed — so the census fixture now sends **two** digest messages against **one**
full-bytes for the same arm. Swapping the two names in `SummariesWireForm::stem` turns
`single_entry_census_is_per_emitter_leg_split_and_excludes_wide_messages` **red**; before
the fixture change it would have stayed green. The idle-window loop can only check
presence — at all-zeros a transposition is both invisible and harmless there — and that
limit is stated in the test rather than left for a reader to over-read.

## Telemetry schema

Additive, no breaking change. `differing_by_contract` stays private and is never
serialized; only `summary_differing_contracts` is emitted, as an array of
`{contract, count}` objects that each gain a `single_count`. Consumers reading `contract`
and `count` are unaffected and preserved captures stay parseable.

## Follow-ups

- **#5304** — promote the contamination recipe to a rollup-collection API, and reconcile it
  against the Python analysis that actually computes the decision value.
- **#5305** — evaluate a version-gated emitter tag on `InterestMessage` against this
  send-side census (permanent protocol surface, so it carries removal conditions).
- **#5306** — the `operations/update.rs` multi-entry claim that justifies a shipped
  digest-first scope decision.
- **#5307** — filter request-reply arrivals locally at the receiver instead of subtracting
  them fleet-wide.

[AI-assisted - Claude]
