### PR TITLE
test(stores): cover the executor entry point that the store tests could not see

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1522,6 +1522,113 @@ mod remove_contract_tests {
             .with_extension("wasm")
     }
 
+    /// The executor's "code already stored" branch must refuse a container whose
+    /// instance id is not derived from its own code and parameters — tested at the
+    /// executor entry point, not at the store.
+    ///
+    /// This test exists because of WHERE the original defect lived. Every test for
+    /// the identity check was scoped to `contract_store.rs`, and the bypass was one
+    /// layer up: `bridged_upsert_contract_state_inner` reached the durable
+    /// instance→code index through a bare index-write helper instead of through
+    /// `store_contract`, so the store's own tests could not see it and a four-lens
+    /// review did not catch it. A pin on the source text is not the same thing as
+    /// exercising the entry point, so this drives the real
+    /// `Executor<Runtime>` — real `ContractStore`, real `StateStore`, no network.
+    ///
+    /// # Why garbage WASM bytes are sufficient
+    ///
+    /// The refusal happens in the store/index branch, BEFORE
+    /// `fetch_related_for_validation` (and therefore before any WASM call), so the
+    /// forged container is rejected without the module ever being compiled. The
+    /// control below relies on the same ordering from the other side: an HONEST
+    /// second instance gets past the identity check and is indexed, then fails
+    /// later in WASM validation because `vec![3u8; 64]` is not a real module. That
+    /// asymmetry — indexed-and-failed-late versus refused-and-not-indexed — is
+    /// what makes this discriminating rather than a blanket "PUT fails" assertion.
+    #[tokio::test]
+    async fn already_stored_branch_refuses_an_underived_instance() {
+        use crate::contract::executor::ContractExecutor;
+        use crate::wasm_runtime::ContractStoreBridge;
+        use either::Either;
+        use freenet_stdlib::prelude::RelatedContracts;
+
+        let (mut executor, contracts_dir, _temp) = build_disk_executor("identity-gate").await;
+
+        // Precondition: the code blob is on disk, so `code_blob_stored` reports
+        // true and a PUT of another instance of that code takes the already-stored
+        // branch. Established through the store directly because this is setup,
+        // not the behaviour under test — and because routing it through the
+        // executor would fail in WASM validation and then remove the blob again.
+        let (honest, honest_key) = make_contract(3, 3);
+        executor
+            .runtime
+            .store_contract(honest)
+            .expect("seeding the code blob must succeed");
+        assert!(
+            wasm_path(&contracts_dir, &honest_key).exists(),
+            "fixture must leave the code blob on disk"
+        );
+
+        // CONTROL first: an honest second instance of the same code. Its identity
+        // is derived, so the branch indexes it; it then dies in WASM validation.
+        let (honest_b, honest_b_key) = make_contract(3, 9);
+        assert_eq!(
+            honest_b_key.code_hash(),
+            honest_key.code_hash(),
+            "fixture must share the code blob"
+        );
+        assert_ne!(honest_b_key.id(), honest_key.id(), "must be a NEW instance");
+        let control = executor
+            .upsert_contract_state(
+                honest_b_key,
+                Either::Left(WrappedState::new(vec![7u8; 8])),
+                RelatedContracts::default(),
+                Some(honest_b),
+            )
+            .await;
+        assert!(
+            !format!("{control:?}").contains("identity does not match its code"),
+            "an honestly-derived instance must pass the identity check (it may fail \
+             later in WASM validation): {control:?}"
+        );
+        assert_eq!(
+            executor.runtime.code_hash_from_id(honest_b_key.id()),
+            Some(*honest_key.code_hash()),
+            "the honest new instance must have been indexed by the guarded ingress"
+        );
+
+        // Now the forgery: same code, so the blob is present and the branch is
+        // taken, but an instance id derived from DIFFERENT parameters.
+        let code = ContractCode::from(vec![3u8; 64]);
+        let real_params = Parameters::from(vec![3u8; 8]);
+        let unrelated_instance =
+            *ContractKey::from_params_and_code(&Parameters::from(vec![200u8; 8]), &code).id();
+        let mut forged = WrappedContract::new(Arc::new(code.clone()), real_params);
+        forged.key = ContractKey::from_id_and_code(unrelated_instance, *code.hash());
+        let forged_key = forged.key;
+
+        let err = executor
+            .upsert_contract_state(
+                forged_key,
+                Either::Left(WrappedState::new(vec![7u8; 8])),
+                RelatedContracts::default(),
+                Some(ContractContainer::Wasm(ContractWasmAPIVersion::V1(forged))),
+            )
+            .await
+            .expect_err("an underived instance must be refused at the executor entry point");
+        assert!(
+            format!("{err:?}").contains("identity does not match its code"),
+            "expected the store's identity refusal to surface here, got: {err:?}"
+        );
+        assert!(
+            executor
+                .runtime
+                .code_hash_from_id(&unrelated_instance)
+                .is_none(),
+            "a refused container must not leave an instance→code index row"
+        );
+    }
+
     /// GHSA-824h-7x5x-wfmf regression: a NON-LOCAL registration must not be able
     /// to write the durable first-registration origin record.
     ///

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1602,7 +1602,7 @@ mod remove_contract_tests {
         let code = ContractCode::from(vec![3u8; 64]);
         let real_params = Parameters::from(vec![3u8; 8]);
         let unrelated_instance =
-            *ContractKey::from_params_and_code(&Parameters::from(vec![200u8; 8]), &code).id();
+            *ContractKey::from_params_and_code(Parameters::from(vec![200u8; 8]), &code).id();
         let mut forged = WrappedContract::new(Arc::new(code.clone()), real_params);
         forged.key = ContractKey::from_id_and_code(unrelated_instance, *code.hash());
         let forged_key = forged.key;

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2987,6 +2987,16 @@ mod full_state_version_gate_pins {
     /// name does not appear in the CODE without tripping over prose that
     /// deliberately names it (the removed index writer is discussed in a comment
     /// right where it used to be called).
+    ///
+    /// This strips whole-line `//` comments only — not block comments, not trailing
+    /// comments, not `//` inside a string literal. That narrowness is deliberate
+    /// rather than an oversight: every gap in it produces a false FAILURE, never a
+    /// false pass, because a real call's identifier can never sit on a line whose
+    /// `trim_start()` begins with `//`. So the filter is sound in the direction that
+    /// matters and does not need to become a lexer. There are no block or trailing
+    /// comments in the scraped region today; if someone adds one naming a forbidden
+    /// symbol, the pin fails with a confusing message, which is why the assertion
+    /// text says how to word it.
     fn upsert_code_only() -> String {
         upsert_body()
             .lines()
@@ -3064,7 +3074,10 @@ mod full_state_version_gate_pins {
             !body.contains("ensure_key_indexed"),
             "the upsert path must not write the instance→code index directly; \
              route through store_contract, which verifies the key against the \
-             code and parameters first (see ContractStore::verify_contract_identity)"
+             code and parameters first (see ContractStore::verify_contract_identity). \
+             If you are seeing this because you MENTIONED the old helper in prose \
+             rather than called it: use a `//` line — only whole-line `//` comments \
+             are stripped, so block comments and string literals still match."
         );
 
         // Slice the branch's OWN region — anchor to its `else if`, and stop at the

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -651,18 +651,33 @@ impl ContractStore {
         match existing {
             Some(recorded) if recorded == *code_hash => return Ok(()),
             Some(recorded) => {
-                // Correcting the row can leave `recorded`'s blob referenced by no
-                // index row at all, if this was its last referent. That is a
-                // bounded disk leak and NOT a correctness problem: `fetch_contract`
-                // resolves code through this index, so an unreferenced blob is
-                // never served, and the disk-budget counter is reconciled against
-                // ground truth by the next `refresh_wasm` walk. It is also strictly
-                // better than the state it replaces, where the wrong row persisted
-                // forever. Deliberately not cleaned up here — orphan reconciliation
-                // in both directions is tracked as #5281, which already covers
-                // orphaned blobs and orphaned state/params rows from other
-                // triggers; a one-off sweep at this call site would be a second,
+                // WHAT THIS TRADE ACTUALLY IS. Correcting the row can leave
+                // `recorded`'s blob referenced by no index row, if this was its last
+                // referent. What the correction BUYS is much larger than what it
+                // costs: without it, instance `key.id()` resolves durably and
+                // forever to code it was never derived from — and the
+                // compiled-module cache is keyed off that resolution — whereas with
+                // it the residue is one unreferenced file on disk.
+                //
+                // The file is never served, because `fetch_contract` resolves code
+                // through this index. But do not read the leak as self-clearing:
+                // NOTHING in the tree frees it. `refresh_wasm` is a `du`-walk that
+                // re-measures bytes for the disk-budget counter and deletes nothing,
+                // and `remove_contract` — the only blob GC — is driven off live
+                // instances. So the bytes stay CORRECTLY counted forever, which
+                // means the orphan permanently consumes admission headroom via
+                // `admit_wasm_write`'s `total_bytes() + blob_len > budget_bytes`
+                // gate. Honest accounting, genuinely spent capacity. Orphan
+                // reconciliation in both directions is #5281 ("orphans of both are
+                // permanent"); a one-off sweep at this call site would be a second,
                 // partial mechanism.
+                //
+                // Nor is a disagreeing row only possible on binaries predating this
+                // check. ReDb rows outlive the binary, and crash-loop auto-rollback
+                // (#4073) can reinstall a pre-check binary during probation, which
+                // can mint fresh disagreeing rows that the next upgrade corrects
+                // here. So this WARN recurring is not evidence of a bug in the
+                // check.
                 tracing::warn!(
                     contract = %key,
                     instance_id = %key.id(),
@@ -1618,6 +1633,24 @@ mod test {
             "exactly two call sites are expected: store_contract's slow path and \
              ensure_key_indexed_locked. A new one needs its own verification, or \
              it must route through store_contract."
+        );
+
+        // The index has TWO halves, and counting only the durable one leaves the
+        // nastier writer class uncovered: a helper that inserts into
+        // `key_to_code_part` WITHOUT calling `store_contract_index` passes the
+        // assertion above while creating a memory-versus-ReDb divergence that
+        // survives until restart — and `remove_contract` decides blob liveness from
+        // ReDb, so the two halves would then disagree about what is referenced.
+        // Three sites are expected: the startup load from ReDb, `store_contract`'s
+        // slow path, and `ensure_key_indexed_locked`. The startup loader is counted
+        // rather than excluded, because a change there is worth noticing too.
+        assert_eq!(
+            production.matches("key_to_code_part.insert(").count(),
+            3,
+            "exactly three in-memory index writes are expected: the startup ReDb \
+             load, store_contract's slow path, and ensure_key_indexed_locked. A new \
+             one that does not also write ReDb would diverge the in-memory index \
+             from the durable one until the next restart."
         );
 
         production


### PR DESCRIPTION
Completes #5285. Test-only, plus one pin strengthened.

## Why this is a separate PR

#5285 shipped the fix. These three items were specified during its review, after the batch that merged, and the merge was a **squash** — so `b5c28a0d6`'s parent chain is not in main and the work could not simply be pushed to the same branch. This is a cherry-pick of that commit onto `0f3f46ecc`. No production behaviour changes here.

## The headline: a test at the layer the original defect lived in

`already_stored_branch_refuses_an_underived_instance` drives a **real `Executor<Runtime>`** — real `ContractStore`, real `StateStore`, no network, `op_manager: None` — through `upsert_contract_state`, and asserts that a container sharing an already-stored code hash but carrying an instance id derived from *different* parameters is refused, and leaves no instance→code index row.

**Mutation-verified against the original defect.** Restoring the bypass (the `ContractStoreBridge` method, both impls, and the executor call site) makes this test fail on the identity assertion, and the error it fails with is the original failure mode caught in the act:

```
expected the store's identity refusal to surface here, got: ExecutorError {
  inner: Left(ContractError(Update { key: ContractKey { instance: ContractInstanceId("cwm2Cf…"), … },
  cause: "execution error: compile: unexpected character '\u{3}'" }))
```

That is the forged container being **accepted at the branch and indexed**, then dying much later in WASM compile — exactly what #5285 fixed.

**No test scoped to `contract_store.rs` could see this**, and that is the whole reason the bypass survived a four-lens review of #5285: every test for the identity check lived in the store, and the unguarded ingress was one layer up in `bridged_upsert_contract_state_inner`. A source pin proves the call site still reads a certain way; it does not exercise the entry point. This test is the durable answer to that class of miss.

It is cheap because `remove_contract_tests::build_disk_executor` already existed, one function away from `remote_registration_cannot_write_the_durable_origin_record`, which tests an analogous identity invariant the same way. `bridged_upsert_contract_state` is the same generic method for `Executor<Runtime>` and `Executor<MockWasmRuntime>`, so the entry point is reachable without a multi-node network.

### Why garbage WASM bytes suffice — and the correction that matters

The review's sketch said no executable WASM is needed. That holds for the **forged** PUT, because the refusal happens in the store/index branch *before* `fetch_related_for_validation` and therefore before any WASM call. It does **not** hold for the honest PUT: `fetch_related_for_validation` calls `validate_state`, so an honest container of `vec![3u8; 64]` cannot complete.

So the control is built from that ordering rather than around it: an **honest** second instance of the same code passes the identity check and **is indexed**, then fails later in WASM validation. The discriminator is therefore

- honest → indexed, fails late, error is *not* an identity mismatch;
- forged → refused at the branch, no index row, error *is* an identity mismatch.

That is sharper than asserting "the honest PUT succeeds" and it needs no real module. **Please do not "simplify" the control back to a plain success assertion** — it would either require compiling a real contract or stop distinguishing the two cases, which is the whole point.

## Pin strengthened: both halves of the index

`the_durable_index_has_one_production_writer` counted only `.store_contract_index(` calls, so a helper that inserts into `key_to_code_part` **without** writing ReDb passed it. That writer class is arguably worse than the one already covered: it creates a memory-versus-ReDb divergence that survives until restart, and `remove_contract` decides blob liveness from ReDb, so the two halves would then disagree about what is referenced.

The pin now also counts `key_to_code_part.insert(` and expects **three** — the startup ReDb load, `store_contract`'s slow path, and `ensure_key_indexed_locked`. The startup loader is counted rather than excluded, since a change there is worth noticing too.

**Mutation-verified:** adding an in-memory-only writer

```rust
pub fn index_now(&mut self, key: &ContractKey) {
    self.key_to_code_part.insert(*key.id(), *key.code_hash());
}
```

fails the pin (4 vs 3). It passed before this change. No such writer exists today, so this closes a gap in the guard rather than a bug.

## Pin failure message made legible

The comment stripping in `upsert_code_only` is whole-line `//` only, so an author who names the removed helper in a **block** comment or a `tracing` string would get a failure whose text blames a direct index write. The assertion now says how to word it. The helper documents why the narrowness is deliberate rather than an oversight: every gap in it produces a false **failure**, never a false pass, because a real call's identifier cannot sit on a line whose `trim_start()` begins with `//`. Sound in the direction that matters, so it does not need to become a lexer.

## Corrections to the orphan-blob rationale in #5285

The comment there claimed the leak was "reconciled against ground truth by the next `refresh_wasm` walk". That was wrong, and the correction cuts both ways:

- `refresh_wasm` is a `du`-walk that re-measures bytes for the disk-budget counter and **deletes nothing**; `remove_contract`, the only blob GC, is driven off live instances. **Nothing in the tree frees an orphaned blob.**
- Because the re-measure is honest, the orphan's bytes stay **correctly counted forever**, so it permanently consumes admission headroom via `admit_wasm_write`'s `total_bytes() + blob_len > budget_bytes` gate. Honest accounting; genuinely spent capacity. Not self-clearing.
- "Only rows predating this check" was a per-version claim. ReDb rows outlive the binary, and crash-loop auto-rollback (#4073) can reinstall a pre-check binary during probation, which can mint fresh disagreeing rows that the next upgrade corrects. **A recurring WARN here is not evidence of a broken check.**

The comment now also states the trade in the form that makes it obviously acceptable: the correction converts *"wrong code served for this instance, durably, forever, with the compiled-module cache keyed off that resolution"* into *"one unreferenced file on disk"*. Orphan reconciliation in both directions is #5281.

## Record: the deferral was mine and it was wrong

I initially declined to write the executor-layer test, on the grounds that it was materially more machinery than the rest of the change. That was defensible on the information I had and it was still wrong — a review lens located `build_disk_executor`, and with it the test compiled first try. Recording it because reviewers finding infrastructure the author missed is the process working, and because the reasoning that produced the deferral would otherwise look sound next time.

## Gates

`cargo fmt --all --check` clean. `cargo clippy --locked -- -D warnings` and `cargo clippy --locked -p freenet --features trace-ot -- -D warnings` both exit 0 with **0 warnings** (the CI invocations, not a bare clippy). `cargo nextest run --lib`: **4856 passed, 0 failed, 28 skipped** — the CI form, on this branch's base.

Refs #5268, #5280, #5281

[AI-assisted - Claude]
