### PR TITLE
ci: install nextest via the maintained action, on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,8 +619,29 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install nextest
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      # nextest is installed by the maintained action on every platform, NOT by
+      # a hand-rolled download. That is a reliability fix and it is worth not
+      # undoing: the one-liners this replaced fetched from get.nexte.st, and on
+      # 2026-08-12 that host failed four times across four PRs and BOTH
+      # platforms within ~78 minutes -- `curl: (56) Connection died` on Linux,
+      # `The response ended prematurely` from Invoke-WebRequest on Windows. Two
+      # different HTTP clients failing against one host is what identifies the
+      # HOST as the fault, so retrying it harder was not the answer.
+      #
+      # The action downloads from GitHub Releases
+      # (github.com/nextest-rs/nextest/releases), so it does not touch that
+      # host at all. It also retries (curl --retry 10 inside a 10-iteration
+      # backoff loop), verifies a SHA256 checksum, and can fall back to
+      # cargo-binstall. The Windows form it replaced had NO retry budget at
+      # all, in a ~34-minute job. It does NOT cache -- see #5296 if the
+      # download cost ever matters.
+      #
+      # There are seven of these across ci.yml, playwright-shell.yml and
+      # simulation-nightly.yml; the others point here. See #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
+        with:
+          tool: cargo-nextest
 
       - name: Build
         env:
@@ -664,7 +685,13 @@ jobs:
             --profile ci -E 'not test(blocked_peers)'
 
       - name: Test blocked-peers (serial)
-        if: ${{ !cancelled() }}
+        # `!cancelled()` deliberately keeps this running after an earlier
+        # TEST failure, so a red test does not hide the rest of the suite.
+        # But it also ran after an INSTALL failure, where it died with
+        # `error: no such command: nextest` -- so the red check named this
+        # step, and a reader saw a plausible test regression instead of a
+        # tool-acquisition problem. Require the install to have succeeded.
+        if: ${{ !cancelled() && steps.install-nextest.conclusion == 'success' }}
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -677,7 +704,13 @@ jobs:
             -E 'test(blocked_peers)' -j 1
 
       - name: Test ping-types
-        if: ${{ !cancelled() }}
+        # `!cancelled()` deliberately keeps this running after an earlier
+        # TEST failure, so a red test does not hide the rest of the suite.
+        # But it also ran after an INSTALL failure, where it died with
+        # `error: no such command: nextest` -- so the red check named this
+        # step, and a reader saw a plausible test regression instead of a
+        # tool-acquisition problem. Require the install to have succeeded.
+        if: ${{ !cancelled() && steps.install-nextest.conclusion == 'success' }}
         # freenet-ping-types tests need the std feature (default).
         # Run separately since the main step uses --no-default-features.
         run: cargo nextest run -p freenet-ping-types --profile ci
@@ -713,8 +746,12 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install nextest
-        run: curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
+        with:
+          tool: cargo-nextest
 
       - name: Build freenet bin
         run: cargo build --locked -p freenet --bin freenet
@@ -765,13 +802,12 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install nextest
-        run: |
-          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-          Invoke-WebRequest -OutFile $tmp https://get.nexte.st/latest/windows
-          $outputDir = if ($Env:CARGO_HOME) { Join-Path $Env:CARGO_HOME "bin" } else { "$Env:USERPROFILE\.cargo\bin" }
-          $tmp | Expand-Archive -DestinationPath $outputDir -Force
-          $tmp | Remove-Item
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
+        with:
+          tool: cargo-nextest
 
       - name: Build freenet bin
         run: cargo build --locked -p freenet --bin freenet
@@ -837,9 +873,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.skip_check.outputs.skip != 'true'
 
-      - name: Install nextest
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
         if: steps.skip_check.outputs.skip != 'true'
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        with:
+          tool: cargo-nextest
 
       # Build the simulation test binaries and fdev up-front in one cargo
       # invocation so they share a single compile of freenet/deps. Then the
@@ -1086,9 +1126,13 @@ jobs:
         if: steps.skip_check.outputs.skip != 'true'
         run: docker pull alpine:latest
 
-      - name: Install nextest
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
         if: steps.skip_check.outputs.skip != 'true'
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+        with:
+          tool: cargo-nextest
 
       - name: Build
         if: steps.skip_check.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,33 +615,59 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: success() || steps.test.conclusion == 'failure'
+        # No `if:` here on purpose. This used to read
+        # `success() || steps.test.conclusion == 'failure'`, intending to save the
+        # cache even when tests failed -- but no step declares `id: test`, so
+        # `steps.test.conclusion` was the empty string and the whole condition
+        # collapsed to `success()`, the default. It was never expressible at this
+        # position anyway: this step runs BEFORE the tests. Do not re-add it; a
+        # post-test cache save would have to be a separate step after them.
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # nextest is installed by the maintained action on every platform, NOT by
-      # a hand-rolled download. That is a reliability fix and it is worth not
-      # undoing: the one-liners this replaced fetched from get.nexte.st, and on
-      # 2026-08-12 that host failed four times across four PRs and BOTH
-      # platforms within ~78 minutes -- `curl: (56) Connection died` on Linux,
-      # `The response ended prematurely` from Invoke-WebRequest on Windows. Two
-      # different HTTP clients failing against one host is what identifies the
-      # HOST as the fault, so retrying it harder was not the answer.
+      # a hand-rolled download. Worth not undoing: on 2026-08-12 the one-liners
+      # this replaced failed four times across four PRs and BOTH platforms
+      # within ~78 minutes, blocking the merge queue -- `curl: (56) Connection
+      # died` on Linux, `The response ended prematurely` from Invoke-WebRequest
+      # on Windows.
       #
-      # The action downloads from GitHub Releases
-      # (github.com/nextest-rs/nextest/releases), so it does not touch that
-      # host at all. It also retries (curl --retry 10 inside a 10-iteration
-      # backoff loop), verifies a SHA256 checksum, and can fall back to
-      # cargo-binstall. The Windows form it replaced had NO retry budget at
-      # all, in a ~34-minute job. It does NOT cache -- see #5296 if the
-      # download cost ever matters.
+      # What actually changed, stated carefully because the obvious reading is
+      # wrong: this did NOT move the download off a bad host.
+      # `get.nexte.st/latest/linux` 302s to the same
+      # github.com/nextest-rs/nextest release asset the action's manifest
+      # names, and both then 302 to release-assets.githubusercontent.com. The
+      # only host removed serves a zero-byte redirect, and both observed errors
+      # are body-transfer failures, which by construction occur downstream of
+      # that redirect -- on the asset host BOTH paths use.
+      #
+      # The win is what wraps the download: `retry curl --retry 10` inside a
+      # 10-iteration backoff loop (main.sh), and a SHA256 checksum verified
+      # against the hash in the action's pinned manifest. The form this replaced
+      # on Windows had NO retry budget at all, in a ~34-minute job, and none of
+      # the three verified what it extracted into $CARGO_HOME/bin before the
+      # next step executed it.
+      #
+      # `fallback: none` is deliberate: it keeps GITHUB_TOKEN out of the
+      # action's environment (action.yml only populates DEFAULT_GITHUB_TOKEN
+      # when fallback == 'cargo-binstall'). It costs nothing, because the
+      # fallback is unreachable for this tool anyway -- it is entered only when
+      # the manifest lacks the tool or the version/platform, never on a network
+      # or checksum failure, which `bail` under `set -e`.
+      #
+      # timeout-minutes bounds that retry budget: 11 attempts x curl --retry 10
+      # with no --retry-max-time can exceed any job budget here, and would be
+      # reported as a job timeout rather than as a failed download.
       #
       # There are seven of these across ci.yml, playwright-shell.yml and
       # simulation-nightly.yml; the others point here. See #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Build
         env:
@@ -742,16 +768,25 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: success() || steps.test.conclusion == 'failure'
+        # No `if:` here on purpose. This used to read
+        # `success() || steps.test.conclusion == 'failure'`, intending to save the
+        # cache even when tests failed -- but no step declares `id: test`, so
+        # `steps.test.conclusion` was the empty string and the whole condition
+        # collapsed to `success()`, the default. It was never expressible at this
+        # position anyway: this step runs BEFORE the tests. Do not re-add it; a
+        # post-test cache save would have to be a separate step after them.
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Build freenet bin
         run: cargo build --locked -p freenet --bin freenet
@@ -804,10 +839,13 @@ jobs:
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Build freenet bin
         run: cargo build --locked -p freenet --bin freenet
@@ -875,11 +913,14 @@ jobs:
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
         if: steps.skip_check.outputs.skip != 'true'
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       # Build the simulation test binaries and fdev up-front in one cargo
       # invocation so they share a single compile of freenet/deps. Then the
@@ -1128,11 +1169,14 @@ jobs:
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
         if: steps.skip_check.outputs.skip != 'true'
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Build
         if: steps.skip_check.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,10 +618,15 @@ jobs:
         # No `if:` here on purpose. This used to read
         # `success() || steps.test.conclusion == 'failure'`, intending to save the
         # cache even when tests failed -- but no step declares `id: test`, so
-        # `steps.test.conclusion` was the empty string and the whole condition
-        # collapsed to `success()`, the default. It was never expressible at this
-        # position anyway: this step runs BEFORE the tests. Do not re-add it; a
-        # post-test cache save would have to be a separate step after them.
+        # `steps.test.conclusion` resolved to null and the whole condition
+        # collapsed to `success()`, the step default. A step `if:` also could not
+        # express that intent from HERE regardless, because this step runs BEFORE
+        # the tests; the save happens in this action's post hook.
+        #
+        # If you do want the cache saved after a failing test run, the supported
+        # way is this action's own `cache-on-failure: true` input ("Cache even if
+        # the build fails"), which its post hook honours -- NOT a resurrected
+        # `if:` here, and NOT a separate step.
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -632,21 +637,36 @@ jobs:
       # died` on Linux, `The response ended prematurely` from Invoke-WebRequest
       # on Windows.
       #
-      # What actually changed, stated carefully because the obvious reading is
-      # wrong: this did NOT move the download off a bad host.
-      # `get.nexte.st/latest/linux` 302s to the same
-      # github.com/nextest-rs/nextest release asset the action's manifest
-      # names, and both then 302 to release-assets.githubusercontent.com. The
-      # only host removed serves a zero-byte redirect, and both observed errors
-      # are body-transfer failures, which by construction occur downstream of
-      # that redirect -- on the asset host BOTH paths use.
+      # WHAT THE LINUX SIGNATURE ACTUALLY MEANS. Two earlier versions of this
+      # comment got this wrong in opposite directions, so it is written from the
+      # emitting source rather than from inference. `Connection died, tried 5
+      # times before giving up` has exactly one emission site in libcurl,
+      # `Curl_retry_request()` in lib/transfer.c, and BOTH of its trigger
+      # branches are guarded by `bytecount + headerbytecount == 0` -- ZERO bytes
+      # received, headers included. So it is not a truncated transfer; it is
+      # "nothing arrived at all", from either a reused pooled connection the
+      # peer had already closed (branch 1) or an HTTP/2 REFUSED_STREAM (branch
+      # 2). The "5 times" is `#define CONN_MAX_RETRIES 5`, libcurl-internal, and
+      # unrelated to any `--retry` value.
       #
-      # The win is what wraps the download: `retry curl --retry 10` inside a
-      # 10-iteration backoff loop (main.sh), and a SHA256 checksum verified
-      # against the hash in the action's pinned manifest. The form this replaced
-      # on Windows had NO retry budget at all, in a ~34-minute job, and none of
-      # the three verified what it extracted into $CARGO_HOME/bin before the
-      # next step executed it.
+      # WHICH HOST IS AT FAULT IS NOT ESTABLISHED, and this comment deliberately
+      # does not claim one. Branch 2 needs no connection reuse, and get.nexte.st
+      # is served over HTTP/2, so the fault can occur on the redirector leg; it
+      # can equally occur on the shared asset leg
+      # (release-assets.githubusercontent.com), which BOTH the old and new paths
+      # traverse. What can be said is narrower: the new path removes one of the
+      # two hosts where this signature can arise. Do not upgrade that into
+      # "changed hosts, fixed it", and do not invert it into "the redirector was
+      # irrelevant" -- this comment has already been wrong both ways.
+      #
+      # The durable win is what WRAPS the download, and it is exactly the right
+      # response to a zero-bytes-on-connection fault: `retry curl --retry 10`
+      # inside a 10-iteration backoff loop (main.sh), plus a SHA256 checksum
+      # verified against the hash in the action's pinned manifest. NONE of the
+      # seven forms this replaced had any retry flag, and none verified what it
+      # extracted into $CARGO_HOME/bin before the next step executed it. On
+      # Windows the consequence was worst, because a single failure lost a
+      # ~34-minute job.
       #
       # `fallback: none` is deliberate: it keeps GITHUB_TOKEN out of the
       # action's environment (action.yml only populates DEFAULT_GITHUB_TOKEN
@@ -657,7 +677,12 @@ jobs:
       #
       # timeout-minutes bounds that retry budget: 11 attempts x curl --retry 10
       # with no --retry-max-time can exceed any job budget here, and would be
-      # reported as a job timeout rather than as a failed download.
+      # reported as a job timeout rather than as a failed download. Measured
+      # install time at this head is 1-2s, and 4s on Windows, so the 5-minute
+      # cap is ~75x headroom rather than a tight bound. (A step killed by
+      # timeout-minutes concludes `failure`, not `cancelled`, so the gates below
+      # skip and the job goes red -- which is the intended outcome. Note
+      # actions/runner#2432: step timeouts may be best-effort on Windows.)
       #
       # There are seven of these across ci.yml, playwright-shell.yml and
       # simulation-nightly.yml; the others point here. See #5296.
@@ -771,10 +796,15 @@ jobs:
         # No `if:` here on purpose. This used to read
         # `success() || steps.test.conclusion == 'failure'`, intending to save the
         # cache even when tests failed -- but no step declares `id: test`, so
-        # `steps.test.conclusion` was the empty string and the whole condition
-        # collapsed to `success()`, the default. It was never expressible at this
-        # position anyway: this step runs BEFORE the tests. Do not re-add it; a
-        # post-test cache save would have to be a separate step after them.
+        # `steps.test.conclusion` resolved to null and the whole condition
+        # collapsed to `success()`, the step default. A step `if:` also could not
+        # express that intent from HERE regardless, because this step runs BEFORE
+        # the tests; the save happens in this action's post hook.
+        #
+        # If you do want the cache saved after a failing test run, the supported
+        # way is this action's own `cache-on-failure: true` input ("Cache even if
+        # the build fails"), which its post hook honours -- NOT a resurrected
+        # `if:` here, and NOT a separate step.
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -83,10 +83,13 @@ jobs:
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       # fdev is the publish path the harness shells out to. Build it (and the
       # test's own crate deps) before the test step so the binary is on disk.

--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -81,8 +81,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install nextest
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
+        with:
+          tool: cargo-nextest
 
       # fdev is the publish path the harness shells out to. Build it (and the
       # test's own crate deps) before the test step so the binary is on disk.

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -78,8 +78,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mold
 
-      - name: Install nextest
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      # nextest via the maintained action, not a hand-rolled download.
+      # Rationale at the first of these in ci.yml (test_unit job); see #5296.
+      - uses: taiki-e/install-action@v2
+        id: install-nextest
+        with:
+          tool: cargo-nextest
 
       - name: Clean test directories
         run: |

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -80,10 +80,13 @@ jobs:
 
       # nextest via the maintained action, not a hand-rolled download.
       # Rationale at the first of these in ci.yml (test_unit job); see #5296.
-      - uses: taiki-e/install-action@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
         id: install-nextest
+        timeout-minutes: 5
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Clean test directories
         run: |


### PR DESCRIPTION
## Problem

`get.nexte.st` fetches failed **four times across four PRs and both platforms inside ~78 minutes** on 2026-08-12, blocking the merge queue:

- Linux, 5 sites: `curl: (56) Connection died, tried 5 times before giving up`
- Windows: `Invoke-WebRequest ... | The response ended prematurely. (ResponseEnded)`

All four sit inside a single window, so a bad window fits the evidence as well as a persistent problem. **The count is not a rate and this PR does not claim one.**

Three things made it worse than a slow step:

1. **The Windows form had no retry budget at all.** A single premature response failed a ~34-minute job. Two lines up in the same log, `rustup` is fetched with `curl --retry 10 --retry-connrefused`, and `dtolnay/rust-toolchain` even ships a step named "Work around spurious network errors in curl 8.0". The toolchain fetch was hardened; the nextest fetch beside it was not.
2. **The red check named innocent tests.** `Test blocked-peers (serial)` and `Test ping-types` carry `if: ${{ !cancelled() }}`, so after an install failure they *ran* and died with `error: no such command: nextest`. Anyone reading the check saw a plausible test regression.
3. **No integrity check.** All three forms extracted an unverified archive into `$CARGO_HOME/bin`, and the next step executed it.

## Solution

Replace all seven hand-rolled installs with `taiki-e/install-action@v2`.

### Correction: this does NOT move the download off a bad host

An earlier version of this PR led with "against a failing host, changing host beats retrying it." **That is wrong, and it is worth stating plainly because it is the reading a future debugger will reach for.**

**Both of the first two explanations were wrong, in opposite directions, so this is written from the emitting source.** `Connection died, tried 5 times before giving up` has exactly one emission site in libcurl — `Curl_retry_request()` in `lib/transfer.c` — and **both** trigger branches are guarded by `bytecount + headerbytecount == 0`, i.e. **zero bytes received, headers included**. That is not a truncated transfer; it is "nothing arrived", from either a reused pooled connection the peer had already closed, or an HTTP/2 `REFUSED_STREAM`. The "5 times" is `#define CONN_MAX_RETRIES 5`, libcurl-internal and unrelated to `--retry`.

**Which host is at fault is not established, and this PR does not claim one.** The `refused_stream` branch requires no connection reuse, and `get.nexte.st` is served over HTTP/2 (verified: `HTTP/2 302`), so the fault can arise on the redirector leg. It can equally arise on `release-assets.githubusercontent.com`, which **both** the old and new paths traverse. The defensible statement is narrower: **the new path removes one of the two hosts where this signature can occur.**

Two factual corrections while here, both from earlier drafts of mine: the redirect served by `get.nexte.st` is **not** zero-length (`content-length: 146`) — the zero-length 302 is **github.com's**, which the new path still traverses; and **none of the seven forms had any retry flag**, so singling Windows out for having "no retry budget" implied a contrast that did not exist. Windows was worst only in consequence, because one failure lost a ~34-minute job.

**The real win is what wraps the download**, which the first version of this reasoning dismissed as treating the symptom:

| Property | Evidence (verified in the pinned tree `b20dedce73af`, not from the README) |
|---|---|
| Nested retries | `main.sh:67` — `retry curl ... --retry 10`, where `retry()` is a 10-iteration loop with increasing backoff |
| Integrity | SHA256 verified against the hash in the action's manifest; on by default |
| All three platforms | `action.yml` has explicit `runner.os == 'Windows'` / `!= 'Windows'` branches; manifest covers x86_64 + aarch64 for linux-gnu, linux-musl, macos, windows |

Framed accurately: this **replaces an implicit unverified trust relationship with an explicit verified one.** Who picks the URL moves from a redirector's CDN account to a manifest committed in a pinned tree; the bytes go from unchecked to sha256-verified; and `-L` with no `--proto` (which would follow a redirect to `http://`) becomes `--proto '=https' --tlsv1.2`.

### The fallback is unreachable, and is now disabled explicitly

An earlier version credited the `cargo-binstall` fallback as resilience. It is not: the fallback is entered only via `unsupported_tools`, populated at `main.sh:972-993` when the manifest lacks the tool or the version/platform. A network or checksum failure `bail`s under `set -e`. **It cannot engage for the fault that prompted this PR.**

`fallback: none` is set on all seven, which costs nothing (cargo-nextest has a manifest entry on all three platforms) and buys two things: it makes that weaker path unreachable rather than merely improbable, and it keeps `GITHUB_TOKEN` out of the action's environment — `action.yml` populates `DEFAULT_GITHUB_TOKEN` only when `fallback == 'cargo-binstall'`. Upstream's own comment at `main.sh:514-516` is worth quoting rather than paraphrasing: it says `fallback: none` "remains the best practice from a security standpoint", **because it prevents the tokens from being set in the first place** — the code `unset`s `GITHUB_TOKEN`/`GH_TOKEN`/`DEFAULT_GITHUB_TOKEN` after reading them into a shell variable, and the comment concedes that "does not prevent token leaks via reading `/proc/*/environ` on Linux or via `ps -Eww` on macOS. It only reduces the risk of leaks." So not populating the token is strictly stronger than the in-process scrubbing, by upstream's own account. Verified `none` is an accepted value (`main.sh:505-508` bails otherwise).

### `timeout-minutes: 5` on all seven

`retry()` makes 11 attempts, each `curl --retry 10` with **no `--retry-max-time`**, and curl's backoff doubles to a 10-minute cap — so a single invocation can run ~17 minutes and the loop can exceed every job budget here (30–40 min). A sustained 503 would burn a whole job and be reported as *"exceeded the maximum execution time"* — **this PR's own misattribution bug in a new guise**, and on the merge queue it would cost 30 minutes per entry instead of seconds. Observed install time is ~1.4s. Only curl-retryable errors (408/429/5xx/timeout) engage the budget, so the observed `curl: (56)` is bounded at about a minute.

### Also fixed: the mis-attributed red check

`Test blocked-peers (serial)` and `Test ping-types` now additionally require the install step to have succeeded. `!cancelled()` is right for surviving a failing **test** and wrong for surviving a failed **install**.

**A near-miss worth recording, because the failure mode is invisible.** The first version of that condition referenced `steps.install-nextest.conclusion` without giving the install step an `id`. GitHub evaluates `steps.<unknown-id>.conclusion` as false with **no error, no warning and no unresolved-reference diagnostic** — so a condition added for safety would have permanently skipped both steps it guarded, and the job would have gone green having tested nothing.

**And two live instances of exactly that class, removed.** `Swatinem/rust-cache@v2` in `test_unit` and `macos_unit` carried `if: success() || steps.test.conclusion == 'failure'`. No step declares `id: test`, so the reference was the empty string and the condition collapsed to `success()` — the step default. The intent (save the cache even when tests fail) was never expressible there anyway, because the step runs *before* the tests. Deleted, with a comment so it is not restored. Leaving them 24 lines above the new gate, in a PR that teaches readers about this class, would have implied the file was clean.

### `pipefail` needs no separate fix

It existed because of the `curl ... | tar` pipe under `bash -e`, which reports tar's status rather than curl's — so a network failure surfaced as `gzip: stdin: unexpected end of file`. There is no longer a pipe in any of these steps; the mis-attribution is gone by deletion. The only remaining piped curl in the workflows is `$(curl ... || true)` in `gateway-update.yml`, which cannot mis-attribute.

## Site inventory: four step-shapes, not three

By **download command** there are three implementations (5 × Linux `curl | tar`, 1 × macOS, 1 × Windows `Invoke-WebRequest` + `Expand-Archive`). By **step shape there are four** — two Linux sites carry an `if: steps.skip_check.outputs.skip != 'true'` guard *between* the step name and the run line.

A mechanical edit written against three forms covers **five of seven and silently leaves two behind**, which is what the first pass here did. Caught by grepping for remaining `get.nexte.st`, not by trusting the replacement count. **For a multi-site mechanical edit, count the sites that no longer match the old pattern, not the replacements made.** Final state: zero `get.nexte.st` anywhere in the tree.

`name: Install nextest` is kept on all seven: a bare `- uses:` renders as "Run taiki-e/install-action@v2", making all seven indistinguishable in a cross-job log search, against this PR's second goal.

## Pinning

Tag-pinned `@v2`, matching house style — `actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, `actions/upload-artifact@v7`, `actions/github-script@v9`. `refs/tags/v2` currently resolves to `b20dedce73af`.

**Both halves of the SHA-pinning question, since the one-sided version is misleading.** Four of the five comparators are `actions/*`, i.e. GitHub's own release process, so this does add one more independent maintainer to the trust set. Against that: `dtolnay/rust-toolchain@stable` is an *unprotected branch*, not a tag, and already runs in all five of these jobs immediately before this step — so a lone SHA pin here would still leave a looser pin in the same job, moving no real risk. `fallback: none` also narrows what is at stake: with no `GITHUB_TOKEN` in the action's environment, the question is code execution only, not credential exposure. Whether this repo should SHA-pin actions generally is a repo-wide posture question and this PR does not settle it.

**`@v2` also pins the nextest version.** `main.sh:672` reads a manifest bundled in `GITHUB_ACTION_PATH`; there is no runtime manifest fetch. So `latest` resolves from the `v2` snapshot — **0.9.143 today, which is what the old path installed too, so no version change lands with this PR** — and the two can diverge later. Arguably better: more deterministic, one fewer network call. A reader would not infer it.

**Incidental finding, flagged not fixed:** `cargo-bins/cargo-binstall@main` in `binstall-smoke-test.yml` is pinned to a *branch*, looser than any tag here.

## Testing

**This PR's own CI is a real test of the changed workflow**, and it has been verified as such rather than inferred from a green tick. On the previous head, the install step concluded `success` in **Unit & Integration (Linux)**, **macOS Service Unit** and **Windows Service Unit**, and `Shell Playwright E2E` passed outright — so `ci.yml` and `playwright-shell.yml` are both exercised across all three platforms. The Linux log shows `x86_64_linux` → `cargo-nextest-0.9.143-x86_64-unknown-linux-gnu.tar.gz` from `github.com/nextest-rs/nextest/releases`, sha256 verified, installed to `/home/runner/.cargo/bin/cargo-nextest`, in ~1.4s: **the Releases path, not a fallback, at the expected version.**

Note also that `test_unit`'s install step carries no `if:`, so it is skipped only when an earlier step failed — which makes the job red. **A green `test_unit` therefore cannot have skipped the gated tests.**

`simulation-nightly.yml` triggers only on `schedule` + `workflow_dispatch`, so it gets no validation from a PR event; a `workflow_dispatch` run on this branch covers it.

**Honest limit.** One green run shows the mechanism **works**; it does not show it is **more reliable**, because the old path also usually succeeded — the defect was intermittent. The reliability claim rests on the retry/checksum structure above, not on this run.

**On workflow linting:** `.pre-commit-config.yaml:33-35` runs `check-yaml` and the `rule_lint` job does lint workflow files, so the earlier flat claim that "nothing validates workflow syntax" was too strong. The substantive gap survives: **nothing catches a bad `uses:` or an unresolved `steps.<id>` reference** — neither the near-miss above nor the two `steps.test` danglers. `actionlint` would catch precisely that class; filed separately.

**It does not cache, and it downloads every time.** An earlier version of this section claimed install-action short-circuits when the tool is already present at the right version, so "a download may still not happen". **That is false for this tool** — in the pinned tree there is no installed-version check between `read_manifest` and `download_from_download_info`; the only such short-circuit is for `cargo-binstall` itself (`main.sh:384-397`), and the `type -P` block after the install is post-hoc verification, not a pre-install skip. So the download does happen each time.

The decision not to add `actions/cache` stands without that justification: the problem was host availability, not download cost, and a measured 1-2s (4s on Windows) does not warrant a stale-key surface and a second failure mode.

**Two residuals, both pre-existing and neither fixed here:** the new gate keys on the install step's *conclusion*, and `main.sh:1030-1034` emits `::warning::` rather than `bail` when the binary is not on PATH, so a success-with-unreachable-binary is possible in principle. And the gate covers everything *before* the install step but not after — a `Build` failure still leaves the gated steps running and failing confusingly.

**Refs, not Closes, #5296:** that issue also covers the `permissions:`/`persist-credentials` hardening and the `actionlint` gap, which are filed separately and remain open after this merges.

[AI-assisted - Claude]
