### PR TITLE
fix(canary): freeze the marker pair, drop the unsound version relation

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -87,7 +87,7 @@ documentation. The source pin then tracks the comment, not the code.
 | `Startup update check complete` | Emitted at `debug!`, so absent from every release binary. The canary's "did the check finish?" assertion could never observe it. |
 | `failed to parse latest version` | Occurs twice in `auto_update.rs`: the production `tracing::warn!` (the format literal `Startup update check: failed to parse latest version '{}'`) and a prose comment inside that file's own `#[cfg(test)] mod tests` (`// WARN failed to parse latest version 'v0.2.121':`). Both are quoted rather than cited by line number on purpose — the first version of this row cited `:1546`/`:1757`, which this very commit's +23 lines had already shifted to `:1569`/`:1780`. A line number in a rule about stale pins rots faster than the thing it describes. Rewording the production line left all 22 assertions green — including `ok - source pin: parse-failure marker` — while a node carrying the #5221 bug then logged check-ran + reworded-warn + check-complete and the canary reported `OK: parsed GitHub's response`. An ordinary log reword deletes the gate, with CI green throughout. |
 | (no marker at all) | The gate had nothing to say WHICH release the node compared against, so its healthy verdict was byte-identical to a silently-wrong comparator's — see the positive-fact rule below. Closed by `MARKER_LATEST_SEEN`. |
-| `triggering auto-update` | A fixed string, so it never matched `freenet.rs:609`'s "triggering IMMEDIATE auto-update". A node that took the urgent path read as one that never decided to update, for as long as that site had existed. Fail-closed, hence unnoticed. Closed by `MARKER_TRIGGERED_RE` plus a count pin. |
+| `triggering auto-update` | A fixed string, so it never matched the urgent site's "triggering IMMEDIATE auto-update" (cited by phrase: the six line numbers this table and the canary once carried were all low by 12 within one release). A node that took the urgent path read as one that never decided to update, for as long as that site had existed. Fail-closed, hence unnoticed. Closed by `MARKER_TRIGGERED_RE` plus a count pin. |
 
 ### The rule
 
@@ -111,7 +111,7 @@ documentation. The source pin then tracks the comment, not the code.
   `api.github.com`): two sources that are allowed to disagree produce failures
   that are not bugs.
 - **Pin the COUNT when a marker is supposed to match a SET of call sites.** A
-  fixed-string `MARKER_TRIGGERED` missed `freenet.rs:609` ("triggering
+  fixed-string `MARKER_TRIGGERED` missed the urgent site ("triggering
   IMMEDIATE auto-update") for as long as that site existed, so a node taking
   the urgent path read as one that never decided to update. It failed CLOSED,
   which is exactly why nobody noticed — **fail-closed is not the same as
@@ -231,6 +231,49 @@ version constant untouched. Two adjacent assertions are not a pair.
 - **Mutation-test the REMEDIATION PATH, not just the regression.** Apply
   the mutation, then do exactly what your own failure message says, and
   check whether the suite goes green while the problem remains.
+
+### Load-bearing justifications rot fastest, and their staleness is self-concealing
+
+A systematic sweep of #5303 found eight stale comments. **Seven were not
+descriptions of code — they were justifications**: *"this is the only thing
+keeping X out"*, *"mutation-tested: deleting this left the suite green"*, *"the
+grep returns nothing, so that hazard is not real"*, *"the lifecycle test covers
+this against real boots"*. Every one was false at the head that carried it.
+
+Two properties make this class worse than an ordinary stale comment:
+
+- **They tell the next reader to stop checking.** That is their whole purpose.
+  So the comment most likely to be wrong is the one most likely to suppress the
+  verification that would catch it. One of them — *"the grep returns nothing"* —
+  was the sole stated reason for deleting a real entry from a
+  contributor-facing list. The grep returned two hits.
+- **They rot precisely when the thing they justify is STRENGTHENED.** "This is
+  the only guard" stops being true the moment you add a second guard, which is
+  the good outcome. Three of the seven rotted that way inside four commits.
+
+They also mislead the *careful* reviewer specifically: a comment that outlived
+its code is indistinguishable from the bug it describes, and the careless reader
+never gets that far. One such comment in #5303 ("recorded from the LAST attempt",
+left behind by the commit that replaced last-writer-wins with a latch) cost a
+full review round — the reviewer read the tree rather than the author's report,
+which was the correct instinct, and the tree lied.
+
+**The rule:**
+
+- **A count or a grep result does not belong in prose.** Compute it where it can
+  go red. #5303's `EXIT_UNVERIFIED_ENVIRONMENTAL` pin reads the constant out of
+  the script instead of restating `75`; its shell-assertion counter recomputes
+  "no `*_test.sh` is invisible to this grep" on every CI run instead of carrying
+  the numbers a reviewer had measured by hand. Both replaced sentences that had
+  already gone stale once.
+- **Prefer "the first of two guards" to "the only guard".** State what a check
+  does, not what nothing else does — the second claim is falsified by the next
+  improvement.
+- **When you change code, the nearby comment is part of the change.** Especially
+  when the change makes an old caveat unnecessary: that is when the sentence
+  survives, because nothing forces you to look at it.
+- **When a comment and the code disagree, verify against the code before
+  reporting** — then fix the comment as a defect in its own right.
 
 ### Relation pins between quantities on different clocks
 

--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -274,6 +274,25 @@ which was the correct instinct, and the tree lied.
   survives, because nothing forces you to look at it.
 - **When a comment and the code disagree, verify against the code before
   reporting** — then fix the comment as a defect in its own right.
+- **A defect found at one site is not fixed until you have ENUMERATED every
+  site of that shape, and "enumerate" means grep, not recall.** This appeared
+  four times in one night in #5303, and the fixes were the misses: the
+  comment-stripping filter was applied to one job-block extraction while three
+  siblings went without (twice, in successive commits); the SIGPIPE fix in
+  #5236 corrected two helpers and left four call sites inside the very function
+  those helpers serve; and a false "on all N attempts" claim was corrected in
+  one branch while its sibling twelve lines away kept it. Each time the author
+  had just understood the defect completely, which is exactly when the
+  remaining instances feel like they cannot be there.
+
+  Three of the four were caught only because a MUTATION FAILED TO APPLY —
+  `PATTERN NOT FOUND` with the suite green. **An unapplied mutation is not a
+  pass; it is an unexplained observation**, and here the explanation was always
+  that the string had moved or been half-fixed. Chase it.
+
+  Prefer removing the class over fixing the instances: three extractions became
+  one `yaml_job_block` helper, so a fourth caller cannot forget the filter
+  because there is nothing to forget.
 
 ### Relation pins between quantities on different clocks
 

--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -195,6 +195,73 @@ hand-rolling a `split_once`. It:
 scrapes `update.rs` cannot be satisfied by its own assertion literal at
 all — a structural guarantee rather than a check someone must remember.
 
+### The same class without `include_str!`: an expectation stored as a copy
+
+A pin does not need a sliding anchor to follow its subject. **An expected
+value stored as a plaintext copy of the value it guards is rewritten by
+the same edit that changes the value**, so the pin renames itself and
+stays green. Nothing self-references; the two literals are simply
+identical, and the realistic edit is a sweep over both.
+
+Seen in #5303. `MARKER_LATEST_SEEN_SINCE` names the first published
+release emitting a log marker; rewording the marker requires moving it,
+and nothing prompted anyone (the source pin interpolates the marker, so
+it follows a rename by construction). A freeze was added storing the
+expected marker text as a literal beside the constant. Its own mutation
+test killed it: a reword is performed as a `sed` sweep across the files
+mentioning the marker, that sweep rewrote the frozen expectation too, and
+the suite passed with the constant still stale.
+
+Then the fix's *fix* failed the same way one level up. With the text
+stored base64 the reword went red — but following the failure message's
+own instruction (regenerate the encoded blob) went green again with the
+version constant untouched. Two adjacent assertions are not a pair.
+
+**The rules:**
+
+- **Encode the expectation** (base64, hash, checksum) whenever the value
+  it guards is text a sweep could match. Leave it plaintext only when the
+  realistic wrong edit is a human typing one new value — a version
+  constant qualifies, since bumps touch `Cargo.toml` and the lockfile,
+  not test scripts. Document the asymmetry where you rely on it.
+- **A freeze forces a decision only if the remediation cannot be
+  performed without making that decision.** Freeze values that must move
+  together as ONE blob, so regenerating the expectation is impossible
+  without re-stating both.
+- **Mutation-test the REMEDIATION PATH, not just the regression.** Apply
+  the mutation, then do exactly what your own failure message says, and
+  check whether the suite goes green while the problem remains.
+
+### Relation pins between quantities on different clocks
+
+A pin asserting a fixed relation between two values that change on
+*different schedules* is correct in one phase and wrong in another. It
+looks anchored — the second quantity is one the author cannot influence,
+which is normally the point — but it encodes a phase assumption nobody
+writes down.
+
+#5290 pinned `MARKER_LATEST_SEEN_SINCE >= crate version`, on the premise
+"the marker is new in this tree, so no published release emits it". True
+until that release published; the pin then blocks the *next* release for
+holding the correct value. Reversing it to `<= crate version` is correct
+after publication and wrong during a marker reword, where the right
+constant is crate+1 and the pin goes red for it.
+
+The constant tracks **release history**; the crate version tracks **this
+tree**. No relation asserting they stay in step holds in both phases.
+
+- Ask **"what future state legitimately requires this to move?"** before
+  pinning a relation. If the answer is "a state where the relation is
+  violated", the relation is the wrong pin.
+- Prefer a **freeze on the value**, which is phase-independent and
+  catches strictly more (the empty string, and the most likely wrong
+  value, neither of which a one-sided relation sees).
+- A *loose plausibility bound* is not the same thing and is not refuted
+  by the above: `<= crate + 1` passes during a reword. Note that the
+  claim "it fires on a reword too" was repeated through two reviews
+  before anyone did the arithmetic — **check a refutation before
+  propagating it**, especially one that is a single comparison.
+
 ### Audit
 
 Every pin must be mutation-tested when written: apply the exact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,58 +414,37 @@ jobs:
 
           if [ "$IS_FIX" -gt 0 ] && [ "$HAS_EXEMPT_LABEL" -eq 0 ]; then
             NEW_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE "$TEST_ATTR_RE" || true)
-            # Some fixes are to shell tooling (e.g. scripts/release-agent/*.sh),
-            # whose regression tests are shell *_test.sh self-tests run in CI,
-            # not Rust #[test]s. Count added assertion lines (`check ...`) in
-            # added *_test.sh files so such fixes aren't forced to claim
-            # test-exempt. Without this, a genuine shell regression test scores
-            # zero against TEST_ATTR_RE (Rust-only) and the fix is wrongly
-            # rejected — the gap that hid the announce-to-river fix's own test.
-            # `check` is one of several assertion helpers in this repo's shell
-            # self-tests; `auto-update-canary_lifecycle_test.sh` reports through
-            # `ok`/`bad` instead. Matching only `check` made this rule miss a
-            # genuine behavioural regression test (#5290 added a lifecycle case
-            # that reproduces the fault and goes red without the fix) and demand
-            # `test-exempt` for a PR that had exactly the test the rule wants —
-            # the same "gate cannot see its subject" shape the comment above
-            # describes. Match the helpers actually in use.
+            # Some fixes are to shell tooling, whose regression tests are shell
+            # *_test.sh self-tests, not Rust #[test]s. Without this they score
+            # zero against TEST_ATTR_RE and the fix is wrongly rejected — the gap
+            # that hid the announce-to-river fix's own test.
             #
-            # Third and fourth forms, same gap. `auto-update-canary_test.sh`
-            # DOES have a helper -- `check()` at the top of the file, 12 call
-            # sites -- but it takes a log fixture and drives
-            # `assert_detection_healthy`, so it can only express the log-fixture
-            # cases; that file's other ~49 assertions (source pins, the frozen
-            # constants, the trigger-site count) have nothing to fixture and are
-            # written as a bare `echo "ok   - ..."`. And four more self-tests
-            # report through `pass` (`release_canary_wiring_test.sh`,
-            # `release_state_restore_test.sh`, and two under `release-agent/`).
-            # A PR whose entire regression test is one of those scored ZERO and
-            # was told to add a test it had already added.
+            # WHAT THIS RECOGNISES, precisely: the SUCCESS-REPORTING LINE of an
+            # assertion, by prefix. Not assertions. A decorative
+            # `echo "ok - looks fine"` satisfies it, and so did `ok "..."` and a
+            # self-comparing `check "x" "a" "a"` before it was widened. What
+            # stops a decorative test is review and mutation-testing, not this
+            # grep; widening only adds spellings.
             #
-            # Be honest about what this can and cannot do. It recognises the
-            # SUCCESS-REPORTING LINE of an assertion, by prefix; it has never
-            # recognised assertions. A single `echo "ok - looks fine"` that
-            # tests nothing satisfies it -- but so does `ok "..."` and so does a
-            # self-comparing `check "x" "a" "a"`, both of which the pre-existing
-            # pattern already accepted. Widening adds spellings, not a weakness;
-            # what actually stops a decorative test is review and
-            # mutation-testing the pin, not this regex.
+            # The alternation was widened three times, each time stopping at the
+            # file in front of whoever was editing. It is now derived from an
+            # ENUMERATION of every `*_test.sh` under scripts/ rather than from
+            # the file at hand: `check` (4 files), `ok`/`bad` (lifecycle),
+            # `pass` (3 files), `echo "ok   - "` (34 sites, and all 34 use that
+            # exact separator, so anchoring on it costs nothing while rejecting
+            # `echo "okay, starting"`), and `echo "PASS [...]"`
+            # (release_state_restore_test.sh, the last file that still scored
+            # zero). Both quote styles. Re-run that enumeration before adding a
+            # sixth pattern; adding one because a file you happen to be editing
+            # scores zero is how the first three went in.
             #
-            # It still has FALSE NEGATIVES, left in deliberately rather than
-            # chased with a fifth pattern: `printf 'ok - ...'` scores zero, and
-            # so does an assertion whose only added line is its `echo "FAIL ..."`
-            # branch. Counting FAIL lines would also let a PR score by adding an
-            # error message alone. The durable fix is one shared assertion helper
-            # across these files, not more regex.
-            #
-            # `["']ok[[:space:]]+-` rather than a bare `"ok`: anchored on the
-            # `ok   - ` separator every one of the ~30 existing sites uses, so
-            # `echo "okay, starting the suite"` and a bare `echo "ok"` no longer
-            # count as regression tests. Both quote styles, since single-quoted
-            # `echo 'ok - ...'` scored zero.
+            # KNOWN FALSE NEGATIVES, left in rather than chased: `printf`-style
+            # reporting, and an assertion whose only added line is its FAIL
+            # branch (counting FAIL would let a PR score by adding an error
+            # message alone). The error text below tells the contributor both.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"']ok[[:space:]]+-' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
@@ -473,11 +452,11 @@ jobs:
           Either satisfies this:
             - a Rust #[test] / #[tokio::test] / etc.
             - an added assertion in a *_test.sh self-test, written with any of the
-              conventions those files use: 'check ...', 'ok ...', 'pass ...', or
-              'echo \"ok   - ...\"'. Known blind spots: printf-style reporting, and
-              an assertion whose only added line is its FAIL branch. If you have a
-              real test the counter cannot see, say so on the PR rather than
-              reshaping the test to please this grep.
+              conventions those files use: 'check ...', 'ok ...', 'pass ...',
+              'echo \"ok   - ...\"' or 'echo \"PASS ...\"'. Known blind spots:
+              printf-style reporting, and an assertion whose only added line is
+              its FAIL branch. If you have a real test the counter cannot see,
+              say so on the PR rather than reshaping the test to please this grep.
           If this fix genuinely cannot have a test, add the 'test-exempt' label with a justification comment."
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,9 +429,18 @@ jobs:
             # `test-exempt` for a PR that had exactly the test the rule wants —
             # the same "gate cannot see its subject" shape the comment above
             # describes. Match the helpers actually in use.
+            #
+            # Third form, same gap: `auto-update-canary_test.sh` -- the largest
+            # shell self-test in the repo, and the one that guards the release
+            # canary -- has no helper at all. It reports each assertion with a
+            # bare `echo "ok   - ..."` / `echo "FAIL - ..." >&2`, so a PR whose
+            # entire regression test is a new assertion there scored ZERO here
+            # and was told to add a test it had already added. Widening for
+            # `ok` covered the lifecycle file's helper and stopped at the file
+            # next to it. Count the echoed form too.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*(check|ok)[[:space:]]' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+"ok' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
             # The alternation was widened three times, each time stopping at the
             # file in front of whoever was editing. It is now derived from an
             # ENUMERATION of every `*_test.sh` in the repo rather than from the
-            # file at hand: `check` (7 files), `ok`/`bad` (lifecycle), `pass`
+            # file at hand: `check` (6 files), `ok`/`bad` (lifecycle), `pass`
             # (3 files), `expect`
             # (rule_lint_shell_assertion_counter_test.sh), `echo "ok   - "`
             # (all sites use that exact separator, so anchoring on it costs
@@ -465,30 +465,46 @@ jobs:
             # `norm_case`, `timeout_guard_case`, `pin_marker`,
             # `pin_warn_literal`, `check_vs_expected`, `check_call_count`,
             # `check_fallback`, `test_restores_persisted_value`. Measured
-            # across all 12 `*_test.sh` files: 378 assertion call sites, of
-            # which the original form saw 286 and missed 92, of which 53 are in
-            # `auto-update-canary_test.sh` alone, whose parameterised cases are
-            # written almost entirely in that style. The patterns added below
-            # (a `check_`/`pin_`/`assert_`/`expect_`/`test_` prefix, a `_case`
-            # suffix, and bare `expect`) take it to 378 of 378 with zero false
-            # positives, checked line by line against a hand-enumerated ground
-            # truth. Definitions do not match either pattern (`foo() {` has no
+            # every `*_test.sh` in the repo at the time: the original form saw
+            # roughly three quarters of the assertion call sites and missed the
+            # rest, almost all of them in `auto-update-canary_test.sh`, whose
+            # parameterised cases are written almost entirely in that style. The
+            # patterns added below (a `check_`/`pin_`/`assert_`/`expect_`/`test_`
+            # prefix, a `_case` suffix, and bare `expect`) closed the gap with no
+            # false positives.
+            #
+            # NO EXACT FIGURES HERE ON PURPOSE. Three counts in this comment went
+            # stale inside this very PR, because every commit that adds an
+            # assertion moves them, and a number in a justification is the kind
+            # of sentence that tells the next reader to stop checking.
+            # `rule_lint_shell_assertion_counter_test.sh` RECOMPUTES the property
+            # that actually matters -- that no `*_test.sh` is invisible to this
+            # counter -- on every CI run, and fails naming the files. Definitions do not match either pattern (`foo() {` has no
             # whitespace where the name ends), so declaring a helper still
             # scores nothing, which is right.
             #
-            # KNOWN FALSE NEGATIVES, left in rather than chased. Both are real
-            # in this repo today; the `printf`-style reporting this comment used
-            # to cite as the first one is NOT: `grep -rnE "printf .*['\"](ok|PASS)"
-            # over scripts/ returns nothing, so it was a hazard nobody had ever
-            # written, and it has been dropped in favour of the two that exist:
-            #   1. An assertion whose only added line is its FAIL branch.
+            # KNOWN FALSE NEGATIVES, left in rather than chased. All three are
+            # real in this repo today:
+            #   1. `printf`-style success reporting. An earlier version of this
+            #      comment DELETED this entry, on the stated ground that
+            #      `grep -rnE "printf .*['\"](ok|PASS)"` over scripts/ returned
+            #      nothing. It returns two:
+            #      `scripts/test-install-sh.sh` and `scripts/test-uninstall-sh.sh`,
+            #      both `pass() { printf 'PASS  %s\\n' "$1"; }`. They escape this
+            #      counter only because the diff above is scoped to
+            #      `**/*_test.sh` and those are named `test-*.sh` -- a naming
+            #      accident, not the absence of the convention. The moment
+            #      someone writes that reporter in a `*_test.sh`, it scores zero.
+            #      `rule_lint_shell_assertion_counter_test.sh` now RECOMPUTES
+            #      this rather than trusting the sentence.
+            #   2. An assertion whose only added line is its FAIL branch.
             #      Deliberate: counting FAIL would let a PR score by adding an
             #      error message alone.
-            #   2. A new entry in a TABLE an existing assertion loops over.
+            #   3. A new entry in a TABLE an existing assertion loops over.
             #      `SIGPIPE_SCRIPTS=(...)` in auto-update-canary_test.sh is the
             #      live instance. Adding a file there genuinely extends what is
             #      audited, and the added line is a bare string.
-            # The error text below tells the contributor both.
+            # The error text below tells the contributor all three.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
               | grep -cE '^\+[[:space:]]*(check|ok|pass|expect)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,37 +430,54 @@ jobs:
             # the same "gate cannot see its subject" shape the comment above
             # describes. Match the helpers actually in use.
             #
-            # Third form, same gap: `auto-update-canary_test.sh`. It DOES have a
-            # helper -- `check()` at the top of the file, 12 call sites -- but
-            # that helper takes a log fixture and drives `assert_detection_healthy`,
-            # so it can only express the log-fixture cases. Its other ~49
-            # assertions (source pins, the constant-relation pins, the
-            # trigger-site count) have nothing to fixture, and are written as a
-            # bare `echo "ok   - ..."` / `echo "FAIL - ..." >&2`. A PR whose
-            # entire regression test is one of those scored ZERO here and was
-            # told to add a test it had already added. Widening for `ok` covered
-            # the lifecycle file's helper and stopped at the file next to it.
-            # Count the echoed form too.
+            # Third and fourth forms, same gap. `auto-update-canary_test.sh`
+            # DOES have a helper -- `check()` at the top of the file, 12 call
+            # sites -- but it takes a log fixture and drives
+            # `assert_detection_healthy`, so it can only express the log-fixture
+            # cases; that file's other ~49 assertions (source pins, the frozen
+            # constants, the trigger-site count) have nothing to fixture and are
+            # written as a bare `echo "ok   - ..."`. And four more self-tests
+            # report through `pass` (`release_canary_wiring_test.sh`,
+            # `release_state_restore_test.sh`, and two under `release-agent/`).
+            # A PR whose entire regression test is one of those scored ZERO and
+            # was told to add a test it had already added.
             #
             # Be honest about what this can and cannot do. It recognises the
             # SUCCESS-REPORTING LINE of an assertion, by prefix; it has never
             # recognised assertions. A single `echo "ok - looks fine"` that
             # tests nothing satisfies it -- but so does `ok "..."` and so does a
-            # self-comparing `check "x" "a" "a"`, both of which the previous
-            # pattern already accepted. Widening does not make the check
-            # decorative; it was already prefix-recognition, and this only adds
-            # the third spelling. What actually stops a decorative test is
-            # review and mutation-testing the pin, not this regex. Prefer
-            # extending an assertion helper over adding a fourth pattern.
+            # self-comparing `check "x" "a" "a"`, both of which the pre-existing
+            # pattern already accepted. Widening adds spellings, not a weakness;
+            # what actually stops a decorative test is review and
+            # mutation-testing the pin, not this regex.
+            #
+            # It still has FALSE NEGATIVES, left in deliberately rather than
+            # chased with a fifth pattern: `printf 'ok - ...'` scores zero, and
+            # so does an assertion whose only added line is its `echo "FAIL ..."`
+            # branch. Counting FAIL lines would also let a PR score by adding an
+            # error message alone. The durable fix is one shared assertion helper
+            # across these files, not more regex.
+            #
+            # `["']ok[[:space:]]+-` rather than a bare `"ok`: anchored on the
+            # `ok   - ` separator every one of the ~30 existing sites uses, so
+            # `echo "okay, starting the suite"` and a bare `echo "ok"` no longer
+            # count as regression tests. Both quote styles, since single-quoted
+            # `echo 'ok - ...'` scored zero.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*(check|ok)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+"ok' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"']ok[[:space:]]+-' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
           Add a test that reproduces the bug (fails without fix, passes with fix).
-          A Rust #[test]/#[tokio::test]/etc. or an added 'check' assertion in a
-          *_test.sh self-test both satisfy this.
+          Either satisfies this:
+            - a Rust #[test] / #[tokio::test] / etc.
+            - an added assertion in a *_test.sh self-test, written with any of the
+              conventions those files use: 'check ...', 'ok ...', 'pass ...', or
+              'echo \"ok   - ...\"'. Known blind spots: printf-style reporting, and
+              an assertion whose only added line is its FAIL branch. If you have a
+              real test the counter cannot see, say so on the PR rather than
+              reshaping the test to please this grep.
           If this fix genuinely cannot have a test, add the 'test-exempt' label with a justification comment."
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,16 @@ jobs:
       - name: Self-test auto-update canary lifecycle
         run: bash scripts/auto-update-canary_lifecycle_test.sh
 
+      # Guards the shell-assertion counter further down THIS file. That
+      # alternation has been wrong three times and nothing in the repo
+      # exercised it, so each miss was found by a human noticing a wrong
+      # number. It fails in the rejecting direction: an under-counting lint
+      # turns away a fix: PR that does have a regression test, and the cheapest
+      # response for the author is to reshape a good test until the grep likes
+      # it. The test extracts the live regex rather than copying it.
+      - name: Self-test Rule Lint shell-assertion counter
+        run: bash scripts/rule_lint_shell_assertion_counter_test.sh
+
       # install.sh now sets up a supervised service by default (issue #4073) so
       # new nodes auto-update. The system-vs-user + lingering decision is the
       # load-bearing new logic; these smoke tests pin it without needing real
@@ -234,7 +244,7 @@ jobs:
       # clean when they landed but were not actually in this list, so nothing
       # held them to it. `-x` because the two test scripts `source` the canary.
       - name: Lint install/uninstall scripts (shellcheck)
-        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/release.sh
+        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/rule_lint_shell_assertion_counter_test.sh scripts/release.sh
       - name: Self-test install.sh service-mode decision
         run: sh scripts/test-install-sh.sh
       - name: Self-test uninstall.sh
@@ -428,23 +438,51 @@ jobs:
             #
             # The alternation was widened three times, each time stopping at the
             # file in front of whoever was editing. It is now derived from an
-            # ENUMERATION of every `*_test.sh` under scripts/ rather than from
-            # the file at hand: `check` (4 files), `ok`/`bad` (lifecycle),
-            # `pass` (3 files), `echo "ok   - "` (34 sites, and all 34 use that
-            # exact separator, so anchoring on it costs nothing while rejecting
+            # ENUMERATION of every `*_test.sh` in the repo rather than from the
+            # file at hand: `check` (7 files), `ok`/`bad` (lifecycle), `pass`
+            # (3 files), `echo "ok   - "` (all sites use that exact separator,
+            # so anchoring on it costs nothing while rejecting
             # `echo "okay, starting"`), and `echo "PASS [...]"`
-            # (release_state_restore_test.sh, the last file that still scored
-            # zero). Both quote styles. Re-run that enumeration before adding a
-            # sixth pattern; adding one because a file you happen to be editing
-            # scores zero is how the first three went in.
+            # (release_state_restore_test.sh). Both quote styles. Re-run that
+            # enumeration before adding another pattern; adding one because a
+            # file you happen to be editing scores zero is how the first three
+            # went in.
             #
-            # KNOWN FALSE NEGATIVES, left in rather than chased: `printf`-style
-            # reporting, and an assertion whose only added line is its FAIL
-            # branch (counting FAIL would let a PR score by adding an error
-            # message alone). The error text below tells the contributor both.
+            # THE BARE-NAME FORMS ABOVE ARE NOT THE WHOLE VOCABULARY, and for a
+            # while this counter behaved as if they were. `[[:space:]]`
+            # immediately after `(check|ok|pass)` requires the helper's name to
+            # END there, so every underscore-suffixed helper scored zero:
+            # `gate_b_arm_case`, `version_ge_case`, `trigger_case`,
+            # `norm_case`, `timeout_guard_case`, `pin_marker`,
+            # `pin_warn_literal`, `check_vs_expected`, `check_call_count`,
+            # `check_fallback`, `test_restores_persisted_value`. Measured
+            # across all 11 `*_test.sh` files: 329 assertion call sites, of
+            # which the bare-name form saw 275 and missed 54, of which 42 are in
+            # `auto-update-canary_test.sh` alone, whose parameterised cases are
+            # written almost entirely in that style. The two patterns added
+            # below (a `check_`/`pin_`/`assert_`/`expect_`/`test_` prefix, and
+            # a `_case` suffix) take it to 329 of 329 with zero false
+            # positives, checked line by line against a hand-enumerated ground
+            # truth. Definitions do not match either pattern (`foo() {` has no
+            # whitespace where the name ends), so declaring a helper still
+            # scores nothing, which is right.
+            #
+            # KNOWN FALSE NEGATIVES, left in rather than chased. Both are real
+            # in this repo today; the `printf`-style reporting this comment used
+            # to cite as the first one is NOT: `grep -rnE "printf .*['\"](ok|PASS)"
+            # over scripts/ returns nothing, so it was a hazard nobody had ever
+            # written, and it has been dropped in favour of the two that exist:
+            #   1. An assertion whose only added line is its FAIL branch.
+            #      Deliberate: counting FAIL would let a PR score by adding an
+            #      error message alone.
+            #   2. A new entry in a TABLE an existing assertion loops over.
+            #      `SIGPIPE_SCRIPTS=(...)` in auto-update-canary_test.sh is the
+            #      live instance. Adding a file there genuinely extends what is
+            #      audited, and the added line is a bare string.
+            # The error text below tells the contributor both.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
@@ -453,10 +491,12 @@ jobs:
             - a Rust #[test] / #[tokio::test] / etc.
             - an added assertion in a *_test.sh self-test, written with any of the
               conventions those files use: 'check ...', 'ok ...', 'pass ...',
-              'echo \"ok   - ...\"' or 'echo \"PASS ...\"'. Known blind spots:
-              printf-style reporting, and an assertion whose only added line is
-              its FAIL branch. If you have a real test the counter cannot see,
-              say so on the PR rather than reshaping the test to please this grep.
+              a 'check_'/'pin_'/'assert_'/'expect_'/'test_'-prefixed helper, a
+              '*_case ...' helper, 'echo \"ok   - ...\"' or 'echo \"PASS ...\"'.
+              Known blind spots: an assertion whose only added line is its FAIL
+              branch, and a new entry in a table an existing assertion loops over
+              (e.g. SIGPIPE_SCRIPTS). If you have a real test the counter cannot
+              see, say so on the PR rather than reshaping the test to please this grep.
           If this fix genuinely cannot have a test, add the 'test-exempt' label with a justification comment."
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,14 +430,28 @@ jobs:
             # the same "gate cannot see its subject" shape the comment above
             # describes. Match the helpers actually in use.
             #
-            # Third form, same gap: `auto-update-canary_test.sh` -- the largest
-            # shell self-test in the repo, and the one that guards the release
-            # canary -- has no helper at all. It reports each assertion with a
-            # bare `echo "ok   - ..."` / `echo "FAIL - ..." >&2`, so a PR whose
-            # entire regression test is a new assertion there scored ZERO here
-            # and was told to add a test it had already added. Widening for
-            # `ok` covered the lifecycle file's helper and stopped at the file
-            # next to it. Count the echoed form too.
+            # Third form, same gap: `auto-update-canary_test.sh`. It DOES have a
+            # helper -- `check()` at the top of the file, 12 call sites -- but
+            # that helper takes a log fixture and drives `assert_detection_healthy`,
+            # so it can only express the log-fixture cases. Its other ~49
+            # assertions (source pins, the constant-relation pins, the
+            # trigger-site count) have nothing to fixture, and are written as a
+            # bare `echo "ok   - ..."` / `echo "FAIL - ..." >&2`. A PR whose
+            # entire regression test is one of those scored ZERO here and was
+            # told to add a test it had already added. Widening for `ok` covered
+            # the lifecycle file's helper and stopped at the file next to it.
+            # Count the echoed form too.
+            #
+            # Be honest about what this can and cannot do. It recognises the
+            # SUCCESS-REPORTING LINE of an assertion, by prefix; it has never
+            # recognised assertions. A single `echo "ok - looks fine"` that
+            # tests nothing satisfies it -- but so does `ok "..."` and so does a
+            # self-comparing `check "x" "a" "a"`, both of which the previous
+            # pattern already accepted. Widening does not make the check
+            # decorative; it was already prefix-recognition, and this only adds
+            # the third spelling. What actually stops a decorative test is
+            # review and mutation-testing the pin, not this regex. Prefer
+            # extending an assertion helper over adding a fourth pattern.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
               | grep -cE '^\+[[:space:]]*(check|ok)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+"ok' || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,13 +440,22 @@ jobs:
             # file in front of whoever was editing. It is now derived from an
             # ENUMERATION of every `*_test.sh` in the repo rather than from the
             # file at hand: `check` (7 files), `ok`/`bad` (lifecycle), `pass`
-            # (3 files), `echo "ok   - "` (all sites use that exact separator,
-            # so anchoring on it costs nothing while rejecting
-            # `echo "okay, starting"`), and `echo "PASS [...]"`
-            # (release_state_restore_test.sh). Both quote styles. Re-run that
-            # enumeration before adding another pattern; adding one because a
-            # file you happen to be editing scores zero is how the first three
-            # went in.
+            # (3 files), `expect`
+            # (rule_lint_shell_assertion_counter_test.sh), `echo "ok   - "`
+            # (all sites use that exact separator, so anchoring on it costs
+            # nothing while rejecting `echo "okay, starting"`), and
+            # `echo "PASS [...]"` (release_state_restore_test.sh). Both quote
+            # styles. `expect` is safe as a bare name only because nothing in
+            # `scripts/` drives the TCL `expect(1)`; check that before assuming
+            # it stays safe.
+            #
+            # RE-RUN THE ENUMERATION AFTER ADDING A TEST FILE, not just before
+            # adding a pattern. The commit that introduced
+            # `rule_lint_shell_assertion_counter_test.sh` -- the file whose
+            # whole job is to stop this counter under-counting -- wrote its 26
+            # assertions as bare `expect 1 ...` calls, which scored ZERO. The
+            # blind spot was reintroduced by the fix for it, in the same PR,
+            # and was caught by re-measuring rather than by reading.
             #
             # THE BARE-NAME FORMS ABOVE ARE NOT THE WHOLE VOCABULARY, and for a
             # while this counter behaved as if they were. `[[:space:]]`
@@ -456,12 +465,12 @@ jobs:
             # `norm_case`, `timeout_guard_case`, `pin_marker`,
             # `pin_warn_literal`, `check_vs_expected`, `check_call_count`,
             # `check_fallback`, `test_restores_persisted_value`. Measured
-            # across all 11 `*_test.sh` files: 329 assertion call sites, of
-            # which the bare-name form saw 275 and missed 54, of which 42 are in
+            # across all 12 `*_test.sh` files: 378 assertion call sites, of
+            # which the original form saw 286 and missed 92, of which 53 are in
             # `auto-update-canary_test.sh` alone, whose parameterised cases are
-            # written almost entirely in that style. The two patterns added
-            # below (a `check_`/`pin_`/`assert_`/`expect_`/`test_` prefix, and
-            # a `_case` suffix) take it to 329 of 329 with zero false
+            # written almost entirely in that style. The patterns added below
+            # (a `check_`/`pin_`/`assert_`/`expect_`/`test_` prefix, a `_case`
+            # suffix, and bare `expect`) take it to 378 of 378 with zero false
             # positives, checked line by line against a hand-enumerated ground
             # truth. Definitions do not match either pattern (`foo() {` has no
             # whitespace where the name ends), so declaring a helper still
@@ -482,7 +491,7 @@ jobs:
             # The error text below tells the contributor both.
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
-              | grep -cE '^\+[[:space:]]*(check|ok|pass)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
+              | grep -cE '^\+[[:space:]]*(check|ok|pass|expect)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
             if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
@@ -491,7 +500,7 @@ jobs:
             - a Rust #[test] / #[tokio::test] / etc.
             - an added assertion in a *_test.sh self-test, written with any of the
               conventions those files use: 'check ...', 'ok ...', 'pass ...',
-              a 'check_'/'pin_'/'assert_'/'expect_'/'test_'-prefixed helper, a
+              'expect ...', a 'check_'/'pin_'/'assert_'/'expect_'/'test_'-prefixed helper, a
               '*_case ...' helper, 'echo \"ok   - ...\"' or 'echo \"PASS ...\"'.
               Known blind spots: an assertion whose only added line is its FAIL
               branch, and a new entry in a table an existing assertion loops over

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -817,7 +817,15 @@ jobs:
           needs.auto-update-selfupdate-canary.outputs.classification == 'environmental'
         uses: ./.github/actions/river-dev-notify
         with:
-          message: "⚠️ ${{ github.ref_name }} published fine, but auto-update for it is **UNVERIFIED** — the self-update canary never reached a verdict. The previous release's binary could not reach GitHub, and neither could the runner, so the run is not evidence in either direction. Nothing suggests a stranded fleet and no fleet action is indicated, but this release has NOT been shown to be reachable by auto-update: re-run the job to actually verify it. If you are seeing this on consecutive releases, stop treating it as noise — the post-publish gate is not working and nothing has been verified since the last green run. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Names BOTH environmental causes rather than assuming the network
+          # one. Exit 75 covers two: the previous release's binary could not
+          # reach GitHub (and neither could the runner), or every attempt lost a
+          # port race on this host. An earlier version of this message asserted
+          # the first, so a self-hosted runner with something holding the ports
+          # sent the operator after DNS. The job log's `UNVERIFIED
+          # (ENVIRONMENTAL)` line says which; this says what to do, which is the
+          # same either way.
+          message: "⚠️ ${{ github.ref_name }} published fine, but auto-update for it is **UNVERIFIED** — the self-update canary never reached a verdict, for an environmental reason: either the previous release's binary could not reach GitHub (and neither could the runner) or every attempt hit a port collision on the runner. The job log's `UNVERIFIED (ENVIRONMENTAL)` line says which. The run is not evidence in either direction. Nothing suggests a stranded fleet and no fleet action is indicated, but this release has NOT been shown to be reachable by auto-update: re-run the job to actually verify it. If you are seeing this on consecutive releases, stop treating it as noise — whatever it names, something is persistently stopping the gate from running, the post-publish gate is not working, and nothing has been verified since the last green run. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
           room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
           gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}
@@ -827,6 +835,13 @@ jobs:
       # anticipated (a cancelled job, an empty classification because the step
       # never ran) lands HERE, in the loud one. A gate's unknown case belongs on
       # the side that gets read.
+      #
+      # DO NOT CONSOLIDATE THESE TWO STEPS. One step with a conditional message
+      # expression is the obvious tidy and it loses the property: the two
+      # conditions must remain each other's exact complement, which is what a
+      # reviewer can check at a glance and what
+      # `release_canary_wiring_test.sh` asserts by comparing them to each other.
+      # Both steps are located there by `id:`, so a rename fails loudly.
       - name: Notify (possible auto-update fault)
         id: notify-fault
         if: >

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -806,12 +806,18 @@ jobs:
       # The job is still RED either way. This changes what is SAID, never
       # whether it is reported.
       - name: Notify (unverified for environmental reasons, not a fleet problem)
+        # `id:` so `release_canary_wiring_test.sh` can find this step by
+        # something structural. Locating it by a phrase from its own message was
+        # tried first and an ordinary reword of that message immediately broke
+        # the pin -- which is the same "expectation stored as a copy of the
+        # thing it guards" shape this PR is about, one level down.
+        id: notify-environmental
         if: >
           needs.attach-to-release.result == 'success' &&
           needs.auto-update-selfupdate-canary.outputs.classification == 'environmental'
         uses: ./.github/actions/river-dev-notify
         with:
-          message: "⚠️ ${{ github.ref_name }} published fine, but the auto-update self-update canary could NOT VERIFY it: the previous release's binary could not reach GitHub from the runner, so the run proves nothing about the updater in either direction. This is NOT a stranded fleet and needs no fleet action — re-run the job to get a verdict. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          message: "⚠️ ${{ github.ref_name }} published fine, but auto-update for it is **UNVERIFIED** — the self-update canary never reached a verdict. The previous release's binary could not reach GitHub, and neither could the runner, so the run is not evidence in either direction. Nothing suggests a stranded fleet and no fleet action is indicated, but this release has NOT been shown to be reachable by auto-update: re-run the job to actually verify it. If you are seeing this on consecutive releases, stop treating it as noise — the post-publish gate is not working and nothing has been verified since the last green run. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
           room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
           gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}
@@ -822,6 +828,7 @@ jobs:
       # never ran) lands HERE, in the loud one. A gate's unknown case belongs on
       # the side that gets read.
       - name: Notify (possible auto-update fault)
+        id: notify-fault
         if: >
           !(needs.attach-to-release.result == 'success' &&
           needs.auto-update-selfupdate-canary.outputs.classification == 'environmental')

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -700,6 +700,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
+    outputs:
+      # 'ok' | 'environmental' | 'fault'. Read by the notify job below to pick
+      # its message. Job outputs are still populated when the job fails, which
+      # is the only case that reads this one.
+      classification: ${{ steps.canary.outputs.classification }}
     steps:
       - uses: actions/checkout@v7
 
@@ -726,11 +731,37 @@ jobs:
           echo "prev_version=${PREV_TAG#v}"  >> "$GITHUB_OUTPUT"
           echo "Canarying ${PREV_TAG} -> ${TAG_NAME}"
 
+      # Exit 75 (EX_TEMPFAIL, EXIT_UNVERIFIED_ENVIRONMENTAL in the canary) means
+      # the run was environmental -- the previous release's binary could not
+      # reach GitHub from this runner, or the ports were held -- so nothing was
+      # learned about the updater in either direction. The step still FAILS on
+      # it: unverified is not verified, and a green job here would be the
+      # vacuous pass the canary exists to remove. What the classification buys
+      # is the WORDING of the Matrix message below, which otherwise tells the
+      # dev room a node on the previous release may not be able to auto-update
+      # -- the #5221 alarm -- because a socket did not open.
+      #
+      # Not hypothetical: the node's startup fetch has no retry, and `framework`
+      # logged that WARN twice on 2026-08-11. Gate B's subject is a PUBLISHED
+      # binary, so that cannot be fixed from this side.
+      #
+      # `|| rc=$?` and NOT `|| true`: the exit code is re-raised at the end of
+      # the step. Swallowing it is how this gate would stop gating.
       - name: Previous release self-updates to this release
+        id: canary
         run: |
+          rc=0
           bash scripts/auto-update-canary.sh selfupdate \
             "${{ steps.prev.outputs.prev_version }}" \
-            "${{ steps.prev.outputs.this_version }}"
+            "${{ steps.prev.outputs.this_version }}" || rc=$?
+          if [ "$rc" -eq 75 ]; then
+            echo "classification=environmental" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -ne 0 ]; then
+            echo "classification=fault" >> "$GITHUB_OUTPUT"
+          else
+            echo "classification=ok" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$rc"
 
   # A red job in a release run is the primary signal, but nobody is guaranteed
   # to be watching Actions at release time — and a silent fail-closed is
@@ -755,7 +786,46 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
-      - uses: ./.github/actions/river-dev-notify
+
+      # The ENVIRONMENTAL case, and the only one that does not raise the alarm.
+      # Both conditions are required: the publish job succeeded (so the release
+      # is out and nothing is stuck as a draft), AND the canary itself said the
+      # run told us nothing about the updater (exit 75; see the canary step's
+      # comment and EXIT_UNVERIFIED_ENVIRONMENTAL in auto-update-canary.sh).
+      #
+      # WHY THIS BRANCH EXISTS. Everything below it says a node on the previous
+      # release "may not be able to auto-update to this one", which is the #5221
+      # text. Before this split, a runner that could not open a socket to
+      # github.com for a few seconds sent exactly that. The previous release's
+      # binary retries its startup fetch zero times, so the trigger is a routine
+      # network blip on a hosted runner, not a rare event -- and an alarm that
+      # cries #5221 on a blip is one the room learns to scroll past. That is the
+      # same alarm-fatigue failure that let `--disable-auto-update` sit unnoticed
+      # on `framework` for nine days.
+      #
+      # The job is still RED either way. This changes what is SAID, never
+      # whether it is reported.
+      - name: Notify (unverified for environmental reasons, not a fleet problem)
+        if: >
+          needs.attach-to-release.result == 'success' &&
+          needs.auto-update-selfupdate-canary.outputs.classification == 'environmental'
+        uses: ./.github/actions/river-dev-notify
+        with:
+          message: "⚠️ ${{ github.ref_name }} published fine, but the auto-update self-update canary could NOT VERIFY it: the previous release's binary could not reach GitHub from the runner, so the run proves nothing about the updater in either direction. This is NOT a stranded fleet and needs no fleet action — re-run the job to get a verdict. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}
+
+      # Everything else, unchanged. Written as the NEGATION of the branch above
+      # rather than as its own list of results, so a state neither branch
+      # anticipated (a cancelled job, an empty classification because the step
+      # never ran) lands HERE, in the loud one. A gate's unknown case belongs on
+      # the side that gets read.
+      - name: Notify (possible auto-update fault)
+        if: >
+          !(needs.attach-to-release.result == 'success' &&
+          needs.auto-update-selfupdate-canary.outputs.classification == 'environmental')
+        uses: ./.github/actions/river-dev-notify
         with:
           # Deliberately does NOT assert which failure happened. The job can be
           # red because the updater is broken OR because GitHub was unreachable,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -643,9 +643,40 @@ a tag that no longer exists is worse than the draft.
 
 ### If Gate B fails
 
-The release is already public and the fleet will **not** converge onto it on
-its own. Ship a fix release, and expect to roll existing nodes by hand
-(`freenet update`) as v0.2.120/v0.2.121 required.
+**Establish which of two things happened before acting.** They need opposite
+responses, and the alarm text names the worse one.
+
+**1. A stale canary constant, which is NOT a fleet problem.** Gate B's
+positive-equality check greps the previous release's log for
+`MARKER_LATEST_SEEN` (`scripts/auto-update-canary.sh`), and it arms only from
+`MARKER_LATEST_SEEN_SINCE` onwards. If that marker's TEXT was reworded and the
+constant was not moved to the release that first ships the new wording, Gate B
+demands text the published binary was never built to emit. Auto-update is fine;
+the gate is asking the wrong question. The Matrix alarm still says "a node on
+the previous release may not be able to auto-update", so read the job log rather
+than the alarm.
+
+Check first:
+
+```bash
+grep -n "MARKER_LATEST_SEEN\b\|MARKER_LATEST_SEEN_SINCE" scripts/auto-update-canary.sh
+```
+
+If the marker text was changed in this release's window, fix the constant (the
+test file freezes the two together and explains the choice) rather than shipping
+anything. The same applies to the other markers Gate B greps against the
+previous binary — `MARKER_DISABLED`, `MARKER_CHECK_RAN`, `MARKER_CHECK_COMPLETE`
+and `MARKER_TRIGGERED_RE` — which are not frozen and would produce the same false
+alarm with a less specific message.
+
+**2. A real detection or install failure.** The previous release genuinely
+cannot reach this one. The release is already public and the fleet will **not**
+converge onto it on its own: ship a fix release, and expect to roll existing
+nodes by hand (`freenet update`) as v0.2.120/v0.2.121 required.
+
+Gate A does not have this failure mode: it runs a binary built from the same
+tree as the canary, so a reword there is self-consistent. Gate B is the only
+place an OLDER binary's log is read.
 
 ## Post-release verification
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -643,10 +643,30 @@ a tag that no longer exists is worse than the draft.
 
 ### If Gate B fails
 
-**Establish which of two things happened before acting.** They need opposite
-responses, and the alarm text names the worse one.
+**Establish which of three things happened before acting.** They need different
+responses, and the loud alarm text names the worst one.
 
-**1. A stale canary constant, which is NOT a fleet problem.** Gate B's
+**0. The runner could not reach GitHub, which is NOT a fleet problem and the
+canary now says so itself.** The previous release's binary retries its startup
+fetch zero times, so an ordinary network blip on a hosted runner makes it log
+
+```
+Startup update check: failed to fetch latest version: error sending request
+for url (.../releases/latest). Continuing with current binary.
+```
+
+and the run learns nothing about the updater in either direction. Gate B retries
+(`CANARY_ATTEMPTS`, 2 by default), and if every attempt lands the same way it
+exits **75** (`EXIT_UNVERIFIED_ENVIRONMENTAL`, sysexits' EX_TEMPFAIL) with a
+message beginning `UNVERIFIED (ENVIRONMENTAL)`. `cross-compile.yml` keys off
+that code and sends the quiet ⚠️ message instead of the 🚨 one, so if you are
+reading the #5221 text this is not what happened. The job is still red: an
+unverified run is not a passed one. **Response: re-run the job.** Adding a retry
+to the node's own fetch (`crates/core/src/bin/commands/auto_update.rs`) would
+remove the class, but only for releases published after that lands, since Gate B
+always drives an already-published binary.
+
+**1. A stale canary constant, which is NOT a fleet problem either.** Gate B's
 positive-equality check greps the previous release's log for
 `MARKER_LATEST_SEEN` (`scripts/auto-update-canary.sh`), and it arms only from
 `MARKER_LATEST_SEEN_SINCE` onwards. If that marker's TEXT was reworded and the
@@ -665,9 +685,16 @@ grep -n "MARKER_LATEST_SEEN\b\|MARKER_LATEST_SEEN_SINCE" scripts/auto-update-can
 If the marker text was changed in this release's window, fix the constant (the
 test file freezes the two together and explains the choice) rather than shipping
 anything. The same applies to the other markers Gate B greps against the
-previous binary — `MARKER_DISABLED`, `MARKER_CHECK_RAN`, `MARKER_CHECK_COMPLETE`
-and `MARKER_TRIGGERED_RE` — which are not frozen and would produce the same false
-alarm with a less specific message (#5309).
+previous binary — `MARKER_DISABLED`, `MARKER_CHECK_RAN`, `MARKER_CHECK_COMPLETE`,
+`MARKER_TRIGGERED_RE` and `MARKER_FETCH_FAIL` — which are not frozen and would
+produce the same false alarm with a less specific message (#5309 tracks the
+first four; it does not name `MARKER_FETCH_FAIL`).
+
+`MARKER_PARSE_FAIL` is the one to be most careful with, and it IS frozen
+(`auto-update-canary_test.sh`), because it is the only marker whose reword fails
+in the PASSING direction: it feeds Gate B's negative check, so a grep that stops
+matching the text published binaries emit reports `OK: parsed GitHub's response`
+for a release carrying the live #5221 bug.
 
 **2. A real detection or install failure.** The previous release genuinely
 cannot reach this one. The release is already public and the fleet will **not**
@@ -694,7 +721,9 @@ verification skill if you have it):
    gateway shows no errors.
 6. The `Auto-update self-update canary` job in the tag's `cross-compile` run
    is green — a node on the previous release reached this one on its own. If
-   it is red, the fleet is stranded; see "Auto-update canary" above.
+   it is red, read the job log before concluding anything: a red job can mean
+   the fleet is stranded OR that the run was environmental (exit 75, quiet ⚠️
+   Matrix message, re-run it). See "If Gate B fails" above.
 
 [PR #4135]: https://github.com/freenet/freenet-core/pull/4135
 [river#241]: https://github.com/freenet/river/issues/241

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -643,38 +643,60 @@ a tag that no longer exists is worse than the draft.
 
 ### If Gate B fails
 
-**Establish which of three things happened before acting.** They need different
-responses, and the loud alarm text names the worst one.
+**A red Gate B is not by itself a fleet problem, and the Matrix message is not
+enough to tell.** Five distinct outcomes end in a red job; only one of them means
+a node on the previous release genuinely cannot reach this one. **Read the
+`::error::` line in the job log before doing anything** — it names which.
 
-**0. The runner could not reach GitHub, which is NOT a fleet problem and the
-canary now says so itself.** The previous release's binary retries its startup
-fetch zero times, so an ordinary network blip on a hosted runner makes it log
+The wording below is generated from the code, so match on the quoted phrases
+rather than on the shape of the alarm.
+
+| What the log says | Exit | Matrix | What it means | Response |
+|---|---|---|---|---|
+| `UNVERIFIED (ENVIRONMENTAL): … could not reach GitHub … and this runner cannot reach it either` | 75 | ⚠️ quiet | The network was down for both the node and the runner. Nothing learned. | Re-run the job. |
+| `UNVERIFIED (ENVIRONMENTAL): every attempt hit a port collision on this host` | 75 | ⚠️ quiet | Something else on the runner held the ports; the node never started. | Re-run the job. |
+| `UNVERIFIED: … reported it could not reach GitHub … but THIS RUNNER reached the same endpoint immediately afterwards` | 1 | 🚨 loud | The published binary consistently could not do what the runner just did. Most likely its persisted poll-budget cooldown (#5102), possibly a published fetch-side regression. **Not a stranded fleet.** | Read the node output. Re-run; if it recurs across releases it is not the runner. |
+| `UNVERIFIED: at least one attempt started the update check and never logged an outcome` | 1 | 🚨 loud | A hung updater, or the check was cut short. Genuinely unknown. | Re-run. Persisting, treat as a real fault. |
+| Anything naming a specific detection or install failure | 1 | 🚨 loud | The real thing. See case 3. | See case 3. |
+
+**The trap this table exists to remove.** An earlier version of this section said
+a fetch failure always gives exit 75 and the quiet ⚠️, and told the reader that
+if they were looking at the 🚨 text "this is not what happened". That stopped
+being true when the corroboration probe landed: the GitHub cause now *also*
+requires this runner to fail the same fetch, and a hosted runner is normally
+online by probe time. So the common case — the previous release's binary logging
 
 ```
 Startup update check: failed to fetch latest version: error sending request
 for url (.../releases/latest). Continuing with current binary.
 ```
 
-and the run learns nothing about the updater in either direction. Gate B retries
-(`CANARY_ATTEMPTS`, 2 by default), and if every attempt lands the same way it
-exits **75** (`EXIT_UNVERIFIED_ENVIRONMENTAL`, sysexits' EX_TEMPFAIL) with a
-message beginning `UNVERIFIED (ENVIRONMENTAL)`. `cross-compile.yml` keys off
-that code and sends the quiet ⚠️ message instead of the 🚨 one, so if you are
-reading the #5221 text this is not what happened. The job is still red: an
-unverified run is not a passed one. **Response: re-run the job.** Adding a retry
-to the node's own fetch (`crates/core/src/bin/commands/auto_update.rs`) would
-remove the class, but only for releases published after that lands, since Gate B
-always drives an already-published binary.
+on an otherwise healthy runner — produces **exit 1 and the loud 🚨**, and the old
+text sent the reader straight past it into "a real detection failure" and on to
+cutting a fix release for a poll-budget cooldown.
 
-**1. A stale canary constant, which is NOT a fleet problem either.** Gate B's
+**1. Environmental (exit 75, quiet ⚠️).** Two causes, both above. The previous
+release's binary retries its startup fetch zero times, so a single bad moment on
+the network is enough to produce the first. Gate B retries (`CANARY_ATTEMPTS`, 2
+by default) and only reports this if every attempt lands the same way AND this
+runner also cannot reach the endpoint. The job stays red: unverified is not
+verified. Adding a retry to the node's own fetch
+(`crates/core/src/bin/commands/auto_update.rs`) would shrink the class, but only
+for releases published after that lands, since Gate B always drives an
+already-published binary.
+
+If either of these appears on **consecutive** releases, stop treating it as
+noise: nothing has been verified since the last green run, and for the GitHub
+cause a persistent node-side failure that this runner does not share is a
+published fetch-side regression rather than weather.
+
+**2. A stale canary constant, which is NOT a fleet problem either.** Gate B's
 positive-equality check greps the previous release's log for
 `MARKER_LATEST_SEEN` (`scripts/auto-update-canary.sh`), and it arms only from
 `MARKER_LATEST_SEEN_SINCE` onwards. If that marker's TEXT was reworded and the
 constant was not moved to the release that first ships the new wording, Gate B
 demands text the published binary was never built to emit. Auto-update is fine;
-the gate is asking the wrong question. The Matrix alarm still says "a node on
-the previous release may not be able to auto-update", so read the job log rather
-than the alarm.
+the gate is asking the wrong question.
 
 Check first:
 
@@ -692,11 +714,10 @@ first four; it does not name `MARKER_FETCH_FAIL`).
 
 `MARKER_FETCH_FAIL` is the one of those five to check first. It is no longer
 just a marker Gate B greps: it is the input to the environmental classification
-described in case 0 above. Reword it and a previous release's failed fetch stops
-being recognised as environmental, so every network blip goes back to firing the
-loud 🚨 "may not be able to auto-update" message — reinstating the false fleet
-alarm that classification exists to remove, from an edit that looks unrelated
-to it.
+in case 1. Reword it and a previous release's failed fetch stops being
+recognised as environmental at all, so even the genuinely-offline case fires the
+loud 🚨 — reinstating the false fleet alarm that classification exists to
+remove, from an edit that looks unrelated to it.
 
 `MARKER_PARSE_FAIL` is the one to be most careful with, and it IS frozen
 (`auto-update-canary_test.sh`), because it is the only marker whose reword fails
@@ -704,14 +725,14 @@ in the PASSING direction: it feeds Gate B's negative check, so a grep that stops
 matching the text published binaries emit reports `OK: parsed GitHub's response`
 for a release carrying the live #5221 bug.
 
-**2. A real detection or install failure.** The previous release genuinely
+**3. A real detection or install failure.** The previous release genuinely
 cannot reach this one. The release is already public and the fleet will **not**
 converge onto it on its own: ship a fix release, and expect to roll existing
 nodes by hand (`freenet update`) as v0.2.120/v0.2.121 required.
 
-Gate A does not have this failure mode: it runs a binary built from the same
-tree as the canary, so a reword there is self-consistent. Gate B is the only
-place an OLDER binary's log is read.
+Gate A does not have the case-2 failure mode: it runs a binary built from the
+same tree as the canary, so a reword there is self-consistent. Gate B is the
+only place an OLDER binary's log is read.
 
 ## Post-release verification
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -690,6 +690,14 @@ previous binary — `MARKER_DISABLED`, `MARKER_CHECK_RAN`, `MARKER_CHECK_COMPLET
 produce the same false alarm with a less specific message (#5309 tracks the
 first four; it does not name `MARKER_FETCH_FAIL`).
 
+`MARKER_FETCH_FAIL` is the one of those five to check first. It is no longer
+just a marker Gate B greps: it is the input to the environmental classification
+described in case 0 above. Reword it and a previous release's failed fetch stops
+being recognised as environmental, so every network blip goes back to firing the
+loud 🚨 "may not be able to auto-update" message — reinstating the false fleet
+alarm that classification exists to remove, from an edit that looks unrelated
+to it.
+
 `MARKER_PARSE_FAIL` is the one to be most careful with, and it IS frozen
 (`auto-update-canary_test.sh`), because it is the only marker whose reword fails
 in the PASSING direction: it feeds Gate B's negative check, so a grep that stops

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -667,7 +667,7 @@ test file freezes the two together and explains the choice) rather than shipping
 anything. The same applies to the other markers Gate B greps against the
 previous binary — `MARKER_DISABLED`, `MARKER_CHECK_RAN`, `MARKER_CHECK_COMPLETE`
 and `MARKER_TRIGGERED_RE` — which are not frozen and would produce the same false
-alarm with a less specific message.
+alarm with a less specific message (#5309).
 
 **2. A real detection or install failure.** The previous release genuinely
 cannot reach this one. The release is already public and the fleet will **not**

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -171,12 +171,22 @@ MARKER_LATEST_SEEN='Startup update check: GitHub reports latest release'
 # constant's value.
 #
 # If a Gate B run reports "never logged which release it compared against" for
-# a previous release at or above this version, the marker was REMOVED (a real
-# finding) or this constant is set one release too early (bump it).
+# a previous release at or above this version, the marker was REMOVED -- that is
+# a real finding about the node, not a reason to touch this constant.
+#
 # 0.2.125, not 0.2.124: the marker landed in the 0.2.124 tree, but that release
 # was never PUBLISHED (Gate A blocked it on the TMPDIR harness bug, #5290) and a
 # draft is invisible to `/releases/latest`. So no release a node can reach emits
 # this line until 0.2.125, and Gate B must not demand it from 0.2.123.
+#
+# FROZEN. This is a fact about release history -- which release first shipped
+# the line -- and release history does not change, so the value must NOT track
+# the version being cut. Raising it to the current release skips Gate B's only
+# positive assertion for that release, and a constant kept level with the crate
+# version disarms the gate on every release while looking maintained.
+# `auto-update-canary_test.sh` pins both halves: the value against this literal,
+# and the constant against the crate version so it can never sit ABOVE it (from
+# where `prev_emits_latest_seen` could never arm at all).
 MARKER_LATEST_SEEN_SINCE='0.2.125'
 
 MUSL_ASSET='freenet-x86_64-unknown-linux-musl.tar.gz'

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -206,6 +206,31 @@ RELEASE_BASE='https://github.com/freenet/freenet-core/releases/download'
 # not an updater fault -- see where it is classified in the gate commands.
 EXIT_CODE_ALREADY_RUNNING=43
 
+# THIS SCRIPT's exit code for "the run was environmental; nothing was learned
+# about the updater". Gate B only. `cross-compile.yml` keys the WORDING of its
+# Matrix message off this, so the dev room stops being told the fleet may be
+# stranded because a runner could not reach github.com for four seconds.
+#
+# 75 is sysexits.h's EX_TEMPFAIL, "temporary failure; the user is invited to
+# retry", which is the convention this file already follows with its `exit 64`
+# (EX_USAGE) for bad arguments.
+#
+# DELIBERATELY NOT 43. That is the NODE's exit code for a port collision, and
+# reusing it here would make "the canary exited 43" mean either "another process
+# held the port" or "the node started fine and GitHub was unreachable" --
+# indistinguishable at the one moment someone is reading it under time pressure,
+# on a release. The port collision is one of the two things that produce a 75;
+# it is not what 75 means.
+#
+# The job still goes RED on a 75. Unverified is not verified, and reporting green
+# on a run that proved nothing is the vacuous pass this whole file exists to
+# remove. What changes is only what the alarm SAYS.
+#
+# Gate A deliberately does NOT use this: it BLOCKS, an unverified blocking gate
+# leaves the release stuck as a draft, and a stuck draft always needs a human
+# whatever the cause.
+EXIT_UNVERIFIED_ENVIRONMENTAL=75
+
 # Ports deliberately off the node defaults (31337 / 7509) so a canary run does
 # not collide with a real node on the same host.
 #
@@ -306,6 +331,31 @@ node_check_settled() {
     return 0
   fi
   node_decided_to_update "$logdir"
+}
+
+# True when the node itself said it could not reach GitHub.
+#
+# `assert_detection_healthy` returns 2 for TWO different situations -- this one,
+# and "the check started but never logged an outcome" -- and Gate B needs to
+# tell them apart to word its alarm. It cannot: an exit code is one number, and
+# the function is deliberately pure so it stays fixture-testable. So the caller
+# re-reads the logs through this predicate rather than the function growing an
+# out-parameter.
+#
+# WHY THIS MATTERS, and it is a live risk rather than a tidy-up. The node's
+# startup fetch has NO retry (`startup_update_check_with_fetcher`, one
+# `fetcher().await`, warn and return on Err), and it demonstrably fails: two
+# WARNs on the `framework` laptop on 2026-08-11 alone, 17:08:04Z and 00:35:13Z,
+#     Startup update check: failed to fetch latest version: error sending
+#     request for url (.../releases/latest). Continuing with current binary.
+# Gate B's subject is a PUBLISHED binary, so that no-retry fetch is a property
+# of the thing under test and cannot be fixed from here. Adding one to the node
+# is worth doing and is deliberately out of this file's scope.
+#
+# No pipe, for the SIGPIPE reason documented on `node_decided_to_update`.
+node_could_not_reach_github() {
+  local logdir="$1"
+  grep -aqF "$MARKER_FETCH_FAIL" "$logdir"/freenet.*.log 2>/dev/null
 }
 
 # Fixed-string presence / extraction over the node's log FILES.
@@ -1009,32 +1059,86 @@ cmd_selfupdate() {
     note "NOTE: v$prev_version predates the observed-latest log line (#5236, first emitted by v$MARKER_LATEST_SEEN_SINCE), so Gate B's positive-equality check is SKIPPED. It arms itself once the previous release is v$MARKER_LATEST_SEEN_SINCE or newer; no action needed."
   fi
 
-  run_node_until_check "$work/bin/freenet" "$work"
+  # RETRY the environmental cases, exactly as Gate A does. Gate B had NO retry
+  # at all -- `CANARY_ATTEMPTS` was read only by `cmd_preflight` -- so a single
+  # transient blip in a ~40s window decided a release's post-publish verdict,
+  # and the blip is not hypothetical: the previous release's own startup fetch
+  # has no retry (see `node_could_not_reach_github`).
+  #
+  # `$work/bin` is preserved across attempts and everything else is wiped, which
+  # is the opposite of Gate A's `rm -rf "${work:?}"` and deliberate: the
+  # downloaded previous release is the SUBJECT, not state. State must go, for
+  # Gate A's reason -- the node persists its GitHub poll token-bucket and
+  # rate-limit cooldown under `$work/home`, so an attempt that reuses them
+  # re-reads the same cooldown and reports the identical INDETERMINATE without
+  # ever asking GitHub. A retry that cannot produce a different answer is not a
+  # retry.
+  #
+  # Only rc=2 and the port collision loop. Everything else is deterministic:
+  # re-running a node that parsed the wrong version burns release time to
+  # reproduce a fact already established. And the loop can never run twice after
+  # a decision to update, because that path leaves the loop with rc=0.
+  local attempt rc environmental=0
+  for attempt in $(seq 1 "$CANARY_ATTEMPTS"); do
+    log "--- attempt $attempt/$CANARY_ATTEMPTS ---"
+    rm -rf "${work:?}/home" "${work:?}/cfg" "${work:?}/data" \
+           "${work:?}/logs" "${work:?}/tmp" "${work:?}/cache"
+    # Distinct ports per attempt, as Gate A does, so a collision that caused the
+    # retry cannot cause the next one too.
+    CANARY_NETWORK_PORT=$((CANARY_NETWORK_PORT + 1))
+    CANARY_WS_PORT=$((CANARY_WS_PORT + 1))
+    run_node_until_check "$work/bin/freenet" "$work"
 
-  # Same port-collision classification as Gate A, and for the same reason: the
-  # log assertion below never consults NODE_EXIT, so a 43 reads as an
-  # auto-update fault. Gate B has no retry loop, so this corrects only the
-  # DIAGNOSIS -- but that is the difference between "re-run this job" and
-  # someone hunting a fleet-wide updater break that does not exist.
-  if [ "$NODE_EXIT" = "$EXIT_CODE_ALREADY_RUNNING" ]; then
-    dump_node_evidence "$work"
-    fail "UNVERIFIED: the node exited $EXIT_CODE_ALREADY_RUNNING (another instance already holds ports $CANARY_NETWORK_PORT/$CANARY_WS_PORT), so Gate B never got to test the updater. This is a port collision on this host -- another canary run, or a local node -- NOT an auto-update fault. Re-run the job."
-    return 1
-  fi
+    # Classified BEFORE the log assertion, for the same reason as in Gate A: the
+    # assertion never consults NODE_EXIT, so a node that died on a port
+    # collision without an update-check line reads as "the startup update check
+    # never ran" -- an auto-update fault reported for another process holding a
+    # port.
+    if [ "$NODE_EXIT" = "$EXIT_CODE_ALREADY_RUNNING" ]; then
+      note "INDETERMINATE: the node exited $EXIT_CODE_ALREADY_RUNNING (another instance already holds ports $CANARY_NETWORK_PORT/$CANARY_WS_PORT). A port collision on this host -- another canary run, or a local node -- not an auto-update fault."
+      rc=2
+      environmental=1
+    else
+      # The two-sided log assertion first: it LOCALISES the failure. If detection
+      # is broken the version check below would also fail, but with a far less
+      # useful message.
+      assert_detection_healthy "$work/logs"
+      rc=$?
+      # Which KIND of indeterminate. Only the node saying outright that it could
+      # not reach GitHub counts as environmental. "The check started and never
+      # logged an outcome" stays a real finding: a hung updater produces exactly
+      # that, and calling it environmental would be the quiet direction.
+      if [ "$rc" -eq 2 ] && node_could_not_reach_github "$work/logs"; then
+        environmental=1
+      else
+        environmental=0
+      fi
+    fi
 
-  # The two-sided log assertion first: it LOCALISES the failure. If detection
-  # is broken the version check below would also fail, but with a far less
-  # useful message.
-  assert_detection_healthy "$work/logs"
-  local rc=$?
-  # Keep the node's own output before the EXIT trap deletes the workdir.
-  [ "$rc" -eq 0 ] || dump_node_evidence "$work"
+    # Keep the node's own output before the next attempt wipes the tree, or the
+    # EXIT trap deletes it. Only on a non-zero verdict, so a healthy release
+    # stays quiet.
+    [ "$rc" -eq 0 ] || dump_node_evidence "$work"
+    [ "$rc" -eq 2 ] || break
+    if [ "$attempt" -lt "$CANARY_ATTEMPTS" ]; then
+      log "indeterminate (no verdict from the update check); retrying in ${CANARY_RETRY_SLEEP}s"
+      sleep "$CANARY_RETRY_SLEEP"
+    fi
+  done
+
   if [ "$rc" -eq 2 ]; then
-    # Infrastructure, not a stranded fleet. Still a failure -- reporting green
-    # on an unverified run is the vacuous-pass this canary exists to prevent --
-    # but worded so nobody reads it as "the fleet is broken" and learns to
-    # ignore the alarm.
-    fail "UNVERIFIED: the update check produced no verdict (GitHub unreachable, or it never logged an outcome), so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works. Re-run the job."
+    if [ "$environmental" -eq 1 ]; then
+      # The node told us why, and the reason is not the updater. Distinct exit
+      # code so `cross-compile.yml` can word the Matrix message accordingly:
+      # the alarm that says a node "may not be able to auto-update to this one"
+      # must not fire for a runner that could not open a socket. Still a
+      # non-zero exit and still a red job -- unverified is not verified.
+      fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub from this runner in $CANARY_ATTEMPTS attempts, so the canary never got to test whether it reaches v$expected_version. This says NOTHING about auto-update, in either direction: the node's startup fetch has no retry, and a runner that cannot resolve or connect to github.com produces exactly this. Re-run the job. Do NOT read this as a stranded fleet."
+      return "$EXIT_UNVERIFIED_ENVIRONMENTAL"
+    fi
+    # Infrastructure, not a stranded fleet -- but the node never said WHY, so
+    # this keeps the ordinary failure exit. A hung updater lands here.
+    fail "UNVERIFIED: the update check produced no verdict in $CANARY_ATTEMPTS attempts (it started and never logged an outcome), so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works. Note that the node did NOT report a failed GitHub fetch, so this is not simply an unreachable runner. Re-run the job."
     return 1
   fi
   [ "$rc" -eq 0 ] || return 1

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -200,6 +200,13 @@ MARKER_LATEST_SEEN_SINCE='0.2.125'
 
 MUSL_ASSET='freenet-x86_64-unknown-linux-musl.tar.gz'
 RELEASE_BASE='https://github.com/freenet/freenet-core/releases/download'
+# The endpoint the NODE uses for its startup check (the 302 from
+# `/releases/latest`). Named once because two callers must hit exactly the same
+# URL: `resolve_expected_latest`, which reads the tag out of the redirect, and
+# `runner_can_reach_github`, whose whole job is to answer whether the runner can
+# reach the endpoint the node just failed on. Two copies that could drift would
+# make the corroboration compare different things.
+RELEASES_LATEST_URL='https://github.com/freenet/freenet-core/releases/latest'
 
 # The node's exit code for "another instance already holds my WS port"
 # (EXIT_CODE_ALREADY_RUNNING in crates/core/src/bin/freenet.rs). Environmental,
@@ -931,7 +938,7 @@ resolve_expected_latest() {
   # which is all bare `--retry` covers.
   url="$(curl -fsS --max-time 30 --retry 2 --retry-all-errors \
     -o /dev/null -w '%{redirect_url}' \
-    'https://github.com/freenet/freenet-core/releases/latest' 2>/dev/null)" || return 1
+    "$RELEASES_LATEST_URL" 2>/dev/null)" || return 1
   case "$url" in
     */releases/tag/*) tag="${url##*/releases/tag/}" ;;
     *) return 1 ;;
@@ -942,10 +949,37 @@ resolve_expected_latest() {
 
 # True when THIS RUNNER can reach the release endpoint the node uses.
 #
-# A named one-liner rather than the call inlined, so the decision below can be
+# A named function rather than the call inlined, so the decision below can be
 # unit-tested by overriding it. Same reason `prev_emits_latest_seen` exists.
+#
+# IT ASKS CURL DIRECTLY rather than going through `resolve_expected_latest`,
+# and the difference is the whole point. That function collapses every
+# non-answer to `return 1` -- a 403, a captive portal, a changed redirect shape,
+# curl missing from the image -- so "the probe malfunctioned" and "the network
+# is down" become the same value. Read as corroboration, every one of those
+# falls to the QUIET path, which is the direction that hides things.
+#
+# So only the CONNECT-CLASS curl exits count as "cannot reach". Anything else,
+# including success and including an HTTP error, means the runner did reach
+# GitHub and the node's inability to is not explained by the network -- loud.
+# An unusable body is likewise not evidence of an outage. Curl absent (127)
+# lands in the same arm, which is right: a broken harness must not buy silence.
+#
+#   6  could not resolve host      7  failed to connect
+#   28 operation timed out         35 SSL connect error
+#
+# Not a full closure of the class: a transient probe failure coinciding with a
+# genuine node-side fault still yields one quiet run. A PERSISTENT probe break
+# is caught earlier -- Gate A exercises the same path on the shipping binary and
+# blocks -- and the quiet message's own consecutive-releases text covers the
+# rest.
 runner_can_reach_github() {
-  resolve_expected_latest >/dev/null 2>&1
+  local rc=0
+  curl -fsS --max-time 30 -o /dev/null "$RELEASES_LATEST_URL" 2>/dev/null || rc=$?
+  case "$rc" in
+    6|7|28|35) return 1 ;;
+    *)         return 0 ;;
+  esac
 }
 
 # gate_b_unverified_class <env-cause> -- "environmental" or "fault", for a Gate
@@ -1254,15 +1288,34 @@ cmd_selfupdate() {
       fi
     fi
 
-    # Fold this attempt into the run-level classification. An explained
-    # indeterminate records its cause; an UNEXPLAINED one latches and is never
-    # overwritten (see the note on `saw_unexplained` above).
+    # Fold this attempt into the run-level classification, STICKY BY STRENGTH
+    # rather than by recency:
+    #
+    #     unexplained  >  github  >  ports
+    #
+    # `saw_unexplained` is the top tier and is handled separately below. The
+    # same rule has to apply one level down, and the first version of this got
+    # that wrong: `env_cause="$attempt_cause"` unconditionally, so the two
+    # orderings of the same pair of attempts disagreed.
+    #
+    #   ports THEN github  -> env_cause=github -> the runner probe runs -> loud.
+    #   github THEN ports  -> env_cause=ports  -> the probe NEVER RUNS, because
+    #                         a port collision is not probed, so the run exits
+    #                         75 quiet AND claims "every attempt hit a port
+    #                         collision on this host", which is false.
+    #
+    # Reachable at the default two attempts. A recorded `github` must therefore
+    # never be downgraded to `ports`: ports is the weakest cause because it is
+    # the only one that buys the quiet path without any corroboration.
     if [ "$rc" -eq 2 ]; then
-      if [ -n "$attempt_cause" ]; then
-        env_cause="$attempt_cause"
-      else
-        saw_unexplained=1
-      fi
+      case "$attempt_cause" in
+        '')     saw_unexplained=1 ;;
+        github) env_cause=github ;;
+        ports)  [ "$env_cause" = "github" ] || env_cause=ports ;;
+        *)      # An unrecognised cause is not quiet-eligible; treat it as
+                # unexplained rather than letting it fall through unrecorded.
+                saw_unexplained=1 ;;
+      esac
     fi
 
     # Keep the node's own output before the next attempt wipes the tree, or the

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -1355,15 +1355,23 @@ cmd_selfupdate() {
           fail "UNVERIFIED (ENVIRONMENTAL): every attempt hit a port collision on this host, so Gate B never got to test the updater. v$expected_version has NOT been verified as reachable by a node on v$prev_version -- this run says nothing either way. Another canary run or a local node is holding the ports. Re-run the job; if it recurs, something on this runner is holding them persistently and the gate is not working."
           ;;
         *)
-          fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub in $CANARY_ATTEMPTS attempts, and this runner cannot reach it either, so the canary never got to test whether v$prev_version reaches v$expected_version. v$expected_version has NOT been verified as reachable by auto-update -- this run is not evidence in either direction. The node's startup fetch has no retry, so a bad network moment produces exactly this. Re-run the job. If Gate B reports this on CONSECUTIVE releases it is not the runner: the same WARN is also what a published fetch-side regression logs (a bad URL, a TLS or user-agent change, a rate-limited endpoint), and either way the post-publish gate is not working and nothing has been verified since the last green run."
+          fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub on $github_attempts of $CANARY_ATTEMPTS attempt(s), and this runner cannot reach it either, so the canary never got to test whether v$prev_version reaches v$expected_version. v$expected_version has NOT been verified as reachable by auto-update -- this run is not evidence in either direction. The node's startup fetch has no retry, so a bad network moment produces exactly this. Re-run the job. If Gate B reports this on CONSECUTIVE releases it is not the runner: the same WARN is also what a published fetch-side regression logs (a bad URL, a TLS or user-agent change, a rate-limited endpoint), and either way the post-publish gate is not working and nothing has been verified since the last green run."
           ;;
       esac
       return "$EXIT_UNVERIFIED_ENVIRONMENTAL"
     fi
     if [ "$env_cause" = "github" ]; then
-      # The node said it could not reach GitHub, on every attempt -- and this
-      # runner reached the same endpoint moments later. Not a blip, so not
+      # The node said it could not reach GitHub on at least one attempt -- and
+      # this runner reached the same endpoint moments later. Not a blip, so not
       # something to reassure anyone about.
+      #
+      # "at least one", not "every": sticky-by-strength promotes `github` over
+      # `ports`, so a mixed run lands here with one github attempt. Both this
+      # branch and its environmental SIBLING above print `$github_attempts`
+      # rather than `$CANARY_ATTEMPTS` for that reason. The sibling was missed
+      # when this one was fixed, and stated the false unanimity for a further
+      # commit -- see the enumeration note in
+      # `.claude/rules/bug-prevention-patterns.md`.
       fail "UNVERIFIED: v$prev_version reported it could not reach GitHub on $github_attempts of $CANARY_ATTEMPTS attempt(s), but THIS RUNNER reached the same endpoint immediately afterwards. So the network is not simply down: the published binary consistently cannot do something this runner can. That may still not be an auto-update fault -- a poll-budget cooldown persisted under the node's HOME is the obvious candidate (#5102) -- but it is not environmental noise, and v$expected_version is NOT verified as reachable. Read the node output above before re-running."
       return 1
     fi

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -1233,11 +1233,20 @@ cmd_selfupdate() {
       # useful message.
       assert_detection_healthy "$work/logs"
       rc=$?
-      # Which KIND of indeterminate, recorded from the LAST attempt. Only the
-      # node saying outright that it could not reach GitHub is a candidate for
-      # the quiet path; "the check started and never logged an outcome" is not,
-      # because a hung updater produces exactly that. The candidacy is not the
-      # verdict -- see `gate_b_unverified_class`, which demands corroboration.
+      # Which KIND of indeterminate THIS attempt was. Deliberately per-attempt
+      # and NOT the run's answer: the fold below decides that, and it latches.
+      #
+      # (This comment used to read "recorded from the LAST attempt", which was
+      # true of the last-writer-wins version and became false when the latch
+      # landed. A reviewer read the tree, read this line, and correctly
+      # concluded the bug was still present -- from the comment, not the code.
+      # A stale comment on a fixed bug costs a review round.)
+      #
+      # Only the node saying outright that it could not reach GitHub is a
+      # CANDIDATE for the quiet path; "the check started and never logged an
+      # outcome" is not, because a hung updater produces exactly that.
+      # Candidacy is not the verdict -- see `gate_b_unverified_class`, which
+      # demands corroboration on top.
       if [ "$rc" -eq 2 ] && node_could_not_reach_github "$work/logs"; then
         attempt_cause=github
       else

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -161,32 +161,41 @@ MARKER_CHECK_COMPLETE='Startup update check complete'
 # the value against the tag GitHub actually published (see
 # CANARY_EXPECTED_LATEST) and fail on a mismatch.
 MARKER_LATEST_SEEN='Startup update check: GitHub reports latest release'
-# The first release whose binary EMITS the line above. It is new in #5236, and
-# Gate B's subject is the PREVIOUS release -- so for exactly one release the
-# binary under test predates the marker and has no observed-latest line to
-# compare. Arming the equality check against it would fail the gate for a line
-# that binary was never built to emit: a release blocked by its predecessor's
-# age. Gate B therefore arms the check only from `prev_version` onwards, which
-# makes this self-retiring -- permanently true from the release AFTER this
-# constant's value.
-#
-# If a Gate B run reports "never logged which release it compared against" for
-# a previous release at or above this version, the marker was REMOVED -- that is
-# a real finding about the node, not a reason to touch this constant.
+# The first PUBLISHED release whose binary emits the exact text above. Gate B's
+# subject is whatever release is currently newest-published, and a binary older
+# than this value has no observed-latest line to compare -- arming the equality
+# check against it would fail the gate for a line that binary was never built to
+# emit. So Gate B arms the check only from this version onwards.
 #
 # 0.2.125, not 0.2.124: the marker landed in the 0.2.124 tree, but that release
 # was never PUBLISHED (Gate A blocked it on the TMPDIR harness bug, #5290) and a
 # draft is invisible to `/releases/latest`. So no release a node can reach emits
 # this line until 0.2.125, and Gate B must not demand it from 0.2.123.
 #
-# FROZEN. This is a fact about release history -- which release first shipped
-# the line -- and release history does not change, so the value must NOT track
-# the version being cut. Raising it to the current release skips Gate B's only
-# positive assertion for that release, and a constant kept level with the crate
-# version disarms the gate on every release while looking maintained.
-# `auto-update-canary_test.sh` pins both halves: the value against this literal,
-# and the constant against the crate version so it can never sit ABOVE it (from
-# where `prev_emits_latest_seen` could never arm at all).
+# WHEN THIS CONSTANT SHOULD AND SHOULD NOT MOVE
+#
+# It is a fact about release history -- which published release first shipped
+# this exact text -- so under ordinary releases it does NOT move. Raising it to
+# the version being cut skips Gate B's only positive assertion for that release,
+# and a constant kept level with the crate version disarms the gate on every
+# release while looking maintained. Do not "refresh" it.
+#
+# But there is one edit where moving it IS correct, and it is easy to miss:
+# REWORDING OR REMOVING THE MARKER. Change the text above and the value below
+# must move to the first release that will SHIP the new text -- normally the
+# NEXT release, since the bump happens inside the release commit. Leave it and
+# Gate B demands the new wording from a published binary that emits the old one,
+# which surfaces as a POST-PUBLISH red canary and a Matrix alarm whose text
+# blames the node ("may not be able to auto-update"). Nothing else in the suite
+# notices: the source pin interpolates $MARKER_LATEST_SEEN, so it follows a
+# rename by construction. `auto-update-canary_test.sh` therefore freezes the
+# marker text and this version TOGETHER, so a reword fails there and forces the
+# author to decide about this line in the same edit.
+#
+# If a Gate B run reports "never logged which release it compared against" for a
+# previous release at or above this version, work out which of the two it is:
+# the marker was REMOVED from the node (a real finding), or the marker was
+# REWORDED and this constant was not moved with it (fix it here).
 MARKER_LATEST_SEEN_SINCE='0.2.125'
 
 MUSL_ASSET='freenet-x86_64-unknown-linux-musl.tar.gz'
@@ -773,11 +782,38 @@ normalise_release_tag() {
   printf '%s' "${1#v}"
 }
 
-# version_at_least <a> <b> -- true when semver <a> is >= <b>.
+# is_dotted_version <s> -- true for a bare dotted numeric version (`0.2.125`).
+#
+# Deliberately narrower than semver: this repo cuts no pre-release or build
+# metadata, `sort -V` orders `0.2.125-rc.1` ABOVE `0.2.125` where semver puts it
+# below, and accepting a form the comparator gets wrong is worse than refusing
+# it. If rc tags are ever cut, fix the comparator before widening this.
+is_dotted_version() {
+  case "$1" in
+    ''|*[!0-9.]*|.*|*.) return 1 ;;
+    *..*)               return 1 ;;
+    *)                  return 0 ;;
+  esac
+}
+
+# version_at_least <a> <b> -- true when dotted version <a> is >= <b>.
 #
 # `sort -V` rather than a field split: it gets 0.2.9 < 0.2.10 right, which a
 # lexical compare does not, and equal inputs land on the last line either way.
+#
+# MALFORMED INPUT IS REFUSED, LOUDLY, and that is not defensive tidying -- the
+# bare comparison answers TRUE for garbage. Measured on GNU coreutils 9.4:
+# `version_at_least "not-a-version" "0.2.125"` is TRUE (non-numeric sorts after
+# digits under `sort -V`), and `version_at_least "0.2.125" ""` is TRUE. So an
+# unreadable version or an emptied constant silently PASSES a comparison it
+# should not even be able to answer. Refusing returns false, so callers must
+# decide what an unanswerable comparison means for them rather than inheriting
+# an accidental yes; `prev_emits_latest_seen` below does exactly that.
 version_at_least() {
+  if ! is_dotted_version "$1" || ! is_dotted_version "$2"; then
+    note "version_at_least: refusing to compare '$1' with '$2' -- not both bare dotted versions. Treating as FALSE; the comparison cannot be answered, and answering it by accident is how a malformed value passes a version gate."
+    return 1
+  fi
   [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
 }
 
@@ -791,7 +827,19 @@ version_at_least() {
 # inversion. Inverted, Gate B arms against pre-#5236 binaries (a spurious red)
 # and SKIPS for post-#5236 ones, which is the silent direction: its only
 # positive assertion goes permanently vacuous while every release looks fine.
+#
+# An UNUSABLE version arms the check rather than skipping it, which is the
+# opposite of what `version_at_least` returns for the same input and is
+# deliberate. The two functions answer different questions. "Is a >= b" has no
+# answer for garbage, so the comparator refuses. "Should Gate B assert anything"
+# does have one: skipping is the silent direction this whole file exists to
+# remove, and arming against an unknown binary costs at worst a loud red on a
+# release whose version string was already unreadable. Fail toward asserting.
 prev_emits_latest_seen() {
+  if ! is_dotted_version "$1"; then
+    note "could not read the previous release's version from '$1', so whether it predates the observed-latest marker is unknown. ARMING Gate B's positive-equality check anyway: a skip here is silent and permanent, while a spurious red is visible and cheap. Check how the previous release was resolved."
+    return 0
+  fi
   version_at_least "$1" "$MARKER_LATEST_SEEN_SINCE"
 }
 

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -243,12 +243,45 @@ EXIT_UNVERIFIED_ENVIRONMENTAL=75
 # breaks the local-debugging path this file's header invites, which is exactly
 # when someone is trying to understand a blocked release.
 #
-# Block of 8 with the WS port at +4, so the per-attempt increments below (at
-# most +2, for CANARY_ATTEMPTS=3) can never walk the network port onto this
-# run's own WS port. Both stay overridable; the lifecycle test pins them.
+# Block of 8 with the WS port at +4. Both ports are incremented in LOCKSTEP at
+# the top of each attempt in both gates, so the +4 gap is invariant and the
+# network port can never walk onto this run's own WS port -- for any attempt
+# count. (An earlier version of this comment said "at most +2, for
+# CANARY_ATTEMPTS=3", which was wrong twice over: the increment happens before
+# each run, so it is +N for N attempts, and the hazard it described is
+# unreachable anyway because both ports move together. Gate B now has an attempt
+# loop of its own, so the stale arithmetic described that too.) The block still
+# earns its keep by keeping a run's ports away from a neighbouring run's.
+# Both stay overridable; the lifecycle test pins them.
 CANARY_PORT_BLOCK="${CANARY_PORT_BLOCK:-$(( 39000 + (RANDOM % 320) * 8 ))}"
 CANARY_NETWORK_PORT="${CANARY_NETWORK_PORT:-$CANARY_PORT_BLOCK}"
 CANARY_WS_PORT="${CANARY_WS_PORT:-$(( CANARY_PORT_BLOCK + 4 ))}"
+
+# sanitise_positive_int <value> <fallback> -- echoes <value> if it is a positive
+# integer, otherwise <fallback>.
+#
+# One function for all three budgets below, because the hand-written guard they
+# each carried had the same hole and fixing one instance is how this file's own
+# rules say not to do it. The guard was
+# `case "$v" in ''|*[!0-9]*|0) v=$default ;; esac`, and `00` passes it: it is
+# all digits and is not the literal string `0`. `seq 1 00` is EMPTY, so with
+# `CANARY_ATTEMPTS=00` the retry loop never executes, `rc` is never assigned,
+# and the read after the loop aborts under `set -u` with "rc: unbound variable"
+# -- a shell error where a release verdict should be. `$((10#$v))` folds `00`,
+# `007` and similar to their decimal value so the `-lt 1` test can see it; the
+# digits-only case guard above it is what keeps `10#` itself safe.
+sanitise_positive_int() {
+  local value="$1" fallback="$2"
+  case "$value" in
+    ''|*[!0-9]*) printf '%s' "$fallback"; return ;;
+  esac
+  value=$((10#$value))
+  if [ "$value" -lt 1 ]; then
+    printf '%s' "$fallback"
+  else
+    printf '%s' "$value"
+  fi
+}
 
 # How long to let the node run before giving up on the startup check. The
 # check fires after a 0-60s anti-thundering-herd jitter, so this must clear
@@ -259,9 +292,7 @@ CANARY_TIMEOUT_SECS="${CANARY_TIMEOUT_SECS:-240}"
 # reaches the `$((...))` in the lifecycle guard and, under `set -u`, kills the
 # canary with a shell arithmetic error rather than a canary verdict -- a
 # release-blocking failure whose message says nothing about the release.
-case "$CANARY_TIMEOUT_SECS" in
-  ''|*[!0-9]*|0) CANARY_TIMEOUT_SECS=240 ;;
-esac
+CANARY_TIMEOUT_SECS="$(sanitise_positive_int "$CANARY_TIMEOUT_SECS" 240)"
 
 # Retry budget for the INDETERMINATE (GitHub unreachable) case only. Kept
 # small on purpose: this sits on the release critical path inside a job with a
@@ -272,9 +303,7 @@ CANARY_ATTEMPTS="${CANARY_ATTEMPTS:-2}"
 # A non-numeric or zero override would make the retry loop body never execute
 # and the script report "could not reach GitHub in 0 attempts" -- a blocking
 # failure backed by no attempt at all.
-case "$CANARY_ATTEMPTS" in
-  ''|*[!0-9]*|0) CANARY_ATTEMPTS=2 ;;
-esac
+CANARY_ATTEMPTS="$(sanitise_positive_int "$CANARY_ATTEMPTS" 2)"
 CANARY_RETRY_SLEEP="${CANARY_RETRY_SLEEP:-20}"
 
 # How long to wait, AFTER the "check started" line appears, for the check to
@@ -286,10 +315,7 @@ CANARY_RETRY_SLEEP="${CANARY_RETRY_SLEEP:-20}"
 # within ~10s of that line, and this is 2x that. Below PROBE_CHAIN_TIMEOUT the
 # canary stops the node mid-request and reads the resulting silence as health
 # (#5236).
-CANARY_OUTCOME_WAIT_SECS="${CANARY_OUTCOME_WAIT_SECS:-20}"
-case "$CANARY_OUTCOME_WAIT_SECS" in
-  ''|*[!0-9]*|0) CANARY_OUTCOME_WAIT_SECS=20 ;;
-esac
+CANARY_OUTCOME_WAIT_SECS="$(sanitise_positive_int "${CANARY_OUTCOME_WAIT_SECS:-20}" 20)"
 
 log()  { printf '%s\n' "$*"; }
 fail() { printf '::error::%s\n' "$*" >&2; }
@@ -955,6 +981,17 @@ runner_can_reach_github() {
 # The PORT case needs no probe: another process holding a port says nothing
 # about the network, and demanding a network probe for it would make a
 # collision on a healthy runner take the loud path for no reason.
+#
+# ONE MORE THING THIS CANNOT SEE, and it is why the quiet message says what it
+# says about recurrence. The GitHub branch trusts the node's self-report of WHY
+# its fetch failed, and that same WARN fires for a fetch-side REGRESSION too --
+# a malformed URL, a TLS or user-agent change, a 403 from a rate-limited
+# endpoint (#5102 moved the node off `api.github.com` for exactly that). Such a
+# regression would look environmental on every release, permanently. Gate A
+# narrows it, because it runs the same code path on the binary being shipped, so
+# a regression introduced in THIS tree fails there first. What is left is a
+# regression already published, which is why "if this recurs across consecutive
+# releases it is not the runner" belongs in the message rather than in a comment.
 gate_b_unverified_class() {
   case "$1" in
     ports)
@@ -1152,7 +1189,25 @@ cmd_selfupdate() {
   #
   # The loop also cannot run twice after a decision to update: that path leaves
   # the loop with rc=0.
-  local attempt rc env_cause=""
+  # `saw_unexplained` LATCHES, and `env_cause` alone would not. It records that
+  # some attempt produced an indeterminate the node could not explain -- the
+  # hung-updater shape -- and once that has happened no later attempt may buy
+  # the quiet message.
+  #
+  # Without the latch the flag is last-writer-wins, and the sequence that breaks
+  # it is ordinary rather than contrived: attempt 1 starts the check and logs no
+  # outcome (a real finding), attempt 2 loses a port race (environmental), and
+  # the dev room is told a hung updater on the previous release is "not a
+  # stranded fleet and needs no fleet action". A false quiet on exactly the
+  # class this gate exists to raise, produced by the retry that was added to
+  # reduce false alarms. This file's own rule: a gate's unknown case belongs on
+  # the side that gets read.
+  #
+  # `rc=1` up front so a `CANARY_ATTEMPTS` that somehow yields an empty `seq`
+  # cannot reach the read below unset. Under `set -u` that is an "unbound
+  # variable" abort, which exits 1 and takes the LOUD path -- safe, but the
+  # operator gets a shell error where a verdict should be.
+  local attempt rc=1 env_cause="" attempt_cause="" saw_unexplained=0
   for attempt in $(seq 1 "$CANARY_ATTEMPTS"); do
     log "--- attempt $attempt/$CANARY_ATTEMPTS ---"
     rm -rf "${work:?}/home" "${work:?}/cfg" "${work:?}/data" \
@@ -1171,7 +1226,7 @@ cmd_selfupdate() {
     if [ "$NODE_EXIT" = "$EXIT_CODE_ALREADY_RUNNING" ]; then
       note "INDETERMINATE: the node exited $EXIT_CODE_ALREADY_RUNNING (another instance already holds ports $CANARY_NETWORK_PORT/$CANARY_WS_PORT). A port collision on this host -- another canary run, or a local node -- not an auto-update fault."
       rc=2
-      env_cause=ports
+      attempt_cause=ports
     else
       # The two-sided log assertion first: it LOCALISES the failure. If detection
       # is broken the version check below would also fail, but with a far less
@@ -1184,9 +1239,20 @@ cmd_selfupdate() {
       # because a hung updater produces exactly that. The candidacy is not the
       # verdict -- see `gate_b_unverified_class`, which demands corroboration.
       if [ "$rc" -eq 2 ] && node_could_not_reach_github "$work/logs"; then
-        env_cause=github
+        attempt_cause=github
       else
-        env_cause=""
+        attempt_cause=""
+      fi
+    fi
+
+    # Fold this attempt into the run-level classification. An explained
+    # indeterminate records its cause; an UNEXPLAINED one latches and is never
+    # overwritten (see the note on `saw_unexplained` above).
+    if [ "$rc" -eq 2 ]; then
+      if [ -n "$attempt_cause" ]; then
+        env_cause="$attempt_cause"
+      else
+        saw_unexplained=1
       fi
     fi
 
@@ -1205,6 +1271,13 @@ cmd_selfupdate() {
     # EVERY branch below is a release this gate did NOT verify. They differ only
     # in whether we can say why, and therefore in how loudly to say it -- never
     # in whether the job is red.
+    #
+    # The latch is applied HERE rather than inside the loop so the loop stays a
+    # plain record of what each attempt saw.
+    if [ "$saw_unexplained" -eq 1 ]; then
+      fail "UNVERIFIED: at least one attempt started the update check and never logged an outcome, so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works -- but it is also NOT environmental noise, whatever a later attempt ran into: the node did not report a failed GitHub fetch on the attempt that produced this. A hung updater looks exactly like it. Re-run the job."
+      return 1
+    fi
     if [ "$(gate_b_unverified_class "$env_cause")" = "environmental" ]; then
       # Distinct exit code so `cross-compile.yml` can word the Matrix message
       # accordingly: the alarm that says a node "may not be able to auto-update
@@ -1215,7 +1288,7 @@ cmd_selfupdate() {
           fail "UNVERIFIED (ENVIRONMENTAL): every attempt hit a port collision on this host, so Gate B never got to test the updater. v$expected_version has NOT been verified as reachable by a node on v$prev_version -- this run says nothing either way. Another canary run or a local node is holding the ports. Re-run the job; if it recurs, something on this runner is holding them persistently and the gate is not working."
           ;;
         *)
-          fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub in $CANARY_ATTEMPTS attempts, and this runner cannot reach it either, so the canary never got to test whether v$prev_version reaches v$expected_version. v$expected_version has NOT been verified as reachable by auto-update -- this run is not evidence in either direction. The node's startup fetch has no retry, so a bad network moment produces exactly this. Re-run the job. If Gate B reports this on consecutive releases, stop reading it as noise: the post-publish gate is not working and nothing has been verified since the last green run."
+          fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub in $CANARY_ATTEMPTS attempts, and this runner cannot reach it either, so the canary never got to test whether v$prev_version reaches v$expected_version. v$expected_version has NOT been verified as reachable by auto-update -- this run is not evidence in either direction. The node's startup fetch has no retry, so a bad network moment produces exactly this. Re-run the job. If Gate B reports this on CONSECUTIVE releases it is not the runner: the same WARN is also what a published fetch-side regression logs (a bad URL, a TLS or user-agent change, a rate-limited endpoint), and either way the post-publish gate is not working and nothing has been verified since the last green run."
           ;;
       esac
       return "$EXIT_UNVERIFIED_ENVIRONMENTAL"
@@ -1227,8 +1300,11 @@ cmd_selfupdate() {
       fail "UNVERIFIED: v$prev_version reported it could not reach GitHub on all $CANARY_ATTEMPTS attempts, but THIS RUNNER reached the same endpoint immediately afterwards. So the network is not simply down: the published binary consistently cannot do something this runner can. That may still not be an auto-update fault -- a poll-budget cooldown persisted under the node's HOME is the obvious candidate (#5102) -- but it is not environmental noise, and v$expected_version is NOT verified as reachable. Read the node output above before re-running."
       return 1
     fi
-    # The node never said WHY. A hung updater lands here.
-    fail "UNVERIFIED: the update check produced no verdict in $CANARY_ATTEMPTS attempts (it started and never logged an outcome), so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works -- but it is also NOT evidence of a bad network: the node did not report a failed GitHub fetch. Re-run the job."
+    # Unreachable today: every rc=2 either records a cause or sets
+    # `saw_unexplained`, both handled above. Kept because "the classifier grew a
+    # case nobody routed" must not fall out of the function with rc=2 read as a
+    # SUCCESS -- the shape that let #5236 ship.
+    fail "UNVERIFIED: the update check produced no verdict in $CANARY_ATTEMPTS attempts and the canary could not classify why (env_cause='"'"'$env_cause'"'"'). This is a canary bug, not a verdict about v$prev_version. Re-run the job and report this message."
     return 1
   fi
   [ "$rc" -eq 0 ] || return 1

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -101,18 +101,22 @@ MARKER_FETCH_FAIL='failed to fetch latest version'
 MARKER_DISABLED='Auto-update is DISABLED'
 # freenet.rs -- detection succeeded and an update was requested. There are
 # FIVE such sites and one REFUSAL that shares the phrase:
-#   :524 "Startup check: newer version on GitHub, triggering auto-update"
-#   :609 "Urgent update confirmed on GitHub, triggering immediate auto-update"
-#   :670 "Update confirmed on GitHub after stagger, triggering auto-update"
-#   :751 "Newer version confirmed on GitHub, triggering auto-update"
-#   :873 "Periodic re-poll: newer version on GitHub, triggering auto-update"
-#   :519 "...repeated install failures); not triggering auto-update (#4073)"
+# Cited by PHRASE, never by line number. The six that were here were all low
+# by 12 within one release, and this file's own rules already say a line number
+# in a note about stale pins rots faster than the thing it describes. The
+# phrases are also what the detector actually matches.
+#   "Startup check: newer version on GitHub, triggering auto-update"
+#   "Urgent update confirmed on GitHub, triggering immediate auto-update"
+#   "Update confirmed on GitHub after stagger, triggering auto-update"
+#   "Newer version confirmed on GitHub, triggering auto-update"
+#   "Periodic re-poll: newer version on GitHub, triggering auto-update"
+#   "...repeated install failures); not triggering auto-update (#4073)"  <- the refusal
 # Matching the bare substring counts the refusal as a trigger; anchoring on any
 # ONE site's full phrase misses the others, reporting "did not decide to
 # update" for a node that did. So: match the phrase, subtract the refusal.
 #
-# A REGEX, not a fixed string, and that is the whole point: the urgent site at
-# :609 says "triggering IMMEDIATE auto-update", so the fixed substring
+# A REGEX, not a fixed string, and that is the whole point: the urgent site
+# says "triggering IMMEDIATE auto-update", so the fixed substring
 # `triggering auto-update` did not match it. A node that took the urgent path
 # was reported as never having decided to update. It failed CLOSED (Gate B
 # refuses rather than passes), so nothing broke visibly -- which is precisely
@@ -1241,7 +1245,7 @@ cmd_selfupdate() {
   # cannot reach the read below unset. Under `set -u` that is an "unbound
   # variable" abort, which exits 1 and takes the LOUD path -- safe, but the
   # operator gets a shell error where a verdict should be.
-  local attempt rc=1 env_cause="" attempt_cause="" saw_unexplained=0
+  local attempt rc=1 env_cause="" attempt_cause="" saw_unexplained=0 github_attempts=0
   for attempt in $(seq 1 "$CANARY_ATTEMPTS"); do
     log "--- attempt $attempt/$CANARY_ATTEMPTS ---"
     rm -rf "${work:?}/home" "${work:?}/cfg" "${work:?}/data" \
@@ -1310,7 +1314,7 @@ cmd_selfupdate() {
     if [ "$rc" -eq 2 ]; then
       case "$attempt_cause" in
         '')     saw_unexplained=1 ;;
-        github) env_cause=github ;;
+        github) env_cause=github; github_attempts=$((github_attempts + 1)) ;;
         ports)  [ "$env_cause" = "github" ] || env_cause=ports ;;
         *)      # An unrecognised cause is not quiet-eligible; treat it as
                 # unexplained rather than letting it fall through unrecorded.
@@ -1334,8 +1338,9 @@ cmd_selfupdate() {
     # in whether we can say why, and therefore in how loudly to say it -- never
     # in whether the job is red.
     #
-    # The latch is applied HERE rather than inside the loop so the loop stays a
-    # plain record of what each attempt saw.
+    # The latch is READ here. It is SET inside the loop, by the precedence fold
+    # (an earlier version of this said the loop "stays a plain record of what
+    # each attempt saw", which stopped being true when the fold moved in).
     if [ "$saw_unexplained" -eq 1 ]; then
       fail "UNVERIFIED: at least one attempt started the update check and never logged an outcome, so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works -- but it is also NOT environmental noise, whatever a later attempt ran into: the node did not report a failed GitHub fetch on the attempt that produced this. A hung updater looks exactly like it. Re-run the job."
       return 1
@@ -1359,7 +1364,7 @@ cmd_selfupdate() {
       # The node said it could not reach GitHub, on every attempt -- and this
       # runner reached the same endpoint moments later. Not a blip, so not
       # something to reassure anyone about.
-      fail "UNVERIFIED: v$prev_version reported it could not reach GitHub on all $CANARY_ATTEMPTS attempts, but THIS RUNNER reached the same endpoint immediately afterwards. So the network is not simply down: the published binary consistently cannot do something this runner can. That may still not be an auto-update fault -- a poll-budget cooldown persisted under the node's HOME is the obvious candidate (#5102) -- but it is not environmental noise, and v$expected_version is NOT verified as reachable. Read the node output above before re-running."
+      fail "UNVERIFIED: v$prev_version reported it could not reach GitHub on $github_attempts of $CANARY_ATTEMPTS attempt(s), but THIS RUNNER reached the same endpoint immediately afterwards. So the network is not simply down: the published binary consistently cannot do something this runner can. That may still not be an auto-update fault -- a poll-budget cooldown persisted under the node's HOME is the obvious candidate (#5102) -- but it is not environmental noise, and v$expected_version is NOT verified as reachable. Read the node output above before re-running."
       return 1
     fi
     # Unreachable today: every rc=2 either records a cause or sets

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -914,6 +914,67 @@ resolve_expected_latest() {
   normalise_release_tag "$tag"
 }
 
+# True when THIS RUNNER can reach the release endpoint the node uses.
+#
+# A named one-liner rather than the call inlined, so the decision below can be
+# unit-tested by overriding it. Same reason `prev_emits_latest_seen` exists.
+runner_can_reach_github() {
+  resolve_expected_latest >/dev/null 2>&1
+}
+
+# gate_b_unverified_class <env-cause> -- "environmental" or "fault", for a Gate
+# B run that produced no verdict. Echoes; never exits.
+#
+# WHY A DECISION AND NOT JUST A LOOKUP. The quiet Matrix message says the run
+# tells us nothing and needs no fleet action, so every input that reaches it is
+# a release NOT verified by the gate that exists to verify it. Trusting a single
+# WARN from the node to send us down that path is how a persistent problem
+# becomes a permanent silence: five releases in a row report "environmental",
+# nobody is alarmed, and we believe we have a post-publish gate when we have
+# verified nothing since v0.2.125.
+#
+# So the GitHub case demands corroboration from a second, independent observer
+# in the same run -- this runner's own fetch of the same endpoint. That splits
+# two situations a single WARN cannot:
+#
+#   node failed, runner ALSO cannot reach GitHub -> the network really is bad
+#       right now. Genuinely environmental, quiet, re-run.
+#   node failed on EVERY attempt, runner is fine -> the published binary
+#       consistently cannot do something this runner can, seconds apart. That is
+#       not a blip. It may still not be a fault (a poll-budget cooldown is the
+#       obvious candidate, #5102) but it is not something to reassure anyone
+#       about, so it takes the loud path.
+#
+# THE RESIDUAL WINDOW, stated rather than implied: a condition that persistently
+# breaks the node's fetch AND this runner's probe but NOT the release-asset
+# download would still be quiet every time. Both are github.com and Gate B
+# downloads the previous release's tarball moments earlier -- if that fails the
+# gate has already returned a loud failure -- so a sustained CI-wide outage
+# cannot reach the quiet path at all. What is left is narrow.
+#
+# The PORT case needs no probe: another process holding a port says nothing
+# about the network, and demanding a network probe for it would make a
+# collision on a healthy runner take the loud path for no reason.
+gate_b_unverified_class() {
+  case "$1" in
+    ports)
+      printf 'environmental'
+      ;;
+    github)
+      if runner_can_reach_github; then
+        printf 'fault'
+      else
+        printf 'environmental'
+      fi
+      ;;
+    *)
+      # Includes the empty cause: the check started and never logged an
+      # outcome, which is what a HUNG updater looks like. Never quiet.
+      printf 'fault'
+      ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
 # Gate A: preflight -- BLOCKS publication.
 #
@@ -1074,11 +1135,24 @@ cmd_selfupdate() {
   # ever asking GitHub. A retry that cannot produce a different answer is not a
   # retry.
   #
-  # Only rc=2 and the port collision loop. Everything else is deterministic:
-  # re-running a node that parsed the wrong version burns release time to
-  # reproduce a fact already established. And the loop can never run twice after
-  # a decision to update, because that path leaves the loop with rc=0.
-  local attempt rc environmental=0
+  # ONLY rc=2 (no verdict) and the port collision loop, and that boundary is the
+  # load-bearing part of this whole block rather than an optimisation.
+  #
+  # A retry over a REAL assertion failure is the disaster this canary exists to
+  # prevent, arriving by way of the canary. Each attempt wipes the tree and boots
+  # a fresh node, so a genuine detection fault that happens to be intermittent --
+  # a race, a timing-dependent parse, a node that reaches the update path only
+  # sometimes -- would eventually produce one passing attempt, and Gate B would
+  # report the release healthy. A flaky pass on the post-publish gate is strictly
+  # worse than no gate: it is a green light nobody re-examines.
+  #
+  # rc=1 therefore breaks IMMEDIATELY, and that is pinned behaviourally in
+  # `auto-update-canary_lifecycle_test.sh` by counting node boots, not by
+  # grepping for this comment.
+  #
+  # The loop also cannot run twice after a decision to update: that path leaves
+  # the loop with rc=0.
+  local attempt rc env_cause=""
   for attempt in $(seq 1 "$CANARY_ATTEMPTS"); do
     log "--- attempt $attempt/$CANARY_ATTEMPTS ---"
     rm -rf "${work:?}/home" "${work:?}/cfg" "${work:?}/data" \
@@ -1097,21 +1171,22 @@ cmd_selfupdate() {
     if [ "$NODE_EXIT" = "$EXIT_CODE_ALREADY_RUNNING" ]; then
       note "INDETERMINATE: the node exited $EXIT_CODE_ALREADY_RUNNING (another instance already holds ports $CANARY_NETWORK_PORT/$CANARY_WS_PORT). A port collision on this host -- another canary run, or a local node -- not an auto-update fault."
       rc=2
-      environmental=1
+      env_cause=ports
     else
       # The two-sided log assertion first: it LOCALISES the failure. If detection
       # is broken the version check below would also fail, but with a far less
       # useful message.
       assert_detection_healthy "$work/logs"
       rc=$?
-      # Which KIND of indeterminate. Only the node saying outright that it could
-      # not reach GitHub counts as environmental. "The check started and never
-      # logged an outcome" stays a real finding: a hung updater produces exactly
-      # that, and calling it environmental would be the quiet direction.
+      # Which KIND of indeterminate, recorded from the LAST attempt. Only the
+      # node saying outright that it could not reach GitHub is a candidate for
+      # the quiet path; "the check started and never logged an outcome" is not,
+      # because a hung updater produces exactly that. The candidacy is not the
+      # verdict -- see `gate_b_unverified_class`, which demands corroboration.
       if [ "$rc" -eq 2 ] && node_could_not_reach_github "$work/logs"; then
-        environmental=1
+        env_cause=github
       else
-        environmental=0
+        env_cause=""
       fi
     fi
 
@@ -1127,18 +1202,33 @@ cmd_selfupdate() {
   done
 
   if [ "$rc" -eq 2 ]; then
-    if [ "$environmental" -eq 1 ]; then
-      # The node told us why, and the reason is not the updater. Distinct exit
-      # code so `cross-compile.yml` can word the Matrix message accordingly:
-      # the alarm that says a node "may not be able to auto-update to this one"
-      # must not fire for a runner that could not open a socket. Still a
-      # non-zero exit and still a red job -- unverified is not verified.
-      fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub from this runner in $CANARY_ATTEMPTS attempts, so the canary never got to test whether it reaches v$expected_version. This says NOTHING about auto-update, in either direction: the node's startup fetch has no retry, and a runner that cannot resolve or connect to github.com produces exactly this. Re-run the job. Do NOT read this as a stranded fleet."
+    # EVERY branch below is a release this gate did NOT verify. They differ only
+    # in whether we can say why, and therefore in how loudly to say it -- never
+    # in whether the job is red.
+    if [ "$(gate_b_unverified_class "$env_cause")" = "environmental" ]; then
+      # Distinct exit code so `cross-compile.yml` can word the Matrix message
+      # accordingly: the alarm that says a node "may not be able to auto-update
+      # to this one" must not fire for a runner that could not open a socket.
+      # Still non-zero, still a red job -- unverified is not verified.
+      case "$env_cause" in
+        ports)
+          fail "UNVERIFIED (ENVIRONMENTAL): every attempt hit a port collision on this host, so Gate B never got to test the updater. v$expected_version has NOT been verified as reachable by a node on v$prev_version -- this run says nothing either way. Another canary run or a local node is holding the ports. Re-run the job; if it recurs, something on this runner is holding them persistently and the gate is not working."
+          ;;
+        *)
+          fail "UNVERIFIED (ENVIRONMENTAL): v$prev_version could not reach GitHub in $CANARY_ATTEMPTS attempts, and this runner cannot reach it either, so the canary never got to test whether v$prev_version reaches v$expected_version. v$expected_version has NOT been verified as reachable by auto-update -- this run is not evidence in either direction. The node's startup fetch has no retry, so a bad network moment produces exactly this. Re-run the job. If Gate B reports this on consecutive releases, stop reading it as noise: the post-publish gate is not working and nothing has been verified since the last green run."
+          ;;
+      esac
       return "$EXIT_UNVERIFIED_ENVIRONMENTAL"
     fi
-    # Infrastructure, not a stranded fleet -- but the node never said WHY, so
-    # this keeps the ordinary failure exit. A hung updater lands here.
-    fail "UNVERIFIED: the update check produced no verdict in $CANARY_ATTEMPTS attempts (it started and never logged an outcome), so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works. Note that the node did NOT report a failed GitHub fetch, so this is not simply an unreachable runner. Re-run the job."
+    if [ "$env_cause" = "github" ]; then
+      # The node said it could not reach GitHub, on every attempt -- and this
+      # runner reached the same endpoint moments later. Not a blip, so not
+      # something to reassure anyone about.
+      fail "UNVERIFIED: v$prev_version reported it could not reach GitHub on all $CANARY_ATTEMPTS attempts, but THIS RUNNER reached the same endpoint immediately afterwards. So the network is not simply down: the published binary consistently cannot do something this runner can. That may still not be an auto-update fault -- a poll-budget cooldown persisted under the node's HOME is the obvious candidate (#5102) -- but it is not environmental noise, and v$expected_version is NOT verified as reachable. Read the node output above before re-running."
+      return 1
+    fi
+    # The node never said WHY. A hung updater lands here.
+    fail "UNVERIFIED: the update check produced no verdict in $CANARY_ATTEMPTS attempts (it started and never logged an outcome), so the canary could not determine whether v$prev_version reaches v$expected_version. This is NOT evidence that auto-update is broken, and NOT evidence that it works -- but it is also NOT evidence of a bad network: the node did not report a failed GitHub fetch. Re-run the job."
     return 1
   fi
   [ "$rc" -eq 0 ] || return 1

--- a/scripts/auto-update-canary_lifecycle_test.sh
+++ b/scripts/auto-update-canary_lifecycle_test.sh
@@ -556,6 +556,76 @@ else
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# 8. Gate B RETRIES an indeterminate run and does NOT retry a real failure.
+#
+#    THE DANGEROUS HALF IS THE SECOND ONE. Each attempt wipes the tree and boots
+#    a fresh node, so if Gate B retried a genuine detection fault, any fault
+#    that is intermittent -- a race, a timing-dependent parse, a node that
+#    reaches the update path only sometimes -- would eventually produce one
+#    passing attempt and the release would be reported healthy. A flaky pass on
+#    the post-publish gate is strictly worse than no gate: it is a green light
+#    nobody re-examines. That is the disaster this canary exists to prevent,
+#    arriving by way of the canary's own retry loop.
+#
+#    Counted BEHAVIOURALLY, by how many times the node is actually booted,
+#    because that is the property. A source grep for `[ "$rc" -eq 2 ] || break`
+#    would pass just as happily if the surrounding logic stopped reaching it.
+#
+#    cmd_selfupdate downloads and unpacks the previous release before the loop,
+#    so `curl` and `tar` are shadowed by no-op functions -- the script is
+#    SOURCED, so a function definition wins over the external command -- and the
+#    fake node is pre-placed where the extract would have put it.
+boot_count_for() {
+    # boot_count_for <extra-log-line> -- boots Gate B against a fake node that
+    # logs <extra-log-line>, and echoes how many times the node was started.
+    local extra="$1" work counter
+    work="$CANARY_WORKDIR/selfupdate"
+    rm -rf "$work"
+    mkdir -p "$work/bin"
+    counter="$TMPROOT/boots.$$"
+    : > "$counter"
+    make_fake_node "$work/bin/freenet" 0 "$extra"
+    # Count a boot on every invocation that is not `--version`.
+    sed -i "2i if [ \"\${1:-}\" != \"--version\" ]; then echo x >> \"$counter\"; fi" \
+        "$work/bin/freenet"
+    (
+        curl() { :; }
+        tar()  { :; }
+        cmd_selfupdate 0.2.121 0.2.122 >/dev/null 2>&1
+    )
+    grep -c x "$counter" 2>/dev/null || echo 0
+}
+
+SAVED_ATTEMPTS="$CANARY_ATTEMPTS"
+SAVED_SLEEP="$CANARY_RETRY_SLEEP"
+SAVED_OUTCOME="$CANARY_OUTCOME_WAIT_SECS"
+CANARY_ATTEMPTS=2
+CANARY_RETRY_SLEEP=0
+# The fake node writes its lines and exits immediately, so the only thing the
+# outcome poll can wait for here is its own clock. Cut to keep this file inside
+# the Fmt job's 5-minute budget; the REAL bound is exercised by cases 5 and 6,
+# which is where it means something.
+CANARY_OUTCOME_WAIT_SECS=2
+
+boots="$(boot_count_for "WARN freenet::commands::auto_update: Startup update check: failed to fetch latest version: error sending request. Continuing with current binary.")"
+if [[ "$boots" == "2" ]]; then
+    ok "Gate B retries an INDETERMINATE run (2 attempts, node booted twice)"
+else
+    bad "Gate B booted the node $boots time(s) for an indeterminate run, expected 2 (CANARY_ATTEMPTS). Without the retry, one transient blip in a ~40s window decides a release's post-publish verdict -- and the previous release's own startup fetch has no retry either, so the blip is routine."
+fi
+
+boots="$(boot_count_for "$PARSE_FAIL_LINE")"
+if [[ "$boots" == "1" ]]; then
+    ok "Gate B does NOT retry a REAL detection failure (node booted once)"
+else
+    bad "Gate B booted the node $boots time(s) for a genuine #5221 parse failure, expected exactly 1. Retrying a real assertion failure lets an INTERMITTENT fault produce a passing attempt, and Gate B then reports a broken release healthy -- a flaky pass on the post-publish gate, which is worse than no gate at all."
+fi
+
+CANARY_ATTEMPTS="$SAVED_ATTEMPTS"
+CANARY_RETRY_SLEEP="$SAVED_SLEEP"
+CANARY_OUTCOME_WAIT_SECS="$SAVED_OUTCOME"
+
 echo
 if [[ "$FAILURES" -eq 0 ]]; then
     echo "All auto-update-canary lifecycle assertions passed."

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -467,6 +467,59 @@ env_case "a healthy run is NOT environmental"              no "$HEALTHY"
 env_case "a truncated run (no outcome logged) is NOT environmental" no "$PENDING"
 env_case "a disabled updater is NOT environmental"         no "$DISABLED"
 
+# --- and the DECISION the classification feeds -------------------------------
+# `node_could_not_reach_github` establishes CANDIDACY for the quiet path;
+# `gate_b_unverified_class` decides. The split exists because the quiet message
+# tells the dev room a red release needs no action, so a single WARN from the
+# node is not enough to earn it: a persistent problem would otherwise report
+# "environmental" release after release, nobody would be alarmed, and we would
+# believe we had a post-publish gate while verifying nothing.
+#
+# The GitHub case therefore demands corroboration from a second observer in the
+# same run -- this runner's own fetch. Stubbed here, so the decision is tested
+# without a network.
+#
+# The real implementation is captured and put back afterwards rather than
+# re-sourcing the script: sourcing it again would run its top-level `mktemp -d`
+# a second time and re-register `trap cleanup EXIT`, leaking the first workdir
+# on every CI run. A stub left installed would be worse -- it would silently
+# weaken any later assertion that reaches it.
+real_runner_can_reach_github="$(declare -f runner_can_reach_github)"
+if [[ -z "$real_runner_can_reach_github" ]]; then
+    echo "FAIL - runner_can_reach_github is not defined; the corroboration tests would" >&2
+    echo "       stub a function nothing calls and pass vacuously." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+class_case() {
+    # class_case <description> <env-cause> <runner-reachable yes|no> <expected>
+    local desc="$1" cause="$2" reachable="$3" expect="$4" got
+    if [[ "$reachable" == yes ]]; then
+        runner_can_reach_github() { return 0; }
+    else
+        runner_can_reach_github() { return 1; }
+    fi
+    got="$(gate_b_unverified_class "$cause")"
+    if [[ "$got" == "$expect" ]]; then
+        echo "ok   - unverified class: $desc"
+    else
+        echo "FAIL - unverified class: $desc (got '$got', expected '$expect')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+class_case "node could not reach GitHub and neither can the runner -> quiet" \
+    github no  environmental
+class_case "node could not reach GitHub but the RUNNER can -> loud" \
+    github yes fault
+class_case "port collision needs no network corroboration -> quiet" \
+    ports  yes environmental
+class_case "port collision, runner offline too -> still quiet" \
+    ports  no  environmental
+class_case "no cause recorded (hung updater) -> loud even with a dead network" \
+    ""     no  fault
+class_case "an unrecognised cause is loud, not quiet" \
+    weather no fault
+eval "$real_runner_can_reach_github"
+
 # Gate B's use of it. Three separate things can each silently undo the split,
 # and the first two fail in the QUIET direction:
 #   - returning 1 instead of the distinct code, so cross-compile.yml cannot
@@ -487,6 +540,13 @@ elif [[ "$selfupdate_body" != *'node_could_not_reach_github "$work/logs"'* ]]; t
     echo "       assert_detection_healthy returns 2 for two different situations. Treating" >&2
     echo "       both as environmental quietens a run where the check started and never" >&2
     echo "       logged an outcome, which is what a HUNG updater looks like." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$selfupdate_body" != *'gate_b_unverified_class "$env_cause"'* ]]; then
+    echo "FAIL - cmd_selfupdate no longer routes the quiet path through gate_b_unverified_class." >&2
+    echo "       Taking the node's WARN as sufficient on its own restores the silent-skip" >&2
+    echo "       shape: a persistent problem reports 'environmental' release after release," >&2
+    echo "       nobody is alarmed, and the post-publish gate verifies nothing while looking" >&2
+    echo "       maintained. The corroboration probe is what earns the quiet message." >&2
     FAILURES=$((FAILURES + 1))
 elif [[ "$selfupdate_body" != *'for attempt in $(seq 1 "$CANARY_ATTEMPTS")'* ]]; then
     echo "FAIL - cmd_selfupdate no longer retries the indeterminate case." >&2

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -994,6 +994,72 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# --- ...and the BEHAVIOURAL half, which is the one that forces the decision --
+# The freeze above notifies. It cannot force, and the difference is the whole
+# lesson of this file's history, so it is worth being exact about what was
+# measured rather than asserting a property.
+#
+# Reword the marker, then do EXACTLY what the failure message's recipe says and
+# nothing else: suite green, every assertion passing. Then hand the resulting
+# canary a verbatim real v0.2.121 log -- the live #5221 break, the thing Gate B
+# exists to catch on the previous release -- and it answers:
+#
+#     OK: startup update check ran to completion and parsed GitHub's response.
+#     RC=0
+#
+# That is the round-4 shape restated at one remove: "a freeze forces a decision
+# only if the remediation cannot be performed without making that decision," and
+# re-stating a single value can always be performed.
+#
+# So the DETECTOR is asserted against a log line no sweep can rewrite: the
+# historical WARN, base64 here, driven through the real `assert_detection_healthy`
+# rather than compared against a constant. After a reword this stays RED until
+# the canary can actually still read an already-published binary -- which is
+# option (a) in the message above, an alternation over old and new wording. The
+# only way to green it otherwise is to delete this assertion, which is the
+# deliberate, reviewable form of option (b).
+#
+# Scaffolding lines interpolate the LIVE $MARKER_CHECK_RAN on purpose, so this
+# stays a pin on MARKER_PARSE_FAIL alone and does not go red for a reword of a
+# marker #5309 owns. The diagnosis is asserted as well as the exit code: rc=1 is
+# also what "the startup update check never ran" returns, and a pin that cannot
+# tell those apart would pass while reporting the wrong subsystem.
+PARSE_FAIL_HISTORICAL_WARN_B64='MjAyNi0wOC0wOFQwMTo1OTozNi4xMTEwNzNaICBXQVJOIGZyZWVuZXQ6OmNvbW1hbmRzOjphdXRvX3VwZGF0ZTogU3RhcnR1cCB1cGRhdGUgY2hlY2s6IGZhaWxlZCB0byBwYXJzZSBsYXRlc3QgdmVyc2lvbiAndjAuMi4xMjInOiB1bmV4cGVjdGVkIGNoYXJhY3RlciAndicgd2hpbGUgcGFyc2luZyBtYWpvciB2ZXJzaW9uIG51bWJlcg=='
+if ! historical_warn="$(printf '%s' "$PARSE_FAIL_HISTORICAL_WARN_B64" | base64 -d 2>/dev/null)"; then
+    historical_warn=""
+fi
+if [[ -z "$historical_warn" ]]; then
+    echo "FAIL - could not decode PARSE_FAIL_HISTORICAL_WARN_B64; the #5221 detection test is not running" >&2
+    FAILURES=$((FAILURES + 1))
+else
+    historical_dir="$(mktemp -d "$TMPROOT/historical.XXXXXX")"
+    printf '%s\n%s\n' \
+        "2026-08-08T01:59:35.950835Z  INFO freenet: $MARKER_CHECK_RAN current=\"0.2.121\" jitter_secs=40" \
+        "$historical_warn" \
+        > "$historical_dir/freenet.2026-08-08-01.log"
+    historical_stderr="$(assert_detection_healthy "$historical_dir" 2>&1 >/dev/null)"
+    historical_rc=$?
+    if [[ "$historical_rc" == 1 && "$historical_stderr" == *"could not parse the version GitHub returned"* ]]; then
+        echo "ok   - the canary still detects #5221 in a log an ALREADY-PUBLISHED binary emits"
+    else
+        echo "FAIL - the canary no longer detects #5221 in the log a published binary emits." >&2
+        echo "         fixture line: $historical_warn" >&2
+        echo "         got exit $historical_rc, wanted 1 with 'could not parse the version GitHub returned'" >&2
+        echo "         stderr: ${historical_stderr:-<none>}" >&2
+        echo "       This is Gate B's subject: it greps the PREVIOUS release's binary, and that" >&2
+        echo "       binary emits the text above no matter what this tree calls the marker." >&2
+        echo "       A canary that cannot match it reports \"OK: parsed GitHub's response\" for a" >&2
+        echo "       release carrying the live #5221 bug -- measured, exit 0." >&2
+        echo "       If you are here after rewording MARKER_PARSE_FAIL: re-stating the frozen" >&2
+        echo "       blob above does NOT fix this, and going green is not the goal. Make the" >&2
+        echo "       detector match the OLD wording as well (MARKER_TRIGGERED_RE is the" >&2
+        echo "       precedent for an alternation), or delete this assertion deliberately and" >&2
+        echo "       say in the commit message that Gate B is now blind to #5221 on every" >&2
+        echo "       release published before the new wording ships." >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+fi
+
 # The parse-failure marker gets a STRONGER pin than pin_marker can give.
 # `failed to parse latest version` appears twice in auto_update.rs: the
 # production warn!, and a comment inside its own `#[cfg(test)] mod tests`

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -455,6 +455,26 @@ else
     echo "ok   - cmd_selfupdate gates the equality check on prev_emits_latest_seen (un-negated)"
 fi
 
+# ...and that the DECISION reads the constant rather than a literal of its
+# current value. Nothing else covers this: hardcoding `version_at_least "$1"
+# "0.2.125"` inside the function leaves the whole suite green, the freeze
+# included, because the constant is untouched and the freeze has nothing to
+# disagree with. It matters at exactly the moment the constant is supposed to
+# move -- a correct reword bump would then silently not take effect, which is
+# the same shape as the reword hazard the freeze above exists to close.
+# shellcheck disable=SC2016  # literal source text; must not expand
+if [[ "$(declare -f prev_emits_latest_seen)" == *'"$MARKER_LATEST_SEEN_SINCE"'* ]]; then
+    echo "ok   - prev_emits_latest_seen compares against the CONSTANT, not a literal"
+else
+    echo "FAIL - prev_emits_latest_seen no longer reads \$MARKER_LATEST_SEEN_SINCE." >&2
+    echo "       Its body:" >&2
+    declare -f prev_emits_latest_seen | sed 's/^/         /' >&2
+    echo "       A literal threshold here decouples the decision from the constant, so" >&2
+    echo "       moving the constant -- which is exactly what a marker reword requires --" >&2
+    echo "       changes nothing and the whole suite stays green." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
 # ...and what that gate DECIDES, which the text match above cannot see. An
 # inversion inside the function flips both of these.
 gate_b_arm_case() {
@@ -770,112 +790,115 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 # assertion -- the same silent direction as the `!` inversion, reached by
 # editing a different line.
 #
-# WHY THERE IS NO RELATION PIN HERE, AND MUST NOT BE ONE.
+# NO EQUALITY-STYLE RELATION PIN HERE. Two were tried and each was right in one
+# phase and wrong in another. Writing C for the crate version, and noting that a
+# dev tree's C equals the last PUBLISHED release (the bump happens inside the
+# release commit), so a marker reworded today first ships in C+1 and the correct
+# constant during a reword is C+1:
 #
-# Two have been tried and both were wrong, in opposite phases:
+#   constant >= C   (#5290)  rests on "no published release emits the marker
+#                            yet"; true until 0.2.125 published, false one
+#                            second later. Detonates on the next bump.
+#   constant <= C   (first   C+1 <= C is FALSE, so it goes RED for the CORRECT
+#                   attempt) value during a reword, and the value that makes it
+#                            green makes Gate B demand new text from a binary
+#                            emitting the old one.
 #
-#   `constant >= crate version` (#5290). Premise: "the marker is new in this
-#     tree, so no published release emits it". True until 0.2.125 published,
-#     false one second later. It would have gone red on the 0.2.126 bump and
-#     blocked a healthy release. Self-detonating; verified by setting the crate
-#     version to 0.2.126 and watching it fail.
+# The constant tracks RELEASE HISTORY and C tracks THIS TREE, so a relation
+# asserting they stay in step cannot hold in both phases. That is the reason
+# neither of the above works, and it is a claim about EQUALITY-STYLE relations
+# only.
 #
-#   `constant <= crate version` (this PR's first attempt). Correct after
-#     publication, wrong during a marker REWORD. A marker reworded on main first
-#     ships in crate+1, so the CORRECT constant is crate+1 -- which this
-#     assertion calls a failure, while the value that makes it green (constant =
-#     crate) makes Gate B demand the new text from a published binary that emits
-#     the old one: a post-publish red canary and a Matrix alarm blaming the node.
-#     Verified by execution. A `<= crate+1` variant fires on the reword too.
+# CORRECTION, and it is worth stating because the wrong version of it was
+# repeated through two reviews and into this comment: a LOOSE bound of the form
+# `constant <= C+1` does NOT fire on a reword. C+1 <= C+1 passes. It was
+# described as firing, the reviewer who proposed it withdrew it on that basis,
+# and nobody checked the arithmetic until a later reviewer did. Such a bound is
+# phase-independent and would catch a constant more than one release ahead. It
+# is deliberately NOT added here -- the freeze below already rejects every wrong
+# value, so a second overlapping pin needs its own justification -- but the
+# reason is redundancy, not unsoundness. Do not re-cite the refuted claim.
 #
-# The generalisation, and the reason not to try a third: the constant tracks
-# RELEASE HISTORY while the crate version tracks THIS TREE, and no fixed
-# relation between them holds across publication and reword both. A pin on a
-# relation between two quantities that move on different clocks is a pin that
-# will be right in one phase and wrong in another.
-#
-# So the pin is a FREEZE, which is phase-independent, and it covers strictly
-# more: the relation only ever caught "constant strictly above crate version",
-# while the freeze catches every wrong value including the empty string and the
-# most likely wrong one (the version being cut). It also cannot be tripped by
+# The freeze below is phase-independent and catches strictly more than either
+# relation did: every wrong value, including the empty string and the most
+# likely wrong one (the version being cut). It also cannot be tripped by
 # `version.workspace = true`, which broke the relation pin's Cargo.toml read.
 #
-# WHY BOTH HALVES ARE FROZEN TOGETHER.
+# WHY THE TWO VALUES ARE ONE BLOB, and why it is encoded. Both properties were
+# forced by mutation, in two rounds:
 #
-# The version alone is not enough, and the gap is silent rather than annoying.
-# Reword MARKER_LATEST_SEEN everywhere a developer must touch it -- auto_update.rs,
-# freenet.rs, the canary, and the log fixtures in both test files -- leave the
-# constant alone, and the whole suite passes: verified, zero red. The source pin
-# interpolates $MARKER_LATEST_SEEN so it follows the rename by construction, and
-# nothing else looks at the marker at all. A stale constant is the DEFAULT
-# outcome of a reword, not an escape from a warning, and it surfaces post-publish
-# on the release Matrix channel with text that blames the node.
+#   Plaintext expectation -> a reword is done as a `sed` sweep, the sweep
+#   rewrote the expectation too, suite green. An expectation stored as a copy of
+#   the value it guards follows any rename of that value.
 #
-# Freezing the PAIR is what closes that: a reword fails HERE, in the same edit,
-# with the version constant named.
+#   Two adjacent encoded assertions -> the reword went red, but following this
+#   pin's OWN failure message (regenerate the text blob) went green again with
+#   the version constant untouched, because the message never asked about it.
+#   A freeze forces a decision only if the remediation cannot be performed
+#   without making that decision.
 #
-# THE EXPECTED TEXT IS BASE64, AND THAT IS THE WHOLE MECHANISM. The first
-# version of this pin stored the marker as a plain literal, and it did not
-# survive its own mutation test: a reword is performed as a `sed` sweep over the
-# files that mention the marker, that sweep rewrote this expectation along with
-# everything else, and the suite stayed green. Same shape as the source pin this
-# was meant to compensate for -- an expectation textually identical to the value
-# under test follows any rename of it. Encoded, a text sweep cannot reach it.
+# One blob of both values fixes both: a sweep cannot reach it, and the recipe
+# cannot be run without supplying a version. Mutation-test the REMEDIATION PATH,
+# not just the regression, before trusting any replacement.
 #
-# To change it deliberately:  printf '%s' '<new marker text>' | base64 -w0
-MARKER_LATEST_SEEN_FROZEN_B64='U3RhcnR1cCB1cGRhdGUgY2hlY2s6IEdpdEh1YiByZXBvcnRzIGxhdGVzdCByZWxlYXNl'
-MARKER_LATEST_SEEN_FROZEN="$(printf '%s' "$MARKER_LATEST_SEEN_FROZEN_B64" | base64 -d)"
-# The version half stays plain. It is not exposed to the same hazard: the edit
-# that would rewrite it is a repo-wide `sed` on a version string, and version
-# bumps here touch Cargo.toml and the lockfile, not these scripts. The realistic
-# wrong edit is a human raising it on purpose, which a plain comparison catches.
-MARKER_LATEST_SEEN_SINCE_FROZEN='0.2.125'
+# WHAT IT STILL CANNOT DO, so nobody reads more into a green run than is there:
+# it makes the question unavoidable, it does not verify the answer. Regenerate
+# the blob with the new text and the OLD version and this goes green -- measured.
+# No local check can know which release will ship a given wording, and any
+# relation that tried to infer it is back to the phase problem above. The value
+# here is that the version cannot be left unconsidered, not that it is correct.
+#
+# 0.2.125 is the first release a running node can REACH whose binary emits this
+# text: the marker landed in the 0.2.124 tree, but 0.2.124 was never published
+# (Gate A blocked it, #5290) and a draft does not appear at `/releases/latest`.
+# Ground-truthed by downloading the published v0.2.125 musl asset and finding
+# the string in it.
+#
+# WHAT THIS DOES NOT COVER: `assert_detection_healthy` greps four other markers
+# against the PREVIOUS release's binary in Gate B -- MARKER_DISABLED,
+# MARKER_CHECK_RAN, MARKER_CHECK_COMPLETE and MARKER_TRIGGERED_RE -- and
+# rewording any of those produces the same post-publish false alarm with a worse
+# message. Only MARKER_LATEST_SEEN is frozen here. The asymmetry is real, not an
+# oversight: Gate A runs a binary built from THIS tree, so a reword there is
+# self-consistent, and Gate B is the only place an older binary is read.
+# Tracked as a follow-up.
+#
+# To change it deliberately, re-state BOTH values:
+#   printf '%s\n%s' '<marker text>' '<first release shipping it>' | base64 | tr -d '\n'
+# (`base64 -w0` is GNU-only and fails on macOS, which is where someone reading
+# this failure is most likely to be.)
+MARKER_PAIR_FROZEN_B64='U3RhcnR1cCB1cGRhdGUgY2hlY2s6IEdpdEh1YiByZXBvcnRzIGxhdGVzdCByZWxlYXNlCjAuMi4xMjU='
+marker_pair_frozen="$(printf '%s' "$MARKER_PAIR_FROZEN_B64" | base64 -d)"
+marker_pair_live="$(printf '%s\n%s' "$MARKER_LATEST_SEEN" "$MARKER_LATEST_SEEN_SINCE")"
 
-if [[ -z "$MARKER_LATEST_SEEN_FROZEN" ]]; then
-    # `base64 -d` failing would leave the expectation empty and make the
-    # comparison below vacuous in the quiet direction.
-    echo "FAIL - could not decode MARKER_LATEST_SEEN_FROZEN_B64; the marker freeze is not running" >&2
+if [[ -z "$marker_pair_frozen" ]]; then
+    # A failed decode would leave the expectation empty and make the comparison
+    # vacuous in the quiet direction.
+    echo "FAIL - could not decode MARKER_PAIR_FROZEN_B64; the marker/version freeze is not running" >&2
     FAILURES=$((FAILURES + 1))
-elif [[ "$MARKER_LATEST_SEEN" == "$MARKER_LATEST_SEEN_FROZEN" ]]; then
-    echo "ok   - MARKER_LATEST_SEEN still matches the text v$MARKER_LATEST_SEEN_SINCE_FROZEN shipped"
+elif [[ "$marker_pair_live" == "$marker_pair_frozen" ]]; then
+    echo "ok   - (MARKER_LATEST_SEEN, MARKER_LATEST_SEEN_SINCE) frozen as a pair at v$MARKER_LATEST_SEEN_SINCE"
 else
-    echo "FAIL - the observed-latest MARKER TEXT changed, and MARKER_LATEST_SEEN_SINCE must be" >&2
-    echo "       reconsidered in the same edit." >&2
-    echo "         was: '$MARKER_LATEST_SEEN_FROZEN'" >&2
-    echo "         now: '$MARKER_LATEST_SEEN'" >&2
-    echo "       MARKER_LATEST_SEEN_SINCE names the first PUBLISHED release emitting that text." >&2
-    echo "       Reword it and no published binary emits the new text yet, so the constant must" >&2
-    echo "       move to the release that will first SHIP it -- normally the NEXT one, since the" >&2
-    echo "       bump happens inside the release commit. Leave it and Gate B demands the new" >&2
-    echo "       wording from a binary that emits the old one: a POST-PUBLISH red canary and a" >&2
-    echo "       Matrix alarm whose text blames the node." >&2
-    echo "       Nothing else in this suite would have told you: the source pin interpolates" >&2
-    echo "       \$MARKER_LATEST_SEEN and follows the rename by construction. This assertion is" >&2
-    echo "       the only prompt. Once you have decided, update BOTH frozen values here:" >&2
-    echo "         MARKER_LATEST_SEEN_FROZEN_B64=\"\$(printf '%s' '$MARKER_LATEST_SEEN' | base64 -w0)\"" >&2
-    echo "         MARKER_LATEST_SEEN_SINCE_FROZEN=<first release that will SHIP the new text>" >&2
-    FAILURES=$((FAILURES + 1))
-fi
-
-# ...and the version half. 0.2.125 is the first release a running node can REACH
-# whose binary emits that text: the marker landed in the 0.2.124 tree, but
-# 0.2.124 was never published (Gate A blocked it on the #5290 TMPDIR harness
-# bug) and a draft does not appear at `/releases/latest`, so no node ever saw a
-# 0.2.124 binary. Ground-truthed during review by downloading the published
-# v0.2.125 musl asset and finding the string in it.
-if [[ "$MARKER_LATEST_SEEN_SINCE" == "$MARKER_LATEST_SEEN_SINCE_FROZEN" ]]; then
-    echo "ok   - MARKER_LATEST_SEEN_SINCE is frozen at the historical value ($MARKER_LATEST_SEEN_SINCE_FROZEN)"
-else
-    echo "FAIL - MARKER_LATEST_SEEN_SINCE is '$MARKER_LATEST_SEEN_SINCE', expected '$MARKER_LATEST_SEEN_SINCE_FROZEN'." >&2
-    echo "       It records which PUBLISHED release first emitted the marker text, so under an" >&2
-    echo "       ordinary release it does not move. Raising it to the version being cut skips" >&2
-    echo "       Gate B's only positive assertion for that release, silently, and a constant" >&2
-    echo "       kept level with the crate version disarms the gate on every release while" >&2
-    echo "       looking maintained." >&2
-    echo "       If you got here by RAISING it, the fix is almost certainly to put it back." >&2
-    echo "       There is one edit where moving it is correct -- rewording the marker text --" >&2
-    echo "       and that fails the assertion ABOVE this one, naming the reword. If that" >&2
-    echo "       assertion is green, this is not a reword and the constant should not move." >&2
+    echo "FAIL - the frozen (marker text, first release that shipped it) pair changed." >&2
+    echo "         was: '$(printf '%s' "$marker_pair_frozen" | head -1)' @ v$(printf '%s' "$marker_pair_frozen" | tail -1)" >&2
+    echo "         now: '$MARKER_LATEST_SEEN' @ v$MARKER_LATEST_SEEN_SINCE" >&2
+    echo "       These are frozen TOGETHER because they only make sense together." >&2
+    echo "       If the TEXT changed: no published binary emits the new wording yet, so" >&2
+    echo "       MARKER_LATEST_SEEN_SINCE must move to the release that will first SHIP it" >&2
+    echo "       -- normally the NEXT one, since the bump happens inside the release commit." >&2
+    echo "       Leave it and Gate B demands the new wording from a binary that emits the old" >&2
+    echo "       one: a POST-PUBLISH red canary and a Matrix alarm that blames the node." >&2
+    echo "       Nothing else in this suite would have told you -- the source pin interpolates" >&2
+    echo "       \$MARKER_LATEST_SEEN and follows a rename by construction." >&2
+    echo "       If only the VERSION changed: raising it skips Gate B's only positive" >&2
+    echo "       assertion for every release below the new value, silently. Unless you are" >&2
+    echo "       here because of a reword, the fix is to put it back." >&2
+    echo "       Once decided, re-state BOTH:" >&2
+    # printf, not echo: the recipe contains \n sequences that must reach the
+    # reader literally, and `echo`'s handling of those is shell-dependent.
+    # shellcheck disable=SC2016  # the `$(...)` is literal recipe text for the reader
+    printf '         MARKER_PAIR_FROZEN_B64="$(printf %s %s | base64 | tr -d %s)"\n' \
+        "'%s\\n%s'" "'$MARKER_LATEST_SEEN' '<release>'" "'\\n'" >&2
     FAILURES=$((FAILURES + 1))
 fi
 # The parse-failure marker gets a STRONGER pin than pin_marker can give.

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -471,7 +471,10 @@ gate_b_arm_case() {
     fi
 }
 gate_b_arm_case "$MARKER_LATEST_SEEN_SINCE" yes   # the release the marker lands in
-gate_b_arm_case "0.2.125"                   yes   # every release after it
+# Was a literal `0.2.125`, which is the constant's own value and so duplicated
+# the case above rather than covering "after it". The constant is frozen (pinned
+# below), so a later release is a literal one release on.
+gate_b_arm_case "0.2.126"                   yes   # every release after it
 gate_b_arm_case "0.3.0"                     yes
 gate_b_arm_case "0.2.123"                   no    # the one release that must skip
 gate_b_arm_case "0.2.99"                    no    # numeric, not lexical
@@ -730,61 +733,91 @@ pin_marker "source pin: #4073 refusal phrase"   "$SRC"    "$MARKER_NOT_TRIGGERED
 pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 
 # --- the MARKER_LATEST_SEEN_SINCE constant itself ---------------------------
-# Gate B's version gate is now pinned in both directions (the behavioural cases
-# on `prev_emits_latest_seen`, and the un-negated call site), but neither looks
-# at the CONSTANT they compare against. Raising it 0.2.124 -> 0.2.999 left the
+# Gate B's version gate is pinned in both directions (the behavioural cases on
+# `prev_emits_latest_seen`, and the un-negated call site), but neither looks at
+# the CONSTANT they compare against. Raising it 0.2.124 -> 0.2.999 left the
 # whole suite green while permanently disarming Gate B's only positive
 # assertion -- the same silent direction as the `!` inversion, reached by
 # editing a different line.
 #
-# Anchored against the crate version, which the constant cannot influence. The
-# relationship is real rather than arbitrary: the constant names the first
-# release whose binary emits MARKER_LATEST_SEEN, that marker is emitted by THIS
-# source tree (pinned above), and this tree ships as the NEXT release. So the
-# constant must be just ahead of the version in Cargo.toml -- not behind it (the
-# marker is new here, so no already-published release emits it) and not far
-# ahead of it (that is a typo, or a change that has sat unmerged for many
-# releases and needs the value re-confirmed rather than assumed).
+# THE RELATION IS `constant <= crate version`, AND IT USED TO BE THE OPPOSITE.
+# The first version of this block asserted the constant was NOT BELOW the crate
+# version. Its premise was stated in its own comment: "the marker is new in this
+# tree, so no already-published release emits it". That premise was true for
+# exactly as long as 0.2.125 was unpublished, and it EXPIRED the moment 0.2.125
+# shipped. The constant is a historical fact and correctly stays at 0.2.125
+# forever, so the old assertion would have gone red on the 0.2.126 bump and
+# blocked a healthy release -- a self-detonating pin, verified by setting the
+# crate version to 0.2.126 and watching it fail.
 #
-# The window is a guard against a wrong constant, not a proof of the right one.
-# If a release genuinely slips further than this, update the constant on
-# purpose -- which is the outcome this assertion exists to force.
+# The relation worth pinning is the other one, because only one direction is
+# SILENT:
+#
+#   constant ABOVE the crate version -- `prev_emits_latest_seen` compares the
+#     PREVIOUS release against it, and the previous release is always below the
+#     crate version, so the gate can never arm. Gate B's only positive assertion
+#     is skipped on every release, indefinitely, and the run still reports
+#     success. This is the dangerous direction and the one asserted below.
+#
+#   constant AT or BELOW the crate version -- the check runs (from the release
+#     after the constant onwards). Nothing to catch.
+#
+# Anchored against the crate version, which the constant cannot influence.
 CORE_TOML="$SCRIPT_DIR/../crates/core/Cargo.toml"
-SINCE_SKEW_MAX=5
 if [[ ! -f "$CORE_TOML" ]]; then
     echo "FAIL - cannot check MARKER_LATEST_SEEN_SINCE: $CORE_TOML not found" >&2
     FAILURES=$((FAILURES + 1))
 else
     crate_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$CORE_TOML" | head -1)"
-    IFS=. read -r c_maj c_min c_pat <<< "$crate_version"
-    IFS=. read -r s_maj s_min s_pat <<< "$MARKER_LATEST_SEEN_SINCE"
     if [[ -z "$crate_version" ]]; then
         echo "FAIL - could not read the crate version from $CORE_TOML" >&2
         FAILURES=$((FAILURES + 1))
-    elif [[ "$s_maj" != "$c_maj" || "$s_min" != "$c_min" ]]; then
-        echo "FAIL - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is not on the same" >&2
-        echo "       major.minor as the crate ($crate_version). Gate B skips its positive" >&2
-        echo "       equality check for every release below the constant, so a constant set" >&2
-        echo "       too high leaves the gate permanently vacuous and silent about it." >&2
-        FAILURES=$((FAILURES + 1))
-    elif [[ "$s_pat" -lt "$c_pat" ]]; then
-        echo "FAIL - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is BELOW the crate" >&2
-        echo "       version ($crate_version). It names the first release that emits" >&2
-        echo "       '$MARKER_LATEST_SEEN', and that marker is new in this tree -- no" >&2
-        echo "       already-published release emits it, so Gate B would demand the line" >&2
-        echo "       from binaries never built to log it." >&2
-        FAILURES=$((FAILURES + 1))
-    elif [[ "$s_pat" -gt $(( c_pat + SINCE_SKEW_MAX )) ]]; then
-        echo "FAIL - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is more than" >&2
-        echo "       $SINCE_SKEW_MAX patch releases ahead of the crate version ($crate_version)." >&2
-        echo "       Gate B skips its only positive assertion for every release below the" >&2
-        echo "       constant, so an over-high value disarms the gate permanently and" >&2
-        echo "       silently. If the release really has slipped this far, re-confirm the" >&2
-        echo "       value and widen SINCE_SKEW_MAX deliberately." >&2
+    elif ! version_at_least "$crate_version" "$MARKER_LATEST_SEEN_SINCE"; then
+        echo "FAIL - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is ABOVE the crate" >&2
+        echo "       version ($crate_version). Gate B arms its positive-equality check only" >&2
+        echo "       when the PREVIOUS release is >= the constant, and the previous release is" >&2
+        echo "       always below this tree's version -- so a constant set above it can never" >&2
+        echo "       arm. Gate B then skips its only positive assertion on every release," >&2
+        echo "       reports success, and the silently-wrong-comparator hole it exists to" >&2
+        echo "       close is open again." >&2
         FAILURES=$((FAILURES + 1))
     else
-        echo "ok   - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is the next release after the crate version ($crate_version)"
+        echo "ok   - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is at or below the crate version ($crate_version), so Gate B's equality check can arm"
     fi
+fi
+
+# ...and the value itself, which the relation above deliberately does not pin.
+#
+# `constant <= crate version` permits the constant to CREEP FORWARD with each
+# release. That creep passes every assertion in this file and is wrong every
+# time: setting the constant to the version being cut skips Gate B's equality
+# check for that release, so a constant kept level with the crate version
+# disarms the gate on every release while looking maintained.
+#
+# There is exactly one correct value, and it is not a policy choice: 0.2.125 is
+# the first release a running node can REACH whose binary emits
+# MARKER_LATEST_SEEN. The marker landed in the 0.2.124 tree, but 0.2.124 was
+# never published (Gate A blocked it on the #5290 TMPDIR harness bug) and a
+# draft does not appear at `/releases/latest`, so no node ever saw a 0.2.124
+# binary. That makes the constant a statement about release history, not about
+# this tree, and release history does not change -- FREEZE IT.
+#
+# Moving it forward is therefore always a mistake. If the FACT turns out to be
+# wrong (0.2.125 does not emit the line after all), change both the constant and
+# this expectation in the same commit and say why. That deliberate edit is the
+# outcome this assertion exists to force; the accidental bump is what it stops.
+MARKER_LATEST_SEEN_SINCE_FROZEN='0.2.125'
+if [[ "$MARKER_LATEST_SEEN_SINCE" == "$MARKER_LATEST_SEEN_SINCE_FROZEN" ]]; then
+    echo "ok   - MARKER_LATEST_SEEN_SINCE is frozen at the historical value ($MARKER_LATEST_SEEN_SINCE_FROZEN)"
+else
+    echo "FAIL - MARKER_LATEST_SEEN_SINCE is '$MARKER_LATEST_SEEN_SINCE', expected the frozen" >&2
+    echo "       historical value '$MARKER_LATEST_SEEN_SINCE_FROZEN'. The constant records WHICH" >&2
+    echo "       published release first emitted '$MARKER_LATEST_SEEN'" >&2
+    echo "       -- a fact about release history, which does not change. Raising it skips Gate" >&2
+    echo "       B's positive-equality check for every release below the new value, silently." >&2
+    echo "       If the historical fact is genuinely wrong, change the constant and this" >&2
+    echo "       expectation together, in one commit, with the reason." >&2
+    FAILURES=$((FAILURES + 1))
 fi
 # The parse-failure marker gets a STRONGER pin than pin_marker can give.
 # `failed to parse latest version` appears twice in auto_update.rs: the

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -428,6 +428,85 @@ else
     echo "ok   - cmd_selfupdate arms the equality check from its expected-version argument"
 fi
 
+# --- environmental classification: the alarm must not blame the fleet -------
+# `node_could_not_reach_github` is what stops the post-publish Matrix alarm
+# saying "a node on the previous release may not be able to auto-update to this
+# one" because a hosted runner could not open a socket.
+#
+# It is a real risk rather than a tidy-up, and the numbers matter: Gate B's
+# subject is a PUBLISHED binary, whose startup fetch retries ZERO times
+# (`startup_update_check_with_fetcher` warns and returns on the first Err), and
+# `framework` logged that WARN twice on 2026-08-11 -- 17:08:04Z and 00:35:13Z.
+#
+# Both directions, because only one of them is safe to get wrong. Classifying a
+# real fault as environmental would quieten the exact alarm this canary exists
+# to raise, so the negative case is the load-bearing one.
+env_case() {
+    # env_case <description> <expect yes|no> <log-content>
+    local desc="$1" expect="$2" content="$3" dir got
+    dir="$(mktemp -d "$TMPROOT/env.XXXXXX")"
+    printf '%s\n' "$content" > "$dir/freenet.2026-08-08-02.log"
+    if node_could_not_reach_github "$dir"; then got=yes; else got=no; fi
+    if [[ "$got" == "$expect" ]]; then
+        echo "ok   - environmental classification: $desc"
+    else
+        echo "FAIL - environmental classification: $desc (got '$got', expected '$expect')" >&2
+        if [[ "$expect" == no ]]; then
+            echo "       Classifying this as environmental silences the #5221 alarm for a run" >&2
+            echo "       that found a real fault." >&2
+        else
+            echo "       Not classifying it means a runner that could not reach github.com" >&2
+            echo "       tells the dev room the fleet may be stranded." >&2
+        fi
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+env_case "the node's own fetch-failure WARN" yes "$FETCH_FAIL"
+env_case "a real #5221 parse failure is NOT environmental" no "$BROKEN"
+env_case "a healthy run is NOT environmental"              no "$HEALTHY"
+env_case "a truncated run (no outcome logged) is NOT environmental" no "$PENDING"
+env_case "a disabled updater is NOT environmental"         no "$DISABLED"
+
+# Gate B's use of it. Three separate things can each silently undo the split,
+# and the first two fail in the QUIET direction:
+#   - returning 1 instead of the distinct code, so cross-compile.yml cannot
+#     tell the cases apart and every blip fires the #5221 alarm again;
+#   - classifying without consulting the logs (e.g. treating every rc=2 as
+#     environmental), which quietens a genuine no-outcome run;
+#   - dropping the retry loop, so one blip in a ~40s window decides a release.
+# shellcheck disable=SC2016  # literal source text; must not expand
+if [[ "$selfupdate_body" != *'return "$EXIT_UNVERIFIED_ENVIRONMENTAL"'* ]]; then
+    echo "FAIL - cmd_selfupdate no longer returns the distinct environmental exit code." >&2
+    echo "       cross-compile.yml keys the WORDING of its Matrix message off that code." >&2
+    echo "       Without it a runner that could not reach GitHub tells the dev room that a" >&2
+    echo "       node on the previous release may not be able to auto-update -- the #5221" >&2
+    echo "       text -- and an alarm that cries wolf on a network blip stops being read." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$selfupdate_body" != *'node_could_not_reach_github "$work/logs"'* ]]; then
+    echo "FAIL - cmd_selfupdate classifies without consulting the node's logs." >&2
+    echo "       assert_detection_healthy returns 2 for two different situations. Treating" >&2
+    echo "       both as environmental quietens a run where the check started and never" >&2
+    echo "       logged an outcome, which is what a HUNG updater looks like." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$selfupdate_body" != *'for attempt in $(seq 1 "$CANARY_ATTEMPTS")'* ]]; then
+    echo "FAIL - cmd_selfupdate no longer retries the indeterminate case." >&2
+    echo "       Gate B had no retry at all until this was added: CANARY_ATTEMPTS was read" >&2
+    echo "       only by cmd_preflight, so a single transient blip in a ~40s window decided" >&2
+    echo "       a release's post-publish verdict." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$selfupdate_body" != *'rm -rf "${work:?}/home"'* ]]; then
+    echo "FAIL - cmd_selfupdate does not wipe the node's state between attempts." >&2
+    echo "       It must clear \$work/home and friends but NOT \$work/bin, which holds the" >&2
+    echo "       downloaded previous release -- the SUBJECT of the test, not state. Gate A's" >&2
+    echo "       'rm -rf \${work:?}' would delete the binary and every retry would run" >&2
+    echo "       nothing; keeping \$work/home makes the retry re-read the node's persisted" >&2
+    echo "       GitHub poll cooldown and reproduce the same INDETERMINATE without asking" >&2
+    echo "       GitHub at all. A retry that cannot produce a different answer is not one." >&2
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   - cmd_selfupdate retries, classifies from the logs, and keeps \$work/bin"
+fi
+
 # The version gate around it. The observed-latest marker is new in #5236 and
 # Gate B drives the PREVIOUS release, so for one release there is no line to
 # compare; the gate must skip rather than fail. Both halves are pinned, because

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -136,11 +136,15 @@ check "broken: #5221 unparseable tag -> fail" 1 "$BROKEN" \
 
 # BOTH markers in one log, which pins the ORDER of the two branches. The
 # parse-failure check runs BEFORE the fetch-failure check, and that ordering is
-# the only thing keeping a real #5221 out of the environmental classification
+# the FIRST of two things keeping a real #5221 out of the environmental
+# classification
 # Gate B gained this round. Swap the two branches -- an innocent-looking tidy,
 # "infra check before product check" -- and this log returns 2 instead of 1,
-# Gate B calls it environmental, and the dev room is told "not a stranded
-# fleet" about a log carrying the live #5221 signature.
+# Gate B treats it as a candidate for the environmental class. The runner probe
+# is the second guard and would usually catch it from there, so this is an
+# ordering hazard rather than a guaranteed false quiet -- but the two together
+# are what make it safe, and a guard that only holds when its sibling also does
+# is worth its own case.
 #
 # Realistic rather than contrived: a node whose startup fetch failed and whose
 # periodic re-poll then returned an unparseable tag logs exactly this, and so
@@ -597,8 +601,13 @@ eval "$real_runner_can_reach_github"
 #
 # `run_node_until_check` is stubbed rather than booting a node: the sequence is
 # the subject, and a real boot costs seconds per attempt. The lifecycle test
-# covers the same retry property against REAL boots, so the stub cannot quietly
-# diverge from the thing it stands in for. `curl`/`tar` are shadowed so the
+# covers the same retry property by actually running `run_node_until_check`
+# against a FAKE NODE BINARY -- a real process, real ports, real log files, but
+# not a real node. So the two differ in how much of the harness executes, not in
+# whether the subject is genuine; neither is a live cross-check against a real
+# release. (An earlier version of this claimed "against REAL boots", which
+# overstated the lifecycle test in the direction of "you need not check this".)
+# `curl`/`tar` are shadowed so the
 # download preamble is a no-op. Same shape as
 # `release_wait_for_binaries_test.sh`'s `check_call_count`.
 GATE_B_ATTEMPT=0
@@ -697,8 +706,12 @@ gate_b_case "an indeterminate IS retried, then exits 75" 75 2 no \
 gate_b_case "a port collision exits 75 without a network probe" 75 2 yes \
     "every attempt hit a port collision on this host" "43:" "43:"
 # The corroboration: the same node-side symptom, opposite runner state.
+# The COUNT is asserted, not just the phrase. The message used to say "on all
+# $CANARY_ATTEMPTS attempts" unconditionally, which sticky-by-strength made
+# false the moment one attempt was a port collision -- and the original
+# assertion picked a substring that did not span the number, so it passed.
 gate_b_case "node cannot reach GitHub but the runner can -> loud, not 75" 1 2 yes \
-    "THIS RUNNER reached the same endpoint immediately afterwards" \
+    "could not reach GitHub on 2 of 2 attempt(s), but THIS RUNNER reached" \
     "0:FETCH_FAIL" "0:FETCH_FAIL"
 # A hung updater must never be quiet.
 gate_b_case "no outcome logged on every attempt -> loud" 1 2 no \
@@ -721,10 +734,10 @@ gate_b_case "environmental THEN unexplained stays loud (the latch)" 1 2 no \
 # attempt hit a port collision -- which the message assertion is what catches,
 # since the exit code alone is 75 in the correct `ports`-only case too.
 gate_b_case "ports THEN github runs the probe and goes loud" 1 2 yes \
-    "THIS RUNNER reached the same endpoint immediately afterwards" \
+    "could not reach GitHub on 1 of 2 attempt(s), but THIS RUNNER reached" \
     "43:" "0:FETCH_FAIL"
 gate_b_case "github THEN ports still runs the probe and goes loud" 1 2 yes \
-    "THIS RUNNER reached the same endpoint immediately afterwards" \
+    "could not reach GitHub on 1 of 2 attempt(s), but THIS RUNNER reached" \
     "0:FETCH_FAIL" "43:"
 
 eval "$real_run_node_until_check"
@@ -1480,7 +1493,7 @@ pin_marker "source pin: fetch-failure marker"   "$AU_SRC" "$MARKER_FETCH_FAIL"
 # grep tracks prose, and this one carries the gate's only POSITIVE assertion.
 # It must also stay at INFO -- `release_max_level_info` compiles out anything
 # below, so a `debug!` here would delete the equality check from every shipped
-# binary while leaving all 30 assertions green.
+# binary while leaving every assertion in this file green.
 if [[ "$(tr -d '[:space:]' < "$AU_SRC")" == *"tracing::info!(latest=%latest,\"${MARKER_LATEST_SEEN//[[:space:]]/}"* ]]; then
     echo "ok   - source pin: observed-latest marker is emitted at INFO with a latest= field"
 else
@@ -1494,7 +1507,8 @@ fi
 
 # --- the trigger-site ENUMERATION -------------------------------------------
 # `MARKER_TRIGGERED_RE` has to match every site that requests an update. It
-# missed the urgent one at :609 for as long as that site has existed, because
+# missed the urgent one ("triggering IMMEDIATE auto-update") for as long as that
+# site has existed, because
 # the marker was a fixed string and the site says "triggering IMMEDIATE
 # auto-update".
 #
@@ -1555,7 +1569,7 @@ else
     echo "       $versioned_sends version-detecting trigger sites ('update_tx.send(new_version)')." >&2
     echo "       ($actual_sites regex matches minus $actual_refusals refusals.) If the regex matches FEWER, a" >&2
     echo "       trigger site is worded so the canary cannot see it -- a node that took that path reads as one" >&2
-    echo "       that never decided to update, which is how the urgent site at :609 went unseen. If it matches" >&2
+    echo "       that never decided to update, which is how the urgent site went unseen. If it matches" >&2
     echo "       MORE, the regex is picking up prose. Either way, reconcile MARKER_TRIGGERED_RE with the" >&2
     echo "       enumeration comment in auto-update-canary.sh." >&2
     grep -nE "$MARKER_TRIGGERED_RE" "$SRC" >&2

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -854,14 +854,28 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 # Ground-truthed by downloading the published v0.2.125 musl asset and finding
 # the string in it.
 #
-# WHAT THIS DOES NOT COVER: `assert_detection_healthy` greps four other markers
-# against the PREVIOUS release's binary in Gate B -- MARKER_DISABLED,
-# MARKER_CHECK_RAN, MARKER_CHECK_COMPLETE and MARKER_TRIGGERED_RE -- and
-# rewording any of those produces the same post-publish false alarm with a worse
-# message. Only MARKER_LATEST_SEEN is frozen here. The asymmetry is real, not an
-# oversight: Gate A runs a binary built from THIS tree, so a reword there is
-# self-consistent, and Gate B is the only place an older binary is read.
-# Tracked as #5309.
+# WHAT THIS DOES NOT COVER. `assert_detection_healthy` greps SEVEN markers, and
+# in Gate B every one of them is put to the PREVIOUS release's binary -- the one
+# place in the pipeline where a published binary is asked for text this tree
+# chose. Two are frozen: MARKER_LATEST_SEEN here, MARKER_PARSE_FAIL immediately
+# below. The remaining five are not:
+#
+#   MARKER_DISABLED, MARKER_CHECK_RAN, MARKER_CHECK_COMPLETE,
+#   MARKER_TRIGGERED_RE        -- the four tracked by #5309
+#   MARKER_FETCH_FAIL          -- grepped too, and NOT named in #5309's
+#                                 enumeration (that issue counts five markers
+#                                 and misses this one and MARKER_PARSE_FAIL).
+#                                 Its reword direction is the loud one: an old
+#                                 binary's fetch failure would stop being
+#                                 classified INDETERMINATE and fall through to
+#                                 the equality check, which reports a missing
+#                                 observed-latest line. Wrong diagnosis, but red
+#                                 rather than green.
+#
+# So this class is NOT closed, and neither freeze closes it. The asymmetry that
+# creates it is real rather than an oversight: Gate A runs a binary built from
+# THIS tree, so a reword there is self-consistent, and Gate B is the only place
+# an older binary is read.
 #
 # To change it deliberately, re-state BOTH values:
 #   printf '%s\n%s' '<marker text>' '<first release shipping it>' | base64 | tr -d '\n'
@@ -901,6 +915,85 @@ else
         "'%s\\n%s'" "'$MARKER_LATEST_SEEN' '<release>'" "'\\n'" >&2
     FAILURES=$((FAILURES + 1))
 fi
+# --- the #5221 signature text, frozen ---------------------------------------
+# MARKER_PARSE_FAIL is the marker this whole canary was built around: it is the
+# #5221 regression's log signature, and `assert_detection_healthy`'s only
+# NEGATIVE check greps for it.
+#
+# WHY IT NEEDS A FREEZE WHEN IT ALREADY HAS TWO SOURCE PINS. `pin_warn_literal`
+# below interpolates $MARKER_PARSE_FAIL, so it follows a rename BY CONSTRUCTION
+# -- the same defect that left MARKER_LATEST_SEEN's source pin unable to notice
+# a reword. Measured on this branch: a `sed` sweep replacing the text in the
+# three files a developer must touch (auto-update-canary.sh, this file's
+# fixtures, auto_update.rs) leaves ALL assertions green. Sweeping only the first
+# two of those goes red -- which is worse than useless as a guard, because it
+# tells whoever does the incomplete sweep that finishing it is the fix.
+#
+# WHY THIS ONE IS THE DANGEROUS MEMBER OF THE CLASS, and the reason it is frozen
+# ahead of #5309's four. The other markers feed POSITIVE checks, so losing them
+# makes Gate B red against a healthy release: loud, and someone investigates.
+# This one feeds a negative check. Reword it and the grep stops matching the
+# text every ALREADY-PUBLISHED binary emits, so a previous release carrying the
+# live #5221 bug logs check-ran + reworded-warn + check-complete and Gate B
+# reports "OK: parsed GitHub's response". A silent false PASS, on the exact
+# failure this canary exists to catch, on the exact binary Gate B exists to
+# question.
+#
+# WHY NO COMPANION VERSION CONSTANT, i.e. why this is a single value and not the
+# pair above. MARKER_LATEST_SEEN needs MARKER_LATEST_SEEN_SINCE because Gate B
+# SKIPS its positive check for binaries that predate the marker, and that skip
+# needs a version to compare against. There is no skip branch here and no
+# constant to leave stale, so there is no second value a remediation could
+# quietly avoid restating.
+#
+# WHAT TO ACTUALLY DO IF THIS FIRES ON A DELIBERATE REWORD is in the failure
+# message, and it is not "regenerate the blob and move on": no published binary
+# emits the new wording, so re-stating the freeze alone hands Gate B a grep that
+# matches nothing older than the next release.
+MARKER_PARSE_FAIL_FROZEN_B64='U3RhcnR1cCB1cGRhdGUgY2hlY2s6IGZhaWxlZCB0byBwYXJzZQ=='
+# A decode failure must not leave the expectation empty and the comparison
+# vacuous -- the quiet direction, and the one this freeze exists to remove.
+# `printf | base64 -d` reads to EOF and cannot short-circuit, so it is not the
+# `| grep -q` SIGPIPE shape banned elsewhere in this file.
+if ! parse_fail_frozen="$(printf '%s' "$MARKER_PARSE_FAIL_FROZEN_B64" | base64 -d 2>/dev/null)"; then
+    parse_fail_frozen=""
+fi
+if [[ -z "$parse_fail_frozen" ]]; then
+    echo "FAIL - could not decode MARKER_PARSE_FAIL_FROZEN_B64; the #5221 signature freeze is not running" >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$MARKER_PARSE_FAIL" == "$parse_fail_frozen" ]]; then
+    echo "ok   - MARKER_PARSE_FAIL (the #5221 signature) frozen against a rename sweep"
+else
+    echo "FAIL - the frozen #5221 signature text changed." >&2
+    echo "         was: '$parse_fail_frozen'" >&2
+    echo "         now: '$MARKER_PARSE_FAIL'" >&2
+    echo "       This marker feeds the canary's only NEGATIVE check, so a reword fails" >&2
+    echo "       SILENTLY and in the passing direction. Gate B greps the PREVIOUS" >&2
+    echo "       release's binary, which emits the OLD text; a grep for the new text" >&2
+    echo "       matches nothing, so a published release carrying the live #5221 bug" >&2
+    echo "       logs check-ran + warn + check-complete and Gate B reports" >&2
+    echo "       \"OK: parsed GitHub's response\". Every already-published binary is" >&2
+    echo "       affected, not just the next one." >&2
+    echo "       Nothing else in this suite would have told you: pin_warn_literal" >&2
+    echo "       interpolates \$MARKER_PARSE_FAIL and follows a rename by construction." >&2
+    echo "       DECIDE THIS BEFORE RE-STATING THE FREEZE -- re-stating it alone is not" >&2
+    echo "       the fix, it just makes the suite agree with the blind spot:" >&2
+    echo "         (a) keep matching the OLD text as well, so Gate B can still see" >&2
+    echo "             #5221 on binaries that are already out there. MARKER_TRIGGERED_RE" >&2
+    echo "             is the precedent for an alternation marker in this file; or" >&2
+    echo "         (b) accept knowingly that Gate B cannot detect #5221 on any release" >&2
+    echo "             published before the new wording ships." >&2
+    echo "       Once decided, re-state it:" >&2
+    # printf, not echo: the recipe must reach the reader literally, and echo's
+    # handling of backslash sequences is shell-dependent. `base64 -w0` is
+    # GNU-only and fails on macOS, which is where someone reading this is most
+    # likely to be -- hence `tr -d '\n'`.
+    # shellcheck disable=SC2016  # the `$(...)` is literal recipe text for the reader
+    printf '         MARKER_PARSE_FAIL_FROZEN_B64="$(printf %s %s | base64 | tr -d %s)"\n' \
+        "'%s'" "'$MARKER_PARSE_FAIL'" "'\\n'" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
 # The parse-failure marker gets a STRONGER pin than pin_marker can give.
 # `failed to parse latest version` appears twice in auto_update.rs: the
 # production warn!, and a comment inside its own `#[cfg(test)] mod tests`

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -701,7 +701,7 @@ gate_b_case() {
 gate_b_case "a real #5221 failure is never retried" 1 1 no \
     "could not parse the version GitHub returned" "0:BROKEN" "0:BROKEN"
 gate_b_case "an indeterminate IS retried, then exits 75" 75 2 no \
-    "could not reach GitHub in 2 attempts, and this runner cannot reach it either" \
+    "could not reach GitHub on 2 of 2 attempt(s), and this runner cannot reach it either" \
     "0:FETCH_FAIL" "0:FETCH_FAIL"
 gate_b_case "a port collision exits 75 without a network probe" 75 2 yes \
     "every attempt hit a port collision on this host" "43:" "43:"
@@ -738,6 +738,20 @@ gate_b_case "ports THEN github runs the probe and goes loud" 1 2 yes \
     "43:" "0:FETCH_FAIL"
 gate_b_case "github THEN ports still runs the probe and goes loud" 1 2 yes \
     "could not reach GitHub on 1 of 2 attempt(s), but THIS RUNNER reached" \
+    "0:FETCH_FAIL" "43:"
+
+# The QUIET github branch, which the three cases above never reach: they all
+# have the runner UP, so they land on the loud sibling. With the runner DOWN a
+# mixed run is environmental, and that branch printed "in $CANARY_ATTEMPTS
+# attempts" for a further commit after its sibling was fixed -- the same false
+# unanimity, in the branch nobody had a case for. Found because a reviewer's
+# mutation reported PATTERN NOT FOUND, which is why an unapplied mutation is
+# never a pass.
+gate_b_case "ports THEN github with the runner DOWN is quiet, and counts honestly" 75 2 no \
+    "could not reach GitHub on 1 of 2 attempt(s), and this runner cannot reach it either" \
+    "43:" "0:FETCH_FAIL"
+gate_b_case "github THEN ports with the runner DOWN is quiet, and counts honestly" 75 2 no \
+    "could not reach GitHub on 1 of 2 attempt(s), and this runner cannot reach it either" \
     "0:FETCH_FAIL" "43:"
 
 eval "$real_run_node_until_check"

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -813,10 +813,30 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 #
 # Freezing the PAIR is what closes that: a reword fails HERE, in the same edit,
 # with the version constant named.
-MARKER_LATEST_SEEN_FROZEN='Startup update check: GitHub reports latest release'
+#
+# THE EXPECTED TEXT IS BASE64, AND THAT IS THE WHOLE MECHANISM. The first
+# version of this pin stored the marker as a plain literal, and it did not
+# survive its own mutation test: a reword is performed as a `sed` sweep over the
+# files that mention the marker, that sweep rewrote this expectation along with
+# everything else, and the suite stayed green. Same shape as the source pin this
+# was meant to compensate for -- an expectation textually identical to the value
+# under test follows any rename of it. Encoded, a text sweep cannot reach it.
+#
+# To change it deliberately:  printf '%s' '<new marker text>' | base64 -w0
+MARKER_LATEST_SEEN_FROZEN_B64='U3RhcnR1cCB1cGRhdGUgY2hlY2s6IEdpdEh1YiByZXBvcnRzIGxhdGVzdCByZWxlYXNl'
+MARKER_LATEST_SEEN_FROZEN="$(printf '%s' "$MARKER_LATEST_SEEN_FROZEN_B64" | base64 -d)"
+# The version half stays plain. It is not exposed to the same hazard: the edit
+# that would rewrite it is a repo-wide `sed` on a version string, and version
+# bumps here touch Cargo.toml and the lockfile, not these scripts. The realistic
+# wrong edit is a human raising it on purpose, which a plain comparison catches.
 MARKER_LATEST_SEEN_SINCE_FROZEN='0.2.125'
 
-if [[ "$MARKER_LATEST_SEEN" == "$MARKER_LATEST_SEEN_FROZEN" ]]; then
+if [[ -z "$MARKER_LATEST_SEEN_FROZEN" ]]; then
+    # `base64 -d` failing would leave the expectation empty and make the
+    # comparison below vacuous in the quiet direction.
+    echo "FAIL - could not decode MARKER_LATEST_SEEN_FROZEN_B64; the marker freeze is not running" >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$MARKER_LATEST_SEEN" == "$MARKER_LATEST_SEEN_FROZEN" ]]; then
     echo "ok   - MARKER_LATEST_SEEN still matches the text v$MARKER_LATEST_SEEN_SINCE_FROZEN shipped"
 else
     echo "FAIL - the observed-latest MARKER TEXT changed, and MARKER_LATEST_SEEN_SINCE must be" >&2
@@ -831,7 +851,9 @@ else
     echo "       Matrix alarm whose text blames the node." >&2
     echo "       Nothing else in this suite would have told you: the source pin interpolates" >&2
     echo "       \$MARKER_LATEST_SEEN and follows the rename by construction. This assertion is" >&2
-    echo "       the only prompt. Update BOTH frozen values here once you have decided." >&2
+    echo "       the only prompt. Once you have decided, update BOTH frozen values here:" >&2
+    echo "         MARKER_LATEST_SEEN_FROZEN_B64=\"\$(printf '%s' '$MARKER_LATEST_SEEN' | base64 -w0)\"" >&2
+    echo "         MARKER_LATEST_SEEN_SINCE_FROZEN=<first release that will SHIP the new text>" >&2
     FAILURES=$((FAILURES + 1))
 fi
 

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -861,7 +861,7 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 # message. Only MARKER_LATEST_SEEN is frozen here. The asymmetry is real, not an
 # oversight: Gate A runs a binary built from THIS tree, so a reword there is
 # self-consistent, and Gate B is the only place an older binary is read.
-# Tracked as a follow-up.
+# Tracked as #5309.
 #
 # To change it deliberately, re-state BOTH values:
 #   printf '%s\n%s' '<marker text>' '<first release shipping it>' | base64 | tr -d '\n'

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -470,14 +470,31 @@ gate_b_arm_case() {
         FAILURES=$((FAILURES + 1))
     fi
 }
-gate_b_arm_case "$MARKER_LATEST_SEEN_SINCE" yes   # the release the marker lands in
+gate_b_arm_case "$MARKER_LATEST_SEEN_SINCE" yes   # the first release that emits it
 # Was a literal `0.2.125`, which is the constant's own value and so duplicated
 # the case above rather than covering "after it". The constant is frozen (pinned
 # below), so a later release is a literal one release on.
 gate_b_arm_case "0.2.126"                   yes   # every release after it
 gate_b_arm_case "0.3.0"                     yes
-gate_b_arm_case "0.2.123"                   no    # the one release that must skip
+# BOTH releases below the constant must skip, and both are listed on purpose.
+# With only 0.2.123 here the cases straddled the gap: 0.2.123 no / 0.2.125 yes is
+# satisfied by ANY threshold in {0.2.124, 0.2.125}, so nothing pinned that the
+# decision reads the CONSTANT rather than a literal. Verified vacuity: replacing
+# the body of `prev_emits_latest_seen` with a hardcoded
+# `version_at_least "$1" "0.2.124"` left the entire suite green. 0.2.124 is the
+# case that closes it -- and it is the interesting one anyway, being the release
+# whose tree HAS the marker but which was never published.
+gate_b_arm_case "0.2.124"                   no    # in-tree but never published
+gate_b_arm_case "0.2.123"                   no    # predates the marker entirely
 gate_b_arm_case "0.2.99"                    no    # numeric, not lexical
+
+# Malformed input ARMS the check rather than skipping it. Skipping is the silent
+# direction; arming an unknown binary costs at worst a loud red on a release
+# whose version string was already unreadable. Note this is the OPPOSITE of what
+# `version_at_least` returns for the same input (below) -- deliberately, because
+# the two answer different questions. See the comment on prev_emits_latest_seen.
+gate_b_arm_case "not-a-version"             yes   # unreadable -> assert, don't skip
+gate_b_arm_case ""                          yes
 
 # `version_at_least` decides whether the gate above arms, so it gets its own
 # cases: an off-by-one here silently disarms Gate B's only positive assertion.
@@ -492,13 +509,26 @@ version_ge_case() {
         FAILURES=$((FAILURES + 1))
     fi
 }
-version_ge_case "0.2.124" "0.2.124" yes   # the release the marker lands in
+version_ge_case "0.2.124" "0.2.124" yes   # equal
 version_ge_case "0.2.125" "0.2.124" yes
-version_ge_case "0.2.123" "0.2.124" no    # the one release that must skip
+version_ge_case "0.2.123" "0.2.124" no    # strictly below
 version_ge_case "0.3.0"   "0.2.124" yes
 # Numeric, not lexical: a lexical compare puts 0.2.99 above 0.2.124 and would
 # disarm the gate for every release in between.
 version_ge_case "0.2.99"  "0.2.124" no
+
+# MALFORMED INPUT MUST NOT COMPARE TRUE. The bare `sort -V` form answered TRUE
+# for all three of these -- non-numeric text sorts after digits, and an empty
+# operand loses to anything -- so an unreadable version or an emptied constant
+# passed a comparison that has no answer. Measured on GNU coreutils 9.4 before
+# the guard: cases 1 and 2 below both returned yes.
+version_ge_case "not-a-version" "0.2.125" no
+version_ge_case "0.2.125"       ""        no
+version_ge_case ""              ""        no
+# Rejected rather than ordered, because `sort -V` puts a pre-release ABOVE the
+# release where semver puts it below. This repo cuts no rc tags; accepting a
+# form the comparator gets backwards would be worse than refusing it.
+version_ge_case "0.2.125-rc.1"  "0.2.125" no
 
 # --- no status-consuming pipe into a short-circuiting reader ----------------
 # The defect that produced this rule: `printf '%s' "$logs" | grep -aqF …` under
@@ -732,7 +762,7 @@ fi
 pin_marker "source pin: #4073 refusal phrase"   "$SRC"    "$MARKER_NOT_TRIGGERED"
 pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 
-# --- the MARKER_LATEST_SEEN_SINCE constant itself ---------------------------
+# --- the (marker text, first release that shipped it) PAIR ------------------
 # Gate B's version gate is pinned in both directions (the behavioural cases on
 # `prev_emits_latest_seen`, and the un-negated call site), but neither looks at
 # the CONSTANT they compare against. Raising it 0.2.124 -> 0.2.999 left the
@@ -740,83 +770,90 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 # assertion -- the same silent direction as the `!` inversion, reached by
 # editing a different line.
 #
-# THE RELATION IS `constant <= crate version`, AND IT USED TO BE THE OPPOSITE.
-# The first version of this block asserted the constant was NOT BELOW the crate
-# version. Its premise was stated in its own comment: "the marker is new in this
-# tree, so no already-published release emits it". That premise was true for
-# exactly as long as 0.2.125 was unpublished, and it EXPIRED the moment 0.2.125
-# shipped. The constant is a historical fact and correctly stays at 0.2.125
-# forever, so the old assertion would have gone red on the 0.2.126 bump and
-# blocked a healthy release -- a self-detonating pin, verified by setting the
-# crate version to 0.2.126 and watching it fail.
+# WHY THERE IS NO RELATION PIN HERE, AND MUST NOT BE ONE.
 #
-# The relation worth pinning is the other one, because only one direction is
-# SILENT:
+# Two have been tried and both were wrong, in opposite phases:
 #
-#   constant ABOVE the crate version -- `prev_emits_latest_seen` compares the
-#     PREVIOUS release against it, and the previous release is always below the
-#     crate version, so the gate can never arm. Gate B's only positive assertion
-#     is skipped on every release, indefinitely, and the run still reports
-#     success. This is the dangerous direction and the one asserted below.
+#   `constant >= crate version` (#5290). Premise: "the marker is new in this
+#     tree, so no published release emits it". True until 0.2.125 published,
+#     false one second later. It would have gone red on the 0.2.126 bump and
+#     blocked a healthy release. Self-detonating; verified by setting the crate
+#     version to 0.2.126 and watching it fail.
 #
-#   constant AT or BELOW the crate version -- the check runs (from the release
-#     after the constant onwards). Nothing to catch.
+#   `constant <= crate version` (this PR's first attempt). Correct after
+#     publication, wrong during a marker REWORD. A marker reworded on main first
+#     ships in crate+1, so the CORRECT constant is crate+1 -- which this
+#     assertion calls a failure, while the value that makes it green (constant =
+#     crate) makes Gate B demand the new text from a published binary that emits
+#     the old one: a post-publish red canary and a Matrix alarm blaming the node.
+#     Verified by execution. A `<= crate+1` variant fires on the reword too.
 #
-# Anchored against the crate version, which the constant cannot influence.
-CORE_TOML="$SCRIPT_DIR/../crates/core/Cargo.toml"
-if [[ ! -f "$CORE_TOML" ]]; then
-    echo "FAIL - cannot check MARKER_LATEST_SEEN_SINCE: $CORE_TOML not found" >&2
-    FAILURES=$((FAILURES + 1))
+# The generalisation, and the reason not to try a third: the constant tracks
+# RELEASE HISTORY while the crate version tracks THIS TREE, and no fixed
+# relation between them holds across publication and reword both. A pin on a
+# relation between two quantities that move on different clocks is a pin that
+# will be right in one phase and wrong in another.
+#
+# So the pin is a FREEZE, which is phase-independent, and it covers strictly
+# more: the relation only ever caught "constant strictly above crate version",
+# while the freeze catches every wrong value including the empty string and the
+# most likely wrong one (the version being cut). It also cannot be tripped by
+# `version.workspace = true`, which broke the relation pin's Cargo.toml read.
+#
+# WHY BOTH HALVES ARE FROZEN TOGETHER.
+#
+# The version alone is not enough, and the gap is silent rather than annoying.
+# Reword MARKER_LATEST_SEEN everywhere a developer must touch it -- auto_update.rs,
+# freenet.rs, the canary, and the log fixtures in both test files -- leave the
+# constant alone, and the whole suite passes: verified, zero red. The source pin
+# interpolates $MARKER_LATEST_SEEN so it follows the rename by construction, and
+# nothing else looks at the marker at all. A stale constant is the DEFAULT
+# outcome of a reword, not an escape from a warning, and it surfaces post-publish
+# on the release Matrix channel with text that blames the node.
+#
+# Freezing the PAIR is what closes that: a reword fails HERE, in the same edit,
+# with the version constant named.
+MARKER_LATEST_SEEN_FROZEN='Startup update check: GitHub reports latest release'
+MARKER_LATEST_SEEN_SINCE_FROZEN='0.2.125'
+
+if [[ "$MARKER_LATEST_SEEN" == "$MARKER_LATEST_SEEN_FROZEN" ]]; then
+    echo "ok   - MARKER_LATEST_SEEN still matches the text v$MARKER_LATEST_SEEN_SINCE_FROZEN shipped"
 else
-    crate_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$CORE_TOML" | head -1)"
-    if [[ -z "$crate_version" ]]; then
-        echo "FAIL - could not read the crate version from $CORE_TOML" >&2
-        FAILURES=$((FAILURES + 1))
-    elif ! version_at_least "$crate_version" "$MARKER_LATEST_SEEN_SINCE"; then
-        echo "FAIL - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is ABOVE the crate" >&2
-        echo "       version ($crate_version). Gate B arms its positive-equality check only" >&2
-        echo "       when the PREVIOUS release is >= the constant, and the previous release is" >&2
-        echo "       always below this tree's version -- so a constant set above it can never" >&2
-        echo "       arm. Gate B then skips its only positive assertion on every release," >&2
-        echo "       reports success, and the silently-wrong-comparator hole it exists to" >&2
-        echo "       close is open again." >&2
-        FAILURES=$((FAILURES + 1))
-    else
-        echo "ok   - MARKER_LATEST_SEEN_SINCE ($MARKER_LATEST_SEEN_SINCE) is at or below the crate version ($crate_version), so Gate B's equality check can arm"
-    fi
+    echo "FAIL - the observed-latest MARKER TEXT changed, and MARKER_LATEST_SEEN_SINCE must be" >&2
+    echo "       reconsidered in the same edit." >&2
+    echo "         was: '$MARKER_LATEST_SEEN_FROZEN'" >&2
+    echo "         now: '$MARKER_LATEST_SEEN'" >&2
+    echo "       MARKER_LATEST_SEEN_SINCE names the first PUBLISHED release emitting that text." >&2
+    echo "       Reword it and no published binary emits the new text yet, so the constant must" >&2
+    echo "       move to the release that will first SHIP it -- normally the NEXT one, since the" >&2
+    echo "       bump happens inside the release commit. Leave it and Gate B demands the new" >&2
+    echo "       wording from a binary that emits the old one: a POST-PUBLISH red canary and a" >&2
+    echo "       Matrix alarm whose text blames the node." >&2
+    echo "       Nothing else in this suite would have told you: the source pin interpolates" >&2
+    echo "       \$MARKER_LATEST_SEEN and follows the rename by construction. This assertion is" >&2
+    echo "       the only prompt. Update BOTH frozen values here once you have decided." >&2
+    FAILURES=$((FAILURES + 1))
 fi
 
-# ...and the value itself, which the relation above deliberately does not pin.
-#
-# `constant <= crate version` permits the constant to CREEP FORWARD with each
-# release. That creep passes every assertion in this file and is wrong every
-# time: setting the constant to the version being cut skips Gate B's equality
-# check for that release, so a constant kept level with the crate version
-# disarms the gate on every release while looking maintained.
-#
-# There is exactly one correct value, and it is not a policy choice: 0.2.125 is
-# the first release a running node can REACH whose binary emits
-# MARKER_LATEST_SEEN. The marker landed in the 0.2.124 tree, but 0.2.124 was
-# never published (Gate A blocked it on the #5290 TMPDIR harness bug) and a
-# draft does not appear at `/releases/latest`, so no node ever saw a 0.2.124
-# binary. That makes the constant a statement about release history, not about
-# this tree, and release history does not change -- FREEZE IT.
-#
-# Moving it forward is therefore always a mistake. If the FACT turns out to be
-# wrong (0.2.125 does not emit the line after all), change both the constant and
-# this expectation in the same commit and say why. That deliberate edit is the
-# outcome this assertion exists to force; the accidental bump is what it stops.
-MARKER_LATEST_SEEN_SINCE_FROZEN='0.2.125'
+# ...and the version half. 0.2.125 is the first release a running node can REACH
+# whose binary emits that text: the marker landed in the 0.2.124 tree, but
+# 0.2.124 was never published (Gate A blocked it on the #5290 TMPDIR harness
+# bug) and a draft does not appear at `/releases/latest`, so no node ever saw a
+# 0.2.124 binary. Ground-truthed during review by downloading the published
+# v0.2.125 musl asset and finding the string in it.
 if [[ "$MARKER_LATEST_SEEN_SINCE" == "$MARKER_LATEST_SEEN_SINCE_FROZEN" ]]; then
     echo "ok   - MARKER_LATEST_SEEN_SINCE is frozen at the historical value ($MARKER_LATEST_SEEN_SINCE_FROZEN)"
 else
-    echo "FAIL - MARKER_LATEST_SEEN_SINCE is '$MARKER_LATEST_SEEN_SINCE', expected the frozen" >&2
-    echo "       historical value '$MARKER_LATEST_SEEN_SINCE_FROZEN'. The constant records WHICH" >&2
-    echo "       published release first emitted '$MARKER_LATEST_SEEN'" >&2
-    echo "       -- a fact about release history, which does not change. Raising it skips Gate" >&2
-    echo "       B's positive-equality check for every release below the new value, silently." >&2
-    echo "       If the historical fact is genuinely wrong, change the constant and this" >&2
-    echo "       expectation together, in one commit, with the reason." >&2
+    echo "FAIL - MARKER_LATEST_SEEN_SINCE is '$MARKER_LATEST_SEEN_SINCE', expected '$MARKER_LATEST_SEEN_SINCE_FROZEN'." >&2
+    echo "       It records which PUBLISHED release first emitted the marker text, so under an" >&2
+    echo "       ordinary release it does not move. Raising it to the version being cut skips" >&2
+    echo "       Gate B's only positive assertion for that release, silently, and a constant" >&2
+    echo "       kept level with the crate version disarms the gate on every release while" >&2
+    echo "       looking maintained." >&2
+    echo "       If you got here by RAISING it, the fix is almost certainly to put it back." >&2
+    echo "       There is one edit where moving it is correct -- rewording the marker text --" >&2
+    echo "       and that fails the assertion ABOVE this one, naming the reword. If that" >&2
+    echo "       assertion is green, this is not a reword and the constant should not move." >&2
     FAILURES=$((FAILURES + 1))
 fi
 # The parse-failure marker gets a STRONGER pin than pin_marker can give.

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -500,6 +500,43 @@ env_case "a disabled updater is NOT environmental"         no "$DISABLED"
 # a second time and re-register `trap cleanup EXIT`, leaking the first workdir
 # on every CI run. A stub left installed would be worse -- it would silently
 # weaken any later assertion that reaches it.
+# --- the probe itself, before the decision that consumes it -----------------
+# `runner_can_reach_github` is the corroboration. Every way it can MALFUNCTION
+# used to be indistinguishable from "the network is down", because it went
+# through `resolve_expected_latest`, which collapses a 403, a captive portal, a
+# changed redirect shape and a missing curl all to `return 1`. Read as
+# corroboration, every one of those bought the quiet path.
+#
+# Only connect-class curl exits may now answer "cannot reach". Stubbing `curl`
+# rather than the function, so what is tested is the classification of exit
+# codes and not a restatement of it.
+probe_case() {
+    # probe_case <description> <curl-exit> <expected reachable|unreachable>
+    local desc="$1" curl_rc="$2" expect="$3" got
+    if (
+        curl() { return "$curl_rc"; }
+        runner_can_reach_github
+    ); then got=reachable; else got=unreachable; fi
+    if [[ "$got" == "$expect" ]]; then
+        echo "ok   - probe: $desc"
+    else
+        echo "FAIL - probe: $desc (got '$got', expected '$expect')" >&2
+        if [[ "$expect" == reachable ]]; then
+            echo "       Reading this as 'the network is down' hands the quiet path to a" >&2
+            echo "       probe malfunction, which is the direction that hides things." >&2
+        fi
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+probe_case "curl succeeds"                        0   reachable
+probe_case "could not resolve host (6)"           6   unreachable
+probe_case "failed to connect (7)"                7   unreachable
+probe_case "operation timed out (28)"             28  unreachable
+probe_case "SSL connect error (35)"               35  unreachable
+probe_case "HTTP error, e.g. 403 rate limit (22)" 22  reachable
+probe_case "unsupported protocol / bad URL (1)"   1   reachable
+probe_case "curl not installed (127)"             127 reachable
+
 real_runner_can_reach_github="$(declare -f runner_can_reach_github)"
 if [[ -z "$real_runner_can_reach_github" ]]; then
     echo "FAIL - runner_can_reach_github is not defined; the corroboration tests would" >&2
@@ -593,14 +630,23 @@ if [[ -z "$real_run_node_until_check" ]]; then
     FAILURES=$((FAILURES + 1))
 fi
 
+# THE MESSAGE IS ASSERTED, not just the code. Exit 75 is reached from two
+# branches whose operator-facing text differs, and the quiet Matrix message
+# deliberately points the reader at the job log line as the ONLY thing that says
+# which -- so that line is the disambiguator and it was untested. Measured:
+# deleting the entire `ports)` arm of the message `case` left all four suites
+# green. `check()` in this same file exists for exactly this reason and says so
+# in its own comment; this is that gap reintroduced one function over.
 gate_b_case() {
-    # gate_b_case <desc> <expected-rc> <expected-attempts> <runner-reachable> <spec...>
+    # gate_b_case <desc> <expected-rc> <expected-attempts> <runner-reachable> \
+    #             <expected-message-substring> <spec...>
     # Each <spec> is "<node-exit>:<fixture-variable-name>" for one attempt.
-    local desc="$1" want_rc="$2" want_attempts="$3" reachable="$4"
-    shift 4
+    local desc="$1" want_rc="$2" want_attempts="$3" reachable="$4" want_msg="$5"
+    shift 5
     GATE_B_SCRIPT=("$@")
     GATE_B_ATTEMPT=0
-    local got_rc got_attempts out
+    local got_rc got_attempts out err errfile
+    errfile="$(mktemp "$TMPROOT/gateb.XXXXXX")"
     out="$(
         CANARY_ATTEMPTS="${#GATE_B_SCRIPT[@]}"
         CANARY_RETRY_SLEEP=0
@@ -616,18 +662,25 @@ gate_b_case() {
         printf '#!/bin/sh\necho "Freenet version: 0.2.121"\n' \
             > "$CANARY_WORKDIR/selfupdate/bin/freenet"
         chmod +x "$CANARY_WORKDIR/selfupdate/bin/freenet"
-        cmd_selfupdate 0.2.121 0.2.122 >/dev/null 2>&1
+        cmd_selfupdate 0.2.121 0.2.122 2>"$errfile" >/dev/null
         printf '%s %s' "$?" "$GATE_B_ATTEMPT"
     )"
     got_rc="${out%% *}"
     got_attempts="${out##* }"
-    if [[ "$got_rc" == "$want_rc" && "$got_attempts" == "$want_attempts" ]]; then
-        echo "ok   - Gate B: $desc"
-    else
+    err="$(cat "$errfile")"
+    rm -f "$errfile"
+    if [[ "$got_rc" != "$want_rc" || "$got_attempts" != "$want_attempts" ]]; then
         echo "FAIL - Gate B: $desc" >&2
         echo "         got exit $got_rc after $got_attempts attempt(s);" >&2
         echo "         wanted exit $want_rc after $want_attempts" >&2
         FAILURES=$((FAILURES + 1))
+    elif [[ "$err" != *"$want_msg"* ]]; then
+        echo "FAIL - Gate B: $desc (exit $got_rc correct, but the operator sees the wrong text)" >&2
+        echo "         wanted a message containing: $want_msg" >&2
+        echo "         got: ${err:-<nothing on stderr>}" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   - Gate B: $desc"
     fi
 }
 
@@ -636,25 +689,43 @@ gate_b_case() {
 # intermittent fault produce one passing attempt, and Gate B then reports a
 # broken release healthy. A flaky pass on the post-publish gate is worse than
 # no gate.
-gate_b_case "a real #5221 failure is never retried" 1 1 no "0:BROKEN" "0:BROKEN"
+gate_b_case "a real #5221 failure is never retried" 1 1 no \
+    "could not parse the version GitHub returned" "0:BROKEN" "0:BROKEN"
 gate_b_case "an indeterminate IS retried, then exits 75" 75 2 no \
+    "could not reach GitHub in 2 attempts, and this runner cannot reach it either" \
     "0:FETCH_FAIL" "0:FETCH_FAIL"
 gate_b_case "a port collision exits 75 without a network probe" 75 2 yes \
-    "43:" "43:"
+    "every attempt hit a port collision on this host" "43:" "43:"
 # The corroboration: the same node-side symptom, opposite runner state.
 gate_b_case "node cannot reach GitHub but the runner can -> loud, not 75" 1 2 yes \
+    "THIS RUNNER reached the same endpoint immediately afterwards" \
     "0:FETCH_FAIL" "0:FETCH_FAIL"
 # A hung updater must never be quiet.
 gate_b_case "no outcome logged on every attempt -> loud" 1 2 no \
+    "at least one attempt started the update check and never logged an outcome" \
     "0:PENDING" "0:PENDING"
-# THE LATCH. An unexplained indeterminate on attempt 1 must survive an
+# THE LATCH, top tier. An unexplained indeterminate on attempt 1 must survive an
 # environmental attempt 2. Last-writer-wins here returned 75 and told the dev
 # room a hung updater was "not a stranded fleet and needs no fleet action".
 gate_b_case "unexplained THEN environmental stays loud (the latch)" 1 2 no \
+    "at least one attempt started the update check and never logged an outcome" \
     "0:PENDING" "43:"
 # ...and in the other order, so the latch is not merely "the first attempt wins".
 gate_b_case "environmental THEN unexplained stays loud (the latch)" 1 2 no \
+    "at least one attempt started the update check and never logged an outcome" \
     "43:" "0:PENDING"
+
+# STICKY BY STRENGTH, one tier down: `github` must never be downgraded to
+# `ports`. Both orderings, because they disagreed. The second was the live bug:
+# the probe never ran, the run exited 75 quiet, and the message claimed every
+# attempt hit a port collision -- which the message assertion is what catches,
+# since the exit code alone is 75 in the correct `ports`-only case too.
+gate_b_case "ports THEN github runs the probe and goes loud" 1 2 yes \
+    "THIS RUNNER reached the same endpoint immediately afterwards" \
+    "43:" "0:FETCH_FAIL"
+gate_b_case "github THEN ports still runs the probe and goes loud" 1 2 yes \
+    "THIS RUNNER reached the same endpoint immediately afterwards" \
+    "0:FETCH_FAIL" "43:"
 
 eval "$real_run_node_until_check"
 

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -134,6 +134,22 @@ check "healthy: check ran and completed up-to-date -> pass" 0 "$HEALTHY_UP_TO_DA
 check "broken: #5221 unparseable tag -> fail" 1 "$BROKEN" \
     "could not parse the version GitHub returned"
 
+# BOTH markers in one log, which pins the ORDER of the two branches. The
+# parse-failure check runs BEFORE the fetch-failure check, and that ordering is
+# the only thing keeping a real #5221 out of the environmental classification
+# Gate B gained this round. Swap the two branches -- an innocent-looking tidy,
+# "infra check before product check" -- and this log returns 2 instead of 1,
+# Gate B calls it environmental, and the dev room is told "not a stranded
+# fleet" about a log carrying the live #5221 signature.
+#
+# Realistic rather than contrived: a node whose startup fetch failed and whose
+# periodic re-poll then returned an unparseable tag logs exactly this, and so
+# does the reverse. Until this case existed no fixture in the suite held both.
+BROKEN_PLUS_FETCH_FAIL="$BROKEN
+2026-08-08T02:05:00.000000Z  WARN freenet::commands::auto_update: Startup update check: failed to fetch latest version: error sending request. Continuing with current binary."
+check "broken: a parse failure OUTRANKS a fetch failure in the same log" 1 \
+    "$BROKEN_PLUS_FETCH_FAIL" "could not parse the version GitHub returned"
+
 # --- THE VACUOUS-PASS CASES -------------------------------------------------
 # Each of these contains NO error line. A one-sided "grep -q 'failed to parse'
 # && fail" assertion passes all of them, which is exactly how a dead updater
@@ -520,6 +536,128 @@ class_case "an unrecognised cause is loud, not quiet" \
     weather no fault
 eval "$real_runner_can_reach_github"
 
+# --- Gate B END TO END, driven per attempt ----------------------------------
+# Everything above tests a PIECE. This drives the real `cmd_selfupdate` over a
+# scripted sequence of attempts and asserts BOTH the returned exit code and the
+# attempt count, which is the only way several of these properties can be
+# observed at all.
+#
+# WHY, CONCRETELY. Three mutations that break the classifier in the QUIET
+# direction were confirmed to leave the whole suite green before this existed:
+#
+#   1. `[ "$rc" -eq 2 ] && node_could_not_reach_github …` -> `||`, so every
+#      indeterminate becomes environmental. The source pin survives because the
+#      CALL TEXT is still there -- the same defect the round-2
+#      `prev_emits_latest_seen` fix was written to close, reappearing one
+#      function over. A pin that greps for a call cannot see the operator
+#      joining it to anything.
+#   2. `-eq 1` -> `-ne 1` on the corroboration, swapping 75 and 1.
+#   3. deleting the `attempt_cause=""` reset.
+#
+# And the run-level latch -- an unexplained indeterminate on ANY attempt must
+# never be overwritten by a later environmental one -- is a property OF THE
+# SEQUENCE. No single-attempt test can express it.
+#
+# `run_node_until_check` is stubbed rather than booting a node: the sequence is
+# the subject, and a real boot costs seconds per attempt. The lifecycle test
+# covers the same retry property against REAL boots, so the stub cannot quietly
+# diverge from the thing it stands in for. `curl`/`tar` are shadowed so the
+# download preamble is a no-op. Same shape as
+# `release_wait_for_binaries_test.sh`'s `check_call_count`.
+GATE_B_ATTEMPT=0
+GATE_B_SCRIPT=()
+run_node_until_check_stub() {
+    local work="$2" spec exit_code logvar
+    GATE_B_ATTEMPT=$((GATE_B_ATTEMPT + 1))
+    # Past the end of the script means the loop ran more times than the case
+    # expects; repeat the last entry so the attempt-COUNT assertion is what
+    # reports it, with a number, rather than an unbound-variable abort.
+    if [[ "$GATE_B_ATTEMPT" -le "${#GATE_B_SCRIPT[@]}" ]]; then
+        spec="${GATE_B_SCRIPT[$((GATE_B_ATTEMPT - 1))]}"
+    else
+        spec="${GATE_B_SCRIPT[$((${#GATE_B_SCRIPT[@]} - 1))]}"
+    fi
+    exit_code="${spec%%:*}"
+    logvar="${spec#*:}"
+    NODE_EXIT="$exit_code"
+    mkdir -p "$work/logs"
+    if [[ -n "$logvar" ]]; then
+        printf '%s\n' "${!logvar}" > "$work/logs/freenet.2026-08-08-02.log"
+    fi
+}
+
+real_run_node_until_check="$(declare -f run_node_until_check)"
+if [[ -z "$real_run_node_until_check" ]]; then
+    echo "FAIL - run_node_until_check is not defined; the Gate B driver would stub" >&2
+    echo "       nothing and every case below would pass vacuously." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+gate_b_case() {
+    # gate_b_case <desc> <expected-rc> <expected-attempts> <runner-reachable> <spec...>
+    # Each <spec> is "<node-exit>:<fixture-variable-name>" for one attempt.
+    local desc="$1" want_rc="$2" want_attempts="$3" reachable="$4"
+    shift 4
+    GATE_B_SCRIPT=("$@")
+    GATE_B_ATTEMPT=0
+    local got_rc got_attempts out
+    out="$(
+        CANARY_ATTEMPTS="${#GATE_B_SCRIPT[@]}"
+        CANARY_RETRY_SLEEP=0
+        curl() { :; }
+        tar()  { :; }
+        run_node_until_check() { run_node_until_check_stub "$@"; }
+        if [[ "$reachable" == yes ]]; then
+            runner_can_reach_github() { return 0; }
+        else
+            runner_can_reach_github() { return 1; }
+        fi
+        mkdir -p "$CANARY_WORKDIR/selfupdate/bin"
+        printf '#!/bin/sh\necho "Freenet version: 0.2.121"\n' \
+            > "$CANARY_WORKDIR/selfupdate/bin/freenet"
+        chmod +x "$CANARY_WORKDIR/selfupdate/bin/freenet"
+        cmd_selfupdate 0.2.121 0.2.122 >/dev/null 2>&1
+        printf '%s %s' "$?" "$GATE_B_ATTEMPT"
+    )"
+    got_rc="${out%% *}"
+    got_attempts="${out##* }"
+    if [[ "$got_rc" == "$want_rc" && "$got_attempts" == "$want_attempts" ]]; then
+        echo "ok   - Gate B: $desc"
+    else
+        echo "FAIL - Gate B: $desc" >&2
+        echo "         got exit $got_rc after $got_attempts attempt(s);" >&2
+        echo "         wanted exit $want_rc after $want_attempts" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# The load-bearing one, and the reason the retry is gated on rc=2. Each attempt
+# wipes the tree and boots a fresh node, so retrying a REAL failure lets any
+# intermittent fault produce one passing attempt, and Gate B then reports a
+# broken release healthy. A flaky pass on the post-publish gate is worse than
+# no gate.
+gate_b_case "a real #5221 failure is never retried" 1 1 no "0:BROKEN" "0:BROKEN"
+gate_b_case "an indeterminate IS retried, then exits 75" 75 2 no \
+    "0:FETCH_FAIL" "0:FETCH_FAIL"
+gate_b_case "a port collision exits 75 without a network probe" 75 2 yes \
+    "43:" "43:"
+# The corroboration: the same node-side symptom, opposite runner state.
+gate_b_case "node cannot reach GitHub but the runner can -> loud, not 75" 1 2 yes \
+    "0:FETCH_FAIL" "0:FETCH_FAIL"
+# A hung updater must never be quiet.
+gate_b_case "no outcome logged on every attempt -> loud" 1 2 no \
+    "0:PENDING" "0:PENDING"
+# THE LATCH. An unexplained indeterminate on attempt 1 must survive an
+# environmental attempt 2. Last-writer-wins here returned 75 and told the dev
+# room a hung updater was "not a stranded fleet and needs no fleet action".
+gate_b_case "unexplained THEN environmental stays loud (the latch)" 1 2 no \
+    "0:PENDING" "43:"
+# ...and in the other order, so the latch is not merely "the first attempt wins".
+gate_b_case "environmental THEN unexplained stays loud (the latch)" 1 2 no \
+    "43:" "0:PENDING"
+
+eval "$real_run_node_until_check"
+
 # Gate B's use of it. Three separate things can each silently undo the split,
 # and the first two fail in the QUIET direction:
 #   - returning 1 instead of the distinct code, so cross-compile.yml cannot
@@ -540,6 +678,13 @@ elif [[ "$selfupdate_body" != *'node_could_not_reach_github "$work/logs"'* ]]; t
     echo "       assert_detection_healthy returns 2 for two different situations. Treating" >&2
     echo "       both as environmental quietens a run where the check started and never" >&2
     echo "       logged an outcome, which is what a HUNG updater looks like." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$selfupdate_body" != *'saw_unexplained=1'* ]]; then
+    echo "FAIL - cmd_selfupdate no longer latches an UNEXPLAINED indeterminate." >&2
+    echo "       The per-attempt cause is last-writer-wins without it: an attempt that" >&2
+    echo "       started the check and logged no outcome (a hung updater) followed by an" >&2
+    echo "       attempt that lost a port race reports exit 75 and the quiet 'no fleet" >&2
+    echo "       action' message. The behavioural cases above cover both orderings." >&2
     FAILURES=$((FAILURES + 1))
 elif [[ "$selfupdate_body" != *'gate_b_unverified_class "$env_cause"'* ]]; then
     echo "FAIL - cmd_selfupdate no longer routes the quiet path through gate_b_unverified_class." >&2
@@ -1004,12 +1149,23 @@ pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
 #   MARKER_FETCH_FAIL          -- grepped too, and NOT named in #5309's
 #                                 enumeration (that issue counts five markers
 #                                 and misses this one and MARKER_PARSE_FAIL).
-#                                 Its reword direction is the loud one: an old
-#                                 binary's fetch failure would stop being
-#                                 classified INDETERMINATE and fall through to
-#                                 the equality check, which reports a missing
-#                                 observed-latest line. Wrong diagnosis, but red
-#                                 rather than green.
+#                                 It is now the highest-priority member of that
+#                                 set, and the reason CHANGED under this PR.
+#                                 It used to be simply loud: an old binary's
+#                                 fetch failure would stop being classified
+#                                 INDETERMINATE and fall through to the equality
+#                                 check, reporting a missing observed-latest
+#                                 line -- wrong diagnosis, but red. Since Gate B
+#                                 gained the environmental classification the
+#                                 marker is ALSO the input to
+#                                 `node_could_not_reach_github`, so a reword
+#                                 silently disables that classification and
+#                                 sends every network blip back to the loud
+#                                 #5221 alarm: it reinstates precisely the false
+#                                 fleet alarm that change removed, by editing a
+#                                 different line. Still not a silent PASS, which
+#                                 is why it is handed to #5309 rather than
+#                                 frozen here alongside MARKER_PARSE_FAIL.
 #
 # So this class is NOT closed, and neither freeze closes it. The asymmetry that
 # creates it is real rather than an oversight: Gate A runs a binary built from
@@ -1172,9 +1328,17 @@ if [[ -z "$historical_warn" ]]; then
     FAILURES=$((FAILURES + 1))
 else
     historical_dir="$(mktemp -d "$TMPROOT/historical.XXXXXX")"
-    printf '%s\n%s\n' \
+    # THREE lines, and the completion line is not padding. `freenet.rs` emits
+    # `Startup update check complete` on every non-triggering outcome, so a real
+    # #5221 log has it, and WITHOUT it this fixture returns 2 (indeterminate)
+    # rather than the 0 the failure message below claims a reworded marker
+    # produces. The assertion goes red either way, but a fixture that fails for
+    # a different reason than its message names is how a pin comes to be
+    # trusted for the wrong thing. Measured: two lines -> rc=2, three -> rc=0.
+    printf '%s\n%s\n%s\n' \
         "2026-08-08T01:59:35.950835Z  INFO freenet: $MARKER_CHECK_RAN current=\"0.2.121\" jitter_secs=40" \
         "$historical_warn" \
+        "2026-08-08T01:59:36.200000Z  INFO freenet: $MARKER_CHECK_COMPLETE: staying on the current version current=\"0.2.121\"" \
         > "$historical_dir/freenet.2026-08-08-01.log"
     historical_stderr="$(assert_detection_healthy "$historical_dir" 2>&1 >/dev/null)"
     historical_rc=$?
@@ -1195,6 +1359,11 @@ else
         echo "       precedent for an alternation), or delete this assertion deliberately and" >&2
         echo "       say in the commit message that Gate B is now blind to #5221 on every" >&2
         echo "       release published before the new wording ships." >&2
+        echo "       (Deleting this block IS a way out and nothing stops it: ci.yml's" >&2
+        echo "       removed-tests guard scans crates/core/**/*.rs only, so a deleted" >&2
+        echo "       SHELL assertion is flagged nowhere, and the counter this PR widened" >&2
+        echo "       measures additions rather than deletions. Accepted, and said out" >&2
+        echo "       loud so nobody reads 'the suite went green' as 'the property holds'.)" >&2
         FAILURES=$((FAILURES + 1))
     fi
 fi

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -399,8 +399,14 @@ else
             | tr -s '[:space:]' ' '
     }
 
-    quiet_step="$(step_containing 'could NOT VERIFY')"
-    loud_step="$(step_containing '#5221 failure mode')"
+    # Located by `id:`, not by a phrase from the message. Locating them by
+    # message text was tried and an ordinary reword of the quiet message broke
+    # the pin on the first edit -- the same "expectation stored as a copy"
+    # shape this PR exists to remove. An `id:` is structural and exists to be
+    # referenced; a rename of one still fails here, but loudly and for a reason
+    # the message names.
+    quiet_step="$(step_containing 'id: notify-environmental')"
+    loud_step="$(step_containing 'id: notify-fault')"
 
     if [[ -z "$quiet_step" ]]; then
         fail "the environmental (quiet) notification step is gone from the notify job" \

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -58,11 +58,38 @@ done
 # above the step that runs it, so matching raw text would compare the canary
 # against a sentence and report the gate inverted. A pin that fails on prose is
 # no better than one that passes on prose.
-JOB_BLOCK="$(awk '
-    /^  attach-to-release:[[:space:]]*$/ { inblock = 1; print NR ":" $0; next }
-    inblock && /^  [A-Za-z_.-]+:/        { inblock = 0 }
-    inblock && $0 !~ /^[[:space:]]*#/    { print NR ":" $0 }
-' "$WF")"
+# ONE extraction for every job block in this file, so the comment filter cannot
+# be forgotten at a new call site. It was forgotten at two: `selfupdate_block`
+# (fixed after a mutation of `|| rc=$?` hit the comment quoting it and the pin
+# stayed green) and then `notify_block`, where the consequence was worse --
+# widening the quiet notification's `if:` to `result == 'failure'` while leaving
+# a one-line comment recording the old condition left ALL FOUR suites green,
+# with the reassuring "no fleet action is indicated" message firing on every red
+# Gate B run including a real #5221. Two single-site fixes in a row is what
+# turned this into a function.
+#
+# (That second one was saved only by luck: the comment had to be on ONE line,
+# because the `# ` on a wrapped continuation breaks the whitespace-collapsed
+# match. Nobody designed that.)
+#
+# `--numbered` keeps the original line NUMBERS so ordering comparisons stay
+# meaningful; the others do not need them.
+yaml_job_block() {
+    # yaml_job_block <job-key> [--numbered]
+    local job="$1" numbered="${2:-}"
+    awk -v jobre="^  $job:[[:space:]]*\$" -v numbered="$numbered" '
+        { prefix = (numbered != "" ? NR ":" : "") }
+        $0 ~ jobre                        { inblock = 1; print prefix $0; next }
+        inblock && /^  [A-Za-z_.-]+:/     { inblock = 0 }
+        inblock && $0 !~ /^[[:space:]]*#/ { print prefix $0 }
+    ' "$WF"
+}
+
+# The `attach-to-release:` job block: from its own key to the next top-level
+# job key. Job keys sit at exactly two spaces; everything inside the job is
+# indented further, so this needs no YAML parser and cannot be fooled by a
+# matching string in a comment elsewhere in the file.
+JOB_BLOCK="$(yaml_job_block attach-to-release --numbered)"
 
 if [[ -z "$JOB_BLOCK" ]]; then
     fail "the 'attach-to-release' job no longer exists in cross-compile.yml" \
@@ -286,11 +313,7 @@ fi
 #
 # Whole-file scan, not the attach-to-release block: these are separate
 # top-level jobs.
-notify_block="$(awk '
-    /^  notify-auto-update-canary-failure:[[:space:]]*$/ { inblock = 1; print; next }
-    inblock && /^  [A-Za-z_.-]+:/                        { inblock = 0 }
-    inblock                                              { print }
-' "$WF")"
+notify_block="$(yaml_job_block notify-auto-update-canary-failure)"
 
 if [[ -z "$notify_block" ]]; then
     fail "the 'notify-auto-update-canary-failure' job is gone from cross-compile.yml" \
@@ -448,11 +471,7 @@ fi
 # assertions below would have passed against the explanation after the code
 # was removed. Found by mutation, and only because the mutation hit the comment
 # first and the pin stayed green -- the harness accident that exposed it.
-selfupdate_block="$(awk '
-    /^  auto-update-selfupdate-canary:[[:space:]]*$/ { inblock = 1; print; next }
-    inblock && /^  [A-Za-z_.-]+:/                    { inblock = 0 }
-    inblock && $0 !~ /^[[:space:]]*#/                { print }
-' "$WF")"
+selfupdate_block="$(yaml_job_block auto-update-selfupdate-canary)"
 
 # shellcheck disable=SC2016  # literal workflow text: the `${{ }}` must not expand
 if [[ "$selfupdate_block" == *'classification: ${{ steps.canary.outputs.classification }}'* ]]; then

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -456,16 +456,68 @@ else
         "Missing, it evaluates to '' and every run takes the loud #5221 branch."
 fi
 
-# shellcheck disable=SC2016  # literal workflow text: `$rc` is the step's variable
-if [[ "$selfupdate_block" == *'exit "$rc"'* ]]; then
-    pass "Gate B's step re-raises the canary's exit code"
+# --- 6d. the environmental exit code is the SAME number on both sides -------
+# The canary defines `EXIT_UNVERIFIED_ENVIRONMENTAL` and the workflow tests a
+# LITERAL. They are one contract written in two files, and nothing made them
+# agree. Change the constant and every environmental run silently takes the
+# loud #5221 branch instead of the quiet one -- the direction is safe, which is
+# exactly why it would go unnoticed. Read from the canary rather than restated
+# here, so this test cannot be the thing that is stale.
+canary_env_code="$(sed -n 's/^EXIT_UNVERIFIED_ENVIRONMENTAL=\([0-9]\{1,\}\).*/\1/p' \
+    "$SCRIPT_DIR/auto-update-canary.sh" | head -1)"
+if [[ -z "$canary_env_code" ]]; then
+    fail "could not read EXIT_UNVERIFIED_ENVIRONMENTAL from auto-update-canary.sh" \
+        "Without it this assertion would compare the workflow against an empty" \
+        "string and pass on anything."
+elif [[ "$selfupdate_block" == *"-eq $canary_env_code "* ]]; then
+    pass "the workflow tests the same environmental exit code the canary returns ($canary_env_code)"
 else
+    fail "cross-compile.yml does not test exit $canary_env_code, the canary's EXIT_UNVERIFIED_ENVIRONMENTAL" \
+        "The two are one contract in two files. If they disagree, every" \
+        "environmental run is classified 'fault' and takes the loud #5221" \
+        "branch -- safe, and therefore silent."
+fi
+
+# --- 6e. the step CAPTURES the exit status as well as re-raising it ---------
+# BOTH halves, because pinning only the second leaves the cheaper mutation wide
+# open. Confirmed by mutation: change `|| rc=$?` to `|| true` and `rc` stays 0,
+# `classification` is reported as `ok`, `exit "$rc"` exits 0 -- so Gate B goes
+# GREEN on a genuinely broken updater, the job result is `success`, and the
+# notify job never fires. The `exit "$rc"` pin sees nothing, because that line
+# is untouched.
+#
+# Assertion 3a closes the same neutering route for GATE A only: it scans
+# `$CANARY_STEP`, the preflight invocation inside `attach-to-release`. Gate B is
+# a different top-level job and was never scanned.
+#
+# One directive for the whole compound command: shellcheck rejects a directive
+# in front of an individual `elif` branch (SC1123).
+# shellcheck disable=SC2016  # literal workflow text; `$rc` must not expand
+if [[ "$selfupdate_block" != *'|| rc=$?'* ]]; then
+    fail "Gate B's step no longer captures the canary's exit status into \$rc" \
+        "It must run the canary as '... || rc=\$?' and re-raise at the end." \
+        "Replaced with '|| true' the step exits 0 whatever the canary found:" \
+        "Gate B is green on a broken updater and the notify job never fires," \
+        "because the job result is 'success'. The 'exit \$rc' pin below cannot" \
+        "see this -- that line is left untouched by the mutation."
+elif [[ "$selfupdate_block" != *'exit "$rc"'* ]]; then
     fail "Gate B's step no longer re-raises the canary's exit status" \
         "It runs the canary with '|| rc=\$?' so it can classify exit 75. That is" \
         "only safe while the code is raised again at the end of the step. Without" \
         "the re-raise the step always exits 0, Gate B is green on a broken" \
         "updater, and nothing notifies -- the exact silent fail this file exists" \
         "to prevent, reached by deleting one line."
+else
+    swallowed_b="$(printf '%s\n' "$selfupdate_block" \
+        | grep -cE '\|\|[[:space:]]*(true|:)[[:space:]]*$|set[[:space:]]+\+e')"
+    if [[ "$swallowed_b" -eq 0 ]]; then
+        pass "Gate B's step captures AND re-raises the canary's exit code, and swallows nothing"
+    else
+        fail "Gate B's step swallows an exit status ('|| true', '|| :' or 'set +e')" \
+            "$(printf '%s\n' "$selfupdate_block" | grep -E '\|\|[[:space:]]*(true|:)[[:space:]]*$|set[[:space:]]+\+e')" \
+            "Same route assertion 3a closes for Gate A: the step still runs and" \
+            "still reports, but it can no longer fail."
+    fi
 fi
 
 # --- 7. Gate B's job still exists -------------------------------------------

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -343,6 +343,91 @@ else
                 "empty string, so every clause above silently stops matching."
         fi
     done
+
+    # --- 6b. the ENVIRONMENTAL split cannot swallow the real alarm ----------
+    # The notify job now picks between two messages: a quiet one when the
+    # canary classified the run as environmental (it could not reach GitHub, so
+    # it learned nothing), and the loud #5221 one otherwise. Silencing the
+    # channel is now a two-line edit -- widen the quiet branch's condition, or
+    # delete the loud step -- and either would look like tidying.
+    #
+    # Three properties, each of which alone is enough to lose the alarm:
+    #
+    #   (a) the loud message still exists at all;
+    #   (b) the quiet branch requires BOTH that the publish job succeeded and
+    #       that the classification is exactly 'environmental'. Drop the first
+    #       and a release stuck as a DRAFT gets the reassuring message; drop
+    #       the second and everything does;
+    #   (c) the loud branch is the NEGATION of the quiet one rather than its
+    #       own enumeration of results. That is what puts every unanticipated
+    #       state -- a cancelled job, an empty classification because the step
+    #       never ran -- on the side that gets read.
+    if [[ "$notify_block" == *'#5221 failure mode'* ]]; then
+        pass "the notify job still carries the loud #5221 message"
+    else
+        fail "the loud '#5221 failure mode' message is gone from the notify job" \
+            "That text is the only thing that tells the room a node on the previous" \
+            "release may be unable to reach this one. If it was removed to stop" \
+            "false alarms, the fix is the environmental classification, not silence."
+    fi
+
+    quiet_cond="needs.attach-to-release.result == 'success' &&"
+    quiet_cond+=" needs.auto-update-selfupdate-canary.outputs.classification == 'environmental'"
+    # Whitespace-collapsed: the condition is written across two lines in a
+    # folded scalar, and a reflow must not decide whether this is checked.
+    notify_flat="$(printf '%s' "$notify_block" | tr -s '[:space:]' ' ')"
+    if [[ "$notify_flat" == *"$quiet_cond"* ]]; then
+        pass "the quiet branch requires a successful publish AND an environmental classification"
+    else
+        fail "the environmental notification's condition changed" \
+            "Expected it to require both:" \
+            "  $quiet_cond" \
+            "Widened, the quiet 'nothing to worry about' message starts covering" \
+            "real faults and a release stuck as a draft."
+    fi
+
+    if [[ "$notify_flat" == *"!($quiet_cond)"* ]]; then
+        pass "the loud branch is the negation of the quiet one (unknown states stay loud)"
+    else
+        fail "the loud notification is no longer the exact negation of the quiet one" \
+            "Written as its own list of results instead, any state neither branch" \
+            "anticipated -- a cancelled job, an empty classification -- falls" \
+            "through both and nothing is sent at all."
+    fi
+fi
+
+# --- 6c. Gate B's step still classifies, and still re-raises its exit code ---
+# The classification only reaches the notify job because the canary step writes
+# it to GITHUB_OUTPUT and the job re-exports it. Two ways to break that
+# silently: drop the job-level `outputs:` (every clause above reads '' and the
+# loud branch fires for everything, which is merely noisy), or swallow the
+# script's exit code so the job goes GREEN on a failed canary, which is not
+# noisy at all.
+selfupdate_block="$(awk '
+    /^  auto-update-selfupdate-canary:[[:space:]]*$/ { inblock = 1; print; next }
+    inblock && /^  [A-Za-z_.-]+:/                    { inblock = 0 }
+    inblock                                          { print }
+' "$WF")"
+
+# shellcheck disable=SC2016  # literal workflow text: the `${{ }}` must not expand
+if [[ "$selfupdate_block" == *'classification: ${{ steps.canary.outputs.classification }}'* ]]; then
+    pass "Gate B's job still exports the 'classification' output"
+else
+    fail "Gate B's job no longer exports 'classification'" \
+        "The notify job reads it to choose between the quiet and the loud message." \
+        "Missing, it evaluates to '' and every run takes the loud #5221 branch."
+fi
+
+# shellcheck disable=SC2016  # literal workflow text: `$rc` is the step's variable
+if [[ "$selfupdate_block" == *'exit "$rc"'* ]]; then
+    pass "Gate B's step re-raises the canary's exit code"
+else
+    fail "Gate B's step no longer re-raises the canary's exit status" \
+        "It runs the canary with '|| rc=\$?' so it can classify exit 75. That is" \
+        "only safe while the code is raised again at the end of the step. Without" \
+        "the re-raise the step always exits 0, Gate B is green on a broken" \
+        "updater, and nothing notifies -- the exact silent fail this file exists" \
+        "to prevent, reached by deleting one line."
 fi
 
 # --- 7. Gate B's job still exists -------------------------------------------

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -373,26 +373,58 @@ else
 
     quiet_cond="needs.attach-to-release.result == 'success' &&"
     quiet_cond+=" needs.auto-update-selfupdate-canary.outputs.classification == 'environmental'"
-    # Whitespace-collapsed: the condition is written across two lines in a
-    # folded scalar, and a reflow must not decide whether this is checked.
-    notify_flat="$(printf '%s' "$notify_block" | tr -s '[:space:]' ' ')"
-    if [[ "$notify_flat" == *"$quiet_cond"* ]]; then
-        pass "the quiet branch requires a successful publish AND an environmental classification"
+
+    # PER-STEP, and that is not fussiness. The first version of this scanned the
+    # whole job block for "$quiet_cond", which the LOUD step satisfies all by
+    # itself -- its condition is `!(<quiet_cond>)`, so the quiet condition is a
+    # substring of it. Mutation-tested: replacing the quiet step's `if:` with a
+    # bare `result == 'failure'`, so the reassuring message covers every red
+    # run including a real #5221, left this suite fully GREEN. A pin whose
+    # subject can be satisfied by the thing it is distinguishing from is not a
+    # pin, which is the whole subject of #5303.
+    #
+    # Steps are split on their leading `- name:` / `- uses:` key and identified
+    # by text from their own message, so neither depends on step ORDER.
+    notify_steps="$(printf '%s\n' "$notify_block" | awk '
+        /^      - (name|uses):/ { n++ }
+        { print n "\t" $0 }
+    ')"
+    step_containing() {
+        # step_containing <needle> -- the whole step chunk holding <needle>,
+        # whitespace-collapsed, or empty if no single step holds it.
+        local needle="$1" n
+        n="$(printf '%s\n' "$notify_steps" | grep -F -- "$needle" | head -1 | cut -f1)"
+        [[ -n "$n" ]] || return 0
+        printf '%s\n' "$notify_steps" | awk -F'\t' -v n="$n" '$1 == n { print $2 }' \
+            | tr -s '[:space:]' ' '
+    }
+
+    quiet_step="$(step_containing 'could NOT VERIFY')"
+    loud_step="$(step_containing '#5221 failure mode')"
+
+    if [[ -z "$quiet_step" ]]; then
+        fail "the environmental (quiet) notification step is gone from the notify job" \
+            "Without it every red Gate B run takes the loud #5221 branch again, so a" \
+            "runner that could not reach github.com tells the room the fleet may be" \
+            "stranded. That is the alarm-fatigue failure this split exists to stop."
+    elif [[ "$quiet_step" == *"$quiet_cond"* && "$quiet_step" != *'!('* ]]; then
+        pass "the quiet step requires a successful publish AND an environmental classification"
     else
-        fail "the environmental notification's condition changed" \
-            "Expected it to require both:" \
+        fail "the environmental notification's own condition changed" \
+            "Its step must be conditioned on exactly:" \
             "  $quiet_cond" \
-            "Widened, the quiet 'nothing to worry about' message starts covering" \
-            "real faults and a release stuck as a draft."
+            "Widened, the reassuring 'nothing to worry about' message starts covering" \
+            "real faults and a release stuck as a DRAFT. Its condition is currently:" \
+            "  $quiet_step"
     fi
 
-    if [[ "$notify_flat" == *"!($quiet_cond)"* ]]; then
-        pass "the loud branch is the negation of the quiet one (unknown states stay loud)"
+    if [[ -n "$loud_step" && "$loud_step" == *"!($quiet_cond)"* ]]; then
+        pass "the loud step is the exact negation of the quiet one (unknown states stay loud)"
     else
         fail "the loud notification is no longer the exact negation of the quiet one" \
             "Written as its own list of results instead, any state neither branch" \
-            "anticipated -- a cancelled job, an empty classification -- falls" \
-            "through both and nothing is sent at all."
+            "anticipated -- a cancelled job, an empty classification because the" \
+            "step never ran -- falls through both and nothing is sent at all."
     fi
 fi
 

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -441,10 +441,17 @@ fi
 # loud branch fires for everything, which is merely noisy), or swallow the
 # script's exit code so the job goes GREEN on a failed canary, which is not
 # noisy at all.
+# COMMENT-ONLY LINES ARE DROPPED, exactly as `JOB_BLOCK` drops them for
+# `attach-to-release`, and for the reason this repo keeps rediscovering: a pin
+# that scans raw text is satisfied by PROSE. This block's own comments quote
+# `|| rc=$?` and `exit "$rc"` while explaining why they must stay, so the
+# assertions below would have passed against the explanation after the code
+# was removed. Found by mutation, and only because the mutation hit the comment
+# first and the pin stayed green -- the harness accident that exposed it.
 selfupdate_block="$(awk '
     /^  auto-update-selfupdate-canary:[[:space:]]*$/ { inblock = 1; print; next }
     inblock && /^  [A-Za-z_.-]+:/                    { inblock = 0 }
-    inblock                                          { print }
+    inblock && $0 !~ /^[[:space:]]*#/                { print }
 ' "$WF")"
 
 # shellcheck disable=SC2016  # literal workflow text: the `${{ }}` must not expand

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -406,8 +406,14 @@ else
     # subject can be satisfied by the thing it is distinguishing from is not a
     # pin, which is the whole subject of #5303.
     #
-    # Steps are split on their leading `- name:` / `- uses:` key and identified
-    # by text from their own message, so neither depends on step ORDER.
+    # Steps are split on their leading `- name:` / `- uses:` key, so nothing
+    # here depends on step ORDER. How each one is then IDENTIFIED is stated at
+    # the two `step_containing` calls below, and deliberately not restated
+    # here: an earlier version of this comment said "identified by text from
+    # their own message", which the very next commit made false, leaving two
+    # comments fifteen lines apart contradicting each other. A reviewer reading
+    # top-down would have recognised the anti-pattern and reported a defect
+    # already fixed.
     notify_steps="$(printf '%s\n' "$notify_block" | awk '
         /^      - (name|uses):/ { n++ }
         { print n "\t" $0 }

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -118,6 +118,13 @@ expect 1 "bare 'ok' (lifecycle)" \
     '+ok "the canary refuses a node that never checked"'
 expect 1 "bare 'pass' (3 files)" \
     '+pass "cross-compile.yml still has the pre-flight failure notification job"'
+# THIS file's own convention, and the case that proves the point it makes.
+# When this file was first added, its 26 `expect` calls scored ZERO -- the very
+# under-count it exists to prevent, reintroduced by the fix for it, inside the
+# same PR, and found by re-measuring rather than by reading. Safe as a bare
+# name only because nothing in scripts/ drives the TCL `expect(1)`.
+expect 1 "bare 'expect' (this file)" \
+    '+expect 1 "bare check (7 files)" \'
 expect 1 "inline echo \"ok   - ...\"" \
     '+    echo "ok   - MARKER_PARSE_FAIL frozen against a rename sweep"'
 expect 1 "inline echo 'PASS ...' (release_state_restore_test.sh)" \

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -207,7 +207,13 @@ while IFS= read -r f; do
     if [[ "$(eval "sed 's/^/+/' \"\$f\" | grep -cE $FRAG")" -eq 0 ]]; then
         invisible+=("$f")
     fi
-done < <(git -C "$SCRIPT_DIR/.." ls-files '*_test.sh' 2>/dev/null | sed "s|^|$SCRIPT_DIR/../|")
+    # Filesystem glob, NOT `git ls-files`, and the difference matters: a
+    # contributor adding a test file has not necessarily staged it yet, and that
+    # unstaged file is precisely the one whose convention the counter may not
+    # know. Mutation-tested -- with `git ls-files` an untracked probe file was
+    # invisible to this very check, so the check that exists to find invisible
+    # files could not see the newest one.
+done < <(find "$SCRIPT_DIR" -name '*_test.sh' -type f | sort)
 
 if [[ ${#invisible[@]} -eq 0 ]]; then
     echo "ok   - every tracked *_test.sh contains at least one assertion the counter sees"

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -10,9 +10,15 @@
 # to END there, so EVERY underscore-suffixed helper scored zero --
 # `gate_b_arm_case`, `version_ge_case`, `pin_marker`, `check_vs_expected`,
 # `check_call_count`, `check_fallback`, `test_restores_persisted_value` and
-# more. Measured across all 11 `*_test.sh` files in the repo at the time:
-# 329 assertion call sites, 275 seen, 54 missed, 42 of those in
-# `auto-update-canary_test.sh` alone.
+# more. Measured across every `*_test.sh` in the repo, the original form saw
+# roughly three quarters of the assertion call sites; the great majority of the
+# misses were in `auto-update-canary_test.sh`, which is written almost entirely
+# in that style.
+#
+# Deliberately no exact figures: they moved three times inside the PR that added
+# this file, and a stale number in a justification is the sentence that tells
+# the next reader not to re-measure. The computed checks at the bottom of this
+# file are where the real numbers live, and they fail naming the files.
 #
 # Nothing in the repo exercised the regex, so each of those misses was found by
 # a human noticing a wrong number rather than by CI. The failure direction is
@@ -112,19 +118,20 @@ expect() {
 # Each line is a real one from the file named, with a leading '+' as the diff
 # would present it. Add a row here when a new convention appears; that is the
 # enumeration the ci.yml comment tells you to re-run.
-expect 1 "bare 'check' (7 files)" \
+expect 1 "bare 'check' (most files)" \
     '+check "healthy: check ran, parsed, triggered -> pass" 0 "$HEALTHY"'
 expect 1 "bare 'ok' (lifecycle)" \
     '+ok "the canary refuses a node that never checked"'
 expect 1 "bare 'pass' (3 files)" \
     '+pass "cross-compile.yml still has the pre-flight failure notification job"'
 # THIS file's own convention, and the case that proves the point it makes.
-# When this file was first added, its 26 `expect` calls scored ZERO -- the very
-# under-count it exists to prevent, reintroduced by the fix for it, inside the
-# same PR, and found by re-measuring rather than by reading. Safe as a bare
+# When this file was first added, EVERY ONE of its `expect` calls scored ZERO --
+# the very under-count it exists to prevent, reintroduced by the fix for it,
+# inside the same PR, and found by re-measuring rather than by reading. The
+# computed check at the bottom of this file is what now catches that shape. Safe as a bare
 # name only because nothing in scripts/ drives the TCL `expect(1)`.
 expect 1 "bare 'expect' (this file)" \
-    '+expect 1 "bare check (7 files)" \'
+    '+expect 1 "bare check (most files)" \'
 expect 1 "inline echo \"ok   - ...\"" \
     '+    echo "ok   - MARKER_PARSE_FAIL frozen against a rename sweep"'
 expect 1 "inline echo 'PASS ...' (release_state_restore_test.sh)" \
@@ -175,6 +182,70 @@ expect 0 "echo that merely starts with the letters 'ok'" \
     '+    echo "okay, starting the node"'
 expect 0 "a bare string added to a table (a KNOWN blind spot, documented in ci.yml)" \
     '+    "$SCRIPT_DIR/release.sh"'
+
+# --- COMPUTED, not asserted in prose ----------------------------------------
+# Everything above is a hand-written case. These two are measurements, and they
+# are here because the claims they replace were both WRONG in a comment while
+# the suite was green.
+#
+# The rule they come from: a justification that states a COUNT or a GREP RESULT
+# is the one kind of comment whose staleness actively suppresses the check that
+# would catch it -- it tells the next reader they may stop looking. So compute
+# it where it can go red, and let the prose point here.
+
+# 1. EVERY *_test.sh the counter can see must contain at least one line it
+#    recognises. A file scoring zero means the counter cannot see that file's
+#    convention AT ALL, so a `fix:` PR whose only regression test lives there is
+#    rejected for having no test. This is not hypothetical: when
+#    THIS file was added, its 26 bare `expect` calls scored zero -- the miss it
+#    exists to prevent, in the file written to prevent it, caught by measuring.
+invisible=()
+while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    # Same `eval` path as `counter_matches`, so this measures the LIVE pattern
+    # rather than a re-quoted copy of it.
+    if [[ "$(eval "sed 's/^/+/' \"\$f\" | grep -cE $FRAG")" -eq 0 ]]; then
+        invisible+=("$f")
+    fi
+done < <(git -C "$SCRIPT_DIR/.." ls-files '*_test.sh' 2>/dev/null | sed "s|^|$SCRIPT_DIR/../|")
+
+if [[ ${#invisible[@]} -eq 0 ]]; then
+    echo "ok   - every tracked *_test.sh contains at least one assertion the counter sees"
+else
+    echo "FAIL - these *_test.sh files are INVISIBLE to the shell-assertion counter:" >&2
+    for f in "${invisible[@]}"; do echo "         $f" >&2; done
+    echo "       A fix: PR whose only regression test is in one of them scores zero and" >&2
+    echo "       is rejected for having no test. Either the file uses a convention the" >&2
+    echo "       alternation does not know, or it has no assertions at all. Widen the" >&2
+    echo "       alternation in ci.yml -- do not reshape the tests to please the grep." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+# 2. The `printf`-style reporter, which ci.yml lists as a known blind spot. That
+#    entry was once DELETED on the stated ground that the grep returned nothing;
+#    it returns two, in `test-*.sh` files the counter's `**/*_test.sh` glob does
+#    not reach. The sentence was wrong and nothing could tell. So: if that
+#    convention ever appears in a file the counter DOES scan, the blind spot has
+#    stopped being theoretical and this fails.
+printf_in_scanned=()
+while IFS= read -r hit; do
+    printf_in_scanned+=("$hit")
+done < <(grep -rnE "printf[[:space:]]+.*['\"](ok|PASS)" \
+    "$SCRIPT_DIR"/*_test.sh "$SCRIPT_DIR"/release-agent/*_test.sh 2>/dev/null || true)
+
+if [[ ${#printf_in_scanned[@]} -eq 0 ]]; then
+    echo "ok   - no printf-style success reporter in any file the counter scans (blind spot still theoretical)"
+else
+    echo "FAIL - a printf-style success reporter now exists in a file the counter SCANS:" >&2
+    for hit in "${printf_in_scanned[@]}"; do echo "         $hit" >&2; done
+    echo "       ci.yml lists this as a known-but-unreached blind spot. It is now" >&2
+    echo "       reached: those assertions score zero. Add a printf pattern to the" >&2
+    echo "       alternation and a MUST-COUNT row above, then update ci.yml's list." >&2
+    echo "       (The two pre-existing hits, scripts/test-install-sh.sh and" >&2
+    echo "       scripts/test-uninstall-sh.sh, are OUT of scope by filename: the diff" >&2
+    echo "       is globbed to '**/*_test.sh' and they are 'test-*.sh'.)" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 echo
 if [[ "$FAILURES" -eq 0 ]]; then

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression test for the Rule Lint shell-assertion counter in
+# .github/workflows/ci.yml -- the grep that decides whether a `fix:` PR whose
+# regression test is a shell self-test has any test at all.
+#
+# WHY THIS FILE EXISTS. That alternation has been wrong three times, and each
+# time it was widened only as far as the file in front of whoever was editing.
+# The most recent miss was structural rather than a missing spelling: the
+# `[[:space:]]` immediately after `(check|ok|pass)` requires the helper's name
+# to END there, so EVERY underscore-suffixed helper scored zero --
+# `gate_b_arm_case`, `version_ge_case`, `pin_marker`, `check_vs_expected`,
+# `check_call_count`, `check_fallback`, `test_restores_persisted_value` and
+# more. Measured across all 11 `*_test.sh` files in the repo at the time:
+# 329 assertion call sites, 275 seen, 54 missed, 42 of those in
+# `auto-update-canary_test.sh` alone.
+#
+# Nothing in the repo exercised the regex, so each of those misses was found by
+# a human noticing a wrong number rather than by CI. The failure direction is
+# the bad one: an under-counting lint REJECTS a `fix:` PR that does have a
+# regression test, and the path of least resistance for the author is to reshape
+# a good test until the grep likes it, or to reach for `test-exempt`.
+#
+# WHAT IT PINS. Not the regex text -- that would be a copy, and a copy is
+# rewritten by the same edit it is supposed to guard (the failure mode #5303
+# spent two rounds on). It EXTRACTS the live regex out of ci.yml and runs it
+# against call-site shapes taken verbatim from the repo's own test files, in
+# both directions. A widening that starts matching plumbing, and a narrowing
+# that stops matching an existing convention, both fail here.
+#
+# Run manually: bash scripts/rule_lint_shell_assertion_counter_test.sh
+# Also wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+# Every single-quoted string below the fixture header is VERBATIM diff text --
+# a line as the counter's grep will see it, `$SRC` and trailing backslashes
+# included. Not expanding them is the entire point, so SC2016 ("expressions
+# don't expand in single quotes") and SC1003 (a literal trailing backslash read
+# as an attempted quote-escape) are both correct observations about code that is
+# deliberately literal. Disabled file-wide because the fixtures are the bulk of
+# the file; there is no other single-quoted `$` here for the rule to catch.
+# shellcheck disable=SC2016,SC1003
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WF="$SCRIPT_DIR/../.github/workflows/ci.yml"
+FAILURES=0
+
+if [[ ! -f "$WF" ]]; then
+    echo "FAIL - ci.yml not found at $WF" >&2
+    exit 1
+fi
+
+# The counter's own line, identified by the two things that make it that line
+# rather than any other grep in the file: it pipes into `grep -cE` and its
+# alternation mentions PASS.
+COUNTER_LINE="$(grep -F "| grep -cE '" "$WF" | grep -F 'PASS' | tail -1)"
+FRAG="${COUNTER_LINE#*| grep -cE }"
+FRAG="${FRAG% || true)}"
+
+# THE VACUITY GUARD, and it is not boilerplate: the first draft of this file
+# extracted the fragment with a `grep -oP` lookbehind that stopped at the
+# embedded `'"'"'`, leaving a truncated pattern. An EMPTY pattern makes
+# `grep -cE ''` match every line, so all ten negative cases below "passed" while
+# reporting 1. A test that cannot fail is exactly what this file exists to stop
+# someone else shipping.
+if [[ -z "$COUNTER_LINE" || -z "$FRAG" ]]; then
+    echo "FAIL - could not find the Rule Lint shell-assertion counter in ci.yml." >&2
+    echo "       Looked for a line piping into \`grep -cE '...'\` whose pattern mentions PASS." >&2
+    echo "       If the step was reshaped, update this extraction; if it was DELETED, a fix:" >&2
+    echo "       PR whose only test is a shell self-test can no longer be recognised at all." >&2
+    exit 1
+fi
+if [[ "$FRAG" != \'*\' ]]; then
+    echo "FAIL - the extracted pattern is not a single-quoted shell word: $FRAG" >&2
+    echo "       Extraction is out of step with ci.yml; every case below would be unreliable." >&2
+    exit 1
+fi
+
+# `eval` because FRAG is still shell-quoted, exactly as ci.yml writes it
+# (including the `'"'"'` dance for the embedded single quote). Re-quoting it by
+# hand here would be the copy this file is built to avoid.
+counter_matches() {
+    local line="$1" n
+    n="$(eval "printf '%s\n' \"\$line\" | grep -cE $FRAG")"
+    printf '%s' "$n"
+}
+
+expect() {
+    # expect <want 0|1> <what the line is> <line, as it appears in a diff>
+    local want="$1" desc="$2" line="$3" got
+    got="$(counter_matches "$line")"
+    if [[ "$got" == "$want" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc" >&2
+        echo "         line:  $line" >&2
+        echo "         wanted the counter to score it $want, it scored $got" >&2
+        if [[ "$want" == 1 ]]; then
+            echo "       This is a convention the repo's *_test.sh files ALREADY use, so a" >&2
+            echo "       fix: PR whose regression test is written this way now scores zero" >&2
+            echo "       and is rejected for having no test. Widen the alternation in" >&2
+            echo "       ci.yml rather than reshaping the test." >&2
+        else
+            echo "       The counter now scores a line that is not an assertion, so a fix:" >&2
+            echo "       PR can satisfy the test requirement without adding a test." >&2
+        fi
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# --- MUST COUNT: every call-site convention in use across scripts/**/*_test.sh
+# Each line is a real one from the file named, with a leading '+' as the diff
+# would present it. Add a row here when a new convention appears; that is the
+# enumeration the ci.yml comment tells you to re-run.
+expect 1 "bare 'check' (7 files)" \
+    '+check "healthy: check ran, parsed, triggered -> pass" 0 "$HEALTHY"'
+expect 1 "bare 'ok' (lifecycle)" \
+    '+ok "the canary refuses a node that never checked"'
+expect 1 "bare 'pass' (3 files)" \
+    '+pass "cross-compile.yml still has the pre-flight failure notification job"'
+expect 1 "inline echo \"ok   - ...\"" \
+    '+    echo "ok   - MARKER_PARSE_FAIL frozen against a rename sweep"'
+expect 1 "inline echo 'PASS ...' (release_state_restore_test.sh)" \
+    "+echo \"PASS restores the persisted value\""
+expect 1 "'*_case' helper: gate_b_arm_case" \
+    '+gate_b_arm_case "0.2.126"                   yes   # every release after it'
+expect 1 "'*_case' helper: version_ge_case" \
+    '+version_ge_case "0.2.123" "0.2.124" no    # strictly below'
+expect 1 "'*_case' helper: trigger_case" \
+    '+trigger_case "urgent path" "triggering immediate auto-update" yes'
+expect 1 "'pin_' helper: pin_marker" \
+    '+pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"'
+expect 1 "'pin_' helper: pin_warn_literal, continued on the next line" \
+    '+pin_warn_literal "source pin: parse-failure marker (latest-version arm)" \'
+expect 1 "'check_' helper: check_vs_expected" \
+    '+check_vs_expected "equality: node saw the published tag -> pass" 0 "$SEEN_OK" 0.2.122'
+expect 1 "'check_' helper: check_call_count" \
+    '+check_call_count "  and it really did re-poll after the failure" jobs 2'
+expect 1 "'check_' helper: check_fallback" \
+    '+check_fallback "success-fallback + allow empty -> hold (fail closed)" \'
+expect 1 "'test_' helper called with arguments" \
+    '+test_restores_persisted_value "v0.2.42 regression" "0.3.205" "0.3.206" "0.3.205"'
+expect 1 "'test_' helper called with none" \
+    '+test_no_persisted_keeps_tentative'
+
+# --- MUST NOT COUNT ---------------------------------------------------------
+# A `fix:` PR must not be able to satisfy the test requirement without adding a
+# test, so each of these has to score zero.
+expect 0 "a helper DEFINITION, not a call" \
+    '+check_vs_expected() {'
+expect 0 "a '*_case' helper definition" \
+    '+gate_b_arm_case() {'
+expect 0 "a bare-name helper definition" \
+    '+pass() { echo "ok   - $1"; }'
+expect 0 "a FAIL branch (deliberate: an error message is not a test)" \
+    '+    echo "FAIL - the frozen #5221 signature text changed." >&2'
+expect 0 "plumbing: run_driver" \
+    '+run_driver "scenario" 3'
+expect 0 "plumbing: make_fake_node" \
+    '+make_fake_node "$dir" 42'
+expect 0 "plumbing: a stub redefinition" \
+    '+read_room_state() { READ_CALLS=$((READ_CALLS + 1)); return 0; }'
+expect 0 "an ordinary local assignment that happens to start with 'check'" \
+    '+local checked=1'
+expect 0 "prose in a comment" \
+    '+# check that the marker is still frozen'
+expect 0 "echo that merely starts with the letters 'ok'" \
+    '+    echo "okay, starting the node"'
+expect 0 "a bare string added to a table (a KNOWN blind spot, documented in ci.yml)" \
+    '+    "$SCRIPT_DIR/release.sh"'
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo "All Rule Lint shell-assertion counter assertions passed."
+else
+    echo "$FAILURES assertion(s) FAILED." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Two bugs in the release auto-update canary, one of which **would have blocked the 0.2.126 release**.

`MARKER_LATEST_SEEN_SINCE` names the first release whose binary emits `Startup update check: GitHub reports latest release`. Gate B skips its positive equality check for any previous release below that value.

**Bug 1 — a self-detonating pin.** The self-test added in #5290 asserted the constant was *not below* the crate version, and stated its own premise in its comment: *"the marker is new in this tree, so no already-published release emits it."* That premise was true only while 0.2.125 was unpublished. It expired at 00:11Z on 2026-08-13 when 0.2.125 shipped. The constant correctly stays at `0.2.125` forever, so the pin goes red on the next bump and blocks a healthy release. Reproduced: set the crate version to 0.2.126 against `main` and the pin fails.

**Bug 2 — a silent one, found during review.** Reword the marker text in every place a developer must touch it (`auto_update.rs`, `freenet.rs`, `auto-update-canary.sh`, and the log fixtures in both test files) and leave the constant alone: **the entire suite passes.** Nothing prompts anyone. A stale constant is the *default* outcome of a reword, not an escape from a warning. The consequence lands post-publish, where Gate B arms, greps for text the previous release never emitted, and trips the release Matrix alarm with a message blaming the node.

## Solution

**Delete the version relation entirely, and freeze the pair.**

Three attempts at a relation between the constant and the crate version were considered, and the conclusion is that **no fixed relation between two quantities on different clocks survives both publication and a reword**:

| relation | correct when | wrong when |
|---|---|---|
| `constant >= crate` (shipped in #5290) | before publication | after publication — blocks 0.2.126 |
| `constant <= crate` (first attempt here) | after publication | during a reword — red for the *correct* value |
| `constant <= crate + 1` (proposed in review) | see correction below | — |

**Correction, found by a later reviewer:** an earlier revision of this table claimed `<= crate + 1` "also fires on a reword", and that is arithmetically false. Under a reword the correct constant *is* crate+1, and `crate+1 <= crate+1` passes. The claim entered this description because it was relayed from a reviewer who withdrew their own suggestion on that reasoning; nobody checked the arithmetic. A loose upper bound of that shape appears to be phase-independent — it is violated only when the constant is more than one release ahead, which is never legitimate — so it is being re-evaluated as plausibility bounding alongside the freeze rather than as a replacement for it.

The two *equality-style* relations are what cannot work: the constant tracks release history and the crate version tracks this tree, so no relation asserting they stay in step survives both publication and a reword. What remains is:

1. **The value frozen** against its historical literal `0.2.125`. This catches strictly more than the relation ever did, including the empty string and forward creep at release time.
2. **The marker text frozen alongside it**, so a reword forces the author to confront the version constant in the same edit. This is what closes Bug 2.
3. **A format guard on `version_at_least`**, which previously accepted garbage as a pass: `version_at_least "not-a-version" "0.2.125"` returned true.

### Why the marker freeze is base64-encoded

Written first as a plain literal, and it **did not work**. The mutation it exists to catch is a rename sweep — and the sweep rewrote the frozen expectation too, because the expectation was byte-identical to the value it guarded. The pin followed the rename and the suite stayed green.

Encoded, a text sweep cannot reach it, and a deliberate reword has to regenerate it, which is exactly the moment of attention the pin exists to create. The failure message prints the decoded old text, the new text, and the re-encode command; an empty decode fails loudly rather than making the comparison vacuous.

The version half stays plaintext deliberately, and the asymmetry is documented: a repo-wide `sed` on a version string is not how bumps happen here (they touch `Cargo.toml` and the lockfile), so the realistic wrong edit is a human raising it in one place, which a plain compare catches.

### Also

- `gate_b_arm_case "0.2.124" no` closes a verified vacuity hole: hardcoding the threshold inside the decision previously left the *whole suite green*, because the existing cases straddled the gap.
- The frozen pin's failure message no longer reads as instructions for the creep edit that disarms Gate B.
- The operator-facing comment regains its reword escape hatch, under a heading naming when the constant should and should not move.
- The retraction-valve reason is written into the constant's comment, so the next reader does not conclude the skip branch is dead code. `prev_version` is the newest *currently-published* release, so a retraction legitimately puts it back below the constant.

## Testing

Suite is 68 assertions, all green. Every pin was mutation-tested by applying the exact regression it names to a **committed** tree and confirming it goes red.

| Mutation | Result |
|---|---|
| crate → 0.2.126 (the landmine) | `main`'s pin FAILS, reproduced. This HEAD green. Defused. |
| marker reword sweep, constant left stale | **plaintext freeze: GREEN — the bug above.** base64 freeze: RED, naming both strings |
| constant → 0.2.126 | RED via the freeze (which catches strictly more than the deleted relation) |
| `version.workspace = true` in Cargo.toml | green — the second spurious fire of the deleted relation, now gone |
| format guard removed | 4 RED: `not-a-version >= 0.2.125`, `0.2.125 >= ''`, `'' >= ''`, `0.2.125-rc.1 >= 0.2.125` all wrongly reported yes |
| threshold hardcoded to 0.2.124 in the decision | RED (was green before the new case) |
| `prev_emits_latest_seen` made to skip on malformed input | 2 RED |

The refuse-vs-arm asymmetry is deliberate and both directions are pinned: `version_at_least` refuses malformed input because *"is a >= b"* has no answer for garbage, while `prev_emits_latest_seen` arms Gate B on it because *"should Gate B assert anything"* does, and skipping is the silent direction.

`shellcheck -x` clean; the exact CI shellcheck invocation rc=0; `cargo fmt --all --check` clean. No Rust files changed.

## The `ci(rule-lint)` commits

Scope beyond the fix, called out as a **deliberate exception** to one-logical-change: without it the Rule Lint check rejects this PR for having no regression test, and `test-exempt` would put a false statement in the record on a PR that demonstrably has tests.

`"ok` is tightened to `["']ok[[:space:]]+-` and `pass` is added. Measured on a fixture: `echo "okay, the suite is starting"` and bare `echo "ok"` are now **rejected**; single-quoted `echo 'ok - ...'` and `pass "..."` are now **accepted**.

An honest limit, now stated in the CI comment itself: this check has never recognised assertions. It recognises the *success-reporting line* by prefix. `check "x" "a" "a"` is a real call to a real helper that compares a value with itself and asserts nothing, and the old pattern already matched it. A shared assertion helper would make it tidier without making it non-decorative. Whether something is a real regression test belongs to review and mutation testing.

Two false negatives are left in deliberately and documented rather than chased with a fifth pattern: `printf`-style reporting, and an assertion whose only added line is its FAIL branch (counting FAIL would let a PR score by adding an error message alone).

## Corrections to earlier revisions of this description

Kept visible rather than silently edited:

- An earlier version said the suite was "32/32". It was 61 at that point and is 68 now.
- An earlier version, and the comment added to `ci.yml`, claimed `auto-update-canary_test.sh` "has no helper at all". False — `check()` is at line 55 with 12 call sites. It is specialised to log-fixture cases; the file's other assertions have nothing to fixture and are written as bare echoes.
- An earlier version proposed `constant <= crate version` as the fix. That is the approach this HEAD deletes, for the reason in the table above.

## Fixes

Refs #5290. Prevents a self-inflicted block on the 0.2.126 release, and closes the silent reword path.

[AI-assisted - Claude]
