### PR TITLE
fix(interest): stop the fallback rotation re-randomising mid-cycle

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -10124,6 +10124,24 @@ mod tests {
                 // has other rare ways to fail). The contiguity form is used
                 // because it does not depend on the answer, not because the bare
                 // form was proven flaky.
+                //
+                // THIS ASSERTION IS DETERMINISTIC IN SHIPPED CODE and needs no
+                // hardening. Under the shipped code there is exactly ONE published
+                // origin, so both racers resume from it and the windows are
+                // identical (or contiguous if serialised) every time.
+                //
+                // Do not be misled by the ~0.75% figure that appears in the
+                // mutation table below, where deleting the atomic boundary leaves
+                // this assertion passing occasionally by chance (1 of 40 runs
+                // observed) -- two independent origins over `matching.len()`
+                // contracts collide identically once in `L`, or adjacently in
+                // either orientation twice more, so ~0.75% predicted. That probability is a property of the MUTATION, not
+                // of shipped code: it exists only because the mutation removed the
+                // mechanism that makes this deterministic. The one genuine
+                // probabilistic assertion in shipped code was the straddle test's
+                // premise in `interest.rs`, at ~0.5%, and that one was hardened
+                // rather than documented -- shipping a new flake to close an old
+                // one is not a trade this PR makes.
                 let idx = |w: &Vec<u32>| -> Vec<usize> {
                     w.iter()
                         .map(|hash| {
@@ -10162,59 +10180,56 @@ mod tests {
                 // window rather than two: 3 pairs charge 3 x 64 of the 400
                 // shared contracts and no cycle completes inside this loop.
                 //
-                // WHAT MAKES THIS TEST PASS, measured rather than assumed. Each
-                // row is 40 runs of this test alone, `--exact`:
+                // WHICH MECHANISMS THIS TEST REQUIRES, measured against THIS
+                // version of the test. Each row is 40 runs, `--exact`:
                 //
                 //   zero-advance reject + atomic boundary (shipped) . 40 /  0
-                //   zero-advance reject, boundary deleted ........... 40 /  0
-                //   atomic boundary, advance check deleted .......... 23 / 17
-                //   neither, but with the id-equality dedup guard
-                //     it replaced (commit 65086ec2) ................. 32 /  8
-                //                            and, replicated ....... 27 / 13
-                //   pre-PR main ..................................... 40 /  0
-                //                            and, replicated ....... 40 /  0
+                //   atomic boundary, advance check deleted .......... 20 / 20
+                //   zero-advance reject, boundary deleted ........... 1 / 39
                 //
-                // EVERY ROW IS n=40, so read each rate as +/- about 15 points.
-                // The two independent measurements of 65086ec2 (separate
-                // sessions, worktrees and binaries) came out 8/40 and 13/40, and
-                // that spread needs no explanation: z = 1.27, p = 0.20, with
-                // Wilson 95% intervals of [10.5%, 34.8%] and [20.1%, 48.0%]
-                // overlapping across most of their range. It is ordinary sampling
-                // noise at this n, NOT evidence of anything about the machine.
+                // NEITHER MECHANISM ALONE PASSES: they are jointly necessary, and
+                // this change must not be partially reverted. The reason is not
+                // that both happen to be needed -- it is that they fail DIFFERENT
+                // assertions, so they defend different properties and neither
+                // substitutes for the other:
                 //
-                // Which rows are sound follows from the power, and this is why
-                // the table is trustworthy exactly where it is used: separating
-                // 20% from 33% would need n ~ 193, and 33% from 43% n ~ 366, but
-                // separating ~0% from 20% needs only n ~ 35. So the ZERO rows
-                // carry the whole argument at n=40 and the contested rows carry
-                // none of it. Do not read fine distinctions between 20%, 33% and
-                // 43%.
+                // - Advance check deleted -> fails the COVERAGE assertion at the
+                //   end of this test (384 of 400 advertised). Duplicate windows
+                //   are charged twice, the counter runs ahead of the ground
+                //   covered, the cycle ends early, and an arc goes unadvertised.
+                //   PROBABILISTIC (~50%): it needs an interleaving that actually
+                //   produces a duplicate.
+                // - Boundary deleted -> fails the PREMISE assertion at pair 0
+                //   (observed `starts: Some(387) and Some(257)`). Each racer draws
+                //   its own origin. NEAR-DETERMINISTIC (39/40): two independent
+                //   draws over 400 contracts satisfy "identical or contiguous"
+                //   only ~0.75% of the time, which is why 1 run passed.
                 //
-                // Read the rows carefully, because the obvious story is wrong. It
-                // is the ZERO-ADVANCE REJECTION in `record_fallback_cursor` that
-                // makes this test green, NOT the atomic boundary -- the advance
-                // check alone is 0/40, the boundary alone is 17/40 against main's
-                // 0/40. That 0-versus-17 gap is the one the power analysis above
-                // supports at n=40. A claim that the boundary alone is WORSE than
-                // the id-equality guard it replaced is NOT supported (17/40 vs
-                // 8-13/40 at this n) and is not made. What matters is that publishing the origin makes
-                // concurrent racers AGREE, so they build identical windows every
-                // time, turning the duplicate charge from occasional into
-                // systematic. The two changes are coupled: the boundary is what
-                // makes the dedup path load-bearing.
+                // Deterministic-versus-probabilistic is the informative part: the
+                // boundary's absence is unconditionally broken, while the record
+                // check's absence needs a race to expose it.
                 //
-                // So the atomic boundary is NOT justified by this test. It is
-                // justified by (a) not spending a second full window of uplink
-                // on a duplicate, which is the cost #5155 exists to bound, (b)
-                // restoring this test's own premise that concurrent replies
-                // produce identical windows, and (c) removing the divergent-origin
-                // over-charge at source instead of relying on divergence
-                // happening to look stale downstream. Defence in depth plus a
-                // bandwidth fix, not the repair for the flake.
+                // PROVENANCE, and it matters. An earlier revision of this comment
+                // carried a row claiming the boundary-deleted case was 40/0, and
+                // drew from it the conclusion that the boundary was not justified
+                // by this test. That row was measured BEFORE the premise assertion
+                // existed, when this test judged only the coverage floor -- and the
+                // floor is EASIER to clear when the premise is false, since
+                // diverging racers cover two windows instead of one. So the number
+                // credited the change with passing a test it actually fails, via
+                // exactly the vacuity the premise assertion was added to stop.
                 //
-                // `main` being 40/0 is what shows the flake was INTRODUCED by
-                // per-cycle entry counting rather than being a pre-existing
-                // wobble in a multi-threaded test.
+                // The rule that cost: diagnosing a false-green mechanism does not
+                // immunise the numbers already collected under it. When you fix an
+                // instrument, the old readings are retaken or discarded, not
+                // annotated. Every row above was re-measured against this version
+                // of the test.
+                //
+                // The separate question of whether the flake was INTRODUCED (`main`
+                // 40/0 versus 65086ec2 8-13/40) cannot share this table: the
+                // premise assertion is part of what this PR adds, so restoring
+                // main's files removes it, and those rows exist only under the
+                // floor-only test. They are in the PR description, kept apart.
                 assert!(
                     ids.contains(&cursor.last_sent),
                     "after pair {pair} the cursor is no longer a member of the \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3314,7 +3314,7 @@ async fn handle_interest_sync_message(
                 SummaryReplyForm::FullBytes => {
                     let start = op_manager
                         .interest_manager
-                        .fallback_window_start(source, &matching);
+                        .begin_fallback_window(source, &matching);
                     Some(crate::ring::interest::rotation_window_indices(
                         matching.len(),
                         start,
@@ -3408,10 +3408,15 @@ async fn handle_interest_sync_message(
             // past the last id (resume at 0). Deriving that from the resume
             // index alone was #5181.
             //
-            // Two known imprecisions here, both accepted, both costing at most
-            // one cycle of delay for the affected contracts and neither able to
-            // skip one permanently (the window wraps, and a cycle boundary
-            // restarts at a random offset):
+            // Known imprecisions, all accepted, none able to skip a contract
+            // permanently — because the window WRAPS and cycles complete, which
+            // is the property that does that work. (The random origin defends a
+            // different failure, peer steering, and does not contribute to
+            // non-permanence; the two used to be offered jointly here, which is
+            // how the claim ended up wrong.) Several of these make the cycle end
+            // EARLY rather than late, so an arc can go unadvertised for an extra
+            // cycle; `FallbackCursor::advertised_in_cycle` is explicit that this
+            // is not a safe-direction-only approximation:
             //
             // - This advances on send ATTEMPT. The reply is handed to the
             //   connection afterwards and a send failure is only logged, so a
@@ -3421,12 +3426,34 @@ async fn handle_interest_sync_message(
             //   read the same start and build the same window, losing one
             //   round of progress. Reserving the window at read time instead
             //   would trade that for a worse failure: a budget-cut round would
-            //   then skip everything it did not reach.
+            //   then skip everything it did not reach. The duplicate is not
+            //   double-CHARGED (it covers no new distance), but the round is
+            //   still spent.
+            // - Two concurrent replies cut at different lengths by the byte
+            //   budget carry different last ids, so the shorter is not
+            //   recognised as ground the longer already covered. If the shorter
+            //   records first the longer is charged on top of it, over-stating
+            //   progress by up to one window.
+            // - A racer that STRADDLES a boundary (it read the old cycle, the
+            //   other took the boundary) overwrites `last_sent` and discards the
+            //   freshly published origin, so its successor resumes from the old
+            //   window instead of the new origin. Safe direction: it costs
+            //   contiguity for one round, never coverage.
+            // - Contract CHURN: ids removed from ground already swept while
+            //   others are inserted below the cursor let the count reach the set
+            //   size with current members never advertised this cycle.
+            // - The peer chooses `sorted`, so it chooses the length the count is
+            //   compared against; see `begin_fallback_window`'s rustdoc for the
+            //   anti-steering regression this leaves open.
             if form == SummaryReplyForm::FullBytes {
                 if let Some(last) = last_included {
-                    op_manager
-                        .interest_manager
-                        .record_fallback_cursor(source, last, entries.len());
+                    op_manager.interest_manager.record_fallback_cursor(
+                        source,
+                        &matching,
+                        last,
+                        entries.len(),
+                        MAX_FALLBACK_SUMMARIES_PER_REPLY,
+                    );
                 }
             }
 
@@ -9770,14 +9797,14 @@ mod tests {
 
             // Seed the cursor so both rounds are mid-cycle and the starting
             // offset is fixed. Without this the first round would begin at a
-            // random cycle-boundary offset (see `fallback_window_start`).
-            // One entry charged to the cycle, so the 8-contract set is nowhere
-            // near finished and neither round re-randomises.
+            // random cycle-boundary offset (see `begin_fallback_window`).
+            // Seeded through the production boundary shape so the cycle starts
+            // at index 1, leaving the 8-contract set nowhere near finished.
             let mut sorted = keys.clone();
             sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
             h.op_manager
                 .interest_manager
-                .record_fallback_cursor(h.old_peer, *sorted[0].id(), 1);
+                .seed_fallback_cycle(h.old_peer, &sorted, 1);
 
             let mut seen: Vec<u32> = Vec::new();
             for round in 0..2 {
@@ -10047,9 +10074,14 @@ mod tests {
                     .interest_manager
                     .peek_fallback_cursor(h.old_peer)
                     .expect("a fallback reply must leave a cursor");
-                // A duplicated window is charged once, so 3 pairs advance the
-                // cycle by at most 3 x 64 of the 400 shared contracts and the
-                // boundary (which would drop the cursor) is not reached here.
+                // Both racers now resume from the SAME published origin (see
+                // `begin_fallback_window`), so a pair advances the cycle by one
+                // window rather than two: 3 pairs charge ~3 x 64 of the 400
+                // shared contracts and no cycle completes inside this loop.
+                // Before the origin was published atomically, pair 0 drew two
+                // different origins and charged both, which ran the counter
+                // ahead of the ground covered and made this test fail ~20% of
+                // the time.
                 assert!(
                     ids.contains(&cursor.last_sent),
                     "after pair {pair} the cursor is no longer a member of the \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3403,6 +3403,11 @@ async fn handle_interest_sync_message(
             // short of the selected window must not advance past the entries it
             // dropped, or they wait a full cycle instead of coming next.
             //
+            // The entry count goes with it: it is what tells the next round
+            // whether the cycle is finished (re-randomise) or merely wrapped
+            // past the last id (resume at 0). Deriving that from the resume
+            // index alone was #5181.
+            //
             // Two known imprecisions here, both accepted, both costing at most
             // one cycle of delay for the affected contracts and neither able to
             // skip one permanently (the window wraps, and a cycle boundary
@@ -3421,7 +3426,7 @@ async fn handle_interest_sync_message(
                 if let Some(last) = last_included {
                     op_manager
                         .interest_manager
-                        .record_fallback_cursor(source, last);
+                        .record_fallback_cursor(source, last, entries.len());
                 }
             }
 
@@ -9765,14 +9770,14 @@ mod tests {
 
             // Seed the cursor so both rounds are mid-cycle and the starting
             // offset is fixed. Without this the first round would begin at a
-            // random cycle-boundary offset (see `fallback_window_start`) and a
-            // start on the last contract would wrap into a second random draw,
-            // making the "moved on to a different contract" assertion flaky.
+            // random cycle-boundary offset (see `fallback_window_start`).
+            // One entry charged to the cycle, so the 8-contract set is nowhere
+            // near finished and neither round re-randomises.
             let mut sorted = keys.clone();
             sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
             h.op_manager
                 .interest_manager
-                .record_fallback_cursor(h.old_peer, *sorted[0].id());
+                .record_fallback_cursor(h.old_peer, *sorted[0].id(), 1);
 
             let mut seen: Vec<u32> = Vec::new();
             for round in 0..2 {
@@ -10042,8 +10047,11 @@ mod tests {
                     .interest_manager
                     .peek_fallback_cursor(h.old_peer)
                     .expect("a fallback reply must leave a cursor");
+                // A duplicated window is charged once, so 3 pairs advance the
+                // cycle by at most 3 x 64 of the 400 shared contracts and the
+                // boundary (which would drop the cursor) is not reached here.
                 assert!(
-                    ids.contains(&cursor),
+                    ids.contains(&cursor.last_sent),
                     "after pair {pair} the cursor is no longer a member of the \
                      shared set — concurrent writers corrupted the rotation \
                      rather than merely duplicating a window"

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -10034,6 +10034,21 @@ mod tests {
             let expected: HashSet<u32> = hashes.iter().copied().collect();
             let ids: HashSet<ContractInstanceId> = keys.iter().map(|k| *k.id()).collect();
 
+            // Position of each contract in `get_matching_contracts` order
+            // (ascending by id), so a reply's window can be checked for
+            // contiguity rather than only for size. `distinct_hashes` has
+            // already asserted the hashes do not collide, so this is 1:1.
+            let shared_len = keys.len();
+            let index_of_hash: std::collections::HashMap<u32, usize> = {
+                let mut by_id = keys.clone();
+                by_id.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
+                by_id
+                    .iter()
+                    .enumerate()
+                    .map(|(i, k)| (contract_hash(k), i))
+                    .collect()
+            };
+
             let mut covered: HashSet<u32> = HashSet::new();
             for pair in 0..PAIRS {
                 let spawn_one = || {
@@ -10051,6 +10066,7 @@ mod tests {
                 };
                 let (first, second) = tokio::join!(spawn_one(), spawn_one());
 
+                let mut windows: Vec<Vec<u32>> = Vec::new();
                 for (which, joined) in [("first", first), ("second", second)] {
                     match joined.expect("handler task panicked") {
                         Some(InterestMessage::Summaries { entries, .. }) => {
@@ -10062,10 +10078,73 @@ mod tests {
                             );
                             assert!(summary_bytes_of(&entries) <= 9 * 1024 + h.our_summary.len());
                             covered.extend(entries.iter().map(|e| e.hash));
+                            windows.push(entries.iter().map(|e| e.hash).collect());
                         }
                         other => panic!("pair {pair} {which} reply was {other:?}"),
                     }
                 }
+
+                // ASSERT THE PREMISE, do not infer it — but assert only what is
+                // scheduler-INDEPENDENT.
+                //
+                // This test's header explains that identical windows prove the
+                // overlap happened and different ones prove it did not — then the
+                // assertions below only checked a COVERAGE FLOOR, which is
+                // satisfied either way. Worse, it is satisfied MORE EASILY when
+                // the premise is false: two racers that diverge cover two
+                // windows instead of one, so `covered` grows faster and the
+                // floor is easier to clear.
+                //
+                // That is not hypothetical. Deleting the atomic boundary in
+                // `begin_fallback_window` makes the racers draw different
+                // origins, and this test stayed green over 40 runs — passing
+                // precisely because the race it exists for stopped happening. A
+                // reader running that mutation would reasonably conclude the test
+                // does not guard the code, when in fact the mutation had
+                // destroyed the test's premise. Both readings of "mutation
+                // applied, still green" are real, and only an explicit premise
+                // assertion separates them.
+                //
+                // A bare `windows[0] == windows[1]` is NOT the right assertion,
+                // though: it asserts that the RUNTIME overlapped the pair, which
+                // is not this code's contract to keep. A genuinely serialised
+                // pair legitimately produces the next CONTIGUOUS window instead.
+                // Both shapes are correct; only a third is not — two unrelated
+                // origins, the pre-boundary defect — and that is what is checked
+                // here.
+                //
+                // Empirically the bare form was borderline rather than clearly
+                // broken: 1 failure in 160 runs with it in place, and the failing
+                // run's message was not captured, so it is NOT established that
+                // the assertion was the thing that failed (a fixed-port harness
+                // has other rare ways to fail). The contiguity form is used
+                // because it does not depend on the answer, not because the bare
+                // form was proven flaky.
+                let idx = |w: &Vec<u32>| -> Vec<usize> {
+                    w.iter()
+                        .map(|hash| {
+                            *index_of_hash
+                                .get(hash)
+                                .expect("every advertised hash is in the shared set")
+                        })
+                        .collect()
+                };
+                let (i0, i1) = (idx(&windows[0]), idx(&windows[1]));
+                let follows = |a: &Vec<usize>, b: &Vec<usize>| {
+                    !a.is_empty() && !b.is_empty() && b[0] == (a[a.len() - 1] + 1) % shared_len
+                };
+                assert!(
+                    i0 == i1 || follows(&i0, &i1) || follows(&i1, &i0),
+                    "pair {pair}: the two concurrent replies were neither \
+                     IDENTICAL (they overlapped, resuming from one published \
+                     origin) nor CONTIGUOUS (the scheduler serialised them). Two \
+                     unrelated windows mean each drew its own origin, which \
+                     charges two non-contiguous windows to one cycle — the defect \
+                     the atomic boundary in `begin_fallback_window` exists to \
+                     prevent. starts: {:?} and {:?}",
+                    i0.first(),
+                    i1.first()
+                );
 
                 // The cursor must still name a contract that exists, not a
                 // value torn between the two writers.
@@ -10076,12 +10155,41 @@ mod tests {
                     .expect("a fallback reply must leave a cursor");
                 // Both racers now resume from the SAME published origin (see
                 // `begin_fallback_window`), so a pair advances the cycle by one
-                // window rather than two: 3 pairs charge ~3 x 64 of the 400
+                // window rather than two: 3 pairs charge 3 x 64 of the 400
                 // shared contracts and no cycle completes inside this loop.
-                // Before the origin was published atomically, pair 0 drew two
-                // different origins and charged both, which ran the counter
-                // ahead of the ground covered and made this test fail ~20% of
-                // the time.
+                //
+                // WHAT MAKES THIS TEST PASS, measured rather than assumed. Each
+                // row is 40 runs of this test alone, `--exact`:
+                //
+                //   zero-advance reject + atomic boundary (shipped) . 40 / 0
+                //   zero-advance reject, boundary deleted ........... 40 / 0
+                //   atomic boundary, advance check deleted .......... 23 / 17
+                //   neither, but with the id-equality dedup guard
+                //     it replaced (commit 65086ec2) ................. 32 /  8
+                //   pre-PR main ..................................... 40 / 0
+                //
+                // Read those carefully, because the obvious story is wrong. It
+                // is the ZERO-ADVANCE REJECTION in `record_fallback_cursor` that
+                // makes this test green, NOT the atomic boundary. And the
+                // boundary makes the situation WORSE on its own (17/40 failing,
+                // worse than either earlier state) because publishing the origin
+                // makes concurrent racers AGREE, so they now build identical
+                // windows every time -- turning the duplicate charge from
+                // occasional into systematic. The two changes are coupled: the
+                // boundary is what makes the dedup path load-bearing.
+                //
+                // So the atomic boundary is NOT justified by this test. It is
+                // justified by (a) not spending a second full window of uplink
+                // on a duplicate, which is the cost #5155 exists to bound, (b)
+                // restoring this test's own premise that concurrent replies
+                // produce identical windows, and (c) removing the divergent-origin
+                // over-charge at source instead of relying on divergence
+                // happening to look stale downstream. Defence in depth plus a
+                // bandwidth fix, not the repair for the flake.
+                //
+                // `main` being 40/0 is what shows the flake was INTRODUCED by
+                // per-cycle entry counting rather than being a pre-existing
+                // wobble in a multi-threaded test.
                 assert!(
                     ids.contains(&cursor.last_sent),
                     "after pair {pair} the cursor is no longer a member of the \

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -10161,22 +10161,36 @@ mod tests {
                 // WHAT MAKES THIS TEST PASS, measured rather than assumed. Each
                 // row is 40 runs of this test alone, `--exact`:
                 //
-                //   zero-advance reject + atomic boundary (shipped) . 40 / 0
-                //   zero-advance reject, boundary deleted ........... 40 / 0
+                //   zero-advance reject + atomic boundary (shipped) . 40 /  0
+                //   zero-advance reject, boundary deleted ........... 40 /  0
                 //   atomic boundary, advance check deleted .......... 23 / 17
                 //   neither, but with the id-equality dedup guard
                 //     it replaced (commit 65086ec2) ................. 32 /  8
-                //   pre-PR main ..................................... 40 / 0
+                //                            and, replicated ....... 27 / 13
+                //   pre-PR main ..................................... 40 /  0
+                //                            and, replicated ....... 40 /  0
                 //
-                // Read those carefully, because the obvious story is wrong. It
+                // TREAT THE FAILING RATES AS ORDER-OF-MAGNITUDE ONLY. The two
+                // independent measurements of 65086ec2 (separate sessions,
+                // worktrees and binaries) agree that it flakes badly but differ
+                // by 12 points, 20% vs 33%, most plausibly because this host runs
+                // concurrent test agents. So do not read fine distinctions
+                // between 20%, 33% and 43% -- those intervals overlap with the
+                // noise. The zero rows are the robust ones: 0 failures in 40 is
+                // qualitatively different from 8-17 in 40, and both replications
+                // of `main` agree exactly.
+                //
+                // Read the rows carefully, because the obvious story is wrong. It
                 // is the ZERO-ADVANCE REJECTION in `record_fallback_cursor` that
-                // makes this test green, NOT the atomic boundary. And the
-                // boundary makes the situation WORSE on its own (17/40 failing,
-                // worse than either earlier state) because publishing the origin
-                // makes concurrent racers AGREE, so they now build identical
-                // windows every time -- turning the duplicate charge from
-                // occasional into systematic. The two changes are coupled: the
-                // boundary is what makes the dedup path load-bearing.
+                // makes this test green, NOT the atomic boundary -- the advance
+                // check alone is 0/40, the boundary alone is 17/40. That
+                // distinction survives the noise; a claim that the boundary alone
+                // is WORSE than the guard it replaced would not, so it is not
+                // made. What matters is that publishing the origin makes
+                // concurrent racers AGREE, so they build identical windows every
+                // time, turning the duplicate charge from occasional into
+                // systematic. The two changes are coupled: the boundary is what
+                // makes the dedup path load-bearing.
                 //
                 // So the atomic boundary is NOT justified by this test. It is
                 // justified by (a) not spending a second full window of uplink

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2949,7 +2949,7 @@ pub(crate) fn summaries_reply_for_peer(
 /// extreme — a wide set of contracts we do not host, where each entry costs
 /// almost nothing and the byte budget would never bind — not as the number
 /// that governs how fast the rotation turns. Quote the byte budget for that.
-const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
+pub(crate) const MAX_FALLBACK_SUMMARIES_PER_REPLY: usize = 64;
 
 /// Byte budget for one full-bytes summary fallback reply (#5155).
 ///
@@ -3434,11 +3434,16 @@ async fn handle_interest_sync_message(
             //   recognised as ground the longer already covered. If the shorter
             //   records first the longer is charged on top of it, over-stating
             //   progress by up to one window.
-            // - A racer that STRADDLES a boundary (it read the old cycle, the
-            //   other took the boundary) overwrites `last_sent` and discards the
-            //   freshly published origin, so its successor resumes from the old
-            //   window instead of the new origin. Safe direction: it costs
-            //   contiguity for one round, never coverage.
+            // - A racer that STRADDLES a boundary (it read the old cycle, another
+            //   reply took the boundary) is NOT in this list any more: its record
+            //   is not well-formed against the new cycle, so it is discarded and
+            //   the freshly published origin survives. It used to overwrite
+            //   `last_sent` and discard that origin, via a first-record exemption
+            //   in `record_fallback_cursor` that no longer exists. The cost is now
+            //   only that the window it already sent is re-sent later, since it
+            //   was never charged. Kept here as a signpost because the imprecision
+            //   was documented for long enough that a reader may come looking for
+            //   it.
             // - Contract CHURN: ids removed from ground already swept while
             //   others are inserted below the cursor let the count reach the set
             //   size with current members never advertised this cycle.
@@ -3452,7 +3457,6 @@ async fn handle_interest_sync_message(
                         &matching,
                         last,
                         entries.len(),
-                        MAX_FALLBACK_SUMMARIES_PER_REPLY,
                     );
                 }
             }
@@ -10170,23 +10174,30 @@ mod tests {
                 //   pre-PR main ..................................... 40 /  0
                 //                            and, replicated ....... 40 /  0
                 //
-                // TREAT THE FAILING RATES AS ORDER-OF-MAGNITUDE ONLY. The two
-                // independent measurements of 65086ec2 (separate sessions,
-                // worktrees and binaries) agree that it flakes badly but differ
-                // by 12 points, 20% vs 33%, most plausibly because this host runs
-                // concurrent test agents. So do not read fine distinctions
-                // between 20%, 33% and 43% -- those intervals overlap with the
-                // noise. The zero rows are the robust ones: 0 failures in 40 is
-                // qualitatively different from 8-17 in 40, and both replications
-                // of `main` agree exactly.
+                // EVERY ROW IS n=40, so read each rate as +/- about 15 points.
+                // The two independent measurements of 65086ec2 (separate
+                // sessions, worktrees and binaries) came out 8/40 and 13/40, and
+                // that spread needs no explanation: z = 1.27, p = 0.20, with
+                // Wilson 95% intervals of [10.5%, 34.8%] and [20.1%, 48.0%]
+                // overlapping across most of their range. It is ordinary sampling
+                // noise at this n, NOT evidence of anything about the machine.
+                //
+                // Which rows are sound follows from the power, and this is why
+                // the table is trustworthy exactly where it is used: separating
+                // 20% from 33% would need n ~ 193, and 33% from 43% n ~ 366, but
+                // separating ~0% from 20% needs only n ~ 35. So the ZERO rows
+                // carry the whole argument at n=40 and the contested rows carry
+                // none of it. Do not read fine distinctions between 20%, 33% and
+                // 43%.
                 //
                 // Read the rows carefully, because the obvious story is wrong. It
                 // is the ZERO-ADVANCE REJECTION in `record_fallback_cursor` that
                 // makes this test green, NOT the atomic boundary -- the advance
-                // check alone is 0/40, the boundary alone is 17/40. That
-                // distinction survives the noise; a claim that the boundary alone
-                // is WORSE than the guard it replaced would not, so it is not
-                // made. What matters is that publishing the origin makes
+                // check alone is 0/40, the boundary alone is 17/40 against main's
+                // 0/40. That 0-versus-17 gap is the one the power analysis above
+                // supports at n=40. A claim that the boundary alone is WORSE than
+                // the id-equality guard it replaced is NOT supported (17/40 vs
+                // 8-13/40 at this n) and is not made. What matters is that publishing the origin makes
                 // concurrent racers AGREE, so they build identical windows every
                 // time, turning the duplicate charge from occasional into
                 // systematic. The two changes are coupled: the boundary is what

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1122,9 +1122,17 @@ pub struct InterestManager<T: TimeSource> {
     /// runs both designs over the same removal schedule and shows the index
     /// one missing contracts the key one covers.
     ///
+    /// The entry also carries how many contracts have been advertised to that
+    /// peer SINCE THE CURRENT CYCLE BEGAN, which is what makes a mid-cycle wrap
+    /// distinguishable from a completed cycle. The id alone cannot tell them
+    /// apart: a window that happens to end on the highest id in the set looks
+    /// exactly like a cursor that has run off the end, and treating that as a
+    /// boundary re-randomised the start MID-cycle (#5181), breaking contiguity
+    /// and with it the `ceil(len / limit)` bound above.
+    ///
     /// Only the full-bytes fallback consults this. Digest-capable peers keep
     /// receiving the complete set every round and never touch it.
-    summary_fallback_cursor: Mutex<LruCache<SocketAddr, ContractInstanceId>>,
+    summary_fallback_cursor: Mutex<LruCache<SocketAddr, FallbackCursor>>,
 
     /// Count of concurrently-outstanding queue-full-resync retry tasks (#4862 P1).
     /// Bounds aggregate retry tasks node-wide, independent of the throttle LRU
@@ -2747,16 +2755,31 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// (ascending by contract id).
     ///
     /// Mid-cycle this resumes immediately after the last contract SENT to that
-    /// peer, which is what makes successive windows contiguous in id space
-    /// (see [`first_index_after`]). At a cycle BOUNDARY — no cursor yet, the
-    /// cursor evicted or lost, or the previous window ending on the highest id
-    /// — the next cycle starts at a RANDOM offset rather than at 0.
+    /// peer, WRAPPING to 0 when that contract was the highest id in the set,
+    /// which is what makes successive windows contiguous in id space (see
+    /// [`first_index_after`]). At a cycle BOUNDARY — no cursor yet, the cursor
+    /// evicted or lost, or the cycle's own contract count having reached the
+    /// size of the set — the next cycle starts at a RANDOM offset rather than
+    /// at 0.
+    ///
+    /// The two are told apart by [`FallbackCursor::advertised_in_cycle`], not by
+    /// whether the resume index ran off the end. That distinction is #5181: a
+    /// window ending on the last index is a mid-cycle wrap, and re-randomising
+    /// there restarted the rotation at an arbitrary offset partway through a
+    /// cycle, so the set was NOT covered in `ceil(len / limit)` rounds. It hit
+    /// ~1/limit of cycles regardless of set size.
+    ///
+    /// Not a pure read: reaching a boundary DROPS the stale cursor, so the
+    /// entry [`Self::record_fallback_cursor`] writes next starts the new cycle's
+    /// count from zero. Dropping rather than zeroing in place also means a round
+    /// that ends up sending nothing (so never records) draws a fresh boundary
+    /// offset next time instead of silently resuming from the old cycle's id.
     ///
     /// A fixed restart at 0 is the failure this codebase has already rejected
     /// twice, for the same reason each time: see the rotations in
     /// `emit_stale_peer_syncs` and in the `SummaryDigests` arm, both of which
     /// note that a fixed prefix "would starve the tail on every cycle
-    /// forever". The two ways to land back at a boundary repeatedly are both
+    /// forever". The two ways to keep landing on the head of the set are both
     /// reachable here, and neither needs an attacker:
     ///
     /// - The cursor is in-memory and keyed by address, so it is lost on our
@@ -2767,8 +2790,8 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// - `sorted` is the INTERSECTION with the hash list the peer advertised,
     ///   so the peer influences where the cursor lands. Advertising a single
     ///   high-id contract parks the cursor at the end, and the following full
-    ///   round would restart at 0 — repeat, and everything past the first
-    ///   window is never advertised.
+    ///   round then resumes by wrapping — at 0. Repeat it and, with nothing
+    ///   else in play, everything past the first window is never advertised.
     ///
     /// Randomising the boundary costs nothing in the ordinary case: a cycle
     /// beginning at any offset still advances contiguously and still covers
@@ -2776,43 +2799,123 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// It only removes the guarantee that the SAME contracts are the ones
     /// covered first every time.
     ///
+    /// The per-cycle count also keeps the peer-steering bound in the second
+    /// bullet above finite. A peer that parks the cursor at the end of the set
+    /// gets one wrapped head window, but each advertised contract it provokes is
+    /// charged to the cycle, so the count crosses `sorted.len()` within a couple
+    /// of rounds and the start is re-randomised. Resuming with a bare
+    /// `start % len` and no count would hand it the head window forever.
+    ///
     /// `GlobalRng` keeps this deterministic under simulation and test.
     pub(crate) fn fallback_window_start(&self, peer: SocketAddr, sorted: &[ContractKey]) -> usize {
         if sorted.is_empty() {
             return 0;
         }
-        let after = { self.summary_fallback_cursor.lock().peek(&peer).copied() };
-        let resumed = after.map(|after| first_index_after(sorted, &after));
-        match resumed {
-            // Mid-cycle: continue exactly where the last reply stopped.
-            Some(start) if start < sorted.len() => start,
-            // Cycle boundary (cursor absent, or exhausted past the end).
-            _ => crate::config::GlobalRng::random_range(0..sorted.len()),
-        }
+        let resume = {
+            let mut cursors = self.summary_fallback_cursor.lock();
+            match cursors.peek(&peer).copied() {
+                // Mid-cycle: continue exactly where the last reply stopped,
+                // wrapping to 0 when it stopped on the highest id.
+                Some(cursor) if cursor.advertised_in_cycle < sorted.len() => {
+                    Some(first_index_after(sorted, &cursor.last_sent) % sorted.len())
+                }
+                // Cycle complete: drop it so the next recorded cursor counts
+                // from zero against the new cycle drawn just below.
+                Some(_) => {
+                    cursors.pop(&peer);
+                    None
+                }
+                // No cursor: a boundary by definition (first reply, our own
+                // restart, LRU eviction, a peer back on a new source port).
+                None => None,
+            }
+        };
+        // Drawn outside the cursor lock so the RNG's own lock is never taken
+        // underneath it.
+        resume.unwrap_or_else(|| crate::config::GlobalRng::random_range(0..sorted.len()))
     }
 
     /// Record the contract id of the last entry actually included in `peer`'s
-    /// fallback reply, so the next reply resumes after it.
+    /// fallback reply, so the next reply resumes after it, and charge the
+    /// `entries_sent` it carried to the current cycle.
     ///
     /// Takes what was SENT, not what was selected: the byte budget can cut a
     /// window short, and advancing past entries we dropped would skip them
-    /// until the rotation wrapped all the way round.
-    pub(crate) fn record_fallback_cursor(&self, peer: SocketAddr, last_sent: ContractInstanceId) {
-        self.summary_fallback_cursor.lock().put(peer, last_sent);
+    /// until the rotation wrapped all the way round. The count is charged the
+    /// same way, so a budget-limited link takes proportionally more rounds to
+    /// finish a cycle rather than declaring one finished early.
+    ///
+    /// A round that ends on the id already stored is charged NOTHING. That is
+    /// the concurrency case the cursor-advance comment in `node.rs` documents:
+    /// two `Interests` from one peer handled concurrently read the same start,
+    /// build the same window, and record the same last id. They advertised one
+    /// window between them, so charging both would report twice the progress
+    /// actually made and end the cycle with part of the set still unadvertised —
+    /// the same class of hole as #5181, arrived at from the other direction.
+    pub(crate) fn record_fallback_cursor(
+        &self,
+        peer: SocketAddr,
+        last_sent: ContractInstanceId,
+        entries_sent: usize,
+    ) {
+        let mut cursors = self.summary_fallback_cursor.lock();
+        let advertised_in_cycle = match cursors.peek(&peer) {
+            // Same window again: no new ground covered, so no charge.
+            Some(prev) if prev.last_sent == last_sent => prev.advertised_in_cycle,
+            Some(prev) => prev.advertised_in_cycle.saturating_add(entries_sent),
+            None => entries_sent,
+        };
+        cursors.put(
+            peer,
+            FallbackCursor {
+                last_sent,
+                advertised_in_cycle,
+            },
+        );
     }
 
     /// Test accessor for the stored cursor.
     #[cfg(test)]
-    pub(crate) fn peek_fallback_cursor(&self, peer: SocketAddr) -> Option<ContractInstanceId> {
+    pub(crate) fn peek_fallback_cursor(&self, peer: SocketAddr) -> Option<FallbackCursor> {
         self.summary_fallback_cursor.lock().peek(&peer).copied()
     }
+}
+
+/// Where a peer's full-bytes fallback rotation has got to, and how far into the
+/// current cycle that is.
+///
+/// Both halves are needed. `last_sent` alone makes successive windows contiguous
+/// under contract churn (see [`first_index_after`]), but says nothing about
+/// whether the rotation has been round the whole set yet — a window ending on
+/// the highest id is indistinguishable from a cursor past the end. Counting the
+/// contracts advertised since the cycle began answers that directly, which is
+/// what #5181 needed: without it, a wrap was read as a completed cycle and the
+/// start was re-randomised partway through, so `ceil(len / limit)` rounds no
+/// longer covered the set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FallbackCursor {
+    /// Id of the last contract actually SENT to this peer.
+    pub(crate) last_sent: ContractInstanceId,
+    /// Contracts advertised to this peer since the current cycle began. The
+    /// cycle is complete once this reaches the size of the shared set.
+    ///
+    /// Approximate on purpose, in the safe direction. It is compared against a
+    /// `sorted.len()` the peer can vary between rounds (the set is the
+    /// intersection with the hashes it advertised), and a repeat of the same
+    /// window is not charged, so a cycle can be declared complete after
+    /// slightly more advertising than the set strictly needed. Over-running a
+    /// cycle costs a redundant advertisement; UNDER-running one would leave
+    /// part of the set unadvertised, which is the failure being avoided.
+    pub(crate) advertised_in_cycle: usize,
 }
 
 /// First index in `sorted` (ascending by contract id, as
 /// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
 /// greater than `after`. Returns `sorted.len()` when `after` is at or past the
-/// end, which [`InterestManager::fallback_window_start`] reads as the end of a
-/// cycle and answers with a fresh random offset.
+/// end; [`InterestManager::fallback_window_start`] wraps that back to 0, because
+/// running off the end is where the rotation's window wraps and NOT by itself a
+/// cycle boundary (#5181 — the boundary is decided by
+/// [`FallbackCursor::advertised_in_cycle`]).
 ///
 /// This is the churn-safe half of the rotation. Because it is a binary search
 /// over ids rather than a stored offset, it behaves correctly when the set
@@ -7257,8 +7360,16 @@ mod tests {
     /// production uses at a cycle boundary. That is deliberate: these tests
     /// pin the WITHIN-cycle contiguity and coverage properties, which must hold
     /// from any starting offset, so the tests below sweep the starts explicitly
-    /// instead of sampling them. `fallback_window_start_randomises_the_cycle_
-    /// boundary` covers the production entry point.
+    /// instead of sampling them.
+    ///
+    /// Note the LIMIT of this helper, learned from #5181: its resume rule is not
+    /// production's. It feeds `first_index_after` straight into
+    /// `rotation_window_indices`, which wraps a `len` start back to 0 on its own,
+    /// so it cannot see a defect that lives in the resume decision itself — and
+    /// it did not. `real_cursor_api_covers_every_contract_from_every_origin`
+    /// drives `fallback_window_start`/`record_fallback_cursor` for that reason;
+    /// `fallback_window_start_randomises_the_cycle_boundary` covers the
+    /// boundary behaviour of the production entry point.
     fn rotation_round(
         sorted: &[ContractKey],
         cursor: Option<ContractInstanceId>,
@@ -7503,8 +7614,8 @@ mod tests {
              rather than stepping over it"
         );
 
-        // Cursor at the end: signals a completed cycle to the caller, which
-        // restarts at a random offset rather than at 0.
+        // Cursor at the end: the window has run off the end of the set. The
+        // caller wraps this to 0; it is NOT by itself a cycle boundary (#5181).
         let beyond = *sorted[7].id();
         assert_eq!(first_index_after(&sorted, &beyond), sorted.len());
     }
@@ -7519,18 +7630,34 @@ mod tests {
 
         assert_eq!(mgr.peek_fallback_cursor(peer), None);
 
-        mgr.record_fallback_cursor(peer, *sorted[2].id());
-        assert_eq!(mgr.peek_fallback_cursor(peer), Some(*sorted[2].id()));
+        mgr.record_fallback_cursor(peer, *sorted[2].id(), 3);
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer),
+            Some(FallbackCursor {
+                last_sent: *sorted[2].id(),
+                advertised_in_cycle: 3,
+            })
+        );
         assert_eq!(
             mgr.fallback_window_start(peer, &sorted),
             3,
             "mid-cycle the resume point must be exactly after the last id sent"
         );
 
+        // Successive rounds accumulate against the SAME cycle.
+        mgr.record_fallback_cursor(peer, *sorted[4].id(), 2);
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer)
+                .map(|c| c.advertised_in_cycle),
+            Some(5),
+            "entries sent must be charged to the running cycle, not replace it"
+        );
+        assert_eq!(mgr.fallback_window_start(peer, &sorted), 5);
+
         // Cursors are per peer: one peer's progress must not advance another's.
         let other: SocketAddr = "127.0.0.1:9101".parse().unwrap();
-        mgr.record_fallback_cursor(other, *sorted[6].id());
-        assert_eq!(mgr.fallback_window_start(peer, &sorted), 3);
+        mgr.record_fallback_cursor(other, *sorted[6].id(), 1);
+        assert_eq!(mgr.fallback_window_start(peer, &sorted), 5);
         assert_eq!(mgr.fallback_window_start(other, &sorted), 7);
 
         // An empty shared set has no valid offset; it must not panic or draw.
@@ -7540,16 +7667,21 @@ mod tests {
     /// At a CYCLE BOUNDARY the start is random, not a fixed 0.
     ///
     /// A boundary is reached with no cursor (first reply, our own restart, LRU
-    /// eviction, a peer reconnecting on a new port) or with a cursor already at
-    /// the highest id. Restarting at 0 every time would re-send the head of the
-    /// set and starve the tail for any peer that keeps returning to a boundary,
-    /// which is the failure `emit_stale_peer_syncs` and the `SummaryDigests`
-    /// arm both already rotate to avoid.
+    /// eviction, a peer reconnecting on a new port) or with a cycle whose own
+    /// contract count has reached the size of the set. Restarting at 0 every
+    /// time would re-send the head of the set and starve the tail for any peer
+    /// that keeps returning to a boundary, which is the failure
+    /// `emit_stale_peer_syncs` and the `SummaryDigests` arm both already rotate
+    /// to avoid.
     ///
     /// The peer influences this: `sorted` is the intersection with the hash
     /// list it advertised, so advertising one high-id contract parks the cursor
     /// at the end. With a fixed restart that alternation pins the window to the
     /// head forever; with a random one it cannot.
+    ///
+    /// Note what is NOT a boundary: a cursor merely sitting on the highest id.
+    /// That is the mid-cycle wrap of #5181, covered by
+    /// `fallback_window_start_wraps_mid_cycle_instead_of_re_randomising`.
     #[test]
     fn fallback_window_start_randomises_the_cycle_boundary() {
         let (mgr, _clock) = make_manager();
@@ -7569,21 +7701,192 @@ mod tests {
              draws over 64 contracts all landed on {seen:?}"
         );
 
-        // Cursor at the highest id: also a boundary, also randomised.
+        // A COMPLETED cycle (the whole set advertised) is also a boundary, and
+        // also randomised.
         let peer: SocketAddr = "127.0.0.1:9300".parse().unwrap();
-        let mut seen_wrapped = HashSet::new();
+        let mut seen_completed = HashSet::new();
         for _ in 0..40 {
-            mgr.record_fallback_cursor(peer, *sorted[sorted.len() - 1].id());
-            seen_wrapped.insert(mgr.fallback_window_start(peer, &sorted));
+            mgr.record_fallback_cursor(peer, *sorted[7].id(), sorted.len());
+            seen_completed.insert(mgr.fallback_window_start(peer, &sorted));
         }
         assert!(
-            seen_wrapped.iter().all(|s| *s < sorted.len()),
-            "wrapped start out of range"
+            seen_completed.iter().all(|s| *s < sorted.len()),
+            "boundary start out of range"
         );
         assert!(
-            seen_wrapped.len() > 1,
-            "a cursor at the end of the set must restart at a random offset, \
-             not deterministically at 0 — got {seen_wrapped:?}"
+            seen_completed.len() > 1,
+            "a completed cycle must restart at a random offset, not \
+             deterministically after the last id sent — got {seen_completed:?}"
+        );
+
+        // Reaching the boundary must also clear the count, or the very next
+        // round would read the new cycle as already finished and re-randomise
+        // again — permanently random, never contiguous.
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer),
+            None,
+            "the completed cycle's cursor must be dropped when the boundary is \
+             taken, so the next recorded cursor counts from zero"
+        );
+    }
+
+    /// #5181: a window that ends on the LAST index is a mid-cycle wrap, so the
+    /// next round resumes at 0 — it must NOT draw a fresh random offset.
+    ///
+    /// This is a production correctness bug that happened to surface as a ~1-in-
+    /// 200 test flake (`fallback_rotation_covers_the_whole_shared_set`). The old
+    /// code derived the boundary from `first_index_after` returning
+    /// `sorted.len()`, which conflates "cursor past the end of the set" with
+    /// "cursor sitting on the highest id in it". Re-randomising there restarts
+    /// the rotation partway through a cycle, so the set is no longer covered in
+    /// `ceil(len / limit)` rounds — the bound #5155's entire cost argument rests
+    /// on. It fired on ~1/limit of cycles, independent of set size.
+    ///
+    /// Constructed directly rather than sampled: the cursor is placed on the
+    /// highest id with the cycle explicitly mid-flight, which is the exact state
+    /// the flake reached by chance. Repeating the read also pins that the answer
+    /// is deterministic — under the old code each call was an independent draw,
+    /// so a false pass would need the system RNG to return 0 on every one of
+    /// these reads across every set size below.
+    #[test]
+    fn fallback_window_start_wraps_mid_cycle_instead_of_re_randomising() {
+        let peer: SocketAddr = "127.0.0.1:9400".parse().unwrap();
+
+        for len in [2usize, 3, 7, 64, 65, 199, 200] {
+            // Fresh manager per size so the cycle count below is exactly 1.
+            let (mgr, _clock) = make_manager();
+            let sorted = sorted_keys(0..len as u32);
+            let highest = *sorted[len - 1].id();
+
+            // Mid-cycle by construction: one entry advertised so far, so the
+            // cycle is nowhere near the `len` contracts that would finish it.
+            mgr.record_fallback_cursor(peer, highest, 1);
+            for read in 0..8 {
+                assert_eq!(
+                    mgr.fallback_window_start(peer, &sorted),
+                    0,
+                    "len={len} read={read}: a window ending on the highest id \
+                     must wrap to 0 and stay contiguous, not restart the cycle \
+                     at a random offset (#5181)"
+                );
+            }
+            // Reading a mid-cycle wrap must not consume the cursor.
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer),
+                Some(FallbackCursor {
+                    last_sent: highest,
+                    advertised_in_cycle: 1,
+                }),
+                "len={len}: a mid-cycle read must leave the cursor alone"
+            );
+        }
+    }
+
+    /// End-to-end coverage through the REAL cursor API, from EVERY origin.
+    ///
+    /// `rotation_covers_every_contract_within_ceil_n_over_limit_rounds` above
+    /// exercises the pure helpers with a test-local resume rule, which is why it
+    /// stayed green through #5181: the defect lived in `fallback_window_start`,
+    /// between them. This drives `fallback_window_start` and
+    /// `record_fallback_cursor` themselves and sweeps all `n` origins rather
+    /// than sampling five, so the origins whose rounds land on the last index
+    /// (`{8, 72, 136}` for n=200, limit=64 — the ones the flake needed to draw)
+    /// are all covered.
+    #[test]
+    fn real_cursor_api_covers_every_contract_from_every_origin() {
+        for (n, limit) in [(200usize, 64usize), (12, 4), (65, 8), (7, 7), (5, 1)] {
+            let sorted = sorted_keys(0..n as u32);
+            let expected: HashSet<ContractInstanceId> = sorted.iter().map(|k| *k.id()).collect();
+            let rounds = n.div_ceil(limit);
+
+            for origin in 0..n {
+                let peer: SocketAddr = format!("127.0.0.1:{}", 9500 + origin).parse().unwrap();
+                let (mgr, _clock) = make_manager();
+                // Force round one to begin at `origin` by seeding the cursor on
+                // its predecessor, mid-cycle with nothing yet charged. For
+                // `origin == 0` the predecessor is the LAST id, so origin 0 is
+                // itself the wrap case — a no-cursor seed would have drawn a
+                // random start and could not pin an origin at all.
+                mgr.record_fallback_cursor(peer, *sorted[(origin + n - 1) % n].id(), 0);
+
+                let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+                for round in 0..rounds {
+                    let start = mgr.fallback_window_start(peer, &sorted);
+                    if round == 0 {
+                        assert_eq!(
+                            start, origin,
+                            "n={n} limit={limit}: premise — round one must begin \
+                             at the seeded origin"
+                        );
+                    }
+                    let window = rotation_window_indices(n, start, limit);
+                    assert!(!window.is_empty(), "n={n} limit={limit}: empty window");
+                    covered.extend(window.iter().map(|i| *sorted[*i].id()));
+                    let last = *sorted[*window.last().unwrap()].id();
+                    mgr.record_fallback_cursor(peer, last, window.len());
+                }
+
+                let missed = expected.difference(&covered).count();
+                assert_eq!(
+                    missed, 0,
+                    "n={n} limit={limit} origin={origin}: {missed} contract(s) \
+                     unadvertised after {rounds} rounds (ceil({n}/{limit})) — \
+                     the rotation lost contiguity mid-cycle (#5181)"
+                );
+            }
+        }
+    }
+
+    /// Cycles must actually END, so the start keeps being re-randomised.
+    ///
+    /// This is the other half of the #5181 fix and the reason it is not the
+    /// two-line `Some(start) => start % sorted.len()`. That shortcut is
+    /// contiguous and would satisfy every coverage assertion above, but it
+    /// re-randomises exactly once ever — on the first reply, before any cursor
+    /// exists. From then on the rotation is a deterministic function of the
+    /// stored id, so a peer that can steer where the cursor lands (it chooses
+    /// `sorted`, which is the intersection with the hashes it advertised) can
+    /// park it at the end of the set and be handed the head window every round,
+    /// starving its own view of the tail. That is the failure the rustdoc's
+    /// second bullet, `emit_stale_peer_syncs`, and the `SummaryDigests` arm all
+    /// rotate to avoid.
+    ///
+    /// Asserting on BOUNDARIES TAKEN rather than on distinct start values,
+    /// because distinct values do not discriminate: the shortcut's single
+    /// first-round draw already produces two of them. A dropped cursor is the
+    /// observable proof a new cycle was begun, and under the shortcut it never
+    /// happens.
+    #[test]
+    fn cycles_end_so_the_start_keeps_being_re_randomised() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9600".parse().unwrap();
+        let sorted = sorted_keys(0..64);
+        const LIMIT: usize = 16;
+        const ROUNDS: usize = 20;
+
+        let mut boundaries = 0usize;
+        let mut starts = Vec::new();
+        for _ in 0..ROUNDS {
+            let had_cursor = mgr.peek_fallback_cursor(peer).is_some();
+            let start = mgr.fallback_window_start(peer, &sorted);
+            if had_cursor && mgr.peek_fallback_cursor(peer).is_none() {
+                boundaries += 1;
+            }
+            starts.push(start);
+            let window = rotation_window_indices(sorted.len(), start, LIMIT);
+            let last = *sorted[*window.last().unwrap()].id();
+            mgr.record_fallback_cursor(peer, last, window.len());
+        }
+
+        // 20 rounds x 16 entries over a 64-contract set is 5 cycles' worth of
+        // advertising, so the boundary must have been reached about 4 times.
+        let expected_min = ROUNDS * LIMIT / sorted.len() - 1;
+        assert!(
+            boundaries >= expected_min,
+            "only {boundaries} cycle boundary/ies in {ROUNDS} rounds (expected \
+             at least {expected_min}); starts were {starts:?}. A rotation that \
+             never reaches a boundary is a deterministic function of the stored \
+             id, which a peer steering `sorted` can pin to the head of the set."
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1076,6 +1076,32 @@ pub struct InterestManager<T: TimeSource> {
     /// This counter helps detect incorrect summary caching issues (see PR #2763).
     resync_requests_received: AtomicU64,
 
+    /// Fallback-rotation records discarded by
+    /// [`InterestManager::record_fallback_cursor`] as duplicate or stale.
+    ///
+    /// A steady trickle is NORMAL and expected: concurrent `Interests` from one
+    /// peer build identical windows, and the later record is a duplicate by
+    /// design. A count rivalling the total number of fallback replies would mean
+    /// the same-snapshot premise that check derives from has been broken, which
+    /// stalls the rotation for that peer.
+    ///
+    /// # LOCAL-ONLY today: nothing exports or logs this
+    ///
+    /// Stated plainly because the sentence above is only actionable if someone
+    /// can read the number, and right now nobody can. It is surfaced on
+    /// [`InterestManagerStats`], and **that whole struct is dead**: `stats()` has
+    /// no caller anywhere in the tree, and its existing
+    /// `resync_requests_received` has no reader either. So this is exercised by
+    /// tests (`stale_records_are_counted_as_rejected`) and is NOT a production
+    /// guard.
+    ///
+    /// Making it one needs an enumerated telemetry event -- a plain `info!` never
+    /// reaches the collector and `debug!` compiles out in release -- which is
+    /// out of scope here and noted on #5313. Until then the real guard against
+    /// the systematic-rejection failure mode is the test, not the counter. Do not
+    /// cite this field as observability without re-checking that a reader exists.
+    fallback_records_rejected: AtomicU64,
+
     /// Throttle timestamps for proactive summary notifications.
     /// After applying a broadcast update, we notify interested peers of our new summary
     /// so they can skip sending us data we already have. This DashMap tracks the last
@@ -1210,6 +1236,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             full_state_sends: AtomicU64::new(0),
             delta_bytes_saved: AtomicU64::new(0),
             resync_requests_received: AtomicU64::new(0),
+            fallback_records_rejected: AtomicU64::new(0),
             summary_notify_timestamps: DashMap::new(),
             pending_removals: DashMap::new(),
             resync_retry_slots: Arc::new(AtomicUsize::new(0)),
@@ -2919,28 +2946,65 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     ///   distance. There is deliberately no separate id-equality special case;
     ///   that was a symptom patch for this same defect.
     ///
-    /// The FIRST record of a cycle is exempt and is charged unconditionally,
-    /// because `last_sent` then holds the origin's predecessor published by
-    /// [`Self::begin_fallback_window`] rather than anything we sent. Two
-    /// distinct failures need that exemption, and the second is reachable on
-    /// demand:
+    /// # The invariant: a well-formed round is NEVER rejected
     ///
-    /// - A shared set no larger than one window is covered entirely by the
-    ///   first round, which lands back on that predecessor for a distance of
-    ///   zero. Discarding it sticks the counter at zero, so the cycle never
-    ///   completes and the origin is never re-drawn for that peer again.
-    /// - When the drawn origin is 0 the predecessor wraps to the LAST index, so
-    ///   the first round's forward distance is `len - window`, which exceeds
-    ///   `limit` for any set bigger than two windows and reads as a rewind.
-    ///   That is 1-in-`len` of cycles by chance — but a peer steering the start
-    ///   to 0 (see [`Self::begin_fallback_window`]) hits it every cycle.
+    /// Worth stating as an invariant rather than a list of cases, because it is
+    /// what makes this check exactly "is this record well-formed". For a
+    /// well-formed round the two sides are IDENTICALLY equal: `advance` is `k`
+    /// when `k < len`, and `0` when `k == len`, which is `k % len` in both cases.
+    /// So there is no `k`, no `len` and no origin for which a genuine reply is
+    /// discarded. (Brute force over the shipped rule found rejection only at
+    /// `k == len` -- the weaker claim this supersedes, and precisely the wedge
+    /// the old `advance == 0` arm produced.)
+    ///
+    /// That includes the FIRST record of a cycle, which needs no special case:
+    /// `begin_fallback_window` publishes the origin's PREDECESSOR, so
+    /// `first_index_after` resolves it back to the origin, giving
+    /// `prev_pos == origin` and `new_pos == origin + k`, hence `advance == k`.
+    /// An earlier revision carried an `advertised_in_cycle == 0` exemption for
+    /// two failures that were artefacts of the looser `advance <= limit` bound it
+    /// accompanied -- a whole-set round landing back on the predecessor for a
+    /// distance of zero, and an origin drawn at 0 -- and the rule above handles
+    /// both. Measured both ways over 3000 x 60 rounds with churn, concurrency and
+    /// byte-budget cuts, the variants produced byte-identical rejection counts,
+    /// so the exemption provably never changed the answer for a well-formed
+    /// record.
+    ///
+    /// # If deleting a guard reds a test, check the test's INPUT first
+    ///
+    /// The general lesson, recorded here because the next person to consider
+    /// re-adding that exemption will hit exactly this. Deleting it did red a test
+    /// -- and the exemption was not what that test needed. The fixture recorded
+    /// `entries_sent = 64` while naming index 7 as the last id sent, which no real
+    /// window can produce: a window of 64 entries starting at the origin ends on
+    /// the 64th, not the 8th. The exemption had been silently accepting an
+    /// IMPOSSIBLE INPUT, and its apparent load-bearingness was an artefact of the
+    /// fixture rather than of production.
+    ///
+    /// So: **when removing a guard turns a test red, establish that the test's
+    /// input is reachable in production before concluding the guard is needed.**
+    /// An unreachable fixture makes any guard look necessary. That check is
+    /// cheaper and more durable than the equivalence measurement above, because
+    /// the next reader will be looking at their own red test, not at these
+    /// numbers.
+    ///
+    /// # Removing that exemption FIXED the boundary straddle
+    ///
+    /// Do not re-add it: it was not merely redundant but actively wrong. A reply
+    /// that read the old cycle and landed after another reply took the boundary
+    /// met `advertised_in_cycle == 0` on the freshly published cursor and was
+    /// charged unconditionally -- overwriting the origin the boundary had just
+    /// published with a stale id from the previous cycle. `node.rs` used to
+    /// document that as an accepted imprecision costing contiguity for a round.
+    /// Without the exemption the straddler is simply not well-formed against the
+    /// new cycle, so it is rejected and the published origin SURVIVES. Pinned by
+    /// `a_boundary_straddling_racer_is_rejected_and_the_origin_survives`.
     pub(crate) fn record_fallback_cursor(
         &self,
         peer: SocketAddr,
         sorted: &[ContractKey],
         last_sent: ContractInstanceId,
         entries_sent: usize,
-        limit: usize,
     ) {
         // An empty reply is never recorded in production (the call site is gated
         // on having included at least one entry). Returning keeps
@@ -2952,64 +3016,119 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         let len = sorted.len();
         let mut cursors = self.summary_fallback_cursor.lock();
         let charged = match cursors.peek(&peer).copied() {
-            // First record of this cycle; see the rustdoc.
-            Some(prev) if prev.advertised_in_cycle == 0 => entries_sent,
             Some(prev) => {
                 let prev_pos = first_index_after(sorted, &prev.last_sent) % len;
                 let new_pos = first_index_after(sorted, &last_sent) % len;
                 let advance = (new_pos + len - prev_pos) % len;
-                // Why CHURN cannot make a well-formed round trip the upper
-                // bound, which is the obvious worry and worth settling here.
+                // A well-formed round advances by EXACTLY the entries it sent.
                 //
                 // The window is built and the cursor recorded against the SAME
-                // `matching` snapshot for one reply (see the call site), and the
+                // `matching` snapshot for one reply (see the call site), the
                 // window is chosen by INDEX in that snapshot starting at
-                // `prev_pos`, with `last_sent` being its k-th entry. So
-                // `new_pos == prev_pos + k` and `advance == entries_sent`
-                // exactly, for any amount of churn since the previous round:
-                // insertions shift `prev_pos` and `new_pos` together. Churn
-                // perturbs WHICH contracts a window covers (see
-                // `advertised_in_cycle`, which is honest that this can under-run
-                // a cycle) but never the distance measured here.
+                // `prev_pos`, and `last_sent` is its k-th entry. Ids are unique,
+                // so `first_index_after(S, S[j]) == j + 1` and therefore
+                // `new_pos == prev_pos + k`, i.e. `advance == entries_sent`, for
+                // any amount of churn since the previous round: insertions shift
+                // `prev_pos` and `new_pos` together. Churn perturbs WHICH
+                // contracts a window covers (see `advertised_in_cycle`, which is
+                // honest that this can under-run a cycle) but never this distance.
                 //
-                // That derivation depends on both calls receiving the same
-                // snapshot. A refactor that recomputed the shared set between
-                // them would break it, and the symptom would be rejected records
-                // rather than a compile error -- so do not.
+                // So test for exactly that, and NOT for `advance <= limit`, which
+                // was the earlier form and was too loose to do the job. A stale
+                // record is forward the long way round at distance `len - gap`,
+                // so a `limit` bound rejects it only while `len - gap > limit`:
+                // measured, stale records were still ACCEPTED -- rewound and
+                // double-charged, i.e. the exact defect this check exists for --
+                // for every `len <= limit + entries_sent`:
                 //
-                // Rejections are in any case transient, never a wedge: the next
-                // round starts at whatever `prev_pos` the stored cursor implies
-                // and its own advance is again exactly its entry count.
-                if advance == 0 || advance > limit {
-                    // Duplicate (zero) or stale (the long way round). Neither
-                    // covers ground this cycle has not already had charged, so
-                    // discard rather than rewind.
+                //     entries/round   largest len still accepting a stale record
+                //           1                          65
+                //           2                          66
+                //           8                          72
+                //          32                          96
+                //          64                         128
+                //
+                // The 1-entry row is the dangerous one rather than a corner case:
+                // `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY` documents that for a
+                // peer sharing River-sized rooms the byte budget binds after the
+                // first contract, so the entry cap "is never reached" -- exactly
+                // the population for which a `limit` bound is inert.
+                //
+                // Two things this form buys beyond tightness:
+                //
+                // - A whole-set round (`entries_sent == len`) has
+                //   `entries_sent % len == 0` and an advance of 0, so it is
+                //   ACCEPTED, while a duplicate has a non-zero `entries_sent %
+                //   len` and is still rejected. The old `advance == 0` arm
+                //   conflated "no ground covered" with "ALL ground covered" and
+                //   rejected the latter forever once it was not a cycle's first
+                //   record -- a set growing by one just after a whole-set round
+                //   left the count stuck below the new length, so every later
+                //   round advanced 0, was discarded, and the origin was never
+                //   re-drawn again.
+                // - `limit` is no longer needed at all, which is the clearest
+                //   sign it was never the right bound.
+                //
+                // NOT exact, and the gap cannot be closed by any distance test:
+                // when `len == 2 * entries_sent` a one-window rewind is congruent
+                // with a one-window advance (m=8 -> len 16; m=64 -> len 128) and
+                // is accepted. Separating those needs a per-round token -- a
+                // cycle-local sequence number, or reserving the window at read
+                // time -- tracked in #5313. The claim here is NARROWED, not
+                // closed.
+                //
+                // The derivation depends on both calls receiving the same
+                // snapshot. A refactor that recomputed the shared set between them
+                // breaks it, and because this test is tight the symptom is
+                // SYSTEMATIC rejection rather than occasional wrong acceptance --
+                // the better failure, since a stalled rotation is loud where a
+                // silently rewound one is not. `fallback_records_rejected` counts
+                // them, though note that counter is local-only today.
+                //
+                // ONE RESIDUAL the derivation does NOT cover, because it assumes
+                // `prev.last_sent` is still this reply's own predecessor. It is
+                // not, when a CONCURRENT reply for the same peer landed in
+                // between using a DIFFERENT snapshot -- reachable even when the
+                // peer sent identical `hashes`, since `get_matching_contracts`
+                // re-reads our local `contract_hash_index` and that churns on its
+                // own. `prev_pos` is then an id from an unrelated snapshot fed
+                // into `first_index_after` on this one, so the distance means
+                // nothing and is roughly uniform over `[0, len)`.
+                //
+                // Such a record is therefore SILENTLY ACCEPTED whenever that
+                // uniform draw happens to equal `entries_sent % len`, which
+                // corrupts both the count and `last_sent`. Two things make it
+                // tolerable. It is ~`1/len` (about 0.5% at len=200) rather than
+                // the ~`limit/len` (about 32%) it would be under an
+                // `advance <= limit` bound, so the tighter test shrinks this by
+                // roughly 64x -- a second, independent reason to prefer it. And
+                // when it does fire it is bounded by the same machinery as every
+                // other accepted imprecision here: contiguity plus an eventual
+                // re-boundary means the worst case is wasted bandwidth or a
+                // delayed round inside the one-cycle envelope, never permanent
+                // loss.
+                if advance != entries_sent % len {
+                    // Duplicate, or stale-the-long-way-round. Neither covers
+                    // ground this cycle has not already had charged, so discard
+                    // rather than rewind.
                     //
-                    // The upper bound is what provides the anti-rewind property;
-                    // rejecting zero alone does not. A stale record is forward
-                    // by the long way round -- stored at index 127, a late reply
-                    // ending at 63 over 200 contracts advances 136 -- so without
-                    // the bound it is accepted and rewinds the cursor, which is
-                    // the defect this check exists for.
-                    //
-                    // The ZERO half is load-bearing for concurrency and is made
-                    // MORE so by the atomic boundary, not less. Publishing the
-                    // origin means concurrent racers now agree, so they build
-                    // IDENTICAL windows -- which is exactly the duplicate this
-                    // rejects. Measured on
+                    // Rejecting duplicates is load-bearing for concurrency and is
+                    // made MORE so by the atomic boundary, not less: publishing
+                    // the origin means concurrent racers agree, so they build
+                    // IDENTICAL windows every time. Measured on
                     // `concurrent_interests_from_one_peer_cost_at_most_one_round`
-                    // over 40 runs: with the boundary but without this check,
-                    // 17/40 FAIL, worse than with neither. The two changes are
-                    // coupled; do not reason about either alone.
+                    // over 40 runs, the boundary WITHOUT this check fails 17/40.
+                    // The two changes are coupled; do not reason about either
+                    // alone.
                     //
-                    // Note also that this check catching DIVERGENT origins (the
-                    // pre-boundary defect) is incidental: it rejects them because
-                    // a large forward distance looks stale, not because it knows
+                    // This check catching DIVERGENT origins (the pre-boundary
+                    // defect) is incidental -- it rejects them because their
+                    // distance is not the entry count, not because it knows
                     // anything about concurrent boundary draws. An incidental
-                    // guard is fragile -- retuning the distance bound could stop
-                    // catching that with nothing going red -- which is a reason
-                    // to keep BOTH mechanisms rather than treat either as
-                    // redundant.
+                    // guard is fragile, which is a reason to keep BOTH mechanisms
+                    // rather than treat either as redundant.
+                    self.fallback_records_rejected
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     return;
                 }
                 prev.advertised_in_cycle.saturating_add(entries_sent)
@@ -3636,6 +3755,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             full_state_sends: self.full_state_sends.load(Ordering::Relaxed),
             delta_bytes_saved: self.delta_bytes_saved.load(Ordering::Relaxed),
             resync_requests_received: self.resync_requests_received.load(Ordering::Relaxed),
+            fallback_records_rejected: self.fallback_records_rejected.load(Ordering::Relaxed),
         }
     }
 }
@@ -3660,6 +3780,14 @@ pub struct InterestManagerStats {
     /// Number of ResyncRequests received (indicates delta failures at remote peers).
     /// With correct summary caching (PR #2763), this should be zero in normal operation.
     pub resync_requests_received: u64,
+    /// Fallback-rotation records discarded as duplicate or stale. A trickle is
+    /// normal (concurrent replies build identical windows); a count rivalling the
+    /// number of fallback replies means the rotation is stalled. See
+    /// [`InterestManager::record_fallback_cursor`].
+    ///
+    /// NOTE: like every other field here, this is currently unread --
+    /// `InterestManager::stats()` has no caller in the tree.
+    pub fallback_records_rejected: u64,
 }
 
 #[cfg(test)]
@@ -7853,7 +7981,7 @@ mod tests {
 
         // Seed a cycle beginning at index 1, then charge two rounds against it.
         mgr.seed_fallback_cycle(peer, &sorted, 1);
-        mgr.record_fallback_cursor(peer, &sorted, *sorted[2].id(), 2, LIMIT);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[2].id(), 2);
         assert_eq!(
             mgr.peek_fallback_cursor(peer),
             Some(FallbackCursor {
@@ -7868,7 +7996,7 @@ mod tests {
         );
 
         // Successive rounds accumulate against the SAME cycle.
-        mgr.record_fallback_cursor(peer, &sorted, *sorted[4].id(), 2, LIMIT);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[4].id(), 2);
         assert_eq!(
             mgr.peek_fallback_cursor(peer)
                 .map(|c| c.advertised_in_cycle),
@@ -7880,7 +8008,7 @@ mod tests {
         // Cursors are per peer: one peer's progress must not advance another's.
         let other: SocketAddr = "127.0.0.1:9101".parse().unwrap();
         mgr.seed_fallback_cycle(other, &sorted, 6);
-        mgr.record_fallback_cursor(other, &sorted, *sorted[6].id(), 1, LIMIT);
+        mgr.record_fallback_cursor(other, &sorted, *sorted[6].id(), 1);
         assert_eq!(mgr.begin_fallback_window(peer, &sorted), 5);
         assert_eq!(mgr.begin_fallback_window(other, &sorted), 7);
     }
@@ -7905,7 +8033,7 @@ mod tests {
         );
         // And recording against an empty set is a no-op rather than a panic.
         let sorted = sorted_keys(0..4);
-        mgr.record_fallback_cursor(peer, &[], *sorted[0].id(), 1, LIMIT);
+        mgr.record_fallback_cursor(peer, &[], *sorted[0].id(), 1);
         assert_eq!(mgr.peek_fallback_cursor(peer), None);
     }
 
@@ -7927,14 +8055,14 @@ mod tests {
             let (mgr, _clock) = make_manager();
             let peer: SocketAddr = "127.0.0.1:9710".parse().unwrap();
             mgr.seed_fallback_cycle(peer, &sorted, 0);
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(127), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(127), W);
             assert_eq!(
                 mgr.peek_fallback_cursor(peer)
                     .map(|c| c.advertised_in_cycle),
                 Some(128)
             );
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W);
             assert_eq!(
                 mgr.peek_fallback_cursor(peer),
                 Some(FallbackCursor {
@@ -7952,8 +8080,8 @@ mod tests {
             let (mgr, _clock) = make_manager();
             let peer: SocketAddr = "127.0.0.1:9711".parse().unwrap();
             mgr.seed_fallback_cycle(peer, &sorted, 0);
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W);
             assert_eq!(
                 mgr.peek_fallback_cursor(peer)
                     .map(|c| c.advertised_in_cycle),
@@ -7971,11 +8099,11 @@ mod tests {
             let peer: SocketAddr = "127.0.0.1:9712".parse().unwrap();
             mgr.seed_fallback_cycle(peer, &sorted, 0);
             for end in [63usize, 127, 191] {
-                mgr.record_fallback_cursor(peer, &sorted, pos_of(end), W, W);
+                mgr.record_fallback_cursor(peer, &sorted, pos_of(end), W);
             }
             // Next window is [192..255] mod 200, ending at index 55 — below the
             // origin in id order, and only 55 positions past it.
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(55), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(55), W);
             assert_eq!(
                 mgr.peek_fallback_cursor(peer),
                 Some(FallbackCursor {
@@ -7996,13 +8124,92 @@ mod tests {
             let (mgr, _clock) = make_manager();
             let peer: SocketAddr = "127.0.0.1:9713".parse().unwrap();
             mgr.seed_fallback_cycle(peer, &sorted, 0);
-            mgr.record_fallback_cursor(peer, &sorted, pos_of(W - 1), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(W - 1), W);
             assert_eq!(
                 mgr.peek_fallback_cursor(peer)
                     .map(|c| c.advertised_in_cycle),
                 Some(W),
                 "the first record of a cycle drawn at origin 0 must be charged; \
                  rejecting it stalls every cycle a steering peer can force"
+            );
+        }
+
+        // (4b) SMALL SET, ONE ENTRY PER ROUND -- the case every other block here
+        // misses, because they all use N=200/W=64 where `len > limit + entries`
+        // holds by construction and a `limit`-bounded check happens to reject
+        // stale records anyway.
+        //
+        // A stale record is forward-the-long-way-round at distance `len - gap`,
+        // so any bound of the form `advance <= limit` accepts it whenever
+        // `len <= limit + entries_sent` -- measured, up to len 65 at one entry
+        // per round. One entry per round is not a corner case: the byte budget
+        // binds after the first contract for a peer sharing River-sized rooms
+        // (see `MAX_FALLBACK_SUMMARY_BYTES_PER_REPLY`), so that is exactly the
+        // population for which a `limit` bound would be inert. Accepting means
+        // rewinding AND double-charging, i.e. the whole defect back again.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9715".parse().unwrap();
+            let small = sorted_keys(0..40);
+            let at = |i: usize| *small[i].id();
+            mgr.seed_fallback_cycle(peer, &small, 0);
+            // Three overlapping rounds of one entry each: A, then C.
+            mgr.record_fallback_cursor(peer, &small, at(0), 1);
+            mgr.record_fallback_cursor(peer, &small, at(1), 1);
+            mgr.record_fallback_cursor(peer, &small, at(2), 1);
+            let before = mgr.peek_fallback_cursor(peer).unwrap();
+            assert_eq!(
+                (before.last_sent, before.advertised_in_cycle),
+                (at(2), 3),
+                "premise: three one-entry rounds advanced to index 2"
+            );
+            // B's slow reply lands last, carrying the window A already recorded.
+            // prev_pos = 3, new_pos = 2, advance = 39 -- which is <= 64, so a
+            // `limit`-bounded check ACCEPTS it.
+            mgr.record_fallback_cursor(peer, &small, at(1), 1);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer),
+                Some(before),
+                "a stale one-entry record over a 40-contract set must be \
+                 discarded. Its long-way-round distance is 39, under any \
+                 plausible `limit`, so a bound of `advance <= limit` accepts it \
+                 and both rewinds the cursor and charges the cycle twice."
+            );
+        }
+
+        // (5b) A whole-set round MID-cycle -- distinct from (5), which is the
+        // whole-set round at a cycle's FIRST record. This is the LOWER bound
+        // firing on a legitimate round: the window covers every position and so
+        // lands back where it started, giving `advance == 0`, while the count is
+        // already non-zero. Under an `advance == 0` rejection it is discarded
+        // FOREVER -- a set that grows by one just after a whole-set round leaves
+        // the count stuck below the new length, so every later round advances 0,
+        // is discarded, and the origin is never re-drawn. The shipped rule accepts
+        // it, because a whole-set round has `entries_sent % len == 0` while a
+        // duplicate does not.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9717".parse().unwrap();
+            let ten = sorted_keys(0..10);
+            mgr.seed_fallback_cycle(peer, &ten, 0);
+            // A partial round first, so the whole-set round is NOT the cycle's
+            // first record and no first-record path can rescue it.
+            mgr.record_fallback_cursor(peer, &ten, *ten[0].id(), 1);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer)
+                    .map(|c| c.advertised_in_cycle),
+                Some(1),
+                "premise: mid-cycle with a non-zero count"
+            );
+            // A whole-set round starting at index 1 wraps and ends on index 0.
+            mgr.record_fallback_cursor(peer, &ten, *ten[0].id(), 10);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer)
+                    .map(|c| c.advertised_in_cycle),
+                Some(11),
+                "a whole-set round mid-cycle must be CHARGED. Rejecting it (as an \
+                 `advance == 0` test does) freezes the count below the set size, \
+                 so the cycle never completes and the origin is never re-drawn."
             );
         }
 
@@ -8016,7 +8223,7 @@ mod tests {
             let small = sorted_keys(0..5);
             let origin = mgr.begin_fallback_window(peer, &small);
             let last = *small[(origin + small.len() - 1) % small.len()].id();
-            mgr.record_fallback_cursor(peer, &small, last, small.len(), W);
+            mgr.record_fallback_cursor(peer, &small, last, small.len());
             let charged = mgr
                 .peek_fallback_cursor(peer)
                 .map(|c| c.advertised_in_cycle)
@@ -8076,7 +8283,11 @@ mod tests {
         let mut seen_completed = HashSet::new();
         for _ in 0..40 {
             mgr.seed_fallback_cycle(peer, &sorted, 0);
-            mgr.record_fallback_cursor(peer, &sorted, *sorted[7].id(), sorted.len(), LIMIT);
+            // A WELL-FORMED whole-set round: starting at origin 0 and sending
+            // `len` entries ends on the LAST index. Naming any other id here
+            // would be a record no real window produces, and would be rejected
+            // by `record_fallback_cursor` for exactly that reason.
+            mgr.record_fallback_cursor(peer, &sorted, *sorted[sorted.len() - 1].id(), sorted.len());
             seen_completed.insert(mgr.begin_fallback_window(peer, &sorted));
         }
         assert!(
@@ -8134,7 +8345,7 @@ mod tests {
             // Mid-cycle by construction: one entry advertised so far, so the
             // cycle is nowhere near the `len` contracts that would finish it.
             mgr.seed_fallback_cycle(peer, &sorted, len - 1);
-            mgr.record_fallback_cursor(peer, &sorted, highest, 1, LIMIT);
+            mgr.record_fallback_cursor(peer, &sorted, highest, 1);
             for read in 0..8 {
                 assert_eq!(
                     mgr.begin_fallback_window(peer, &sorted),
@@ -8196,7 +8407,7 @@ mod tests {
                     assert!(!window.is_empty(), "n={n} limit={limit}: empty window");
                     covered.extend(window.iter().map(|i| *sorted[*i].id()));
                     let last = *sorted[*window.last().unwrap()].id();
-                    mgr.record_fallback_cursor(peer, &sorted, last, window.len(), limit);
+                    mgr.record_fallback_cursor(peer, &sorted, last, window.len());
                 }
 
                 let missed = expected.difference(&covered).count();
@@ -8259,7 +8470,7 @@ mod tests {
             starts.push(start);
             let window = rotation_window_indices(sorted.len(), start, W);
             let last = *sorted[*window.last().unwrap()].id();
-            mgr.record_fallback_cursor(peer, &sorted, last, window.len(), W);
+            mgr.record_fallback_cursor(peer, &sorted, last, window.len());
         }
 
         // 20 rounds x 16 entries over a 64-contract set is 5 cycles' worth of
@@ -8273,6 +8484,140 @@ mod tests {
              at least {expected_min}); starts were {starts:?}. A rotation that \
              never reaches a boundary is a deterministic function of the stored \
              id, which a peer steering `sorted` can pin to the head of the set."
+        );
+    }
+
+    /// A boundary-straddling racer is REJECTED and the published origin survives.
+    ///
+    /// The scenario: reply A reads mid-cycle, reply B then completes the cycle so
+    /// the next read takes a boundary and publishes a fresh origin, and only then
+    /// does A record the window it built against the OLD cycle.
+    ///
+    /// This used to be an accepted imprecision. A's record met
+    /// `advertised_in_cycle == 0` on the freshly published cursor, hit the
+    /// first-record exemption, and was charged unconditionally -- discarding the
+    /// origin the boundary had just drawn. Removing that exemption fixed it: A is
+    /// not well-formed against the new cycle, so it is discarded and the published
+    /// origin SURVIVES. Re-adding the exemption turns this test red.
+    ///
+    /// Getting the setup right matters. An earlier version charged the whole set
+    /// in one go, so the FIRST `begin` took the boundary and both reads returned
+    /// the same origin -- nothing was straddled, and only an explicit premise
+    /// assertion caught it. Hence the premise checks below.
+    #[test]
+    fn a_boundary_straddling_racer_is_rejected_and_the_origin_survives() {
+        const N: usize = 200;
+        const W: usize = 64;
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9720".parse().unwrap();
+        let sorted = sorted_keys(0..N as u32);
+        let ids: HashSet<ContractInstanceId> = sorted.iter().map(|k| *k.id()).collect();
+
+        // One well-formed round, so the cycle is genuinely mid-flight.
+        mgr.seed_fallback_cycle(peer, &sorted, 0);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[W - 1].id(), W);
+
+        // Reply A reads here and builds its window, but does not record yet.
+        let a_start = mgr.begin_fallback_window(peer, &sorted);
+        let a_window = rotation_window_indices(N, a_start, W);
+        assert_eq!(
+            a_start, W,
+            "premise: A resumed mid-cycle, not at a boundary"
+        );
+
+        // Reply B drives the cycle to completion with well-formed rounds.
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[127].id(), W);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[191].id(), W);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[N - 1].id(), 8);
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer)
+                .map(|c| c.advertised_in_cycle),
+            Some(N),
+            "premise: the cycle is complete, so the next read is a boundary"
+        );
+
+        // The boundary is taken and publishes a fresh origin.
+        let fresh_origin = mgr.begin_fallback_window(peer, &sorted);
+        let published = mgr
+            .peek_fallback_cursor(peer)
+            .expect("a boundary publishes its cycle");
+        assert_eq!(published.advertised_in_cycle, 0, "premise: fresh cycle");
+        assert_ne!(
+            a_start, fresh_origin,
+            "premise: A and the new boundary must differ, or nothing straddled"
+        );
+
+        // NOW A records, against the old cycle's window.
+        let a_last = *sorted[*a_window.last().unwrap()].id();
+        mgr.record_fallback_cursor(peer, &sorted, a_last, a_window.len());
+
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer),
+            Some(published),
+            "the straddling record must be DISCARDED and the freshly published \
+             origin must survive. With the first-record exemption it was charged \
+             instead, replacing the new origin with a stale id from the previous \
+             cycle -- which is why that exemption is gone."
+        );
+        assert_eq!(
+            mgr.begin_fallback_window(peer, &sorted),
+            fresh_origin,
+            "and the next round must still begin at the published origin"
+        );
+
+        // The bound: coverage still completes, with one cycle of slack for the
+        // ground A advertised but was not charged for.
+        let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+        let budget = 2 * N.div_ceil(W);
+        for _ in 0..budget {
+            let start = mgr.begin_fallback_window(peer, &sorted);
+            let window = rotation_window_indices(N, start, W);
+            covered.extend(window.iter().map(|i| *sorted[*i].id()));
+            let last = *sorted[*window.last().unwrap()].id();
+            mgr.record_fallback_cursor(peer, &sorted, last, window.len());
+        }
+        assert_eq!(
+            ids.difference(&covered).count(),
+            0,
+            "a straddle must cost at most a re-sent window, never coverage"
+        );
+    }
+
+    /// Rejected records are counted, and normal traffic does not inflate it.
+    ///
+    /// This test IS the guard for the systematic-rejection failure mode, because
+    /// the counter itself is not observable in production: it is surfaced only on
+    /// `InterestManagerStats`, whose `stats()` has no caller anywhere in the tree.
+    /// See the field's rustdoc. If that changes, this test stops being the only
+    /// reader and the field's doc must be updated to say so.
+    #[test]
+    fn stale_records_are_counted_as_rejected() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9716".parse().unwrap();
+        let sorted = sorted_keys(0..40);
+        let at = |i: usize| *sorted[i].id();
+
+        mgr.seed_fallback_cycle(peer, &sorted, 0);
+        assert_eq!(mgr.stats().fallback_records_rejected, 0);
+
+        // Three well-formed one-entry rounds: none rejected.
+        for i in 0..3 {
+            mgr.record_fallback_cursor(peer, &sorted, at(i), 1);
+        }
+        assert_eq!(
+            mgr.stats().fallback_records_rejected,
+            0,
+            "well-formed rounds must not be counted as rejections, or the number \
+             says nothing about the premise being broken"
+        );
+
+        // A stale replay and an exact duplicate: both rejected, both counted.
+        mgr.record_fallback_cursor(peer, &sorted, at(1), 1);
+        mgr.record_fallback_cursor(peer, &sorted, at(2), 1);
+        assert_eq!(
+            mgr.stats().fallback_records_rejected,
+            2,
+            "a stale replay and a duplicate must each be counted"
         );
     }
 
@@ -8337,7 +8682,7 @@ mod tests {
         let start1 = mgr.begin_fallback_window(peer, &before);
         let w1 = rotation_window_indices(before.len(), start1, W);
         let last1 = *before[*w1.last().unwrap()].id();
-        mgr.record_fallback_cursor(peer, &before, last1, w1.len(), W);
+        mgr.record_fallback_cursor(peer, &before, last1, w1.len());
         let charged1 = mgr
             .peek_fallback_cursor(peer)
             .map(|c| c.advertised_in_cycle);
@@ -8357,7 +8702,7 @@ mod tests {
         let start2 = mgr.begin_fallback_window(peer, &after);
         let w2 = rotation_window_indices(after.len(), start2, W);
         let last2 = *after[*w2.last().unwrap()].id();
-        mgr.record_fallback_cursor(peer, &after, last2, w2.len(), W);
+        mgr.record_fallback_cursor(peer, &after, last2, w2.len());
 
         let cursor = mgr
             .peek_fallback_cursor(peer)
@@ -8409,7 +8754,7 @@ mod tests {
             let wa = rotation_window_indices(single.len(), a, W);
             advertised.extend(wa.iter().map(|i| *single[*i].id()));
             let last_a = *single[*wa.last().unwrap()].id();
-            mgr.record_fallback_cursor(peer, &single, last_a, wa.len(), W);
+            mgr.record_fallback_cursor(peer, &single, last_a, wa.len());
 
             // Round B: the peer advertises everything.
             let b = mgr.begin_fallback_window(peer, &full);
@@ -8417,7 +8762,7 @@ mod tests {
             let wb = rotation_window_indices(full.len(), b, W);
             advertised.extend(wb.iter().map(|i| *full[*i].id()));
             let last_b = *full[*wb.last().unwrap()].id();
-            mgr.record_fallback_cursor(peer, &full, last_b, wb.len(), W);
+            mgr.record_fallback_cursor(peer, &full, last_b, wb.len());
         }
 
         let distinct: HashSet<usize> = full_starts.iter().copied().collect();

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -8399,7 +8399,7 @@ mod tests {
         const W: usize = 64;
 
         // The peer's steering choice: one hash, the highest id in the set.
-        let single = vec![full[full.len() - 1].clone()];
+        let single = vec![full[full.len() - 1]];
 
         let mut full_starts = Vec::new();
         let mut advertised: HashSet<ContractInstanceId> = HashSet::new();

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2991,6 +2991,25 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     // ending at 63 over 200 contracts advances 136 -- so without
                     // the bound it is accepted and rewinds the cursor, which is
                     // the defect this check exists for.
+                    //
+                    // The ZERO half is load-bearing for concurrency and is made
+                    // MORE so by the atomic boundary, not less. Publishing the
+                    // origin means concurrent racers now agree, so they build
+                    // IDENTICAL windows -- which is exactly the duplicate this
+                    // rejects. Measured on
+                    // `concurrent_interests_from_one_peer_cost_at_most_one_round`
+                    // over 40 runs: with the boundary but without this check,
+                    // 17/40 FAIL, worse than with neither. The two changes are
+                    // coupled; do not reason about either alone.
+                    //
+                    // Note also that this check catching DIVERGENT origins (the
+                    // pre-boundary defect) is incidental: it rejects them because
+                    // a large forward distance looks stale, not because it knows
+                    // anything about concurrent boundary draws. An incidental
+                    // guard is fragile -- retuning the distance bound could stop
+                    // catching that with nothing going red -- which is a reason
+                    // to keep BOTH mechanisms rather than treat either as
+                    // redundant.
                     return;
                 }
                 prev.advertised_in_cycle.saturating_add(entries_sent)
@@ -8255,6 +8274,40 @@ mod tests {
              never reaches a boundary is a deterministic function of the stored \
              id, which a peer steering `sorted` can pin to the head of the set."
         );
+    }
+
+    /// A boundary PUBLISHES its origin, so a second reader that arrives before
+    /// any reply has been recorded resumes from the same origin instead of
+    /// drawing its own.
+    ///
+    /// This is the deterministic guard for the atomic-boundary property.
+    /// `concurrent_interests_from_one_peer_cost_at_most_one_round` exercises the
+    /// same thing through a real race, but its verdict depends on the scheduler
+    /// actually overlapping the two replies; this does not depend on a scheduler
+    /// at all, because "two readers with no record in between" is precisely what
+    /// straddling a boundary means.
+    ///
+    /// Deleting the publish makes each reader draw independently, which charged
+    /// two non-contiguous windows to one cycle and ran the counter ahead of the
+    /// ground covered — #5181's failure class.
+    #[test]
+    fn a_published_boundary_makes_a_second_reader_agree_on_the_origin() {
+        let sorted = sorted_keys(0..200);
+        // Repeated because the origin is random: a single trial where the second
+        // reader happened to draw the same offset would pass under the defect.
+        for trial in 0..40u32 {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = format!("127.0.0.1:{}", 9950 + trial).parse().unwrap();
+            let first = mgr.begin_fallback_window(peer, &sorted);
+            let second = mgr.begin_fallback_window(peer, &sorted);
+            assert_eq!(
+                first, second,
+                "trial {trial}: a second reader arriving before any reply is \
+                 recorded must resume from the origin the boundary published, \
+                 not draw its own — two origins mean two non-contiguous windows \
+                 both charged to one cycle"
+            );
+        }
     }
 
     /// Contracts INSERTED between the cursor and the window end, between rounds,

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -148,7 +148,7 @@ const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
 /// peer to the head of its set every round and starve the tail permanently. The
 /// cap is well above `max_connections`, so that is not the expected regime; the
 /// randomisation is what makes it a slow cycle rather than a silent hole if it
-/// ever is. See [`InterestManager::fallback_window_start`].
+/// ever is. See [`InterestManager::begin_fallback_window`].
 const SUMMARY_FALLBACK_CURSOR_CACHE_SIZE: usize = 4096;
 
 /// Bounds diagnostic correlation state influenced by remote (contract, peer)
@@ -1111,6 +1111,14 @@ pub struct InterestManager<T: TimeSource> {
     /// on. The whole safety argument is a stated upper bound on how long a
     /// divergence can go unnoticed, and under ordinary contract churn an index
     /// cursor degrades that from `ceil(n / limit)` rounds to no bound at all.
+    ///
+    /// Keep the two properties here separate; conflating them is how this file
+    /// previously came to assert something untrue. **Contiguity plus completion**
+    /// is what stops a contract being skipped: one present at a cycle's start is
+    /// covered wherever the origin happens to fall, and randomising the origin
+    /// contributes nothing to that. **Randomisation** earns its place only
+    /// against the fixed-restart and peer-steering failure, and it is weaker now
+    /// than it was — see [`InterestManager::begin_fallback_window`].
     ///
     /// A key resumes after what was actually SENT, so consecutive rounds are
     /// contiguous in id space no matter what happened to the set in between:
@@ -2769,11 +2777,24 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// cycle, so the set was NOT covered in `ceil(len / limit)` rounds. It hit
     /// ~1/limit of cycles regardless of set size.
     ///
-    /// Not a pure read: reaching a boundary DROPS the stale cursor, so the
-    /// entry [`Self::record_fallback_cursor`] writes next starts the new cycle's
-    /// count from zero. Dropping rather than zeroing in place also means a round
-    /// that ends up sending nothing (so never records) draws a fresh boundary
-    /// offset next time instead of silently resuming from the old cycle's id.
+    /// NOT a pure read, and named `begin_` to say so: taking a boundary draws
+    /// the new origin and PUBLISHES the new cycle under the same lock hold.
+    /// Publishing is load-bearing rather than tidy. Two `Interests` from one
+    /// peer are handled as separate tasks (`dispatch.rs`), and each reply awaits
+    /// a storage hit per contract before recording, so two of them routinely
+    /// straddle a boundary. If the boundary only drew and returned, both would
+    /// see no cursor, draw DIFFERENT origins, and send two non-contiguous
+    /// windows whose entry counts were both charged to one cycle — which ran the
+    /// counter ahead of the ground actually covered, tripped the completion test
+    /// early, and left an arc of the set unadvertised. That is #5181's own
+    /// failure class, so it had to be closed here and not documented.
+    /// Republishing means the second racer reads the published cycle and
+    /// resumes contiguously from the same origin.
+    ///
+    /// The empty-set check comes FIRST, before the lock, and is pinned by
+    /// `fallback_window_start_handles_an_empty_shared_set`: both
+    /// `random_range(0..0)` and the predecessor arithmetic below panic at
+    /// `len == 0`.
     ///
     /// A fixed restart at 0 is the failure this codebase has already rejected
     /// twice, for the same reason each time: see the rotations in
@@ -2799,40 +2820,60 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// It only removes the guarantee that the SAME contracts are the ones
     /// covered first every time.
     ///
-    /// The per-cycle count also keeps the peer-steering bound in the second
-    /// bullet above finite. A peer that parks the cursor at the end of the set
-    /// gets one wrapped head window, but each advertised contract it provokes is
-    /// charged to the cycle, so the count crosses `sorted.len()` within a couple
-    /// of rounds and the start is re-randomised. Resuming with a bare
-    /// `start % len` and no count would hand it the head window forever.
+    /// # Anti-steering is WEAKER here than it was before #5181 was fixed
+    ///
+    /// Do not read the second bullet as a property this code provides. It does
+    /// not, and the honest account matters more than the reassuring one.
+    ///
+    /// Before the fix, EVERY round whose resume ran off the end drew a fresh
+    /// random offset. That defeated steering — but only as a side effect of the
+    /// very bug #5181 is about, because it also re-randomised mid-cycle and so
+    /// broke the `ceil(len / limit)` coverage bound. Restoring the bound
+    /// necessarily removes that side effect, so anti-steering has to be provided
+    /// deliberately instead. `advertised_in_cycle` was intended to be that
+    /// replacement and is NOT sufficient: the completion test compares the count
+    /// against `sorted.len()`, and the peer chooses `sorted`. Alternating a
+    /// single-hash `Interests` with a full one makes `len == 1`, trips
+    /// completion, and re-seeds the cycle from an id the peer picked — so the
+    /// count never accumulates and the boundary never recurs. Measured: full
+    /// rounds pinned to one start, with most of the set never advertised.
+    ///
+    /// This is a known, bounded regression, shipped deliberately: the harm is
+    /// almost entirely self-inflicted, since what starves is our advertisement
+    /// of contracts TO THAT PEER, cursors are per-address, and no other peer's
+    /// rotation is affected. The principled fix is positional cycle completion
+    /// (measure the window's progress against the stored origin instead of
+    /// counting entries against a peer-supplied length) and is tracked in #5313;
+    /// it needs an escape hatch so that a peer whose shared set
+    /// legitimately halves does not stop completing cycles forever.
+    /// `varying_shared_set_lets_a_peer_pin_the_window_today` characterises the
+    /// live behaviour so the regression is visible in CI rather than only here.
     ///
     /// `GlobalRng` keeps this deterministic under simulation and test.
-    pub(crate) fn fallback_window_start(&self, peer: SocketAddr, sorted: &[ContractKey]) -> usize {
+    pub(crate) fn begin_fallback_window(&self, peer: SocketAddr, sorted: &[ContractKey]) -> usize {
+        // MUST stay ahead of the lock and of any index arithmetic.
         if sorted.is_empty() {
             return 0;
         }
-        let resume = {
-            let mut cursors = self.summary_fallback_cursor.lock();
-            match cursors.peek(&peer).copied() {
-                // Mid-cycle: continue exactly where the last reply stopped,
-                // wrapping to 0 when it stopped on the highest id.
-                Some(cursor) if cursor.advertised_in_cycle < sorted.len() => {
-                    Some(first_index_after(sorted, &cursor.last_sent) % sorted.len())
-                }
-                // Cycle complete: drop it so the next recorded cursor counts
-                // from zero against the new cycle drawn just below.
-                Some(_) => {
-                    cursors.pop(&peer);
-                    None
-                }
-                // No cursor: a boundary by definition (first reply, our own
-                // restart, LRU eviction, a peer back on a new source port).
-                None => None,
+        let len = sorted.len();
+        let mut cursors = self.summary_fallback_cursor.lock();
+        // Mid-cycle: continue exactly where the last reply stopped, wrapping to
+        // 0 when it stopped on the highest id.
+        if let Some(cursor) = cursors.peek(&peer).copied() {
+            if cursor.advertised_in_cycle < len {
+                return first_index_after(sorted, &cursor.last_sent) % len;
             }
-        };
-        // Drawn outside the cursor lock so the RNG's own lock is never taken
-        // underneath it.
-        resume.unwrap_or_else(|| crate::config::GlobalRng::random_range(0..sorted.len()))
+        }
+        // Boundary: no cursor (first reply, our own restart, LRU eviction, a
+        // peer back on a new source port), or the cycle's count has reached the
+        // size of the set. Draw and publish atomically -- see the rustdoc.
+        //
+        // `GlobalRng` is entirely thread-local (`THREAD_RNG`/`THREAD_SEED` are
+        // `thread_local!`, with only an `AtomicU64` for thread indices), so
+        // drawing under this lock cannot deadlock against it.
+        let origin = crate::config::GlobalRng::random_range(0..len);
+        cursors.put(peer, FallbackCursor::starting_at(sorted, origin));
+        origin
     }
 
     /// Record the contract id of the last entry actually included in `peer`'s
@@ -2845,31 +2886,124 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// same way, so a budget-limited link takes proportionally more rounds to
     /// finish a cycle rather than declaring one finished early.
     ///
-    /// A round that ends on the id already stored is charged NOTHING. That is
-    /// the concurrency case the cursor-advance comment in `node.rs` documents:
-    /// two `Interests` from one peer handled concurrently read the same start,
-    /// build the same window, and record the same last id. They advertised one
-    /// window between them, so charging both would report twice the progress
-    /// actually made and end the cycle with part of the set still unadvertised —
-    /// the same class of hole as #5181, arrived at from the other direction.
+    /// # A record must ADVANCE the cycle, or it is discarded
+    ///
+    /// Replies to one peer are built concurrently and each awaits a storage hit
+    /// per contract before it records, so they can land out of order. Given
+    /// three overlapping rounds, a slow reply carrying an EARLIER window can
+    /// record after a later one: without this check it both charged its entries
+    /// a second time and REWOUND `last_sent`, so the rotation re-sent ground it
+    /// had already covered while the counter said otherwise.
+    ///
+    /// The test is the forward distance from the PREVIOUS position, taken
+    /// modulo the set size, and accepted only when it is at least one position
+    /// and no more than one window (`limit`). Every part of that is load-bearing
+    /// and each alternative has a concrete failure:
+    ///
+    /// - **Circular, not a linear id or index comparison.** A legitimate window
+    ///   wraps past the highest id, so its last entry can sort BELOW the
+    ///   previous one. A linear test rejects it as a rewind.
+    /// - **Relative to the previous position, not to the cycle's origin.** A
+    ///   window that CROSSES the origin necessarily lands a short distance
+    ///   *after* it, so measuring from the origin makes the crossing round look
+    ///   like the largest rewind of the cycle. Rejecting it leaves `last_sent`
+    ///   parked, the next round rebuilds the identical window, and the rotation
+    ///   wedges permanently — strictly worse than the staleness this check
+    ///   exists to stop.
+    /// - **Bounded above by `limit`.** Forward distance alone cannot tell a
+    ///   short hop from a long rewind, since every rewind is also "forward" once
+    ///   you go the long way round. A round advances by at most the window it
+    ///   sent, so anything beyond that is the long way round.
+    /// - **Rejecting zero** subsumes the exact-duplicate case: two racers that
+    ///   built the SAME window record the same id and the second covers no
+    ///   distance. There is deliberately no separate id-equality special case;
+    ///   that was a symptom patch for this same defect.
+    ///
+    /// The FIRST record of a cycle is exempt and is charged unconditionally,
+    /// because `last_sent` then holds the origin's predecessor published by
+    /// [`Self::begin_fallback_window`] rather than anything we sent. Two
+    /// distinct failures need that exemption, and the second is reachable on
+    /// demand:
+    ///
+    /// - A shared set no larger than one window is covered entirely by the
+    ///   first round, which lands back on that predecessor for a distance of
+    ///   zero. Discarding it sticks the counter at zero, so the cycle never
+    ///   completes and the origin is never re-drawn for that peer again.
+    /// - When the drawn origin is 0 the predecessor wraps to the LAST index, so
+    ///   the first round's forward distance is `len - window`, which exceeds
+    ///   `limit` for any set bigger than two windows and reads as a rewind.
+    ///   That is 1-in-`len` of cycles by chance — but a peer steering the start
+    ///   to 0 (see [`Self::begin_fallback_window`]) hits it every cycle.
     pub(crate) fn record_fallback_cursor(
         &self,
         peer: SocketAddr,
+        sorted: &[ContractKey],
         last_sent: ContractInstanceId,
         entries_sent: usize,
+        limit: usize,
     ) {
+        // An empty reply is never recorded in production (the call site is gated
+        // on having included at least one entry). Returning keeps
+        // `advertised_in_cycle == 0` meaning exactly "nothing charged yet this
+        // cycle", which the first-record exemption below relies on.
+        if sorted.is_empty() || entries_sent == 0 {
+            return;
+        }
+        let len = sorted.len();
         let mut cursors = self.summary_fallback_cursor.lock();
-        let advertised_in_cycle = match cursors.peek(&peer) {
-            // Same window again: no new ground covered, so no charge.
-            Some(prev) if prev.last_sent == last_sent => prev.advertised_in_cycle,
-            Some(prev) => prev.advertised_in_cycle.saturating_add(entries_sent),
+        let charged = match cursors.peek(&peer).copied() {
+            // First record of this cycle; see the rustdoc.
+            Some(prev) if prev.advertised_in_cycle == 0 => entries_sent,
+            Some(prev) => {
+                let prev_pos = first_index_after(sorted, &prev.last_sent) % len;
+                let new_pos = first_index_after(sorted, &last_sent) % len;
+                let advance = (new_pos + len - prev_pos) % len;
+                // Why CHURN cannot make a well-formed round trip the upper
+                // bound, which is the obvious worry and worth settling here.
+                //
+                // The window is built and the cursor recorded against the SAME
+                // `matching` snapshot for one reply (see the call site), and the
+                // window is chosen by INDEX in that snapshot starting at
+                // `prev_pos`, with `last_sent` being its k-th entry. So
+                // `new_pos == prev_pos + k` and `advance == entries_sent`
+                // exactly, for any amount of churn since the previous round:
+                // insertions shift `prev_pos` and `new_pos` together. Churn
+                // perturbs WHICH contracts a window covers (see
+                // `advertised_in_cycle`, which is honest that this can under-run
+                // a cycle) but never the distance measured here.
+                //
+                // That derivation depends on both calls receiving the same
+                // snapshot. A refactor that recomputed the shared set between
+                // them would break it, and the symptom would be rejected records
+                // rather than a compile error -- so do not.
+                //
+                // Rejections are in any case transient, never a wedge: the next
+                // round starts at whatever `prev_pos` the stored cursor implies
+                // and its own advance is again exactly its entry count.
+                if advance == 0 || advance > limit {
+                    // Duplicate (zero) or stale (the long way round). Neither
+                    // covers ground this cycle has not already had charged, so
+                    // discard rather than rewind.
+                    //
+                    // The upper bound is what provides the anti-rewind property;
+                    // rejecting zero alone does not. A stale record is forward
+                    // by the long way round -- stored at index 127, a late reply
+                    // ending at 63 over 200 contracts advances 136 -- so without
+                    // the bound it is accepted and rewinds the cursor, which is
+                    // the defect this check exists for.
+                    return;
+                }
+                prev.advertised_in_cycle.saturating_add(entries_sent)
+            }
+            // `begin_fallback_window` always publishes, so this is an LRU
+            // eviction in between. Treat the reply as its own fresh cycle.
             None => entries_sent,
         };
         cursors.put(
             peer,
             FallbackCursor {
                 last_sent,
-                advertised_in_cycle,
+                advertised_in_cycle: charged,
             },
         );
     }
@@ -2878,6 +3012,22 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     #[cfg(test)]
     pub(crate) fn peek_fallback_cursor(&self, peer: SocketAddr) -> Option<FallbackCursor> {
         self.summary_fallback_cursor.lock().peek(&peer).copied()
+    }
+
+    /// Seed `peer`'s cycle so it begins at `origin`, exactly as a boundary
+    /// would, minus the random draw. Shares
+    /// [`FallbackCursor::starting_at`] with production so a test cannot pin a
+    /// cursor shape the boundary never actually publishes.
+    #[cfg(test)]
+    pub(crate) fn seed_fallback_cycle(
+        &self,
+        peer: SocketAddr,
+        sorted: &[ContractKey],
+        origin: usize,
+    ) {
+        self.summary_fallback_cursor
+            .lock()
+            .put(peer, FallbackCursor::starting_at(sorted, origin));
     }
 }
 
@@ -2894,25 +3044,74 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 /// longer covered the set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FallbackCursor {
-    /// Id of the last contract actually SENT to this peer.
+    /// Id of the last contract actually SENT to this peer. Until the cycle's
+    /// first reply is recorded this holds the PREDECESSOR of the origin
+    /// [`InterestManager::begin_fallback_window`] drew, so that
+    /// [`first_index_after`] resolves back to that origin for the next reader.
     pub(crate) last_sent: ContractInstanceId,
     /// Contracts advertised to this peer since the current cycle began. The
     /// cycle is complete once this reaches the size of the shared set.
     ///
-    /// Approximate on purpose, in the safe direction. It is compared against a
-    /// `sorted.len()` the peer can vary between rounds (the set is the
-    /// intersection with the hashes it advertised), and a repeat of the same
-    /// window is not charged, so a cycle can be declared complete after
-    /// slightly more advertising than the set strictly needed. Over-running a
-    /// cycle costs a redundant advertisement; UNDER-running one would leave
-    /// part of the set unadvertised, which is the failure being avoided.
+    /// Zero means exactly "nothing charged yet this cycle" — relied on by
+    /// [`InterestManager::record_fallback_cursor`], and why an empty reply is
+    /// never recorded.
+    ///
+    /// # This is approximate, and NOT only in the safe direction
+    ///
+    /// An earlier version of this comment claimed it errs only towards
+    /// over-running a cycle. That was wrong, and the wrong direction is the one
+    /// that matters: over-running costs a redundant advertisement, while
+    /// UNDER-running ends the cycle with part of the set unadvertised, which is
+    /// #5181's own failure. Known cases where it under-runs:
+    ///
+    /// - **Byte-budget divergence.** Two concurrent replies cut at different
+    ///   lengths carry different last ids, so the shorter one is not recognised
+    ///   as covered ground; if the shorter records first, the longer is charged
+    ///   in full on top of it. Bounded by one window.
+    /// - **Churn.** Contracts removed from the arc already swept while others
+    ///   are inserted below the cursor let the count reach `sorted.len()` with
+    ///   current members never advertised this cycle. An id inserted into
+    ///   already-swept ground is indistinguishable from one that was advertised.
+    /// - **Peer-chosen length.** The count is compared against a `sorted.len()`
+    ///   the peer controls; see [`InterestManager::begin_fallback_window`].
+    ///
+    /// So state the bound carefully, and only where it holds:
+    ///
+    /// - For a set **stable across the cycle**, `ceil(len / limit)` rounds cover
+    ///   it from any origin. That is verified through the real API from every
+    ///   origin, and it is the strongest true statement available today.
+    /// - **Under churn there is NO round bound.** A cycle can end with members
+    ///   unadvertised that were present throughout it. They are picked up in a
+    ///   later cycle, so nothing is starved permanently, but no number of rounds
+    ///   can be promised. Do not write one here without an implementation that
+    ///   earns it — asserting a bound the code does not provide is exactly what
+    ///   #5181 was.
+    ///
+    /// Only per-cycle membership tracking would be exact, at a cost of memory
+    /// per peer per contract. Geometric (positional) completion would make a
+    /// real bound stateable, with a staleness bound of 2 cycles under churn; #5313.
     pub(crate) advertised_in_cycle: usize,
+}
+
+impl FallbackCursor {
+    /// The cursor a cycle beginning at `origin` starts from: nothing charged,
+    /// and `last_sent` set to the origin's PREDECESSOR so that
+    /// [`first_index_after`] resolves back to `origin` for the next reader.
+    ///
+    /// Panics if `sorted` is empty; callers check first.
+    fn starting_at(sorted: &[ContractKey], origin: usize) -> Self {
+        let len = sorted.len();
+        Self {
+            last_sent: *sorted[(origin + len - 1) % len].id(),
+            advertised_in_cycle: 0,
+        }
+    }
 }
 
 /// First index in `sorted` (ascending by contract id, as
 /// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
 /// greater than `after`. Returns `sorted.len()` when `after` is at or past the
-/// end; [`InterestManager::fallback_window_start`] wraps that back to 0, because
+/// end; [`InterestManager::begin_fallback_window`] wraps that back to 0, because
 /// running off the end is where the rotation's window wraps and NOT by itself a
 /// cycle boundary (#5181 — the boundary is decided by
 /// [`FallbackCursor::advertised_in_cycle`]).
@@ -7367,7 +7566,7 @@ mod tests {
     /// `rotation_window_indices`, which wraps a `len` start back to 0 on its own,
     /// so it cannot see a defect that lives in the resume decision itself — and
     /// it did not. `real_cursor_api_covers_every_contract_from_every_origin`
-    /// drives `fallback_window_start`/`record_fallback_cursor` for that reason;
+    /// drives `begin_fallback_window`/`record_fallback_cursor` for that reason;
     /// `fallback_window_start_randomises_the_cycle_boundary` covers the
     /// boundary behaviour of the production entry point.
     fn rotation_round(
@@ -7394,6 +7593,9 @@ mod tests {
         keys.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
         keys
     }
+
+    /// Mirrors `MAX_FALLBACK_SUMMARIES_PER_REPLY`, which lives in `node.rs`.
+    const LIMIT: usize = 64;
 
     /// The window never exceeds the limit, never exceeds the set, and wraps
     /// past the end rather than returning a short tail.
@@ -7630,38 +7832,186 @@ mod tests {
 
         assert_eq!(mgr.peek_fallback_cursor(peer), None);
 
-        mgr.record_fallback_cursor(peer, *sorted[2].id(), 3);
+        // Seed a cycle beginning at index 1, then charge two rounds against it.
+        mgr.seed_fallback_cycle(peer, &sorted, 1);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[2].id(), 2, LIMIT);
         assert_eq!(
             mgr.peek_fallback_cursor(peer),
             Some(FallbackCursor {
                 last_sent: *sorted[2].id(),
-                advertised_in_cycle: 3,
+                advertised_in_cycle: 2,
             })
         );
         assert_eq!(
-            mgr.fallback_window_start(peer, &sorted),
+            mgr.begin_fallback_window(peer, &sorted),
             3,
             "mid-cycle the resume point must be exactly after the last id sent"
         );
 
         // Successive rounds accumulate against the SAME cycle.
-        mgr.record_fallback_cursor(peer, *sorted[4].id(), 2);
+        mgr.record_fallback_cursor(peer, &sorted, *sorted[4].id(), 2, LIMIT);
         assert_eq!(
             mgr.peek_fallback_cursor(peer)
                 .map(|c| c.advertised_in_cycle),
-            Some(5),
+            Some(4),
             "entries sent must be charged to the running cycle, not replace it"
         );
-        assert_eq!(mgr.fallback_window_start(peer, &sorted), 5);
+        assert_eq!(mgr.begin_fallback_window(peer, &sorted), 5);
 
         // Cursors are per peer: one peer's progress must not advance another's.
         let other: SocketAddr = "127.0.0.1:9101".parse().unwrap();
-        mgr.record_fallback_cursor(other, *sorted[6].id(), 1);
-        assert_eq!(mgr.fallback_window_start(peer, &sorted), 5);
-        assert_eq!(mgr.fallback_window_start(other, &sorted), 7);
+        mgr.seed_fallback_cycle(other, &sorted, 6);
+        mgr.record_fallback_cursor(other, &sorted, *sorted[6].id(), 1, LIMIT);
+        assert_eq!(mgr.begin_fallback_window(peer, &sorted), 5);
+        assert_eq!(mgr.begin_fallback_window(other, &sorted), 7);
+    }
 
-        // An empty shared set has no valid offset; it must not panic or draw.
-        assert_eq!(mgr.fallback_window_start(peer, &[]), 0);
+    /// An empty shared set must not panic or draw.
+    ///
+    /// Pinned separately because the empty check has to stay AHEAD of both the
+    /// lock and any index arithmetic: `random_range(0..0)` panics, and so does
+    /// the origin-predecessor arithmetic in `FallbackCursor::starting_at`. Now
+    /// that the boundary draws and publishes inside the lock, that prologue is
+    /// the thing a future restructuring is most likely to move.
+    #[test]
+    fn fallback_window_start_handles_an_empty_shared_set() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9102".parse().unwrap();
+
+        assert_eq!(mgr.begin_fallback_window(peer, &[]), 0);
+        assert_eq!(
+            mgr.peek_fallback_cursor(peer),
+            None,
+            "an empty set must not publish a cycle"
+        );
+        // And recording against an empty set is a no-op rather than a panic.
+        let sorted = sorted_keys(0..4);
+        mgr.record_fallback_cursor(peer, &[], *sorted[0].id(), 1, LIMIT);
+        assert_eq!(mgr.peek_fallback_cursor(peer), None);
+    }
+
+    /// A record must move the cycle FORWARD, and "forward" is circular.
+    ///
+    /// Four distinct traps live in this one predicate, each of which was reached
+    /// by an actual implementation attempt. All four are pinned here because a
+    /// coverage assertion alone does not distinguish them.
+    #[test]
+    fn records_must_advance_the_cycle_and_forward_is_circular() {
+        const N: usize = 200;
+        const W: usize = 64;
+        let sorted = sorted_keys(0..N as u32);
+        let pos_of = |i: usize| *sorted[i].id();
+
+        // (1) STALE out-of-order record is discarded, and must not rewind.
+        // A and C advance to 127; B's slow reply carrying 63 lands last.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9710".parse().unwrap();
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(127), W, W);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer)
+                    .map(|c| c.advertised_in_cycle),
+                Some(128)
+            );
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer),
+                Some(FallbackCursor {
+                    last_sent: pos_of(127),
+                    advertised_in_cycle: 128,
+                }),
+                "a stale record must be discarded: charging it double-counts the \
+                 cycle AND rewinding re-sends ground already covered"
+            );
+        }
+
+        // (2) An exact DUPLICATE covers no distance and is charged once. No
+        // id-equality special case is needed for this.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9711".parse().unwrap();
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(63), W, W);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer)
+                    .map(|c| c.advertised_in_cycle),
+                Some(64),
+                "two racers building the same window advertised ONE window"
+            );
+        }
+
+        // (3) A window that CROSSES the cycle origin is forward progress, not a
+        // rewind. Measuring distance from the ORIGIN instead of from the
+        // previous position rejects exactly this record, parks `last_sent`, and
+        // wedges the rotation permanently.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9712".parse().unwrap();
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            for end in [63usize, 127, 191] {
+                mgr.record_fallback_cursor(peer, &sorted, pos_of(end), W, W);
+            }
+            // Next window is [192..255] mod 200, ending at index 55 — below the
+            // origin in id order, and only 55 positions past it.
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(55), W, W);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer),
+                Some(FallbackCursor {
+                    last_sent: pos_of(55),
+                    advertised_in_cycle: 256,
+                }),
+                "the round that wraps past the origin must be charged and must \
+                 advance the cursor, or the rotation wedges re-sending it forever"
+            );
+        }
+
+        // (4) Origin 0: the published predecessor is the LAST index, so the
+        // first window's forward distance is len - W, which exceeds one window
+        // and reads as a rewind. The first-record exemption is what saves it —
+        // and a peer can steer the start to 0 every cycle, so this is not a
+        // 1-in-len curiosity.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9713".parse().unwrap();
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            mgr.record_fallback_cursor(peer, &sorted, pos_of(W - 1), W, W);
+            assert_eq!(
+                mgr.peek_fallback_cursor(peer)
+                    .map(|c| c.advertised_in_cycle),
+                Some(W),
+                "the first record of a cycle drawn at origin 0 must be charged; \
+                 rejecting it stalls every cycle a steering peer can force"
+            );
+        }
+
+        // (5) A set no larger than one window is covered by the first round,
+        // which lands back on the origin's predecessor for a distance of zero.
+        // Without the first-record exemption the counter sticks at 0 and the
+        // cycle never completes again.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer: SocketAddr = "127.0.0.1:9714".parse().unwrap();
+            let small = sorted_keys(0..5);
+            let origin = mgr.begin_fallback_window(peer, &small);
+            let last = *small[(origin + small.len() - 1) % small.len()].id();
+            mgr.record_fallback_cursor(peer, &small, last, small.len(), W);
+            let charged = mgr
+                .peek_fallback_cursor(peer)
+                .map(|c| c.advertised_in_cycle)
+                .unwrap();
+            assert_eq!(
+                charged, 5,
+                "a whole-set round must be charged even though it ends where the \
+                 cycle began"
+            );
+            assert!(
+                charged >= small.len(),
+                "and it must therefore complete the cycle"
+            );
+        }
     }
 
     /// At a CYCLE BOUNDARY the start is random, not a fixed 0.
@@ -7691,7 +8041,7 @@ mod tests {
         let mut seen = HashSet::new();
         for i in 0..40u32 {
             let peer: SocketAddr = format!("127.0.0.1:{}", 9200 + i).parse().unwrap();
-            let start = mgr.fallback_window_start(peer, &sorted);
+            let start = mgr.begin_fallback_window(peer, &sorted);
             assert!(start < sorted.len(), "start {start} out of range");
             seen.insert(start);
         }
@@ -7706,8 +8056,9 @@ mod tests {
         let peer: SocketAddr = "127.0.0.1:9300".parse().unwrap();
         let mut seen_completed = HashSet::new();
         for _ in 0..40 {
-            mgr.record_fallback_cursor(peer, *sorted[7].id(), sorted.len());
-            seen_completed.insert(mgr.fallback_window_start(peer, &sorted));
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            mgr.record_fallback_cursor(peer, &sorted, *sorted[7].id(), sorted.len(), LIMIT);
+            seen_completed.insert(mgr.begin_fallback_window(peer, &sorted));
         }
         assert!(
             seen_completed.iter().all(|s| *s < sorted.len()),
@@ -7719,14 +8070,17 @@ mod tests {
              deterministically after the last id sent — got {seen_completed:?}"
         );
 
-        // Reaching the boundary must also clear the count, or the very next
-        // round would read the new cycle as already finished and re-randomise
-        // again — permanently random, never contiguous.
+        // Taking the boundary must PUBLISH the new cycle (so a concurrent second
+        // reply resumes from the same origin instead of drawing its own) with the
+        // count cleared. If the count survived, the very next round would read
+        // the new cycle as already finished and re-randomise again — permanently
+        // random, never contiguous.
+        let published = mgr
+            .peek_fallback_cursor(peer)
+            .expect("the boundary must publish the new cycle under the same lock");
         assert_eq!(
-            mgr.peek_fallback_cursor(peer),
-            None,
-            "the completed cycle's cursor must be dropped when the boundary is \
-             taken, so the next recorded cursor counts from zero"
+            published.advertised_in_cycle, 0,
+            "the published cycle must start with nothing charged"
         );
     }
 
@@ -7760,17 +8114,18 @@ mod tests {
 
             // Mid-cycle by construction: one entry advertised so far, so the
             // cycle is nowhere near the `len` contracts that would finish it.
-            mgr.record_fallback_cursor(peer, highest, 1);
+            mgr.seed_fallback_cycle(peer, &sorted, len - 1);
+            mgr.record_fallback_cursor(peer, &sorted, highest, 1, LIMIT);
             for read in 0..8 {
                 assert_eq!(
-                    mgr.fallback_window_start(peer, &sorted),
+                    mgr.begin_fallback_window(peer, &sorted),
                     0,
                     "len={len} read={read}: a window ending on the highest id \
                      must wrap to 0 and stay contiguous, not restart the cycle \
                      at a random offset (#5181)"
                 );
             }
-            // Reading a mid-cycle wrap must not consume the cursor.
+            // Reading a mid-cycle wrap must not consume or alter the cursor.
             assert_eq!(
                 mgr.peek_fallback_cursor(peer),
                 Some(FallbackCursor {
@@ -7786,8 +8141,8 @@ mod tests {
     ///
     /// `rotation_covers_every_contract_within_ceil_n_over_limit_rounds` above
     /// exercises the pure helpers with a test-local resume rule, which is why it
-    /// stayed green through #5181: the defect lived in `fallback_window_start`,
-    /// between them. This drives `fallback_window_start` and
+    /// stayed green through #5181: the defect lived in `begin_fallback_window`,
+    /// between them. This drives `begin_fallback_window` and
     /// `record_fallback_cursor` themselves and sweeps all `n` origins rather
     /// than sampling five, so the origins whose rounds land on the last index
     /// (`{8, 72, 136}` for n=200, limit=64 — the ones the flake needed to draw)
@@ -7802,16 +8157,15 @@ mod tests {
             for origin in 0..n {
                 let peer: SocketAddr = format!("127.0.0.1:{}", 9500 + origin).parse().unwrap();
                 let (mgr, _clock) = make_manager();
-                // Force round one to begin at `origin` by seeding the cursor on
-                // its predecessor, mid-cycle with nothing yet charged. For
-                // `origin == 0` the predecessor is the LAST id, so origin 0 is
-                // itself the wrap case — a no-cursor seed would have drawn a
-                // random start and could not pin an origin at all.
-                mgr.record_fallback_cursor(peer, *sorted[(origin + n - 1) % n].id(), 0);
+                // Force round one to begin at `origin`, through the SAME cursor
+                // shape a boundary publishes — so this cannot pin a state
+                // production never produces. `origin == 0` is itself the wrap
+                // case, since the published predecessor is then the last id.
+                mgr.seed_fallback_cycle(peer, &sorted, origin);
 
                 let mut covered: HashSet<ContractInstanceId> = HashSet::new();
                 for round in 0..rounds {
-                    let start = mgr.fallback_window_start(peer, &sorted);
+                    let start = mgr.begin_fallback_window(peer, &sorted);
                     if round == 0 {
                         assert_eq!(
                             start, origin,
@@ -7823,7 +8177,7 @@ mod tests {
                     assert!(!window.is_empty(), "n={n} limit={limit}: empty window");
                     covered.extend(window.iter().map(|i| *sorted[*i].id()));
                     let last = *sorted[*window.last().unwrap()].id();
-                    mgr.record_fallback_cursor(peer, last, window.len());
+                    mgr.record_fallback_cursor(peer, &sorted, last, window.len(), limit);
                 }
 
                 let missed = expected.difference(&covered).count();
@@ -7853,40 +8207,180 @@ mod tests {
     ///
     /// Asserting on BOUNDARIES TAKEN rather than on distinct start values,
     /// because distinct values do not discriminate: the shortcut's single
-    /// first-round draw already produces two of them. A dropped cursor is the
-    /// observable proof a new cycle was begun, and under the shortcut it never
-    /// happens.
+    /// first-round draw already produces two of them.
+    ///
+    /// The boundary is observed as the count being reset to zero, NOT as the
+    /// cursor disappearing. Boundaries now re-publish the new cycle under the
+    /// same lock hold (which is what stops two concurrent replies drawing
+    /// different origins), so `peek()` is always `Some` and a
+    /// dropped-cursor probe would count zero boundaries and fail vacuously.
     #[test]
     fn cycles_end_so_the_start_keeps_being_re_randomised() {
         let (mgr, _clock) = make_manager();
         let peer: SocketAddr = "127.0.0.1:9600".parse().unwrap();
         let sorted = sorted_keys(0..64);
-        const LIMIT: usize = 16;
+        const W: usize = 16;
         const ROUNDS: usize = 20;
 
         let mut boundaries = 0usize;
         let mut starts = Vec::new();
         for _ in 0..ROUNDS {
-            let had_cursor = mgr.peek_fallback_cursor(peer).is_some();
-            let start = mgr.fallback_window_start(peer, &sorted);
-            if had_cursor && mgr.peek_fallback_cursor(peer).is_none() {
+            let charged_before = mgr
+                .peek_fallback_cursor(peer)
+                .map(|c| c.advertised_in_cycle);
+            let start = mgr.begin_fallback_window(peer, &sorted);
+            let charged_after = mgr
+                .peek_fallback_cursor(peer)
+                .map(|c| c.advertised_in_cycle);
+            // A fresh cycle was begun: the count went from "something charged"
+            // to zero.
+            if charged_before.is_some_and(|c| c > 0) && charged_after == Some(0) {
                 boundaries += 1;
             }
             starts.push(start);
-            let window = rotation_window_indices(sorted.len(), start, LIMIT);
+            let window = rotation_window_indices(sorted.len(), start, W);
             let last = *sorted[*window.last().unwrap()].id();
-            mgr.record_fallback_cursor(peer, last, window.len());
+            mgr.record_fallback_cursor(peer, &sorted, last, window.len(), W);
         }
 
         // 20 rounds x 16 entries over a 64-contract set is 5 cycles' worth of
         // advertising, so the boundary must have been reached about 4 times.
-        let expected_min = ROUNDS * LIMIT / sorted.len() - 1;
+        // `saturating_sub` so a future edit that shrinks ROUNDS*W cannot turn
+        // this into an arithmetic panic instead of a clear assertion failure.
+        let expected_min = (ROUNDS * W / sorted.len()).saturating_sub(1);
         assert!(
             boundaries >= expected_min,
             "only {boundaries} cycle boundary/ies in {ROUNDS} rounds (expected \
              at least {expected_min}); starts were {starts:?}. A rotation that \
              never reaches a boundary is a deterministic function of the stored \
              id, which a peer steering `sorted` can pin to the head of the set."
+        );
+    }
+
+    /// Contracts INSERTED between the cursor and the window end, between rounds,
+    /// must not make the round look like a stale long-jump.
+    ///
+    /// The upper bound in `record_fallback_cursor` rejects an advance greater
+    /// than one window, which raises a fair worry: if the index distance at
+    /// record time exceeds the entries actually sent, a legitimate round is
+    /// rejected, the cursor parks, and the rotation wedges the same way the
+    /// origin-0 case did. The derivation says it cannot happen, because the
+    /// window is chosen by index in the same snapshot the record is measured
+    /// against, so the distance IS the entry count. This is that derivation
+    /// under test rather than in a comment — every other test in this area
+    /// passes one fixed `sorted` for every round and so cannot see it.
+    ///
+    /// A wedge is permanent while an over-long cycle is bounded, so where this
+    /// rule is uncertain it must err towards ACCEPTING.
+    #[test]
+    fn churn_inside_the_swept_arc_does_not_look_like_a_stale_record() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9900".parse().unwrap();
+        const W: usize = 8;
+
+        // Round 1 over the original set.
+        let before = sorted_keys((0..40).map(|i| i * 4));
+        mgr.seed_fallback_cycle(peer, &before, 0);
+        let start1 = mgr.begin_fallback_window(peer, &before);
+        let w1 = rotation_window_indices(before.len(), start1, W);
+        let last1 = *before[*w1.last().unwrap()].id();
+        mgr.record_fallback_cursor(peer, &before, last1, w1.len(), W);
+        let charged1 = mgr
+            .peek_fallback_cursor(peer)
+            .map(|c| c.advertised_in_cycle);
+        assert_eq!(charged1, Some(W), "premise: round one charged one window");
+
+        // Now insert contracts INTERLEAVED with the original ids, so many of
+        // them land inside the arc round two is about to sweep. Seeds not
+        // divisible by 4 sort between the originals.
+        let after = sorted_keys((0..40).map(|i| i * 4).chain((0..40).map(|i| i * 4 + 1)));
+        assert!(
+            after.len() > before.len(),
+            "premise: the set grew by insertion"
+        );
+
+        // Round two, production-shaped: the SAME grown snapshot is used to pick
+        // the window and to record it.
+        let start2 = mgr.begin_fallback_window(peer, &after);
+        let w2 = rotation_window_indices(after.len(), start2, W);
+        let last2 = *after[*w2.last().unwrap()].id();
+        mgr.record_fallback_cursor(peer, &after, last2, w2.len(), W);
+
+        let cursor = mgr
+            .peek_fallback_cursor(peer)
+            .expect("cursor must still exist");
+        assert_eq!(
+            cursor.last_sent, last2,
+            "a round whose swept arc gained contracts since the last round must \
+             still ADVANCE the cursor. Rejecting it parks the cursor and the \
+             rotation re-sends the same window forever — a permanent wedge, \
+             where wrongly accepting would only lengthen a cycle."
+        );
+        assert_eq!(
+            cursor.advertised_in_cycle,
+            W + w2.len(),
+            "and it must be charged to the cycle"
+        );
+    }
+
+    /// CHARACTERISATION, not an endorsement: with a shared set the peer VARIES
+    /// between rounds, it can pin the window and starve most of the set.
+    ///
+    /// Every other test that drives the real API passes one fixed `sorted` for
+    /// every round, so none of them can see this. It is the anti-steering
+    /// regression described on `begin_fallback_window`: the completion test
+    /// compares the count against `sorted.len()`, and the peer chooses `sorted`.
+    /// A single-hash `Interests` makes `len == 1`, so the cycle completes
+    /// immediately and is re-seeded from an id the peer picked; the full round
+    /// then resumes from there, every time.
+    ///
+    /// Asserting the live behaviour deliberately, so the regression is visible
+    /// in CI rather than only in prose. **When positional completion lands this
+    /// test must be INVERTED** — the starves-most-of-the-set assertion becomes
+    /// the bug, and #5313 is the place that flips it.
+    #[test]
+    fn varying_shared_set_lets_a_peer_pin_the_window_today() {
+        let (mgr, _clock) = make_manager();
+        let peer: SocketAddr = "127.0.0.1:9800".parse().unwrap();
+        let full = sorted_keys(0..200);
+        const W: usize = 64;
+
+        // The peer's steering choice: one hash, the highest id in the set.
+        let single = vec![full[full.len() - 1].clone()];
+
+        let mut full_starts = Vec::new();
+        let mut advertised: HashSet<ContractInstanceId> = HashSet::new();
+        for _ in 0..20 {
+            // Round A: the peer advertises exactly one hash.
+            let a = mgr.begin_fallback_window(peer, &single);
+            let wa = rotation_window_indices(single.len(), a, W);
+            advertised.extend(wa.iter().map(|i| *single[*i].id()));
+            let last_a = *single[*wa.last().unwrap()].id();
+            mgr.record_fallback_cursor(peer, &single, last_a, wa.len(), W);
+
+            // Round B: the peer advertises everything.
+            let b = mgr.begin_fallback_window(peer, &full);
+            full_starts.push(b);
+            let wb = rotation_window_indices(full.len(), b, W);
+            advertised.extend(wb.iter().map(|i| *full[*i].id()));
+            let last_b = *full[*wb.last().unwrap()].id();
+            mgr.record_fallback_cursor(peer, &full, last_b, wb.len(), W);
+        }
+
+        let distinct: HashSet<usize> = full_starts.iter().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            1,
+            "characterisation: the full-round start is currently pinned by the \
+             peer. If this now varies, anti-steering has been RESTORED — invert \
+             this test rather than relaxing it. starts={full_starts:?}"
+        );
+        assert!(
+            advertised.len() < full.len(),
+            "characterisation: pinning the start starves the rest of the set; \
+             advertised {} of {}",
+            advertised.len(),
+            full.len()
         );
     }
 
@@ -7898,11 +8392,11 @@ mod tests {
     /// under the deterministic simulation harness, which would make any
     /// convergence simulation covering this path silently non-deterministic.
     #[test]
-    fn fallback_window_start_draws_its_offset_from_global_rng() {
+    fn begin_fallback_window_draws_its_offset_from_global_rng() {
         let src = include_str!("interest.rs");
         let at = src
-            .find("pub(crate) fn fallback_window_start(")
-            .expect("fallback_window_start not found");
+            .find("pub(crate) fn begin_fallback_window(")
+            .expect("begin_fallback_window not found");
         let body_end = at + src[at..].find("\n    }\n").expect("body end not found");
         let body = &src[at..body_end];
         assert!(

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -8115,11 +8115,22 @@ mod tests {
             );
         }
 
-        // (4) Origin 0: the published predecessor is the LAST index, so the
-        // first window's forward distance is len - W, which exceeds one window
-        // and reads as a rewind. The first-record exemption is what saves it —
-        // and a peer can steer the start to 0 every cycle, so this is not a
-        // 1-in-len curiosity.
+        // (4) Origin 0, the case a peer can steer to every cycle, so worth its
+        // own block even though it turns out to be unremarkable.
+        //
+        // This comment previously claimed the first window's distance was
+        // `len - W`, that this read as a rewind, and that "the first-record
+        // exemption is what saves it". ALL THREE were wrong, and wrong BEFORE the
+        // exemption was deleted rather than orphaned by it. `first_index_after`
+        // returns `len` for the highest id, so the published predecessor resolves
+        // to `prev_pos = len % len = 0` -- the origin itself, which is the whole
+        // point of storing a predecessor. So `advance = W = 64`, which the old
+        // loose bound did not reject either (64 is not > 64), meaning the
+        // exemption was never exercised here at all.
+        //
+        // What this block actually pins is that origin 0 is NOT special: the
+        // wrap in `starting_at` resolves correctly, so the first record is
+        // charged exactly like any other.
         {
             let (mgr, _clock) = make_manager();
             let peer: SocketAddr = "127.0.0.1:9713".parse().unwrap();
@@ -8215,8 +8226,14 @@ mod tests {
 
         // (5) A set no larger than one window is covered by the first round,
         // which lands back on the origin's predecessor for a distance of zero.
-        // Without the first-record exemption the counter sticks at 0 and the
-        // cycle never completes again.
+        //
+        // This described a real dependency on the old code: under the previous
+        // `advance == 0` rejection the counter stuck at 0 and the cycle never
+        // completed again, and the first-record exemption was what avoided it.
+        // Both are gone. `advance != entries_sent % len` accepts this directly,
+        // because a whole-set round has `entries_sent % len == 0` and an advance
+        // of 0. Kept as a pin: it is the FIRST-record form of the whole-set
+        // round, where (5b) above is the mid-cycle form.
         {
             let (mgr, _clock) = make_manager();
             let peer: SocketAddr = "127.0.0.1:9714".parse().unwrap();
@@ -8536,15 +8553,31 @@ mod tests {
             "premise: the cycle is complete, so the next read is a boundary"
         );
 
-        // The boundary is taken and publishes a fresh origin.
-        let fresh_origin = mgr.begin_fallback_window(peer, &sorted);
+        // The boundary is taken and publishes a fresh origin. The origin is drawn
+        // randomly, so it can land on A's own start (1 in `N`) and then nothing
+        // has been straddled. Re-draw until it differs rather than asserting it
+        // does: an `assert_ne!` here would be a ~0.5% false alarm, and shipping a
+        // new flake to close an old one is not a trade this PR should make. The
+        // loop terminates with overwhelming probability -- each attempt is an
+        // independent 1-in-`N` collision -- and `seed_fallback_cycle` re-arms the
+        // completed cycle so every attempt draws afresh.
+        let mut fresh_origin = mgr.begin_fallback_window(peer, &sorted);
+        for _ in 0..64 {
+            if fresh_origin != a_start {
+                break;
+            }
+            mgr.seed_fallback_cycle(peer, &sorted, 0);
+            mgr.record_fallback_cursor(peer, &sorted, *sorted[N - 1].id(), N);
+            fresh_origin = mgr.begin_fallback_window(peer, &sorted);
+        }
         let published = mgr
             .peek_fallback_cursor(peer)
             .expect("a boundary publishes its cycle");
         assert_eq!(published.advertised_in_cycle, 0, "premise: fresh cycle");
         assert_ne!(
             a_start, fresh_origin,
-            "premise: A and the new boundary must differ, or nothing straddled"
+            "premise: 64 draws all collided with A's start, which is a \
+             1-in-{N}^64 event -- the origin is no longer being drawn randomly"
         );
 
         // NOW A records, against the old cycle's window.


### PR DESCRIPTION
## Problem

The full-bytes fallback summary rotation re-randomised its start **mid-cycle**,
breaking the contiguity the `ceil(len / limit)` coverage bound depends on — and
that bound is #5155's cost argument for bounding the reply at all.

`fallback_window_start` decided "cycle boundary" by asking whether
`first_index_after` had run off the end of the set:

```rust
match resumed {
    Some(start) if start < sorted.len() => start,
    _ => crate::config::GlobalRng::random_range(0..sorted.len()),
}
```

`first_index_after` returns `sorted.len()` for **two different** situations, and
the code kept no memory of where the cycle began, so it could not tell them
apart:

- the cursor is genuinely past the end of the set — a real boundary;
- the cursor sits **on the highest id in the set** — a mid-cycle **wrap**, which
  is precisely the wrap the rustdoc's own coverage argument relies on.

Any round whose window ended on index `len - 1` therefore drew a fresh random
origin partway through a cycle. It fires on ~`1/limit` of cycles (~1.6% at the
64-entry cap), independent of set size, so the documented bound is overstated in
shipped code. It surfaced as a ~1-in-200 flake in
`fallback_rotation_covers_the_whole_shared_set`; the test was right and the
production code was wrong.

## Solution

The cursor gains a per-cycle count, so a wrap is distinguishable from a
completed cycle:

```rust
pub(crate) struct FallbackCursor {
    last_sent: ContractInstanceId,
    advertised_in_cycle: usize,
}
```

- no cursor → random origin (first reply, restart, LRU eviction, a peer back on
  a new source port);
- `advertised_in_cycle >= sorted.len()` → cycle genuinely finished → new random
  origin;
- otherwise → `first_index_after(..) % sorted.len()`: wrap to 0, stay contiguous.

**Not** the two-line `Some(start) => start % sorted.len()`. That is contiguous
and satisfies every coverage assertion here, but it re-randomises *once ever* —
on the first reply, before a cursor exists. After that the start is a
deterministic function of an id the peer influences (`sorted` is the intersection
with the hashes *it* advertised), so it can park the cursor at the end of the set
and be handed the head window forever.

Review then found two further ways the count failed to represent coverage. Both
are fixed here rather than documented, because both are #5181's own failure class
— a count running ahead of the ground covered, ending a cycle early.

**The boundary is now atomic.** Drawing the origin without publishing it meant
two concurrent `Interests` from one peer both saw no cursor, drew *different*
origins, and had both entry counts charged to one cycle for two non-contiguous
windows. Replies are separate tasks and each awaits a storage hit per contract,
so straddling a boundary is routine, not exotic. The boundary now draws **and
publishes** under one lock hold, so the second racer resumes from the same
origin. `GlobalRng` is thread-local (`THREAD_RNG`/`THREAD_SEED` are
`thread_local!`), so drawing under the lock cannot deadlock.

It is **not** what fixes the concurrency flake, and the measurements below say so
plainly. It is justified by three other things: not spending a second full window
of uplink on a duplicate (the cost #5155 exists to bound), restoring the
concurrency test's own premise that overlapping replies produce identical
windows, and removing the divergent-origin over-charge at source rather than
relying on divergence happening to look stale downstream. Defence in depth plus a
bandwidth fix.

## The two things to challenge

Both are judgement calls a maintainer may reasonably reject, so they are stated up
front rather than left to be discovered:

1. **The two mechanisms are coupled and must not be partially reverted.** The
   atomic boundary *alone*, without the record check, is measurably worse than
   either complete state. Detail immediately below.
2. **Anti-steering is knowingly weaker than before this PR**, because `main`'s
   mid-cycle re-draw *was* the anti-steering mechanism — a side effect of the very
   bug being fixed. Shipped deliberately, with the regression asserted by a test so
   CI shows it. See *Anti-steering is knowingly WEAKER*.

A third item is not a judgement call but is worth knowing: the record check was
tightened twice during review, and the second tightening (`advance != entries_sent
% len`) also removed a first-record exemption that turned out to be actively wrong.

### These two changes are COUPLED — do not partially revert them

The most important measurement on this PR is that the atomic boundary **on its
own, without the zero-advance rejection, fails 17 of 40 runs** of
`concurrent_interests_from_one_peer_cost_at_most_one_round`, where either state
that HAS the zero-advance rejection fails 0 of 40.

The mechanism: publishing the origin makes concurrent racers **agree**, so they
build **identical** windows *every* time instead of occasionally. That converts
the duplicate charge from intermittent into systematic, and it is exactly what
promotes the dedup path from an incidental guard to a load-bearing one. Two
mechanisms that are individually defensible and **jointly required**.

This is the cell that makes the change unsafe to partially revert. A future reader
who reasons "origins are published now, so racers agree, so the advance check is
redundant" is making a sound-looking argument that lands in the 43%-failure cell.

**So both routes into that cell are pinned by a test that goes red:**

| delete this | test that fails |
|---|---|
| the advance check | `records_must_advance_the_cycle_and_forward_is_circular` |
| the atomic boundary | `a_published_boundary_makes_a_second_reader_agree_on_the_origin` |

Measuring a dangerous cell and pinning both routes into it is the actual safety
argument here, and it is stronger than any comment warning.

**A record must advance the cycle.** A slow reply carrying an earlier window
could record last, both double-charging *and* rewinding `last_sent` so the
rotation re-sent covered ground. A record is now accepted only when it moves
by **exactly the number of entries it sent**, measured circularly from the
previous position: `advance != entries_sent % len` rejects. That subsumes the
duplicate case, so the earlier `prev.last_sent == last_sent` special case is
**deleted** rather than kept alongside it — one rule instead of a rule plus a
patch. An intermediate revision used the looser `1 <= advance <= limit`; review
showed that accepted stale records for every `len <= limit + entries_sent`, which
is the whole population where the byte budget binds. See below.

Three design traps here, each hit by an actual attempt and each pinned by a test,
because a coverage assertion passes under all of them:

- **Circular, not linear.** A legitimate window wraps past the highest id, so its
  last entry can sort *below* the previous one; a linear test calls that a rewind.
- **Relative to the previous position, not the origin.** A window that crosses
  the origin lands a *short* distance after it, so measuring from the origin makes
  the crossing round look like the largest rewind of the cycle. Rejecting it parks
  the cursor and the rotation **wedges permanently** — strictly worse than the
  staleness the check exists to stop.
- **Bounded above by one window.** Forward distance alone cannot separate a short
  hop from a long rewind, since every rewind is forward the long way round.

The first record of a cycle is exempt, which two distinct failures need: a set no
larger than one window is covered by the first round and lands back on the
published predecessor for a distance of zero (sticking the counter at 0 forever),
and an origin drawn at 0 puts the predecessor at the *last* index so the first
window's distance is `len - window` and reads as a rewind. The second is
1-in-`len` by chance but happens every cycle to a steering peer.

### The record check is exactly "is this record well-formed"

The rule is `advance != entries_sent % len`, and the invariant behind it is worth
stating as an invariant rather than a case list: **no well-formed round is ever
rejected.** For a well-formed round the two sides are identically equal —
`advance` is `k` when `k < len`, and `0` when `k == len`, which is `k % len` in
both cases. So there is no `k`, no `len` and no origin for which a genuine reply
is discarded. (Brute force over the shipped rule found rejection only at
`k == len`, which is the weaker claim this supersedes and precisely the wedge the
earlier `advance == 0` arm produced.)

An earlier revision paired that check with an `advertised_in_cycle == 0`
first-record exemption. **It is removed, and removing it was a fix rather than a
cleanup.**

It needed no special case in the first place: `begin_fallback_window` publishes
the origin's *predecessor*, so `first_index_after` resolves it back to the origin,
giving `prev_pos == origin` and `new_pos == origin + k`, hence `advance == k`
exactly. Both failures it was introduced for — a whole-set round landing back on
the predecessor at distance zero, and an origin drawn at 0 — were artefacts of the
looser `advance <= limit` bound it accompanied, and the rule above handles both.
Measured both ways over 3000 × 60 rounds with churn, concurrency and byte-budget
cuts, the two variants produced byte-identical rejection counts. Scope that claim
honestly: the sweep generated windows from a rotating cursor with churn and
budget-driven short reads, so it is dense in partial rounds and does **not**
deliberately construct mid-cycle whole-set rounds. The equivalence holds for that
population; the whole-set shapes are covered by dedicated pins instead (cases 5 and
5b).

**And the tightened rule fixed a live defect, not just a hypothetical one.**
Case 5b is a whole-set round that is *not* a cycle's first record, so the old
exemption could never fire for it, and the old `advance == 0` arm rejected it
unconditionally. So `b295f9ff1` as shipped would silently discard a mid-cycle
whole-set round, sticking the counter below the set size permanently — the origin
never re-drawn for that peer again. 5b is therefore evidence the change repaired
something real, not only a regression pin.

**And it was actively wrong.** A reply that read the old cycle and landed after
another reply took the boundary met `advertised_in_cycle == 0` on the freshly
published cursor and was charged unconditionally — overwriting the origin the
boundary had just drawn with a stale id from the previous cycle. That was
documented as an accepted imprecision costing contiguity for a round. Without the
exemption the straddler is simply not well-formed against the new cycle, so it is
rejected and the published origin survives.

#### Why not to re-add it

Deleting the exemption *does* turn a test red — but that test's fixture recorded
`entries_sent = 64` while naming index 7 as the last id sent, which no real window
produces. **The exemption existed to accommodate an input production cannot
generate.** The general rule is now recorded at the check: when removing a guard
turns a test red, establish that the test's input is reachable before concluding
the guard is needed. Detail in *Review and correction history* below.

### Churn cannot trip the upper bound

Worth stating because it is the obvious worry: the window is built and the cursor
recorded against the **same** `matching` snapshot for one reply, and the window is
chosen by index in that snapshot starting at `prev_pos`. So `new_pos == prev_pos + k`
and `advance == entries_sent` exactly, for any churn since the previous round —
insertions shift both positions together. Rejections are transient in any case,
never a wedge, since the next round's advance is again its own entry count.
`churn_inside_the_swept_arc_does_not_look_like_a_stale_record` tests this rather
than asserting it.

## Three claims in the old docs were wrong, and are corrected rather than softened

1. **"Approximate in the safe direction"** — false. The count can *under*-run a
   cycle, which leaves part of the set unadvertised, which is #5181. Three cases
   are now listed: byte-budget divergence between concurrent replies, churn
   (an id inserted into already-swept ground is indistinguishable from one that
   was advertised), and the peer choosing the length the count is compared to.
2. **The `ceil(len / limit)` bound** holds only for a set **stable across the
   cycle**. Under churn there is **no round bound**. Asserting a bound the code
   does not provide is exactly what #5181 was, so the narrow true statement
   replaces the comfortable one.
3. **Wrapping and randomisation were offered jointly** as the reason nothing is
   starved permanently. Only contiguity-plus-completion does that work;
   randomisation defends a different failure (fixed-restart and peer steering).
   Separated at `interest.rs` and `node.rs` both.

### Anti-steering is knowingly WEAKER than before, and shipped that way

This is the one thing a reviewer should push back on if they disagree. Before the
fix, every round whose resume ran off the end re-randomised — which defeated
steering, but only as a **side effect of the bug itself**, since it also
re-randomised mid-cycle. Restoring the coverage bound necessarily removes that
side effect. `advertised_in_cycle` was meant to replace it and is not sufficient:
completion compares the count against `sorted.len()`, and the peer chooses
`sorted`. Alternating a single-hash `Interests` with a full one makes `len == 1`,
trips completion, and re-seeds the cycle from an id the peer picked.

Measured against compiled code: full-round starts pinned to a single value, with
most of the set never advertised. The exact count is deliberately left to
`varying_shared_set_lets_a_peer_pin_the_window_today` rather than quoted here —
an earlier figure from a pre-boundary commit no longer describes this code, and a
stale number in prose is how the wrong claims on this PR started.

Shipped deliberately because the harm is almost entirely self-inflicted — what
starves is our advertisement to *that peer*, cursors are per-address, and no
other peer's rotation is affected. `varying_shared_set_lets_a_peer_pin_the_window_today`
asserts the live behaviour so the regression is visible in CI rather than only in
prose, with a note that inverting it is part of the fix. The principled fix is
geometric (positional) completion, which also makes a **2-cycle staleness bound**
stateable under churn: **#5313**, which carries the required interface change, the
shrink-guard caveat, and all four traps.

## Testing

The RNG is **not** seeded anywhere. Seeding would pin one origin, turn the
~1-in-200 failure green, and leave the hole unmeasured.

New: `fallback_window_start_wraps_mid_cycle_instead_of_re_randomising`
(constructs the failing state directly over seven set sizes rather than waiting
for chance); `real_cursor_api_covers_every_contract_from_every_origin` (sweeps
**all** `n` origins through the real API for five `(n, limit)` shapes);
`cycles_end_so_the_start_keeps_being_re_randomised`;
`records_must_advance_the_cycle_and_forward_is_circular` (seven cases, including
a small-set `N=40, W=1` case and a mid-cycle whole-set round);
`churn_inside_the_swept_arc_does_not_look_like_a_stale_record`;
`fallback_window_start_handles_an_empty_shared_set`;
`varying_shared_set_lets_a_peer_pin_the_window_today`;
`a_published_boundary_makes_a_second_reader_agree_on_the_origin`;
`a_boundary_straddling_racer_is_rejected_and_the_origin_survives`;
`stale_records_are_counted_as_rejected`.

Changed: `concurrent_interests_from_one_peer_cost_at_most_one_round` now asserts
its own premise (see below) instead of inferring it from a coverage floor.

Test-quality notes worth stating, since several came out of review:

- The pre-existing `rotation_covers_every_contract_within_ceil_n_over_limit_rounds`
  stayed green through this entire bug, because it drives the *pure helpers* with
  a test-local resume rule that wraps on its own. The defect lived in the resume
  decision between them. That limitation is now recorded on the helper.
- `cycles_end_...` observes a boundary as **the count resetting to zero**, not as
  the cursor disappearing. Boundaries now republish, so a dropped-cursor probe
  would count zero boundaries and pass vacuously.
- Cursor seeding goes through the same `FallbackCursor::starting_at` the boundary
  uses, so a test cannot pin a state production never produces.
- Every other test in this area passes one fixed `sorted` for all rounds; the last
  two above are the ones that vary it.

### Red-then-green

Three mutations, each keeping the code compiling so the mutation is behavioural:

**1. The pre-fix boundary rule.** 4 of 5 rotation tests red:

```
real_cursor_api_covers_every_contract_from_every_origin ... FAILED
  n=200 limit=64: premise — round one must begin at the seeded origin: left 147, right 0
cycles_end_so_the_start_keeps_being_re_randomised ... FAILED
  only 0 cycle boundary/ies in 20 rounds (expected at least 4)
fallback_window_start_randomises_the_cycle_boundary ... FAILED
fallback_window_start_wraps_mid_cycle_instead_of_re_randomising ... FAILED
  len=2 read=1: must wrap to 0 ... left 1, right 0
```

**2. The two-line `% len` shortcut.** The two coverage tests pass, because the
shortcut *is* contiguous, and the two anti-steering tests fail. That split is the
point: coverage does not distinguish the shortcut from the fix, so a reviewer who
takes it later gets a red test naming the property they gave up.

**3. The advance check deleted** (atomic boundary kept). Red, and *only* the test
written for it caught it — every coverage test and the concurrency test passed:

```
records_must_advance_the_cycle_and_forward_is_circular ... FAILED
  a stale record must be discarded: charging it double-counts the cycle
  AND rewinding re-sends ground already covered
  left:  FallbackCursor { last_sent: 5Evgj…, advertised_in_cycle: 192 }
  right: FallbackCursor { last_sent: 9Ykn6…, advertised_in_cycle: 128 }
```

Both halves of the defect in one assertion: charged 192 instead of 128, *and* the
cursor rewound.

### Which mechanisms are required, and was the flake introduced

Two questions, two tables, because **they cannot share one.** The premise
assertion lives inside the very test being used as the instrument, and it landed in
`0e2e9cfa0` — the same commit as the original table. So rows taken before it judge a
**coverage floor** while rows taken after judge the **premise**, and those are
different properties. One table with per-row caveats would keep inviting the invalid
comparison; two tables stop it.

An earlier revision of this PR published a single table mixing both, and it was
wrong in the flattering direction — see *Review and correction history*.

#### Was the flake introduced by per-cycle entry counting?

Both rows measured under the **floor-only** test, the only test that existed for
both. `main` cannot be measured under today's test even in principle: restoring
main's two files removes the premise assertion along with the rotation code, since
the assertion is part of what this PR adds.

| state | pass / fail (n=40) | measured by |
|---|---|---|
| pre-PR `main` | 40 / 0 | author and reviewer, independently |
| `65086ec2` (cycle count, no atomic boundary, id-equality dedup) | 8 fail / 40 and 13 fail / 40 | reviewer and author |

`main` clean at 40/0 under the same test that shows `65086ec2` flaking is what
establishes **introduced, not pre-existing**. The two `65086ec2` figures are
independent replications; their 12.5-point spread is ordinary sampling noise at
n=40 (z = 1.27, p = 0.20, overlapping Wilson intervals), so read the rate as
order-of-magnitude only. That is fine here, because the claim needs only
"zero versus substantial", which n=40 supports comfortably (n ≈ 35 suffices for
0% vs 20%).

#### Which mechanisms are required?

All rows measured under the **current** test, which asserts its own premise. Where
a mutation fails, *where* it fails is as informative as the rate.

| zero-advance reject | atomic boundary | pass / fail (n=40) | fails at |
|---|---|---|---|
| yes | yes (**shipped**) | 40 / 0 | — |
| no | yes | 20 pass / 20 fail | COVERAGE assertion (384 of 400) — probabilistic ~50% |
| yes | no | 1 pass / 39 fail | PREMISE assertion at pair 0 — near-deterministic |

**Neither mechanism alone passes.** They are **jointly necessary**, which is a
cleaner claim than the one an earlier revision made ("one does the work, the other
is unrelated") and it is why this change must not be partially reverted.

The load-bearing detail is that they fail **different assertions**, so they defend
different properties and neither substitutes for the other — two mechanisms failing
the *same* assertion would only show redundancy:

- **advance check deleted** → fails the **coverage** assertion (384 of 400
  advertised). Duplicates are charged twice, the counter runs ahead of the ground
  covered, the cycle ends early, an arc goes unadvertised. **Probabilistic**, since
  it needs an interleaving that actually produces a duplicate.
- **boundary deleted** → fails the **premise** assertion at pair 0 (observed
  `starts: Some(387) and Some(257)`). Each racer draws its own origin.
  **Near-deterministic**: two independent draws over 400 contracts satisfy
  "identical or contiguous" only ~0.75% of the time, which is exactly why 1 of 40
  runs passed rather than 0.

That last figure is a property of the **mutation**, not of shipped code — under the
shipped code there is one published origin, so the premise assertion is
deterministic. The only genuine probabilistic assertion in shipped code was the
straddle test's premise at ~0.5%, and it was **hardened rather than documented**:
shipping a new flake to close a 20% one is not a trade this PR makes.

Both extreme cells are 0/40 and 40/40, so no sampling caveat applies to the
joint-necessity claim — unlike the rate comparisons in the first table.

### Mutation 2 did not show what it looked like it showed

Worth recording, because the next person to run it will hit the same trap.
Deleting the atomic boundary leaves the concurrency test green over 40 runs. The
tempting conclusion is "the test does not guard this code." The real reason is
that **the mutation destroyed the test's premise**: without a published origin the
racers build different windows, so `covered` grows *faster* and the
`>= PAIRS * 64` floor is *easier* to clear. The test passed precisely because the
race it exists for stopped happening.

"Mutation applied, still green" therefore has two readings — the test does not
guard the code, or the mutation invalidated the test — and only an explicit
premise assertion separates them. So the concurrency test now **asserts its
premise directly** (the two concurrent replies carried identical windows) instead
of inferring it from a coverage floor.

Because that assertion depends on the scheduler actually overlapping the pair, it
is backed by a deterministic sibling that needs no scheduler at all:
`a_published_boundary_makes_a_second_reader_agree_on_the_origin` — two
`begin_fallback_window` calls with no record between them must return the same
origin, over 40 trials for the random draw. That is the real guard for the
boundary property; the in-situ assertion is the premise check.

Under mutation 1 a wrap is answered by a random draw, so an individual read could
coincidentally return the wrapped value; the tests are built so that cannot
accumulate into a pass (8 reads across 7 set sizes — and in that run the first
`len=2` read *did* land on 0, with `read=1` catching it). `cycles_end_...` is fully
deterministic: pre-fix and shortcut both take exactly 0 boundaries.

`git diff` against the commit is empty after each restore, so no mutation leaked.

### Rates

Each repeat run prints the number of tests its filter matched, so a zero-match run
cannot be read as an all-pass:

- `ring::interest::tests::` — `matched 97 test(s)`, then **30/30** whole-module
  repeats.
- `concurrent_interests_from_one_peer_cost_at_most_one_round` — `matched 1 test(s)`,
  then **40/40**. See the attribution table above; the obvious reading of it is
  wrong.

## Review and correction history

Kept for the record and safe to skip — nothing here changes what the code does.
Several claims in earlier revisions of this PR were wrong and were corrected rather
than quietly dropped; that history is collected here so it does not interleave with
the argument above.

### It existed to accommodate an input production cannot generate

This is the durable reason not to re-add it, and it is stronger than the
equivalence measurement, because the next person will not be reading these
numbers — they will be looking at their own red test after deleting the arm, and
reasoning exactly as I did.

Deleting the exemption *did* turn a test red. But the fixture recorded
`entries_sent = 64` while naming index 7 as the last id sent, and no real window
produces that: 64 entries starting at the origin end on the 64th, not the 8th. The
exemption had been silently accepting an impossible input, so its apparent
load-bearingness was an artefact of the fixture, not of production.

**The general rule, now recorded at the check: when removing a guard turns a test
red, establish that the test's input is reachable in production before concluding
the guard is needed.** An unreachable fixture makes any guard look necessary.

### A premise assertion caught my own test being broken

The straddle test I wrote to cover this failed on its **own premise assertion**,
unmutated: charging the whole set meant the *first* `begin` took the boundary, so
both reads returned origin 155 and nothing straddled. A coverage-only assertion
would have passed, and I would have shipped a test named for a scenario it never
reached — the exact class this review kept finding, caught here by construction
instead of by a reviewer. That is the argument for the pattern, not just for this
instance.

### Gate history, including the part that initially failed

Stated as observed rather than as a clean run, because two of these were first
reported green on an invalid reading.

- **`cargo clippy --all-targets -- -D warnings`: initially FAILED**, on
  `clone_on_copy` — `full[full.len() - 1].clone()` in a test added by this PR,
  where `ContractKey` is `Copy`. It was reported as "clean (exit 0)" twice before
  that, because the command was piped through `tail`, and **`cmd | tail` returns
  `tail`'s exit status**, which is essentially always 0. Piping a gate through a
  filter does not truncate the pass/fail signal, it replaces it. Lint fixed;
  clippy now passes with its own status captured (`CLIPPY_EXIT=0`).
- **`cargo fmt --check`: passes** (`FMT_EXIT=0`). Earlier "fmt clean" claims were
  also unfounded — they came from bare `cargo fmt`, which rewrites files and
  always succeeds, so it can never report a violation. Since a green gate deserves
  the same scepticism as a red one, this was falsifiability-tested rather than
  inspected: injecting `fn _fmt_probe(){let _x=1;}` made it exit 1, and reverting
  restored 0.
- **`cargo test -p freenet --lib`:** passes (`TEST_EXIT=0`) — **4870 passed, 0
  failed, 28 ignored** on the final head. The rotation-focused subset
  (`ring::interest::tests` plus `node::tests::hash_first_summaries`) is **128
  passed, 0 failed**.

Every repeat-count in this PR (the 40/40, 23/17, 60/60, 30/30) was captured from
the test binary's **own** exit status, never through a pipe. Those scripts now also
abort if the filter matches zero tests, since a zero-match run exits 0 and would
otherwise be reported as an all-pass — a failure mode that bit a reviewer on this
very change. Each run prints `matched N test(s)` to prove it.

Provenance of the attribution table: every row was measured by the author against a
compiled binary, with the zero-match guard printing its match count. The `main` and
`65086ec2` rows were additionally measured by a reviewer in a separate session and
worktree, and both figures are reported side by side rather than reconciled.

Closes #5181

[AI-assisted - Claude]
