### PR TITLE
fix(test): make tracing log capture independent of test execution order

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -157,6 +157,39 @@ arms, the INFO-level checks on `MARKER_CHECK_COMPLETE` and
 canary still runs, and still runs before `--draft=false` — is pinned by
 `scripts/release_canary_wiring_test.sh`.
 
+## Cross-test interference through process-global state: CI cannot see it
+
+A guard whose two inputs rot from one cause. Every CI job runs `cargo
+nextest`, which runs each test in its own process, so **no CI job can observe
+a bug in which one test interferes with another through process-global
+state** — there is no shared process for it to happen in. Meanwhile
+`AGENTS.md` tells contributors to run plain `cargo test`, the only runner that
+can expose it. `ci.yml`'s "process isolation handles it (#3051)" describes the
+symptom being absent, not the class being checked, and is exactly the sentence
+that stops a reader investigating. `[profile.ci] retries = 2` is the *smaller*
+half of the gap: it can only launder a failure CI was otherwise able to see.
+
+Generalises past any one library: **any process-global cache whose value is
+decided by whichever thread arrives first** is order-dependent, and
+per-process isolation hides it entirely. Instance ([#4927](https://github.com/freenet/freenet-core/issues/4927),
+fixed in #5314): `tracing` caches each callsite's `Interest` process-globally
+on first touch and resolves it against the *registering* thread's subscriber,
+so a test with no subscriber pinned callsites to `never` and blinded another
+test's thread-local log capture to those callsites only. 29 failures in 1000
+`cargo test -p freenet --lib subscriber_limit_tests` runs across three tests,
+0 in 2000 after the fix, and **unreachable under nextest at any repeat
+count**. `test_utils::TestLogger` still has the same hazard: #5315.
+
+Audit question for any new or changed test: *could this interact with other
+tests through global state* (a static cache, `set_global_default`, an env var,
+a singleton registry, a shared temp path)? If so, run plain `cargo test`
+locally at scale and say so in the PR — a green nextest CI run has not
+examined it. Full guidance, including the fix shape that worked (enough
+permanently-registered dispatchers to defeat the `live <= 1` fast path,
+`Interest::sometimes()` not `always()`, never the global default) and why the
+regression test must run in a child process, is in
+[testing.md](testing.md#cross-test-interference-is-invisible-to-ci--only-plain-cargo-test-can-see-it).
+
 ## Self-satisfying `include_str!` source-scrape pins
 
 A source-scrape pin — a test that `include_str!`s its own crate's source

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -118,6 +118,57 @@ Running specific integration test?
   → Use: cargo test -p freenet --test simulation_integration
 ```
 
+### Cross-test interference is invisible to CI — only plain `cargo test` can see it
+
+Every CI job runs `cargo nextest`, which executes each test in its own
+process. That is deliberate and mostly good (see "Running determinism tests"
+below), but it means **no CI job can observe a bug in which one test
+interferes with another through process-global state** — there is no shared
+process for the interference to happen in. `ci.yml` says "process isolation
+handles it (#3051)", which is true of the symptom and false of the coverage:
+it is blindness, not a guard. `AGENTS.md` tells you to run `cargo test` before
+committing, and that is the only runner that can expose this class.
+
+The mechanism generalises past any one library: **any process-global cache
+whose value is decided by whichever thread arrives first** is order-dependent,
+and per-process isolation hides it completely. The instance that motivated
+this entry (#4927, fixed in #5314): `tracing` caches each callsite's
+`Interest` process-globally on first touch, and resolves it against the
+*registering* thread's subscriber, so a test with no subscriber could pin a
+callsite to `never` and blind another test's thread-local log capture to that
+one callsite. Measured: 29 failures in 1000 `cargo test -p freenet --lib
+subscriber_limit_tests` runs across three tests, 0 in 2000 runs after the fix
+— and **unreachable under `cargo nextest` at any repeat count**.
+
+`[profile.ci] retries = 2` in `.config/nextest.toml` is the *smaller* half of
+this gap: it can only launder a failure CI was otherwise able to see.
+
+```
+WHEN adding or changing a test:
+  Ask: could this interact with other tests through process-global state?
+       (a global/static cache, a `set_global_default`, an env var, a
+        singleton registry, an ambient `tracing`/`log` subscriber, a shared
+        temp path)
+
+  → YES: run plain `cargo test` locally at scale (hundreds of runs of a
+         filter that includes the plausible competitors) and say so in the PR.
+         A green nextest CI run has NOT examined it.
+  → Regression test for such a bug: it must control the interfering
+    population, which usually means a child process (re-exec of the test
+    binary filtered to that one test) — in-process, whether the bug can
+    occur at all depends on what else happens to be running. See
+    `crate::util::test_log_capture` for a worked example, including asserting
+    the child actually ran a test so a rename fails closed.
+```
+
+The fix shape for the `tracing` instance is non-obvious enough to record:
+keep **two** permanently-registered dispatchers alive (`tracing_core`'s
+`has_just_one` fast path triggers at `live <= 1`, so one is not enough),
+report `Interest::sometimes()` rather than `always()` so other subscribers'
+per-event filtering is preserved, and do **not** install as the global
+default — that slot belongs to `test_log`, and taking it silently stops
+`RUST_LOG=… cargo test` printing anything.
+
 ## Reference Patterns
 
 **Time injection:**

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -279,49 +279,19 @@ async fn test_reconnection_does_not_inflate_client_count() {
 /// Install a thread-local `tracing` subscriber that records every event as a
 /// `"<LEVEL> field=value ..."` string. Returns the captured-message buffer and
 /// the default-subscriber guard (drop it to detach the capture).
+///
+/// The mechanics live in [`crate::util::test_log_capture`] because a
+/// thread-local capture alone is order-dependent: a concurrently-running test
+/// that is the first to reach one of the callsites asserted on here can pin its
+/// process-global `tracing` `Interest` to `never`, and the event then never
+/// arrives (#4927). Every test in this file asserting on captured logs depends
+/// on that helper's fix — do not inline a bare `set_default` capture back here.
 #[cfg(feature = "trace")]
 fn install_log_capture() -> (
     std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     tracing::subscriber::DefaultGuard,
 ) {
-    use std::sync::{Arc, Mutex};
-    use tracing_subscriber::Layer;
-    use tracing_subscriber::layer::SubscriberExt;
-
-    #[derive(Default, Clone)]
-    struct Capture(Arc<Mutex<Vec<String>>>);
-    impl<S: tracing::Subscriber> Layer<S> for Capture {
-        fn on_event(
-            &self,
-            event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
-        ) {
-            struct V(String);
-            impl tracing::field::Visit for V {
-                fn record_debug(
-                    &mut self,
-                    field: &tracing::field::Field,
-                    value: &dyn std::fmt::Debug,
-                ) {
-                    use std::fmt::Write;
-                    // Writing into a String is infallible; ignore the Result.
-                    write!(self.0, " {}={value:?}", field.name()).ok();
-                }
-            }
-            let mut v = V(String::new());
-            event.record(&mut v);
-            self.0
-                .lock()
-                .unwrap()
-                .push(format!("{}{}", event.metadata().level(), v.0));
-        }
-    }
-
-    let capture = Capture::default();
-    let messages = capture.0.clone();
-    let subscriber = tracing_subscriber::registry().with(capture);
-    let guard = tracing::subscriber::set_default(subscriber);
-    (messages, guard)
+    crate::util::test_log_capture::install()
 }
 
 /// Re-scope of #4681 by #5040: an ABSENT subscriber entry must NOT warn.

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -147,6 +147,16 @@ impl TestLogger {
     /// When enabled, logs will be stored in memory and can be queried
     /// using `contains()`, `logs()`, etc.
     ///
+    /// Known hazard, shared with every thread-local capture in this crate: the
+    /// capture installed by [`Self::init`] is thread-local, but `tracing`
+    /// caches each callsite's `Interest` **process-globally** the first time any
+    /// thread reaches it. A concurrently-running test that reaches a callsite
+    /// first, from a thread with no subscriber, can pin it to `never` and this
+    /// capture then silently records nothing from it (#4927). Unit tests inside
+    /// the crate should prefer `crate::util::test_log_capture::install`, which
+    /// keeps callsite interest resolvable; this builder cannot use it because
+    /// `test_utils` is also compiled into non-test builds.
+    ///
     /// # Example
     /// ```ignore
     /// let logger = TestLogger::new().capture_logs().init();

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -147,15 +147,20 @@ impl TestLogger {
     /// When enabled, logs will be stored in memory and can be queried
     /// using `contains()`, `logs()`, etc.
     ///
-    /// Known hazard, shared with every thread-local capture in this crate: the
-    /// capture installed by [`Self::init`] is thread-local, but `tracing`
-    /// caches each callsite's `Interest` **process-globally** the first time any
-    /// thread reaches it. A concurrently-running test that reaches a callsite
-    /// first, from a thread with no subscriber, can pin it to `never` and this
-    /// capture then silently records nothing from it (#4927). Unit tests inside
-    /// the crate should prefer `crate::util::test_log_capture::install`, which
-    /// keeps callsite interest resolvable; this builder cannot use it because
-    /// `test_utils` is also compiled into non-test builds.
+    /// Known hazard, tracked in #5315: the capture installed by [`Self::init`]
+    /// is thread-local, but `tracing` caches each callsite's `Interest`
+    /// **process-globally** the first time any thread reaches it. A
+    /// concurrently-running test that reaches a callsite first, from a thread
+    /// with no subscriber, can pin it to `never`, and this capture then
+    /// silently records nothing from that one callsite while recording every
+    /// other one (#4927, fixed for the executor tests by #5314).
+    ///
+    /// Unit tests inside the crate should prefer
+    /// `crate::util::test_log_capture::install`, which keeps callsite interest
+    /// resolvable. This builder cannot use it: that helper is `cfg(test)`
+    /// because it registers process-global `tracing` state, while `test_utils`
+    /// is compiled into non-test builds too. See #5315 for the reachability
+    /// assessment and the candidate fixes.
     ///
     /// # Example
     /// ```ignore

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,6 +1,11 @@
 pub(crate) mod backoff;
 pub mod deterministic_select;
 pub(crate) mod rate_limit_layer;
+/// Order-independent `tracing` capture for tests that assert on emitted events.
+/// Test-only: it registers process-global `tracing` state and must never be
+/// compiled into a shipped binary.
+#[cfg(all(test, feature = "trace"))]
+pub(crate) mod test_log_capture;
 pub(crate) mod time_source;
 pub(crate) mod workspace;
 

--- a/crates/core/src/util/test_log_capture.rs
+++ b/crates/core/src/util/test_log_capture.rs
@@ -1,0 +1,309 @@
+//! Order-independent `tracing` capture for unit tests.
+//!
+//! A test that asserts on emitted `tracing` events installs a capturing
+//! subscriber with [`tracing::subscriber::set_default`], which is **thread
+//! local**: only events emitted inline on the test's own thread are recorded.
+//! That part is fine — libtest gives every test its own thread. What is *not*
+//! fine is that whether an event reaches the capture at all depends on a
+//! **process-global** decision made by whichever thread happens to touch that
+//! event's callsite first.
+//!
+//! # The failure this module exists to prevent (#4927)
+//!
+//! `tracing` caches an [`Interest`] per callsite, once, the first time that
+//! callsite is reached (`tracing_core::callsite::register`). It is never
+//! re-evaluated afterwards unless some thread creates a new `Dispatch` (which
+//! rebuilds the cache for every *already-registered* callsite). Two details of
+//! `tracing_core` 0.1.36 turn that into a cross-test race:
+//!
+//! 1. `Callsites::rebuild_interest` takes a `Rebuilder::JustOne` fast path when
+//!    at most one dispatcher is registered, and that path resolves interest
+//!    against `dispatcher::get_default()` — **the registering thread's**
+//!    dispatcher, not the registered one. A test thread that has installed no
+//!    subscriber resolves to `NoSubscriber`, whose `register_callsite` returns
+//!    [`Interest::never`].
+//! 2. `rebuild_callsite_interest` falls back to `Interest::never()` when no
+//!    dispatcher answers at all.
+//!
+//! So while test A holds a thread-local capture, concurrently-running test B on
+//! another thread can be the first to reach a callsite A asserts on, pin it to
+//! `never` process-wide, and A then observes *nothing* from that callsite — no
+//! matter that its capture is installed and working for every other callsite.
+//! The symptom is an assertion failure whose "captured:" list holds a
+//! *different subset* of the expected events on each run, at roughly 1% per run
+//! locally. It cannot be fixed by re-running, and `cargo nextest --profile ci`
+//! (`retries = 2`) absorbs it, so CI never sees it.
+//!
+//! A third variant of the same root cause: `#[test_log::test]` (used widely in
+//! this crate) installs a **global** default subscriber filtered at `INFO`.
+//! Once it exists, a `DEBUG` callsite first reached from a thread with no
+//! scoped subscriber resolves against that `INFO` filter and is likewise pinned
+//! to `never`, and the global max-level hint drops to `INFO`.
+//!
+//! # The fix
+//!
+//! Keep two permanently-registered, never-defaulted [`InterestKeeper`]
+//! dispatchers alive for the life of the test process. They report interest in
+//! every callsite and are enabled for none, which removes every route to a
+//! cached `never`:
+//!
+//! * With two of them always live, the registered-dispatcher count is never
+//!   `<= 1`, so `Rebuilder::JustOne` is never taken again and interest is
+//!   always resolved against the **full set** of live dispatchers — which
+//!   includes the per-test capture.
+//! * `Interest::and` of differing kinds is `sometimes`, so the combination is
+//!   at worst `sometimes`: enabled-ness is then decided per event against the
+//!   *emitting thread's* dispatcher, which is exactly the correct behaviour for
+//!   both the capture and every filtered subscriber in the binary.
+//! * Their absent max-level hint keeps the global max level at `TRACE`, so
+//!   `test_log`'s `INFO` global cannot compile out `DEBUG` capture.
+//!
+//! Two keepers rather than one is load-bearing: `has_just_one` is
+//! `live_dispatchers <= 1`, so a single keeper would still leave the
+//! `JustOne` path armed whenever it is the only live dispatcher. Do not
+//! "simplify" this to one.
+//!
+//! The keepers are never installed as the *global default*, deliberately:
+//! taking that slot would make `test_log`'s `try_init()` fail and silently stop
+//! `RUST_LOG=... cargo test` from printing anything.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tracing::subscriber::DefaultGuard;
+
+/// Formatted events recorded by an installed capture, newest last.
+pub(crate) type CapturedLogs = Arc<Mutex<Vec<String>>>;
+
+/// A subscriber that is interested in every callsite and enabled for none.
+///
+/// It exists purely to keep callsite `Interest` resolvable; it is never set as
+/// any thread's (or the process's) default, so its `enabled` is only ever
+/// consulted if some future change does install it — in which case answering
+/// `false` keeps it inert.
+struct InterestKeeper;
+
+impl tracing::Subscriber for InterestKeeper {
+    fn register_callsite(
+        &self,
+        _: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        // NOT `always`: `always` tells `tracing` that no per-event `enabled`
+        // check is needed, which would bypass other subscribers' filters when
+        // this interest wins the `Interest::and` combination. `sometimes` keeps
+        // every subscriber's own filtering intact.
+        tracing::subscriber::Interest::sometimes()
+    }
+
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        false
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+    fn event(&self, _: &tracing::Event<'_>) {}
+
+    fn enter(&self, _: &tracing::span::Id) {}
+
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Register (and keep alive forever) the two interest keepers, then re-resolve
+/// every callsite already cached — an earlier test may have pinned one to
+/// `never` before the keepers existed.
+fn ensure_interest_keepers() {
+    static KEEPERS: OnceLock<[tracing::Dispatch; 2]> = OnceLock::new();
+    KEEPERS.get_or_init(|| {
+        // Creating a `Dispatch` is what registers it with the callsite
+        // registry (`tracing_core::dispatcher::Dispatch::new` ->
+        // `callsite::register_dispatch`). Holding them in this `OnceLock` is
+        // what keeps the registry's `Weak`s upgradeable for the whole process.
+        let keepers = [
+            tracing::Dispatch::new(InterestKeeper),
+            tracing::Dispatch::new(InterestKeeper),
+        ];
+        tracing::callsite::rebuild_interest_cache();
+        keepers
+    });
+}
+
+/// Install a thread-local capture that records every event reaching this thread
+/// as a `"<LEVEL> field=value ..."` string.
+///
+/// Returns the buffer and the subscriber guard; drop the guard to detach the
+/// capture (dropping it before reading the buffer also guarantees no further
+/// writes race the assertions).
+pub(crate) fn install() -> (CapturedLogs, DefaultGuard) {
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[derive(Default, Clone)]
+    struct Capture(CapturedLogs);
+    impl<S: tracing::Subscriber> Layer<S> for Capture {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            struct V(String);
+            impl tracing::field::Visit for V {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    use std::fmt::Write;
+                    // Writing into a String is infallible; ignore the Result.
+                    write!(self.0, " {}={value:?}", field.name()).ok();
+                }
+            }
+            let mut v = V(String::new());
+            event.record(&mut v);
+            self.0
+                .lock()
+                .unwrap()
+                .push(format!("{}{}", event.metadata().level(), v.0));
+        }
+    }
+
+    // MUST precede the capture: the keepers' registration is what stops a
+    // concurrent thread from pinning a callsite this capture needs to `never`.
+    ensure_interest_keepers();
+
+    let capture = Capture::default();
+    let messages = capture.0.clone();
+    let subscriber = tracing_subscriber::registry().with(capture);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (messages, guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canary callsite for the regression test below. Reached from nowhere
+    /// else, so the test controls which thread registers it first.
+    fn emit_canary() {
+        tracing::error!(phase = "log_capture_canary", "log capture canary");
+    }
+
+    const CHILD_ENV: &str = "FREENET_LOG_CAPTURE_CANARY_CHILD";
+    const CHILD_TEST: &str =
+        "util::test_log_capture::tests::callsite_first_reached_by_another_thread_is_still_captured";
+
+    /// Regression test for #4927: an event must reach the capture even when its
+    /// callsite was first reached by a *different*, subscriber-less thread
+    /// while the capture was installed.
+    ///
+    /// This runs its assertions in a **child process** (a re-exec of the test
+    /// binary filtered to this one test) on purpose. In-process the outcome
+    /// depends on how many other dispatchers happen to be alive — any second
+    /// live dispatcher disarms `tracing`'s `JustOne` path and the bug hides. A
+    /// child that runs this test alone has a known dispatcher population, so
+    /// the check is deterministic in both directions: it fails every time if
+    /// `ensure_interest_keepers` is removed from `install`, and passes every
+    /// time with it.
+    #[test]
+    fn callsite_first_reached_by_another_thread_is_still_captured() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let (messages, guard) = install();
+
+            // First touch of the canary callsite happens here, on a thread with
+            // no subscriber of its own. Without the interest keepers this pins
+            // the callsite's process-global Interest to `never`, and the
+            // emission below is dropped before it can reach the capture.
+            std::thread::spawn(emit_canary)
+                .join()
+                .expect("canary thread panicked");
+
+            emit_canary();
+            drop(guard);
+
+            let logs = messages.lock().unwrap();
+            let seen = logs
+                .iter()
+                .filter(|l| l.contains("log capture canary"))
+                .count();
+            assert_eq!(
+                seen, 1,
+                "the capture must record the emission on its own thread (and only \
+                 that one) even though another thread registered the callsite \
+                 first; captured: {logs:?}"
+            );
+            return;
+        }
+
+        let exe = std::env::current_exe().expect("test binary path");
+        let output = std::process::Command::new(exe)
+            .args(["--exact", "--test-threads=1", "--nocapture", CHILD_TEST])
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("re-exec the test binary");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "child run of {CHILD_TEST} failed.\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        );
+        // Fail CLOSED on a rename: libtest exits 0 when its filter matches
+        // nothing, so without this the whole regression check would silently
+        // become vacuous the moment this function is renamed.
+        assert!(
+            stdout.contains("1 passed"),
+            "the child must actually have run {CHILD_TEST} — if this function was \
+             renamed, update CHILD_TEST.\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        );
+    }
+
+    /// `always` would let this keeper's interest suppress other subscribers'
+    /// per-event filtering (see `register_callsite`), and `never` would
+    /// reinstate the bug outright. Probed against a real callsite's metadata,
+    /// grabbed from a live event rather than synthesised.
+    #[test]
+    fn interest_keeper_is_interested_in_every_callsite_but_enabled_for_none() {
+        use tracing::Subscriber;
+        use tracing_subscriber::Layer;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        static META: OnceLock<&'static tracing::Metadata<'static>> = OnceLock::new();
+
+        struct Grab;
+        impl<S: tracing::Subscriber> Layer<S> for Grab {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if META.set(event.metadata()).is_err() {
+                    // The first event wins; later ones have nothing to add.
+                }
+            }
+        }
+
+        // This test captures an event itself, so it needs the same protection
+        // `install` gives its callers — otherwise it is flaky in exactly the
+        // way this module exists to prevent.
+        ensure_interest_keepers();
+
+        let guard = tracing::subscriber::set_default(tracing_subscriber::registry().with(Grab));
+        emit_canary();
+        drop(guard);
+
+        let meta = *META
+            .get()
+            .expect("the canary event must reach the grabbing layer");
+        assert!(
+            InterestKeeper.register_callsite(meta).is_sometimes(),
+            "the keeper must report `sometimes` so per-event filtering is preserved"
+        );
+        assert!(
+            !InterestKeeper.enabled(meta),
+            "the keeper must never enable a callsite for itself"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`contract::executor::pool_tests::subscriber_limit_tests::closed_subscriber_channel_drops_entry_at_point_of_loss` fails in a full `cargo test -p freenet --lib` run and passes in isolation. Measured on `main`: **29 failures in 1000 runs** of `cargo test -p freenet --lib subscriber_limit_tests` (2.9%), of which **10 were this test** (1.0%), failing with `left: 0` — the ERROR emitted at the point of loss never reached the capture. Two siblings in the same file fail the same way (`..._local`, `send_update_notification_absent_local_snapshot_does_not_warn`), and #4927 reported a fourth.

The code under test is correct. The capture was losing events, and the loss is **order-dependent, per-callsite, and permanent for the process**:

`install_log_capture` installed its capture with `tracing::subscriber::set_default`, which is thread-local. But whether an event reaches such a capture is decided **process-globally, once**, by whichever thread first touches that event's callsite (`tracing_core` 0.1.36):

* `Callsites::rebuild_interest` takes a `Rebuilder::JustOne` fast path whenever at most one dispatcher is registered, and that path resolves interest against `dispatcher::get_default()` — the **registering** thread's dispatcher, not the registered one. A test thread with no subscriber of its own resolves to `NoSubscriber`, whose `register_callsite` returns `Interest::never()`.
* `rebuild_callsite_interest` also falls back to `Interest::never()` when no dispatcher answers at all, and cached interest is never re-evaluated unless some thread creates a new `Dispatch`.

So a concurrently-running test that reached one of the asserted callsites first pinned it to `never` for the rest of the process; the capturing test then saw nothing from *that* callsite while faithfully recording every other one. That is exactly the observed signature — the "captured:" list in each failure holds a *different subset* of the expected events. `partial_failure_prunes_only_the_dead_subscriber_shared` in the same file reaches the same closed-channel `error!` callsite with no capture installed, and is one such competitor.

A third route to the same end, worth naming because it is crate-wide: `#[test_log::test]` (used widely here) installs a **global** default subscriber filtered at INFO, so a DEBUG callsite first reached from a subscriber-less thread resolves against that filter and is pinned to `never` too, and the global max-level hint drops to INFO.

**CI cannot see this class at all.** Every CI job runs `cargo nextest`, which executes each test in its own process — there is no cross-test interference to observe (`ci.yml` says as much: "process isolation handles it (#3051)"). And `[profile.ci] retries = 2` in `.config/nextest.toml` would absorb a one-off failure anyway; no override exempts these tests. The flake is only reachable via `cargo test`, which is what `AGENTS.md` tells contributors to run before committing. Closing that gap generally is out of scope here; the new regression test below is deterministic under **both** runners, so this specific class is now guarded in CI.

## Solution

The capture moves to `crate::util::test_log_capture` (test-only, `#[cfg(all(test, feature = "trace"))]`), which keeps **two** permanently-registered, never-defaulted `InterestKeeper` dispatchers alive for the life of the process. They report `Interest::sometimes()` for every callsite and are enabled for none, which removes every route to a cached `never`:

* Two of them means the live-dispatcher count is never `<= 1`, so the `JustOne` path is never taken again and interest is always resolved against the **full live set** — which includes the per-test capture. One keeper would still leave that path armed whenever it was the only live dispatcher.
* `sometimes` rather than `always` keeps per-event `enabled` checks, so no other subscriber's filtering is bypassed when this interest wins the `Interest::and` combination.
* Their absent max-level hint keeps the global max level at TRACE, so `test_log`'s INFO global cannot compile out DEBUG capture.

They are deliberately **not** installed as the global default: taking that slot would make `test_log`'s `try_init()` fail and silently stop `RUST_LOG=... cargo test` from printing anything.

`install_log_capture` is now a one-line delegate, with a comment explaining why the plumbing may not be inlined back. `TestLogger::capture_logs` in `test_utils.rs` has the same latent hazard and now carries a note pointing here; it cannot use the helper because `test_utils` is compiled into non-test builds too.

## Testing

* `callsite_first_reached_by_another_thread_is_still_captured` reproduces the mechanism: a fresh canary callsite is first reached from a spawned, subscriber-less thread while the capture is installed, then emitted on the capture's own thread. It runs its assertions in a **child process** (re-exec of the test binary filtered to that one test) on purpose — in-process, any second live dispatcher disarms the `JustOne` path and the bug hides, so the population has to be known. **Mutation-verified**: with `ensure_interest_keepers()` removed from `install`, the child fails every time (`captured: []`, `left: 0 right: 1`); with it, it passes every time. It fails closed on a rename by asserting the child actually ran a test.
* `interest_keeper_is_interested_in_every_callsite_but_enabled_for_none` pins the `sometimes`/not-enabled contract against a real callsite's metadata (grabbed from a live event, not synthesised), so a future "simplification" to `always` or `never` is caught.
* Reproduction rate: **29/1000 before → 0/1000 after** (`cargo test -p freenet --lib subscriber_limit_tests`, 1000 runs each), plus 0 failures across 1000 further module runs and a wider `contract::executor` loop that had failed 2/200 before.
* Full `cargo test -p freenet --lib`: 4862 passed, 0 failed (multiple runs). No measurable runtime change.
* `cargo fmt --check` and `cargo clippy -p freenet --lib --all-targets -- -D warnings` clean. New tests pass under `cargo nextest` too.

Fixes #4927

[AI-assisted - Claude]
