### PR TITLE
fix: bound peer memory at the 2 GiB cap — module-cache keying, Store arena, cache composition

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4,6 +4,7 @@ use std::{
     future::Future,
     io::{Read, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, atomic::AtomicBool},
     time::Duration,
@@ -1744,6 +1745,35 @@ pub struct Config {
 /// Default graceful-shutdown drain window.
 fn default_shutdown_drain_secs() -> u64 {
     30
+}
+
+/// Number of `Executor<Runtime>` workers the `RuntimePool` runs.
+///
+/// Reserve one logical core for the Tokio event loop and OS scheduling. WASM
+/// execution is CPU-bound, so the pool naturally can't exceed useful
+/// parallelism. Capped at 16 to stay well within the max_blocking_threads limit
+/// (see [`default_max_blocking_threads`]), preventing the executor pool from
+/// exhausting the blocking pool. `FREENET_RUNTIME_POOL_SIZE` overrides it
+/// (useful for tests).
+///
+/// This is CPU-derived, and `MemoryMax` does not constrain CPU count — a 20-core
+/// laptop inside a 2 GiB cgroup gets 16 workers. Anything sized PER WORKER must
+/// therefore compose its ceiling against the memory limit rather than assume the
+/// product is affordable (#5268 defect 3), which is why this lives here as one
+/// shared source: `RuntimePool::new` sizes the pool from it and the per-worker
+/// cache budgets divide by it.
+pub(crate) fn runtime_pool_size() -> NonZeroUsize {
+    const MAX_POOL_SIZE: usize = 16;
+    let parallelism = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .saturating_sub(1)
+        .max(1);
+    std::env::var("FREENET_RUNTIME_POOL_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .and_then(|n| NonZeroUsize::new(n.clamp(1, MAX_POOL_SIZE)))
+        .unwrap_or_else(|| NonZeroUsize::new(parallelism.clamp(1, MAX_POOL_SIZE)).unwrap())
 }
 
 /// Default max blocking threads: 2x CPU cores, clamped to 4-32.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1763,17 +1763,36 @@ fn default_shutdown_drain_secs() -> u64 {
 /// shared source: `RuntimePool::new` sizes the pool from it and the per-worker
 /// cache budgets divide by it.
 pub(crate) fn runtime_pool_size() -> NonZeroUsize {
-    const MAX_POOL_SIZE: usize = 16;
-    let parallelism = std::thread::available_parallelism()
-        .map(|n| n.get())
+    let cores = std::thread::available_parallelism().map(|n| n.get()).ok();
+    let override_value = std::env::var(RUNTIME_POOL_SIZE_ENV)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok());
+    resolve_pool_size(cores, override_value)
+}
+
+/// Env var overriding [`runtime_pool_size`] (useful for tests).
+const RUNTIME_POOL_SIZE_ENV: &str = "FREENET_RUNTIME_POOL_SIZE";
+
+/// Upper bound on the executor pool, keeping it well within
+/// [`default_max_blocking_threads`].
+const MAX_RUNTIME_POOL_SIZE: usize = 16;
+
+/// Pure clamp math behind [`runtime_pool_size`], split out so its boundaries are
+/// unit-testable without mutating the process-global environment (which would
+/// race every other test in the binary) or depending on the test host's core
+/// count.
+///
+/// `cores` is `None` when the OS cannot report parallelism; `override_value` is
+/// the parsed env var when set.
+fn resolve_pool_size(cores: Option<usize>, override_value: Option<usize>) -> NonZeroUsize {
+    let from_cores = cores
         .unwrap_or(4)
         .saturating_sub(1)
-        .max(1);
-    std::env::var("FREENET_RUNTIME_POOL_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .and_then(|n| NonZeroUsize::new(n.clamp(1, MAX_POOL_SIZE)))
-        .unwrap_or_else(|| NonZeroUsize::new(parallelism.clamp(1, MAX_POOL_SIZE)).unwrap())
+        .clamp(1, MAX_RUNTIME_POOL_SIZE);
+    let resolved = override_value
+        .map(|n| n.clamp(1, MAX_RUNTIME_POOL_SIZE))
+        .unwrap_or(from_cores);
+    NonZeroUsize::new(resolved).expect("clamped to at least 1")
 }
 
 /// Default max blocking threads: 2x CPU cores, clamped to 4-32.
@@ -5263,6 +5282,37 @@ mod tests {
     use crate::transport::TransportKeypair;
 
     use super::*;
+
+    /// The pool size is the multiplier in every per-worker memory budget
+    /// (#5268 defect 3), so its clamp boundaries are load-bearing, not cosmetic:
+    /// the divisor the budgets use and the count the pool actually creates come
+    /// from this one function, and a mismatch between them WAS the defect.
+    ///
+    /// Exercised through the pure `resolve_pool_size` rather than the env-reading
+    /// wrapper: `FREENET_RUNTIME_POOL_SIZE` is process-global, so a test that set
+    /// it would race every other test in the binary.
+    #[test]
+    fn runtime_pool_size_clamps_cores_and_override() {
+        let size = |cores, over| resolve_pool_size(cores, over).get();
+
+        // One core is reserved for the event loop and OS scheduling.
+        assert_eq!(size(Some(20), None), 16, "capped at MAX");
+        assert_eq!(size(Some(17), None), 16, "exactly at MAX after the reserve");
+        assert_eq!(size(Some(8), None), 7);
+        assert_eq!(size(Some(2), None), 1, "vega's shape: 2 cores -> 1 worker");
+        // Never zero, however few cores are reported.
+        assert_eq!(size(Some(1), None), 1);
+        assert_eq!(size(Some(0), None), 1);
+        // Unknown parallelism falls back to a 4-core assumption.
+        assert_eq!(size(None, None), 3);
+
+        // The override wins, and is clamped the same way — a hostile or fat-
+        // fingered value must not multiply the per-worker budgets past MAX.
+        assert_eq!(size(Some(20), Some(1)), 1);
+        assert_eq!(size(Some(2), Some(16)), 16);
+        assert_eq!(size(Some(2), Some(9_999)), 16);
+        assert_eq!(size(Some(20), Some(0)), 1, "zero clamps up, never panics");
+    }
 
     // ---------------------------------------------------------------------
     // #5124 — `config.toml` key convention.

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -29,8 +29,7 @@ use crate::node::OpManager;
 use crate::operations::get::GetResult;
 use crate::wasm_runtime::{
     ContractRuntimeInterface, ContractStore, DelegateRuntimeInterface, DelegateStore, Runtime,
-    SecretsStore, SharedContractIndex, StateStorage, StateStore, StateStoreError,
-    UserSecretContext,
+    SecretsStore, SharedStores, StateStorage, StateStore, StateStoreError, UserSecretContext,
 };
 use crate::{
     client_events::{ClientId, HostResult},
@@ -1226,11 +1225,18 @@ const SUMMARY_CACHE_RAM_DIVISOR: usize = 64;
 /// a small node — so the count target (coverage) binds, never this floor.
 const SUMMARY_CACHE_MIN_BYTES: usize = 16 * 1024 * 1024;
 
-/// Upper clamp for the summary-cache byte budget (32 MiB). At the ~512 B floor
-/// this holds ~65k small summaries (≈ the count MAX), so coverage still holds at
-/// the count cap for small digests; a large-summary contract instead evicts down
-/// to whatever fits in 32 MiB. Per-executor × up to 16 pool workers → ≤ 512 MiB
-/// aggregate summary-cache RAM.
+/// Upper clamp for the summary-cache byte budget (32 MiB), which binds on a host
+/// with room for it: an unconstrained gateway, or any node whose pool is small
+/// enough that the envelope share is wider. At the ~512 B floor 32 MiB holds
+/// ~65k small summaries (≈ the count MAX), so coverage holds at the count cap for
+/// small digests; a large-summary contract instead evicts down to what fits.
+///
+/// This is a CEILING, not the resolved budget. On a memory-constrained many-core
+/// host `summary_budget_for` composes it down to a share of the node-wide
+/// envelope (#5268 defect 3): a 2 GiB peer with 16 workers resolves to ~5 MiB,
+/// which at the entry floor still holds ~10k small summaries. `pool_size ×
+/// (summary + delta)` is what the node actually commits, and that product is
+/// what `cache_byte_budgets_are_aggregate_safe` bounds.
 const SUMMARY_CACHE_MAX_BYTES: usize = 32 * 1024 * 1024;
 
 /// Fraction of "memory the node may use" that sizes the per-executor DELTA cache
@@ -1246,18 +1252,17 @@ const DELTA_CACHE_RAM_DIVISOR: usize = 16;
 const DELTA_CACHE_MIN_BYTES: usize = 8 * 1024 * 1024;
 
 /// Upper clamp for the delta-cache byte budget (64 MiB). Matches PR #4794's
-/// ceiling. Per-executor × up to 16 pool workers → ≤ 1 GiB aggregate delta-cache
-/// RAM. Combined with the summary cache (≤ 512 MiB aggregate) and the shared
-/// module cache (RAM/8, absolute max 4 GiB — but the divisor binds well below
-/// that on typical gateways: ~950 MiB on a 7.6 GiB box) the total cache
-/// commitment stays a safe fraction of a production gateway's memory (see
-/// `cache_byte_budgets_are_aggregate_safe`, which models the RAM-scaled budget
-/// rather than the absolute max). NOTE: this budget is PER-EXECUTOR; aggregate RAM is
-/// `pool_size × (summary_budget + delta_budget)`, not a single node-wide figure.
-/// `pool_size` tracks CPU count (core count), so a RAM-scaled per-executor budget
-/// is multiplied by cores: on an exotic high-core/low-RAM box the aggregate is a
-/// larger fraction of that box's RAM; production gateways have modest core counts
-/// and stay safe (asserted by `cache_byte_budgets_are_aggregate_safe`).
+/// ceiling.
+///
+/// Like [`SUMMARY_CACHE_MAX_BYTES`] this is a CEILING, not the resolved budget:
+/// it binds where the node has room for it, and `delta_budget_for` composes it
+/// down to a share of the node-wide envelope otherwise (#5268 defect 3). The
+/// budget is PER-EXECUTOR and `pool_size` tracks CPU COUNT, which `MemoryMax`
+/// does not constrain — multiplying a RAM-scaled per-executor budget by cores is
+/// exactly how a 2 GiB peer ended up declaring 1.5 GiB of summary+delta ceiling.
+/// `cache_byte_budgets_are_aggregate_safe` bounds the product, together with the
+/// module caches, the redb page cache, the Store arenas and the source-byte
+/// caches, on both a 2 GiB peer and a production gateway.
 const DELTA_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
 
 /// Per-executor SUMMARY-cache byte budget, scaled to the memory the node may use
@@ -1345,6 +1350,16 @@ const SUMMARY_CACHE_ENVELOPE_SHARE: (usize, usize) = (1, 3);
 
 /// Delta's share of a worker's envelope slice — the remaining two thirds.
 const DELTA_CACHE_ENVELOPE_SHARE: (usize, usize) = (2, 3);
+
+/// Byte ceiling for each of the two source-WASM caches (`ContractStore`'s and
+/// `DelegateStore`'s), which memoize the raw `.wasm` bytes read off disk.
+///
+/// Node-wide, not per-executor: pool executors share one cache each (see
+/// [`SharedStores`]). Before #5268 each executor built its own, so the node's
+/// real commitment was `pool_size × 10 MiB` per cache — 320 MiB across both at
+/// 16 workers, holding up to 16 copies of the same bytes, and counted by no
+/// budget anywhere.
+pub(crate) const SOURCE_CODE_CACHE_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Hard floor for either cache's byte budget once the envelope has been applied.
 ///
@@ -1666,20 +1681,41 @@ where
     pub(crate) fn get_runtime_stores(
         config: &Config,
         db: Storage,
-        shared_contract_index: Option<SharedContractIndex>,
+        shared: Option<SharedStores>,
     ) -> Result<(ContractStore, DelegateStore, SecretsStore), anyhow::Error> {
-        const MAX_SIZE: u64 = 10 * 1024 * 1024;
-
-        let contract_store = match shared_contract_index {
-            Some(index) => ContractStore::new_with_shared_index(
-                config.contracts_dir(),
-                MAX_SIZE,
-                db.clone(),
-                index,
-            )?,
-            None => ContractStore::new(config.contracts_dir(), MAX_SIZE, db.clone())?,
+        let (contract_store, delegate_store) = match shared {
+            // Pool executors: adopt the node's shared indexes AND byte caches, so
+            // one contract/delegate registered anywhere is visible everywhere and
+            // the node holds ONE copy of each WASM blob rather than `pool_size`
+            // copies (#4218 for the index, #5268 for the byte cache).
+            Some(shared) => (
+                ContractStore::new_with_shared(
+                    config.contracts_dir(),
+                    db.clone(),
+                    shared.contract_index,
+                    shared.contract_code,
+                )?,
+                DelegateStore::new_with_shared(
+                    config.delegates_dir(),
+                    db.clone(),
+                    shared.delegate_index,
+                    shared.delegate_code,
+                )?,
+            ),
+            // Standalone / mock executors own their state.
+            None => (
+                ContractStore::new(
+                    config.contracts_dir(),
+                    SOURCE_CODE_CACHE_MAX_BYTES,
+                    db.clone(),
+                )?,
+                DelegateStore::new(
+                    config.delegates_dir(),
+                    SOURCE_CODE_CACHE_MAX_BYTES,
+                    db.clone(),
+                )?,
+            ),
         };
-        let delegate_store = DelegateStore::new(config.delegates_dir(), MAX_SIZE, db.clone())?;
         // Thread the operator-configured per-user secret quota (#4561, P5 of
         // #4381) into the store at construction. `0` = disabled (the default).
         // Every pooled executor passes the SAME limit (same Config), while the
@@ -1983,16 +2019,32 @@ mod tests {
     /// (MAX-clamp safety on a >32 GiB host is guarded separately by
     /// `module_cache::tests::max_clamp_combined_ceiling_is_safe_at_binding_host`.)
     fn declared_cache_ceiling(memory_limit: usize, pool_size: usize) -> usize {
+        // PER-EXECUTOR — multiplied by the pool.
         let summary = summary_budget_for(memory_limit, pool_size);
         let delta = delta_budget_for(memory_limit, pool_size);
+        // One wasmtime Store per executor, each holding retired-instance bytes up
+        // to its arena budget between refreshes. Also per-executor, and added by
+        // this PR — it has to be in the sum it introduced.
+        let arena = crate::wasm_runtime::engine::store_arena_budget_for(memory_limit, pool_size);
+
+        // NODE-WIDE — one of each, shared by every executor.
         let contract_modules = crate::wasm_runtime::budget_for_ram(memory_limit);
         let delegate_modules =
             contract_modules / crate::wasm_runtime::DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
+        // The two source-WASM byte caches. Node-wide only because #5268 made them
+        // shared; each executor used to build its own, so this term was
+        // `pool_size × 2 × 10 MiB` and counted nowhere.
+        let source_code = 2 * SOURCE_CODE_CACHE_MAX_BYTES as usize;
         #[cfg(feature = "redb")]
         let page_cache = crate::contract::storages::redb::page_cache_size_for(memory_limit);
         #[cfg(not(feature = "redb"))]
         let page_cache = 0;
-        pool_size * (summary + delta) + contract_modules + delegate_modules + page_cache
+
+        pool_size * (summary + delta + arena)
+            + contract_modules
+            + delegate_modules
+            + source_code
+            + page_cache
     }
 
     /// The per-executor byte budgets stay within their documented clamps, and the
@@ -2032,7 +2084,16 @@ mod tests {
         // 7600 MiB, not 7.6 GiB).
         let gateway_limit: usize = 7_600 * 1024 * 1024;
 
-        for (label, limit) in [("2 GiB peer", peer_limit), ("gateway", gateway_limit)] {
+        // A 1 GiB VPS is the smallest limit at which the node's own floors still
+        // leave room; below that the pre-existing 64 MiB module-cache MINIMUM
+        // dominates any budget this PR composes (see the small-host note below).
+        let small_vps: usize = 1024 * 1024 * 1024;
+
+        for (label, limit) in [
+            ("1 GiB VPS", small_vps),
+            ("2 GiB peer", peer_limit),
+            ("gateway", gateway_limit),
+        ] {
             for pool_size in [1, 4, MAX_POOL_SIZE] {
                 let total = declared_cache_ceiling(limit, pool_size);
                 assert!(
@@ -2041,6 +2102,86 @@ mod tests {
                      ceiling, which must stay under half its {limit}-byte limit"
                 );
             }
+        }
+    }
+
+    /// `declared_cache_ceiling` must keep naming EVERY declared ceiling.
+    ///
+    /// The bound it feeds is an inequality, so dropping a term does not
+    /// necessarily break it — at the 2 GiB / 16-worker shape the total sits at
+    /// roughly 45% of the limit, with room to lose a 256 MiB term and still pass.
+    /// That is exactly how the original version of this test came to omit the
+    /// Store arena and the per-executor source-byte caches while its doc comment
+    /// claimed to sum "every declared ceiling" (#5268 review, Must Fix 2).
+    ///
+    /// So pin the composition itself: every budget that consumes node memory has
+    /// to appear in the sum, and a new one is added here at the same time it is
+    /// added there.
+    #[test]
+    fn declared_cache_ceiling_names_every_budget() {
+        const FULL: &str = include_str!("executor.rs");
+        let body = FULL
+            .split("fn declared_cache_ceiling(memory_limit: usize, pool_size: usize) -> usize {")
+            .nth(1)
+            .expect("declared_cache_ceiling must exist under that exact signature")
+            .split("\n    }")
+            .next()
+            .expect("function body must terminate");
+
+        for required in [
+            // per-executor, multiplied by the pool
+            "summary_budget_for",
+            "delta_budget_for",
+            "store_arena_budget_for",
+            // node-wide
+            "budget_for_ram",
+            "DELEGATE_MODULE_CACHE_BUDGET_DIVISOR",
+            "SOURCE_CODE_CACHE_MAX_BYTES",
+            "page_cache_size_for",
+        ] {
+            assert!(
+                body.contains(required),
+                "declared_cache_ceiling must include `{required}` in the aggregate \
+                 it claims to sum; without it the bound passes while measuring less \
+                 than the node actually commits"
+            );
+        }
+        assert!(
+            body.contains("pool_size * (summary + delta + arena)"),
+            "the per-executor terms must be multiplied by the pool size — that \
+             product IS defect 3"
+        );
+    }
+
+    /// Below roughly a 1 GiB limit the aggregate is dominated by floors this PR
+    /// does not own — chiefly the 64 MiB module-cache MINIMUM, which alone is the
+    /// whole budget on a 128 MiB host.
+    ///
+    /// Asserted rather than omitted so the boundary is a stated property instead
+    /// of an untested gap: a future change that lowers those floors should see
+    /// this test and extend the matrix above, and one that RAISES a per-worker
+    /// floor will trip the multiplier bound here.
+    #[test]
+    fn small_host_ceiling_is_dominated_by_floors_this_pr_does_not_own() {
+        let tiny: usize = 128 * 1024 * 1024;
+        let module_floor = crate::wasm_runtime::budget_for_ram(tiny);
+        assert!(
+            module_floor >= tiny / 2,
+            "the module-cache floor ({module_floor}) is already half a {tiny}-byte              host — no composition of the budgets around it can bring the              aggregate under half the limit"
+        );
+
+        // What this PR DOES own on such a host stays proportionate: the
+        // per-worker terms it introduces or composes must not, multiplied by the
+        // pool, exceed the memory limit on their own.
+        for pool_size in [1, 4, 16] {
+            let per_worker = summary_budget_for(tiny, pool_size)
+                + delta_budget_for(tiny, pool_size)
+                + crate::wasm_runtime::engine::store_arena_budget_for(tiny, pool_size);
+            assert!(
+                pool_size * per_worker <= tiny,
+                "per-worker terms at {pool_size} workers total {} bytes, which must                  not exceed the {tiny}-byte limit by themselves",
+                pool_size * per_worker
+            );
         }
     }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -2120,13 +2120,34 @@ mod tests {
     #[test]
     fn declared_cache_ceiling_names_every_budget() {
         const FULL: &str = include_str!("executor.rs");
-        let body = FULL
-            .split("fn declared_cache_ceiling(memory_limit: usize, pool_size: usize) -> usize {")
-            .nth(1)
-            .expect("declared_cache_ceiling must exist under that exact signature")
-            .split("\n    }")
-            .next()
-            .expect("function body must terminate");
+        // Built by concatenation so this pin's own copy of the anchor is NOT a
+        // verbatim match for it. A scrape whose anchor can match its own source
+        // silently re-scopes to a later occurrence and passes vacuously — the
+        // failure mode `.claude/rules/bug-prevention-patterns.md` records twice
+        // (#5102). The uniqueness assertion below is what makes that fail loudly
+        // instead: if the signature ever appears twice, or not at all, this stops.
+        let anchor = format!(
+            "fn declared_cache_ceiling(memory_limit: usize, {}",
+            "pool_size: usize) -> usize {"
+        );
+        assert_eq!(
+            FULL.matches(&anchor).count(),
+            1,
+            "the scrape anchor must occur EXACTLY once in this file; a second \
+             occurrence would let the pin scope itself to the wrong region"
+        );
+        let after = FULL.split(&anchor).nth(1).expect("anchor just counted");
+        // A method at 4-space indent closes with `\n    }`. Require it, rather
+        // than letting a missing end anchor widen the region to EOF.
+        let body = after
+            .split_once("\n    }")
+            .expect("could not locate the end of declared_cache_ceiling")
+            .0;
+        assert!(
+            !body.contains("\n    fn ") && !body.contains("\n    #[test]"),
+            "the scoped region escaped past declared_cache_ceiling into a \
+             sibling item — this pin would pass vacuously"
+        );
 
         for required in [
             // per-executor, multiplied by the pool

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1150,6 +1150,16 @@ type SharedClientCounts = Arc<dashmap::DashMap<ClientId, usize>>;
 // In the normal case (summaries are small digests) the count target binds and the
 // byte budget has ample headroom, so coverage holds. Only a large-value contract
 // makes the byte budget bind, holding fewer entries but never OOMing.
+//
+// Both byte budgets are PER EXECUTOR, and the pool size is derived from CPU count
+// — which `MemoryMax` does not constrain. So the RAM-scaled clamps alone were not
+// a bound on what the node commits: a 20-core laptop inside the shipped 2 GiB
+// cgroup got 16 workers × (32 MiB summary + 64 MiB delta) = 1.5 GiB of declared
+// ceiling out of a 2 GiB limit, and no code anywhere composed the two (#5268
+// defect 3). Each budget is therefore additionally capped by its share of
+// `per_executor_cache_envelope_bytes`, the node-wide envelope divided by the pool
+// size. That cap binds only on memory-constrained many-core hosts; a single-worker
+// peer and a large gateway keep exactly the budgets they had.
 // ============================================================================
 
 /// Lower clamp for the summary/delta cache COUNT target (entries). Keeps
@@ -1256,9 +1266,49 @@ const DELTA_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
 /// SUMMARY_CACHE_MIN_BYTES, SUMMARY_CACHE_MAX_BYTES)`. Reuses the module cache's
 /// `read_total_ram_bytes()` so there is a single "memory the node may use" source.
 pub(crate) fn summary_cache_budget_bytes() -> usize {
-    let total_ram = crate::wasm_runtime::read_total_ram_bytes()
-        .unwrap_or(SUMMARY_CACHE_FALLBACK_TOTAL_RAM_BYTES);
-    (total_ram / SUMMARY_CACHE_RAM_DIVISOR).clamp(SUMMARY_CACHE_MIN_BYTES, SUMMARY_CACHE_MAX_BYTES)
+    summary_budget_for(live_total_ram_bytes(), live_pool_size())
+}
+
+/// Pure sizing math behind [`summary_cache_budget_bytes`], split out so
+/// aggregate-commitment tests can ask what a hypothetical host would get instead
+/// of depending on the test machine's own RAM and core count.
+pub(crate) fn summary_budget_for(total_ram: usize, pool_size: usize) -> usize {
+    let ram_scaled = (total_ram / SUMMARY_CACHE_RAM_DIVISOR)
+        .clamp(SUMMARY_CACHE_MIN_BYTES, SUMMARY_CACHE_MAX_BYTES);
+    compose_against_envelope(
+        ram_scaled,
+        SUMMARY_CACHE_ENVELOPE_SHARE,
+        total_ram,
+        pool_size,
+    )
+}
+
+fn live_total_ram_bytes() -> usize {
+    crate::wasm_runtime::read_total_ram_bytes().unwrap_or(SUMMARY_CACHE_FALLBACK_TOTAL_RAM_BYTES)
+}
+
+/// The pool size the node will actually create, from
+/// [`crate::config::runtime_pool_size`] — the same function `RuntimePool::new`
+/// sizes the pool with, so the divisor here can never drift from the multiplier.
+fn live_pool_size() -> usize {
+    crate::config::runtime_pool_size().into()
+}
+
+/// Cap a RAM-scaled per-executor budget at `share` of this executor's slice of
+/// the node-wide cache envelope, never dropping below
+/// [`CACHE_ABSOLUTE_FLOOR_BYTES`].
+fn compose_against_envelope(
+    ram_scaled: usize,
+    share: (usize, usize),
+    total_ram: usize,
+    pool_size: usize,
+) -> usize {
+    let (numerator, denominator) = share;
+    let per_executor_envelope =
+        total_ram / SUMMARY_DELTA_ENVELOPE_RAM_DIVISOR / pool_size.max(1) / denominator * numerator;
+    ram_scaled
+        .min(per_executor_envelope)
+        .max(CACHE_ABSOLUTE_FLOOR_BYTES)
 }
 
 /// Per-executor DELTA-cache byte budget, derived the same way as
@@ -1266,14 +1316,44 @@ pub(crate) fn summary_cache_budget_bytes() -> usize {
 /// larger and higher-cardinality): `clamp(total_ram / DELTA_CACHE_RAM_DIVISOR,
 /// DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES)`.
 pub(crate) fn delta_cache_budget_bytes() -> usize {
-    let total_ram = crate::wasm_runtime::read_total_ram_bytes()
-        .unwrap_or(SUMMARY_CACHE_FALLBACK_TOTAL_RAM_BYTES);
-    (total_ram / DELTA_CACHE_RAM_DIVISOR).clamp(DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES)
+    delta_budget_for(live_total_ram_bytes(), live_pool_size())
+}
+
+/// Pure sizing math behind [`delta_cache_budget_bytes`]; see
+/// [`summary_budget_for`].
+pub(crate) fn delta_budget_for(total_ram: usize, pool_size: usize) -> usize {
+    let ram_scaled =
+        (total_ram / DELTA_CACHE_RAM_DIVISOR).clamp(DELTA_CACHE_MIN_BYTES, DELTA_CACHE_MAX_BYTES);
+    compose_against_envelope(ram_scaled, DELTA_CACHE_ENVELOPE_SHARE, total_ram, pool_size)
 }
 
 /// Fallback total-RAM estimate (1 GiB) when the OS query fails — mirrors the
 /// module cache's `FALLBACK_TOTAL_RAM_BYTES`, yielding a mid-range budget.
 const SUMMARY_CACHE_FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Fraction of the memory the node may use that ALL summary and delta caches
+/// together may declare. An eighth leaves the other seven eighths for the module
+/// cache (also an eighth), the redb page cache, the state store, transport
+/// buffers, the WASM instance arenas and the base runtime — the aggregate that
+/// `cache_byte_budgets_are_aggregate_safe` checks.
+const SUMMARY_DELTA_ENVELOPE_RAM_DIVISOR: usize = 8;
+
+/// Summary's share of a worker's envelope slice, as `(numerator, denominator)`.
+/// A third, matching the 32:64 MiB ratio of the two caches' ceilings — summaries
+/// are small digests, deltas are larger and higher-cardinality.
+const SUMMARY_CACHE_ENVELOPE_SHARE: (usize, usize) = (1, 3);
+
+/// Delta's share of a worker's envelope slice — the remaining two thirds.
+const DELTA_CACHE_ENVELOPE_SHARE: (usize, usize) = (2, 3);
+
+/// Hard floor for either cache's byte budget once the envelope has been applied.
+///
+/// At the `CACHE_ENTRY_OVERHEAD_BYTES` (512 B) per-entry floor this still holds
+/// ~2k small entries, above the `SUMMARY_CACHE_COUNT_MIN` count target, so even
+/// the most constrained node keeps a cache that covers its working set of small
+/// digests. It exists so an extreme memory limit cannot compose the budget down
+/// to something that caches nothing at all.
+const CACHE_ABSOLUTE_FLOOR_BYTES: usize = 1024 * 1024;
 
 /// A count-capped LRU cache with a hard total-byte backstop.
 ///
@@ -1892,46 +1972,108 @@ mod tests {
         }
     }
 
-    /// The default per-executor byte budgets stay within their documented clamps,
-    /// and the worst-case aggregate across the max pool size (16 workers) plus the
-    /// shared module-cache ceiling stays a safe fraction of a production gateway's
-    /// memory (the 7600 MiB = 7.42 GiB gateway limit the review flagged).
+    /// Sum of every cache ceiling a node with `memory_limit` bytes and
+    /// `pool_size` workers declares: the per-executor summary and delta caches
+    /// times the pool, plus the single shared contract and delegate module
+    /// caches, plus the redb page cache.
+    ///
+    /// Module ceilings are sized to the RAM the host actually has, NOT the
+    /// absolute MAX clamp: the 4 GiB module-cache MAX only binds above 32 GiB of
+    /// RAM, so using it would model an impossible cache on a smaller box.
+    /// (MAX-clamp safety on a >32 GiB host is guarded separately by
+    /// `module_cache::tests::max_clamp_combined_ceiling_is_safe_at_binding_host`.)
+    fn declared_cache_ceiling(memory_limit: usize, pool_size: usize) -> usize {
+        let summary = summary_budget_for(memory_limit, pool_size);
+        let delta = delta_budget_for(memory_limit, pool_size);
+        let contract_modules = crate::wasm_runtime::budget_for_ram(memory_limit);
+        let delegate_modules =
+            contract_modules / crate::wasm_runtime::DELEGATE_MODULE_CACHE_BUDGET_DIVISOR;
+        #[cfg(feature = "redb")]
+        let page_cache = crate::contract::storages::redb::page_cache_size_for(memory_limit);
+        #[cfg(not(feature = "redb"))]
+        let page_cache = 0;
+        pool_size * (summary + delta) + contract_modules + delegate_modules + page_cache
+    }
+
+    /// The per-executor byte budgets stay within their documented clamps, and the
+    /// aggregate of EVERY declared cache ceiling stays a safe fraction of the
+    /// node's memory — on a production gateway AND on a peer running under the
+    /// shipped 2 GiB `MemoryMax`.
+    ///
+    /// REGRESSION (issue #5268 defect 3): this test previously modelled only a
+    /// 7600 MiB gateway and multiplied the per-executor budgets by a hardcoded
+    /// worst-case pool size, so it never asked what a 2 GiB peer commits. It
+    /// commits ~2.9 GiB: 16 workers (a 20-core laptop, since `MemoryMax` does not
+    /// constrain CPU count) × (32 MiB summary + 64 MiB delta) = 1.5 GiB, plus
+    /// 256 MiB + 64 MiB of module cache, plus redb's uncounted 1 GiB default page
+    /// cache — against a 2 GiB hard limit. Nothing in the code composed the
+    /// CPU-derived multiplier against the memory limit.
     #[test]
     fn cache_byte_budgets_are_aggregate_safe() {
         let summary = summary_cache_budget_bytes();
         let delta = delta_cache_budget_bytes();
         assert!(
-            (SUMMARY_CACHE_MIN_BYTES..=SUMMARY_CACHE_MAX_BYTES).contains(&summary),
-            "summary budget {summary} must be within [{SUMMARY_CACHE_MIN_BYTES}, {SUMMARY_CACHE_MAX_BYTES}]"
+            (CACHE_ABSOLUTE_FLOOR_BYTES..=SUMMARY_CACHE_MAX_BYTES).contains(&summary),
+            "summary budget {summary} must be within \
+             [{CACHE_ABSOLUTE_FLOOR_BYTES}, {SUMMARY_CACHE_MAX_BYTES}]"
         );
         assert!(
-            (DELTA_CACHE_MIN_BYTES..=DELTA_CACHE_MAX_BYTES).contains(&delta),
-            "delta budget {delta} must be within [{DELTA_CACHE_MIN_BYTES}, {DELTA_CACHE_MAX_BYTES}]"
+            (CACHE_ABSOLUTE_FLOOR_BYTES..=DELTA_CACHE_MAX_BYTES).contains(&delta),
+            "delta budget {delta} must be within \
+             [{CACHE_ABSOLUTE_FLOOR_BYTES}, {DELTA_CACHE_MAX_BYTES}]"
         );
 
-        // Worst case: every one of the (up to 16) pool workers at the MAX budget.
+        // Worst case is the MAXIMUM pool size, because every per-executor budget
+        // is multiplied by it.
         const MAX_POOL_SIZE: usize = 16;
-        let summary_aggregate = MAX_POOL_SIZE * SUMMARY_CACHE_MAX_BYTES; // <= 512 MiB
-        let delta_aggregate = MAX_POOL_SIZE * DELTA_CACHE_MAX_BYTES; // <= 1 GiB
+        // The shipped systemd `MemoryMax=2G`, which 87.5% of peers report.
+        let peer_limit: usize = 2 * 1024 * 1024 * 1024;
         // Reference gateway RAM (7600 MiB ≈ 7.42 GiB; 7_600 * 1024 * 1024 is
         // 7600 MiB, not 7.6 GiB).
         let gateway_limit: usize = 7_600 * 1024 * 1024;
-        // Shared module cache ceiling (single, not per-worker), sized to the RAM
-        // this gateway actually has — NOT the absolute MAX clamp. The 4 GiB MAX
-        // only binds on hosts with >32 GiB RAM; on a 7.6 GiB gateway the
-        // `total_ram / 8` divisor binds at ~950 MiB, so using the MAX here would
-        // model an impossible 4 GiB module cache on a 7.6 GiB box. (MAX-clamp
-        // aggregate safety on a >32 GiB host is guarded separately by
-        // `module_cache::tests::max_clamp_combined_ceiling_is_safe_at_binding_host`.)
-        let module_ceiling = crate::wasm_runtime::budget_for_ram(gateway_limit);
-        let total = summary_aggregate + delta_aggregate + module_ceiling;
-        // Keep total cache commitment under half the gateway RAM.
+
+        for (label, limit) in [("2 GiB peer", peer_limit), ("gateway", gateway_limit)] {
+            for pool_size in [1, 4, MAX_POOL_SIZE] {
+                let total = declared_cache_ceiling(limit, pool_size);
+                assert!(
+                    total <= limit / 2,
+                    "{label} with {pool_size} workers declares {total} bytes of cache \
+                     ceiling, which must stay under half its {limit}-byte limit"
+                );
+            }
+        }
+    }
+
+    /// The per-executor budgets must shrink as the pool grows, because the pool
+    /// size is CPU-derived and the memory limit does not constrain CPU count.
+    ///
+    /// Pins the actual mechanism rather than only its aggregate consequence: a
+    /// future change that restored a flat per-executor budget would still satisfy
+    /// `cache_byte_budgets_are_aggregate_safe` if the envelope happened to be
+    /// generous, but would fail here.
+    #[test]
+    fn per_executor_budgets_shrink_as_the_pool_grows() {
+        let peer_limit: usize = 2 * 1024 * 1024 * 1024;
+        let one = summary_budget_for(peer_limit, 1) + delta_budget_for(peer_limit, 1);
+        let sixteen = summary_budget_for(peer_limit, 16) + delta_budget_for(peer_limit, 16);
         assert!(
-            total <= gateway_limit / 2,
-            "worst-case cache aggregate {total} (summary {summary_aggregate} + delta \
-             {delta_aggregate} + module {module_ceiling}) must stay under half the \
-             gateway limit {gateway_limit}"
+            sixteen < one,
+            "a 16-worker 2 GiB peer must get a smaller per-executor budget ({sixteen}) \
+             than a 1-worker one ({one})"
         );
+
+        // An unconstrained host keeps exactly the ceilings it had: the envelope
+        // is wide enough there that the RAM-scaled clamps still bind.
+        let big: usize = 125 * 1024 * 1024 * 1024;
+        assert_eq!(summary_budget_for(big, 16), SUMMARY_CACHE_MAX_BYTES);
+        assert_eq!(delta_budget_for(big, 16), DELTA_CACHE_MAX_BYTES);
+        // So does a single-worker 2 GiB peer (vega's shape: 2 cores → 1 worker).
+        assert_eq!(summary_budget_for(peer_limit, 1), SUMMARY_CACHE_MAX_BYTES);
+        assert_eq!(delta_budget_for(peer_limit, 1), DELTA_CACHE_MAX_BYTES);
+
+        // Never composed away to nothing.
+        assert!(summary_budget_for(64 * 1024 * 1024, 16) >= CACHE_ABSOLUTE_FLOOR_BYTES);
+        assert!(delta_budget_for(64 * 1024 * 1024, 16) >= CACHE_ABSOLUTE_FLOOR_BYTES);
     }
 
     /// Boundary coverage for [`summary_cache_count_target`], the clamp + round-up

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -87,8 +87,8 @@ fn byte_multiset_eq(a: &[u8], b: &[u8]) -> bool {
 
 use crate::node::OpManager;
 use crate::wasm_runtime::{
-    BackendEngine, MAX_STATE_SIZE, ModuleCache, RuntimeConfig, SharedContractIndex,
-    SharedModuleCache, UserSecretContext,
+    BackendEngine, MAX_STATE_SIZE, ModuleCache, RuntimeConfig, SharedModuleCache, SharedStores,
+    UserSecretContext,
 };
 
 use dashmap::DashMap;
@@ -439,19 +439,19 @@ impl Executor<Runtime> {
         shared_state_store: StateStore<Storage>,
         op_manager: Option<Arc<OpManager>>,
         contract_modules: SharedModuleCache<CodeHash>,
-        delegate_modules: SharedModuleCache<DelegateKey>,
+        delegate_modules: SharedModuleCache<CodeHash>,
         delegate_contexts: crate::wasm_runtime::DelegateContextCache,
         created_delegates_count: crate::wasm_runtime::SharedDelegateCounter,
         inherited_origins: crate::wasm_runtime::SharedInheritedOrigins,
         shared_backend: Option<BackendEngine>,
-        shared_contract_index: SharedContractIndex,
+        shared_stores: SharedStores,
     ) -> anyhow::Result<Self> {
         let db = shared_state_store.storage();
         // Pool executors all share ONE contract instance index (#4218), so a
         // contract stored / indexed / removed via any executor is visible to
         // every other executor's `ContractStore`.
         let (contract_store, delegate_store, secret_store) =
-            Self::get_runtime_stores(&config, db.clone(), Some(shared_contract_index))?;
+            Self::get_runtime_stores(&config, db.clone(), Some(shared_stores))?;
         // Production RuntimeConfig: opt in to compile offload so a cold-contract
         // Cranelift compile can run on a blocking thread instead of stalling the
         // current worker's other tasks (issue #4441). Whether the offload

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -438,7 +438,7 @@ impl Executor<Runtime> {
         config: Arc<Config>,
         shared_state_store: StateStore<Storage>,
         op_manager: Option<Arc<OpManager>>,
-        contract_modules: SharedModuleCache<ContractKey>,
+        contract_modules: SharedModuleCache<CodeHash>,
         delegate_modules: SharedModuleCache<DelegateKey>,
         delegate_contexts: crate::wasm_runtime::DelegateContextCache,
         created_delegates_count: crate::wasm_runtime::SharedDelegateCounter,

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -21,6 +21,69 @@ pub struct PoolHealthStatus {
     pub contracts_in_flight: usize,
 }
 
+/// How long an [`InUseCodeHashes`] snapshot is reused before it is recomputed.
+///
+/// Matches the module cache's own interest-shadow refresh throttle: the split it
+/// feeds is consumed at the 5-minute snapshot cadence and at admission-gate
+/// time, so bounded staleness is harmless, while an unthrottled recompute would
+/// run the O(in-use) scan once per cached entry during an eviction sweep.
+const IN_USE_CODE_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Answers "is any contract this node currently has demand for running this
+/// WASM code?" — the module cache's interest predicate, restated at code-hash
+/// granularity because the cache is keyed by code hash rather than by contract
+/// instance (#5268).
+///
+/// `Ring::contract_in_use` is a per-instance question and the cache no longer
+/// holds instances, so the mapping has to run the other way: enumerate the
+/// in-use instances (a small set — live client subscriptions plus downstream
+/// subscribers) and resolve each through the shared contract index to the code
+/// it runs. The resulting set is memoized for
+/// [`IN_USE_CODE_REFRESH_INTERVAL`] so an eviction sweep over thousands of
+/// cached modules does not re-derive it per entry.
+struct InUseCodeHashes {
+    ring: Arc<crate::ring::Ring>,
+    index: SharedContractIndex,
+    /// `(computed_at, in-use code hashes)`. Real wall-clock `Instant` for the
+    /// same reason the cache's own throttles use one: this rate-limits a
+    /// telemetry/eviction-heuristic recompute, not node behavior.
+    snapshot: Mutex<Option<(Instant, HashSet<CodeHash>)>>,
+}
+
+impl InUseCodeHashes {
+    fn new(ring: Arc<crate::ring::Ring>, index: SharedContractIndex) -> Self {
+        Self {
+            ring,
+            index,
+            snapshot: Mutex::new(None),
+        }
+    }
+
+    fn contains(&self, code: &CodeHash) -> bool {
+        let mut snapshot = match self.snapshot.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let stale = snapshot
+            .as_ref()
+            .is_none_or(|(at, _)| at.elapsed() >= IN_USE_CODE_REFRESH_INTERVAL);
+        if stale {
+            let fresh: HashSet<CodeHash> = self
+                .ring
+                .in_use_contract_ids()
+                .into_iter()
+                .filter_map(|id| self.index.get(&id).map(|entry| *entry.value()))
+                .collect();
+            *snapshot = Some((Instant::now(), fresh));
+        }
+        snapshot
+            .as_ref()
+            .expect("just populated when stale")
+            .1
+            .contains(code)
+    }
+}
+
 /// A pool of executors that enables concurrent contract execution.
 ///
 /// This pool manages multiple `Executor<Runtime>` instances, allowing multiple
@@ -71,8 +134,10 @@ pub struct RuntimePool {
     shared_summaries: SharedSummaries,
     /// Per-client subscription count for O(1) limit enforcement.
     shared_client_counts: SharedClientCounts,
-    /// Shared compiled contract module cache (avoids 16x duplication across pool executors).
-    shared_contract_modules: SharedModuleCache<ContractKey>,
+    /// Shared compiled contract module cache (avoids 16x duplication across pool
+    /// executors), keyed by CODE hash so instances differing only in parameters
+    /// share one compiled module (#5268).
+    shared_contract_modules: SharedModuleCache<CodeHash>,
     /// Shared contract instance index (`ContractInstanceId -> CodeHash`) so a
     /// contract stored / indexed / removed via any executor is visible to all
     /// the others (#4218). Cloned into every executor's `ContractStore` at
@@ -327,18 +392,28 @@ impl RuntimePool {
         // process-global) keeps the gauges per-node. Both caches share one sink;
         // they're routed apart by their `"contract"` / `"delegate"` label.
         let module_cache_metrics = op_manager.ring.module_cache_metrics();
-        // Interest predicate for the CONTRACT cache only: a contract is "of
-        // interest" while `Ring::contract_in_use` holds (a live local client
-        // subscription OR a downstream peer subscriber — deliberately NOT an
-        // upstream-only subscription, which would be unbounded). This drives the
-        // interest-weighted (two-tier) eviction policy AND the always-on shadow
-        // metrics. The delegate cache has no interest concept, so it gets none
-        // and stays pure byte-LRU. Capturing a clone of the `Arc<Ring>` keeps
-        // `wasm_runtime` free of any `ring` dependency. See #4441 / #4534.
-        let ring_for_interest = op_manager.ring.clone();
-        let contract_interest: crate::wasm_runtime::InterestPredicate<ContractKey> =
-            Arc::new(move |key: &ContractKey| ring_for_interest.contract_in_use(key));
-        let shared_contract_modules: SharedModuleCache<ContractKey> =
+        // Pool-owned contract instance index shared by every executor's
+        // `ContractStore` (#4218). The first executor loads it from ReDb; the
+        // rest inherit the same live `Arc`. Created here (before the caches)
+        // because the contract cache's interest predicate resolves instances
+        // through it — see `InUseCodeHashes`.
+        let shared_contract_index: SharedContractIndex = Arc::new(DashMap::new());
+        // Interest predicate for the CONTRACT cache only: code is "of interest"
+        // while some contract running it satisfies `Ring::contract_in_use` (a
+        // live local client subscription OR a downstream peer subscriber —
+        // deliberately NOT an upstream-only subscription, which would be
+        // unbounded). This drives the interest-weighted (two-tier) eviction
+        // policy AND the always-on shadow metrics. The delegate cache has no
+        // interest concept, so it gets none and stays pure byte-LRU. Capturing a
+        // clone of the `Arc<Ring>` keeps `wasm_runtime` free of any `ring`
+        // dependency. See #4441 / #4534 / #5268.
+        let in_use_codes = Arc::new(InUseCodeHashes::new(
+            op_manager.ring.clone(),
+            shared_contract_index.clone(),
+        ));
+        let contract_interest: crate::wasm_runtime::InterestPredicate<CodeHash> =
+            Arc::new(move |code: &CodeHash| in_use_codes.contains(code));
+        let shared_contract_modules: SharedModuleCache<CodeHash> =
             Arc::new(Mutex::new(ModuleCache::with_label_and_interest(
                 contract_cache_budget,
                 "contract",
@@ -403,11 +478,6 @@ impl RuntimePool {
         // All pool executors share this so recovery tracking is consistent.
         let shared_recovery_guard: super::CorruptedStateRecoveryGuard =
             Arc::new(std::sync::Mutex::new(HashSet::new()));
-
-        // Pool-owned contract instance index shared by every executor's
-        // `ContractStore` (#4218). The first executor loads it from ReDb; the
-        // rest inherit the same live `Arc`.
-        let shared_contract_index: SharedContractIndex = Arc::new(DashMap::new());
 
         // Create the first executor to obtain a backend engine, then share it
         // with all subsequent executors. All executors MUST share the same backend

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -42,8 +42,13 @@ const IN_USE_CODE_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 /// [`IN_USE_CODE_REFRESH_INTERVAL`] so an eviction sweep over thousands of
 /// cached modules does not re-derive it per entry.
 struct InUseCodeHashes {
-    ring: Arc<crate::ring::Ring>,
-    index: SharedContractIndex,
+    /// Yields the instance ids currently in use. A closure rather than an
+    /// `Arc<Ring>` so the memoization and the instance→code mapping can be
+    /// tested without standing up a Ring, and so a test can count how often the
+    /// source is consulted.
+    in_use_ids: Box<dyn Fn() -> Vec<ContractInstanceId> + Send + Sync>,
+    index: crate::wasm_runtime::SharedContractIndex,
+    refresh_interval: Duration,
     /// `(computed_at, in-use code hashes)`. Real wall-clock `Instant` for the
     /// same reason the cache's own throttles use one: this rate-limits a
     /// telemetry/eviction-heuristic recompute, not node behavior.
@@ -51,10 +56,23 @@ struct InUseCodeHashes {
 }
 
 impl InUseCodeHashes {
-    fn new(ring: Arc<crate::ring::Ring>, index: SharedContractIndex) -> Self {
-        Self {
-            ring,
+    fn new(ring: Arc<crate::ring::Ring>, index: crate::wasm_runtime::SharedContractIndex) -> Self {
+        Self::with_source(
+            Box::new(move || ring.in_use_contract_ids()),
             index,
+            IN_USE_CODE_REFRESH_INTERVAL,
+        )
+    }
+
+    fn with_source(
+        in_use_ids: Box<dyn Fn() -> Vec<ContractInstanceId> + Send + Sync>,
+        index: crate::wasm_runtime::SharedContractIndex,
+        refresh_interval: Duration,
+    ) -> Self {
+        Self {
+            in_use_ids,
+            index,
+            refresh_interval,
             snapshot: Mutex::new(None),
         }
     }
@@ -66,11 +84,9 @@ impl InUseCodeHashes {
         };
         let stale = snapshot
             .as_ref()
-            .is_none_or(|(at, _)| at.elapsed() >= IN_USE_CODE_REFRESH_INTERVAL);
+            .is_none_or(|(at, _)| at.elapsed() >= self.refresh_interval);
         if stale {
-            let fresh: HashSet<CodeHash> = self
-                .ring
-                .in_use_contract_ids()
+            let fresh: HashSet<CodeHash> = (self.in_use_ids)()
                 .into_iter()
                 .filter_map(|id| self.index.get(&id).map(|entry| *entry.value()))
                 .collect();
@@ -138,13 +154,16 @@ pub struct RuntimePool {
     /// executors), keyed by CODE hash so instances differing only in parameters
     /// share one compiled module (#5268).
     shared_contract_modules: SharedModuleCache<CodeHash>,
-    /// Shared contract instance index (`ContractInstanceId -> CodeHash`) so a
-    /// contract stored / indexed / removed via any executor is visible to all
-    /// the others (#4218). Cloned into every executor's `ContractStore` at
+    /// Per-node store state every executor's `ContractStore`/`DelegateStore`
+    /// shares: the instance indexes (so a contract or delegate stored / indexed
+    /// / removed via any executor is visible to all the others, #4218) and the
+    /// source-WASM byte caches (so the node holds ONE copy of each blob rather
+    /// than `pool_size` copies, #5268). Cloned into every executor at
     /// construction and into replacements.
-    shared_contract_index: SharedContractIndex,
-    /// Shared compiled delegate module cache.
-    shared_delegate_modules: SharedModuleCache<DelegateKey>,
+    shared_stores: SharedStores,
+    /// Shared compiled delegate module cache, keyed by CODE hash for the same
+    /// reason the contract one is (#5268).
+    shared_delegate_modules: SharedModuleCache<CodeHash>,
     /// Shared per-delegate `ctx.write()` cache (see `DelegateContextCache`).
     shared_delegate_contexts: crate::wasm_runtime::DelegateContextCache,
     /// This node's created-delegate count, shared by every executor so
@@ -397,7 +416,7 @@ impl RuntimePool {
         // rest inherit the same live `Arc`. Created here (before the caches)
         // because the contract cache's interest predicate resolves instances
         // through it — see `InUseCodeHashes`.
-        let shared_contract_index: SharedContractIndex = Arc::new(DashMap::new());
+        let shared_stores = SharedStores::new(super::SOURCE_CODE_CACHE_MAX_BYTES);
         // Interest predicate for the CONTRACT cache only: code is "of interest"
         // while some contract running it satisfies `Ring::contract_in_use` (a
         // live local client subscription OR a downstream peer subscriber —
@@ -409,7 +428,7 @@ impl RuntimePool {
         // dependency. See #4441 / #4534 / #5268.
         let in_use_codes = Arc::new(InUseCodeHashes::new(
             op_manager.ring.clone(),
-            shared_contract_index.clone(),
+            shared_stores.contract_index.clone(),
         ));
         let contract_interest: crate::wasm_runtime::InterestPredicate<CodeHash> =
             Arc::new(move |code: &CodeHash| in_use_codes.contains(code));
@@ -420,7 +439,7 @@ impl RuntimePool {
                 Some(module_cache_metrics.clone()),
                 Some(contract_interest),
             )));
-        let shared_delegate_modules: SharedModuleCache<DelegateKey> =
+        let shared_delegate_modules: SharedModuleCache<CodeHash> =
             Arc::new(Mutex::new(ModuleCache::with_label(
                 delegate_cache_budget,
                 "delegate",
@@ -493,7 +512,7 @@ impl RuntimePool {
             shared_delegate_counter.clone(),
             shared_inherited_origins.clone(),
             None, // No shared backend yet — this executor creates the engine
-            shared_contract_index.clone(),
+            shared_stores.clone(),
         )
         .await?;
         let shared_backend_engine = first_executor.runtime.clone_backend_engine();
@@ -517,7 +536,7 @@ impl RuntimePool {
                 shared_delegate_counter.clone(),
                 shared_inherited_origins.clone(),
                 Some(shared_backend_engine.clone()),
-                shared_contract_index.clone(),
+                shared_stores.clone(),
             )
             .await?;
 
@@ -580,7 +599,7 @@ impl RuntimePool {
             shared_summaries,
             shared_client_counts,
             shared_contract_modules,
-            shared_contract_index,
+            shared_stores,
             shared_delegate_modules,
             shared_delegate_contexts,
             shared_delegate_counter,
@@ -770,7 +789,7 @@ impl RuntimePool {
             self.shared_delegate_counter.clone(),
             self.shared_inherited_origins.clone(),
             Some(self.shared_backend_engine.clone()),
-            self.shared_contract_index.clone(),
+            self.shared_stores.clone(),
         )
         .await?;
 
@@ -1476,6 +1495,162 @@ mod tests {
     };
     use std::num::NonZeroUsize;
     use std::sync::Arc;
+
+    /// The contract module cache is keyed by code hash, so its interest
+    /// predicate must answer "is ANY in-use instance running this code?" — a
+    /// many-to-one question `Ring::contract_in_use` cannot answer per key
+    /// (#5268). These pin that translation, the index gating, and the
+    /// memoization window.
+    mod in_use_code_hashes {
+        use super::*;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        fn index_of(entries: &[(ContractKey, u8)]) -> crate::wasm_runtime::SharedContractIndex {
+            let index = crate::wasm_runtime::SharedContractIndex::default();
+            for (key, code_seed) in entries {
+                index.insert(*key.id(), CodeHash::from_code(&[*code_seed; 64]));
+            }
+            index
+        }
+
+        /// Many instances, one code: ONE in-use instance is enough to make the
+        /// whole code hash interested, and a code hash no in-use instance runs
+        /// is not.
+        #[test]
+        fn any_in_use_instance_makes_its_code_interested() {
+            // Three parameterizations of code A, one of code B.
+            let (_, a0) = make_contract(1, 10);
+            let (_, a1) = make_contract(1, 11);
+            let (_, a2) = make_contract(1, 12);
+            let (_, b0) = make_contract(2, 10);
+            let index = index_of(&[(a0, 1), (a1, 1), (a2, 1), (b0, 2)]);
+            let code_a = CodeHash::from_code(&[1u8; 64]);
+            let code_b = CodeHash::from_code(&[2u8; 64]);
+
+            // Only the MIDDLE instance of code A is in use, and nothing of B.
+            let in_use = vec![*a1.id()];
+            let resolver = InUseCodeHashes::with_source(
+                Box::new(move || in_use.clone()),
+                index,
+                Duration::from_secs(10),
+            );
+
+            assert!(
+                resolver.contains(&code_a),
+                "one in-use instance must make its code interested — keeping the \
+                 module its siblings share resident"
+            );
+            assert!(
+                !resolver.contains(&code_b),
+                "code no in-use instance runs must not be interested"
+            );
+        }
+
+        /// Nothing in use, and an in-use instance the index has never heard of,
+        /// both resolve to "not interested" rather than panicking or admitting.
+        #[test]
+        fn unindexed_or_absent_demand_is_not_interested() {
+            let (_, indexed) = make_contract(1, 10);
+            let (_, unindexed) = make_contract(3, 10);
+            let code = CodeHash::from_code(&[1u8; 64]);
+
+            let empty = InUseCodeHashes::with_source(
+                Box::new(Vec::new),
+                index_of(&[(indexed, 1)]),
+                Duration::from_secs(10),
+            );
+            assert!(
+                !empty.contains(&code),
+                "no demand means nothing is interested"
+            );
+
+            // In use, but this node never indexed it, so it cannot be resolved to
+            // any code — the same gate `fetch_contract` applies.
+            let in_use = vec![*unindexed.id()];
+            let unresolvable = InUseCodeHashes::with_source(
+                Box::new(move || in_use.clone()),
+                index_of(&[(indexed, 1)]),
+                Duration::from_secs(10),
+            );
+            assert!(
+                !unresolvable.contains(&code),
+                "an in-use instance absent from the index resolves to no code"
+            );
+        }
+
+        /// The snapshot is reused within its window and recomputed after it, so
+        /// an eviction sweep over thousands of entries pays for one scan.
+        #[test]
+        fn snapshot_is_memoized_within_its_window() {
+            let (_, key) = make_contract(1, 10);
+            let code = CodeHash::from_code(&[1u8; 64]);
+            let index = index_of(&[(key, 1)]);
+            let calls = Arc::new(AtomicUsize::new(0));
+
+            let counted = {
+                let calls = calls.clone();
+                let id = *key.id();
+                move || {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    vec![id]
+                }
+            };
+            let resolver = InUseCodeHashes::with_source(
+                Box::new(counted.clone()),
+                index.clone(),
+                Duration::from_secs(3600),
+            );
+            for _ in 0..50 {
+                assert!(resolver.contains(&code));
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "50 lookups inside the window must cost ONE scan of the in-use set"
+            );
+
+            // A zero-length window recomputes every time — the same code path,
+            // proving the memoization is the interval and not a one-shot latch.
+            calls.store(0, Ordering::SeqCst);
+            let unthrottled =
+                InUseCodeHashes::with_source(Box::new(counted), index, Duration::ZERO);
+            for _ in 0..5 {
+                assert!(unthrottled.contains(&code));
+            }
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                5,
+                "an expired window must recompute rather than latch the first answer"
+            );
+        }
+
+        /// Demand that appears after a snapshot is picked up once the window
+        /// elapses — the staleness bound this design accepts, stated as a test.
+        #[test]
+        fn new_demand_is_visible_after_the_window() {
+            let (_, key) = make_contract(1, 10);
+            let code = CodeHash::from_code(&[1u8; 64]);
+            let live: Arc<Mutex<Vec<ContractInstanceId>>> = Arc::new(Mutex::new(Vec::new()));
+
+            let source = {
+                let live = live.clone();
+                move || live.lock().unwrap().clone()
+            };
+            let resolver = InUseCodeHashes::with_source(
+                Box::new(source),
+                index_of(&[(key, 1)]),
+                Duration::ZERO,
+            );
+            assert!(!resolver.contains(&code));
+
+            live.lock().unwrap().push(*key.id());
+            assert!(
+                resolver.contains(&code),
+                "demand appearing after a snapshot must be picked up on the next \
+                 refresh"
+            );
+        }
+    }
 
     /// Synthetic contract container. The bytes are never executed
     /// (`remove_contract` only deletes files / DB rows), so a fake blob is

--- a/crates/core/src/contract/executor/runtime/pool.rs
+++ b/crates/core/src/contract/executor/runtime/pool.rs
@@ -77,6 +77,19 @@ impl InUseCodeHashes {
         }
     }
 
+    /// # Lock ordering (do not invert)
+    ///
+    /// This runs as the module cache's interest predicate, so the caller already
+    /// holds the module-cache mutex. Nesting is therefore
+    /// `module cache → this snapshot mutex → the hosting DashMaps` (via
+    /// `in_use_ids`) and the contract-index DashMap.
+    ///
+    /// It is deadlock-free only because nothing on the other three ever reaches
+    /// BACK for the module cache: `Ring::in_use_contract_ids` and the index are
+    /// pure reads that call nothing in `wasm_runtime`. Adding a module-cache
+    /// touch to any hosting path — or calling `contains` while holding a hosting
+    /// lock — would close the cycle, so keep this the innermost consumer, not a
+    /// participant.
     fn contains(&self, code: &CodeHash) -> bool {
         let mut snapshot = match self.snapshot.lock() {
             Ok(guard) => guard,

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -31,7 +31,6 @@ use crate::config::Config;
 use crate::message::{QueryResult, Transaction};
 use crate::node::OpManager;
 use crate::wasm_runtime::UserSecretContext;
-use std::num::NonZeroUsize;
 
 pub(crate) struct ClientResponsesReceiver(UnboundedReceiver<(ClientId, RequestId, HostResult)>);
 
@@ -99,22 +98,10 @@ impl ContractHandler for NetworkContractHandler {
     where
         Self: Sized + 'static,
     {
-        // Reserve one logical core for the Tokio event loop and OS scheduling.
-        // WASM execution is CPU-bound, so the pool naturally can't exceed useful parallelism.
-        // Cap at 16 to stay well within the max_blocking_threads limit (default: 2x cores,
-        // clamped to [4, 32]), preventing the executor pool from exhausting the blocking pool.
-        let parallelism = std::thread::available_parallelism()
-            .unwrap_or(NonZeroUsize::new(4).unwrap())
-            .get()
-            .saturating_sub(1)
-            .max(1);
-
-        // Pool size configurable via FREENET_RUNTIME_POOL_SIZE env var (useful for tests)
-        let pool_size = std::env::var("FREENET_RUNTIME_POOL_SIZE")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .and_then(|n| NonZeroUsize::new(n.clamp(1, 16)))
-            .unwrap_or_else(|| NonZeroUsize::new(parallelism.clamp(1, 16)).unwrap());
+        // One shared source (`config::runtime_pool_size`) so the per-worker cache
+        // budgets, which must divide by this to stay within the node's memory
+        // limit, can never disagree with the pool actually created (#5268).
+        let pool_size = crate::config::runtime_pool_size();
 
         tracing::info!(pool_size = %pool_size, "Creating RuntimePool");
 

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -9,6 +9,55 @@ use redb::{
 
 use crate::wasm_runtime::StateStorage;
 
+/// Fraction of the memory the node may use that the redb page cache may hold.
+const PAGE_CACHE_RAM_DIVISOR: usize = 32;
+
+/// Floor for the redb page cache (16 MiB) — small enough for a tightly
+/// constrained peer, large enough to keep the hot index pages resident.
+const PAGE_CACHE_MIN_BYTES: usize = 16 * 1024 * 1024;
+
+/// Ceiling for the redb page cache (1 GiB), which is also redb's own default, so
+/// an unconstrained gateway keeps exactly the cache it had.
+const PAGE_CACHE_MAX_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Page cache size for the contract database.
+///
+/// `Database::create` was called bare, so redb applied its 1 GiB default cache —
+/// an unaccounted third of a peer's whole 2 GiB `MemoryMax`, never composed
+/// against the memory limit alongside the module and summary/delta caches
+/// (#5268 defect 3). Scaling it to `clamp(memory_limit / 32, 16 MiB, 1 GiB)`
+/// makes it part of that composition: 64 MiB on a 2 GiB peer, unchanged at the
+/// 1 GiB default on any host with 32 GiB or more.
+///
+/// The cache is a maximum, not a reservation — redb fills it only as pages are
+/// read — so lowering it costs extra reads on a working set larger than the
+/// cache, never correctness.
+fn page_cache_size_bytes() -> usize {
+    let total_ram =
+        crate::wasm_runtime::read_total_ram_bytes().unwrap_or(PAGE_CACHE_FALLBACK_TOTAL_RAM_BYTES);
+    page_cache_size_for(total_ram)
+}
+
+/// Pure sizing math behind [`page_cache_size_bytes`], split out so aggregate
+/// cache-commitment tests can ask what a hypothetical host would get rather than
+/// depending on the test machine's own RAM.
+pub(crate) fn page_cache_size_for(total_ram: usize) -> usize {
+    (total_ram / PAGE_CACHE_RAM_DIVISOR).clamp(PAGE_CACHE_MIN_BYTES, PAGE_CACHE_MAX_BYTES)
+}
+
+/// Fallback total-RAM estimate (1 GiB) when the OS query fails, mirroring the
+/// module and summary/delta caches' own fallbacks.
+const PAGE_CACHE_FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Open (creating if needed) the contract database with a memory-composed page
+/// cache. Every production open MUST go through this rather than
+/// `Database::create`, which silently applies redb's 1 GiB default.
+fn open_database(db_path: &Path) -> Result<Database, DatabaseError> {
+    redb::Builder::new()
+        .set_cache_size(page_cache_size_bytes())
+        .create(db_path)
+}
+
 /// Minimum reclaimable bytes before a startup compaction is worth the whole-file
 /// rewrite it costs. Paired with [`MIN_COMPACTION_RECLAIM_FRACTION`].
 const MIN_COMPACTION_RECLAIM_BYTES: u64 = 64 * 1024 * 1024;
@@ -494,7 +543,7 @@ impl ReDb {
             "Loading contract store"
         );
 
-        match Database::create(&db_path) {
+        match open_database(&db_path) {
             Ok(db) => {
                 let db = Self::reclaim_free_pages(db, &db_path)?;
                 Self::initialize_database(db)
@@ -516,7 +565,7 @@ impl ReDb {
                     phase = "create_new_db",
                     "Creating new database"
                 );
-                let db = Database::create(&db_path)?;
+                let db = open_database(&db_path)?;
                 // No reclaim pass here: the database was just created empty.
                 Self::initialize_database(db)
             }
@@ -740,7 +789,7 @@ impl ReDb {
         const ATTEMPTS: usize = 5;
         let mut last_err = None;
         for attempt in 1..=ATTEMPTS {
-            match Database::create(db_path) {
+            match open_database(db_path) {
                 Ok(db) => return Ok(db),
                 Err(e) => {
                     tracing::warn!(

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2264,12 +2264,18 @@ where
             // insert/remove) and never reads the interested gauge — we skip it to
             // avoid paying that per-hint cost for nothing (Codex review). The
             // refresh makes the gauge reflect the cache's CURRENT resident hot set
-            // at decision time (no-op before the runtime pool is built). It cannot
+            // as of the last interest-set snapshot (no-op before the runtime pool
+            // is built). Since #5268 that is NOT strictly decision-time fresh: the
+            // cache is keyed by code hash, so its interest predicate answers "is
+            // any in-use contract running this code", and that set is itself
+            // memoized for 10 s (`InUseCodeHashes`). The scan this forces is fresh;
+            // the demand it reads can be up to that window stale. It also cannot
             // see migrations still in-flight (admitted but not yet
             // hosted/compiled), so a tight burst can still overshoot by ~one
             // migration-completion latency before completed migrations push the hot
             // set to the ceiling — a bounded, self-correcting residual, not the
-            // unbounded 10-s-stale window. Uses the GAUGES-ONLY refresher: it must
+            // unbounded 10-s-stale window this refresh was added to close. Uses the
+            // GAUGES-ONLY refresher: it must
             // NOT bump the throttle-sampled would-reclassify counter (a burst would
             // inflate it by hint volume) nor reset that throttle (Codex review).
             if interest_tiered {

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -3951,6 +3951,12 @@ impl Ring {
         self.hosting_manager.contract_in_use(contract)
     }
 
+    /// Instance ids of every contract [`Self::contract_in_use`] holds for. See
+    /// `HostingManager::in_use_contract_ids`.
+    pub(crate) fn in_use_contract_ids(&self) -> Vec<ContractInstanceId> {
+        self.hosting_manager.in_use_contract_ids()
+    }
+
     /// Single helper for every state-write chokepoint. Does the three
     /// things a chokepoint MUST do, in order:
     ///

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -1632,6 +1632,32 @@ impl HostingManager {
         self.has_client_subscriptions(contract.id()) || self.has_downstream_subscribers(contract)
     }
 
+    /// The instance ids of every contract [`contract_in_use`](Self::contract_in_use)
+    /// currently holds true for, i.e. the exact same two demand sources that
+    /// method counts.
+    ///
+    /// Exists because the compiled-module cache is keyed by CODE hash rather
+    /// than by contract instance (#5268), so its interest predicate has to ask
+    /// "is ANY in-use contract running this code?" — a question no per-key
+    /// lookup can answer. Enumerating the (small) in-use set and mapping it
+    /// through the contract store's instance index is far cheaper than scanning
+    /// the whole index. See `RuntimePool`'s `InUseCodeHashes`.
+    pub(crate) fn in_use_contract_ids(&self) -> Vec<ContractInstanceId> {
+        let mut ids: Vec<ContractInstanceId> = self
+            .client_subscriptions
+            .iter()
+            .filter(|entry| !entry.value().is_empty())
+            .map(|entry| *entry.key())
+            .collect();
+        ids.extend(
+            self.downstream_subscribers
+                .iter()
+                .filter(|entry| !entry.value().is_empty())
+                .map(|entry| *entry.key().id()),
+        );
+        ids
+    }
+
     /// The SPLIT genuine-demand counts pinning `contract`:
     /// `(local_client_subscriptions, downstream_subscribers)`. This is the
     /// subscriber-primary eviction key (#4642, Ian's confirmed ordering): the

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -20,9 +20,37 @@ mod tests;
 pub(crate) use contract::{
     ContractRuntimeBridge, ContractRuntimeInterface, ContractStoreBridge, classify_result,
 };
-pub use contract_store::{ContractStore, SharedContractIndex};
+pub use contract_store::{ContractStore, SharedCodeCache, SharedContractIndex};
 pub(crate) use delegate::DelegateRuntimeInterface;
-pub use delegate_store::DelegateStore;
+pub use delegate_store::{DelegateStore, SharedDelegateCodeCache, SharedDelegateIndex};
+
+/// The per-node store state every pool executor's `ContractStore` and
+/// `DelegateStore` share, rather than each building its own.
+///
+/// Bundled instead of passed as four parallel arguments because they must be
+/// adopted together: an executor that shares the index but not the byte cache
+/// (the pre-#5268 shape) silently keeps `pool_size` copies of the same WASM,
+/// and an executor that shares neither cannot see a delegate a sibling
+/// registered. Cloning this is cheap — every field is a handle.
+#[derive(Clone)]
+pub struct SharedStores {
+    pub contract_index: SharedContractIndex,
+    pub contract_code: SharedCodeCache,
+    pub delegate_index: SharedDelegateIndex,
+    pub delegate_code: SharedDelegateCodeCache,
+}
+
+impl SharedStores {
+    /// Build one set of shared handles, each byte cache bounded by `max_size`.
+    pub fn new(max_size: u64) -> Self {
+        Self {
+            contract_index: SharedContractIndex::default(),
+            contract_code: contract_store::new_code_cache(max_size),
+            delegate_index: SharedDelegateIndex::default(),
+            delegate_code: delegate_store::new_code_cache(max_size),
+        }
+    }
+}
 pub(crate) use engine::BackendEngine;
 pub(crate) use error::{ContractError, RuntimeInnerError, RuntimeResult};
 pub use mock_state_storage::MockStateStorage;

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -19,6 +19,41 @@ use super::RuntimeResult;
 /// removal on A left a "ghost" instance live on B until B was rebuilt.
 pub type SharedContractIndex = Arc<DashMap<ContractInstanceId, CodeHash>>;
 
+/// Source-WASM byte cache shared across every pool executor's [`ContractStore`].
+///
+/// `moka::sync::Cache` clones are cheap handles onto ONE shared store, so this is
+/// just the cache itself. It has to be shared for the same reason
+/// [`SharedContractIndex`] does, plus a budget reason: each executor used to
+/// build its own 10 MiB cache, so the node's real commitment was
+/// `pool_size × 10 MiB` (160 MiB at 16 workers) holding up to 16 copies of the
+/// same code bytes — uncounted by any budget, and the same
+/// duplicate-by-parameterization shape #5268 is about, one layer down.
+pub type SharedCodeCache = MokaCache<CodeHash, Arc<ContractCode<'static>>>;
+
+/// Build a source-WASM byte cache bounded by `max_size` bytes.
+pub fn new_code_cache(max_size: u64) -> SharedCodeCache {
+    MokaCache::builder()
+        .max_capacity(max_size)
+        .weigher(
+            |key: &CodeHash, value: &Arc<ContractCode<'static>>| -> u32 {
+                // Saturate to u32::MAX on overflow as moka recommends. A contract
+                // WASM module larger than 4 GiB would indicate a bug in upstream
+                // size validation — log it loudly.
+                let len = value.data().len();
+                u32::try_from(len).unwrap_or_else(|_| {
+                    tracing::warn!(
+                        code_hash = %key,
+                        size_bytes = len,
+                        "Contract code exceeds u32::MAX in cache weigher; \
+                         saturating. This should be impossible."
+                    );
+                    u32::MAX
+                })
+            },
+        )
+        .build()
+}
+
 /// Handle contract blob storage on the file system.
 pub struct ContractStore {
     contracts_dir: PathBuf,
@@ -56,6 +91,22 @@ impl ContractStore {
         Self::new_with_shared_index(contracts_dir, max_size, db, Arc::new(DashMap::new()))
     }
 
+    /// [`ContractStore::new_with_shared_index`] plus a caller-owned
+    /// [`SharedCodeCache`], so pool executors share the source-byte cache too.
+    pub fn new_with_shared_index(
+        contracts_dir: PathBuf,
+        max_size: u64,
+        db: Storage,
+        key_to_code_part: SharedContractIndex,
+    ) -> RuntimeResult<Self> {
+        Self::new_with_shared(
+            contracts_dir,
+            db,
+            key_to_code_part,
+            new_code_cache(max_size),
+        )
+    }
+
     /// Like [`ContractStore::new`] but wires in a caller-owned
     /// [`SharedContractIndex`] so every pool executor sees the same live
     /// `ContractInstanceId -> CodeHash` map (#4218).
@@ -65,11 +116,11 @@ impl ContractStore {
     /// replacements pass the SAME already-populated `Arc`, so they inherit the
     /// live map (including instances stored since startup) instead of paying a
     /// redundant ReDb scan and racing the on-disk state.
-    pub fn new_with_shared_index(
+    pub fn new_with_shared(
         contracts_dir: PathBuf,
-        max_size: u64,
         db: Storage,
         key_to_code_part: SharedContractIndex,
+        shared_code_cache: SharedCodeCache,
     ) -> RuntimeResult<Self> {
         std::fs::create_dir_all(&contracts_dir).map_err(|err| {
             tracing::error!("error creating contract dir: {err}");
@@ -109,26 +160,7 @@ impl ContractStore {
         }
 
         Ok(Self {
-            contract_cache: MokaCache::builder()
-                .max_capacity(max_size)
-                .weigher(
-                    |key: &CodeHash, value: &Arc<ContractCode<'static>>| -> u32 {
-                        // Saturate to u32::MAX on overflow as moka recommends.
-                        // A contract WASM module larger than 4 GiB would indicate
-                        // a bug in upstream size validation — log it loudly.
-                        let len = value.data().len();
-                        u32::try_from(len).unwrap_or_else(|_| {
-                            tracing::warn!(
-                                code_hash = %key,
-                                size_bytes = len,
-                                "Contract code exceeds u32::MAX in cache weigher; \
-                                 saturating. This should be impossible."
-                            );
-                            u32::MAX
-                        })
-                    },
-                )
-                .build(),
+            contract_cache: shared_code_cache,
             contracts_dir,
             key_to_code_part,
             db,

--- a/crates/core/src/wasm_runtime/delegate/interface.rs
+++ b/crates/core/src/wasm_runtime/delegate/interface.rs
@@ -322,10 +322,22 @@ impl DelegateRuntimeInterface for Runtime {
 
     #[inline]
     fn unregister_delegate(&mut self, key: &DelegateKey) -> RuntimeResult<()> {
-        self.delegate_modules.lock().unwrap().remove(key);
+        let code_hash = self.delegate_store.code_hash_from_key(key);
         // Drop persisted ctx.write() bytes so an unregistered delegate can't
         // hold onto stale state if it's later re-registered.
         self.delegate_contexts.remove(key);
-        self.delegate_store.remove_delegate(key)
+        self.delegate_store.remove_delegate(key)?;
+        // Drop the compiled module only once NO remaining delegate runs that
+        // code. The cache is keyed by code hash now (#5268), so one delegate's
+        // removal must not evict the module its still-registered siblings —
+        // other parameterizations of the same WASM — share. Mirrors the
+        // reference check `remove_delegate` already applies to the `.wasm` blob,
+        // and runs after it so the removed key is out of the index.
+        if let Some(code_hash) = code_hash {
+            if !self.delegate_store.code_still_referenced(&code_hash) {
+                self.delegate_modules.lock().unwrap().remove(&code_hash);
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -872,13 +872,6 @@ async fn test_delegate_cache_evicts_by_bytes() -> Result<(), Box<dyn std::error:
 
     // Probe one delegate's compiled size with a generous budget.
     let code = super::super::tests::get_test_module(TEST_DELEGATE_2)?;
-    let mk_delegate = |params: Vec<u8>| {
-        DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((
-            &code.clone().into(),
-            &params.into(),
-        ))))
-    };
-
     let mut runtime = Runtime::build_with_config(
         contract_store,
         delegate_store,
@@ -890,7 +883,10 @@ async fn test_delegate_cache_evicts_by_bytes() -> Result<(), Box<dyn std::error:
         },
     )?;
 
-    // Register + run 6 distinct-param delegates so each is a distinct key.
+    // Register + run 6 delegates over genuinely DISTINCT code. Distinct
+    // PARAMETERS over one code would no longer produce 6 cache entries — that
+    // duplication is the #5268 bug — so eviction has to be driven by real
+    // distinct modules or this test measures nothing.
     let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::IncrementCounter)?;
     let run = |runtime: &mut Runtime, d: &DelegateContainer| -> RuntimeResult<()> {
         let msg = ApplicationMessage::new(payload.clone());
@@ -904,9 +900,14 @@ async fn test_delegate_cache_evicts_by_bytes() -> Result<(), Box<dyn std::error:
         Ok(())
     };
 
-    let delegates: Vec<DelegateContainer> = (0..6)
-        .map(|i| mk_delegate(format!("param-{i}").into_bytes()))
-        .collect();
+    let mk_variant = |i: usize| {
+        let variant = super::super::tests::code_variant(&code, &format!("variant-{i}"));
+        DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((
+            &variant.into(),
+            &Vec::new().into(),
+        ))))
+    };
+    let delegates: Vec<DelegateContainer> = (0..6).map(mk_variant).collect();
     for d in &delegates {
         runtime.delegate_store.store_delegate(d.clone()).unwrap();
         let key = XChaCha20Poly1305::generate_key(&mut OsRng);
@@ -958,6 +959,178 @@ async fn test_delegate_cache_evicts_by_bytes() -> Result<(), Box<dyn std::error:
         "final delegate cache total_bytes {} must be within budget {}",
         cache.total_bytes(),
         cache.budget_bytes()
+    );
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
+/// REGRESSION (issue #5268): delegates whose code is identical and whose
+/// parameters differ MUST share ONE compiled module.
+///
+/// The delegate sibling of the contract-side defect: `prepare_delegate_call`
+/// compiles `delegate.code()` alone, but `DelegateKey`'s identity covers
+/// `key = BLAKE3(code_hash ‖ params)`, so keying the cache by it compiled and
+/// retained one copy of identical machine code per parameter set. Per-user and
+/// per-room parameterized delegates are exactly that shape.
+///
+/// Before the fix this sees 6 entries; after it, 1.
+#[tokio::test(flavor = "multi_thread")]
+async fn same_code_different_params_share_one_delegate_module()
+-> Result<(), Box<dyn std::error::Error>> {
+    use super::super::{ContractStore, SecretsStore, delegate_store::DelegateStore};
+    use crate::contract::storages::Storage;
+
+    let temp_dir = get_temp_dir();
+    let db = Storage::new(temp_dir.path()).await?;
+    let contract_store = ContractStore::new(temp_dir.path().join("c"), 10_000, db.clone())?;
+    let delegate_store = DelegateStore::new(temp_dir.path().join("d"), 10_000, db.clone())?;
+    let secret_store = SecretsStore::new(temp_dir.path().join("s"), Default::default(), db)?;
+
+    let code = super::super::tests::get_test_module(TEST_DELEGATE_2)?;
+    let mut runtime = Runtime::build_with_config(
+        contract_store,
+        delegate_store,
+        secret_store,
+        false,
+        super::super::runtime::RuntimeConfig {
+            module_cache_budget_bytes: 512 * 1024 * 1024,
+            ..Default::default()
+        },
+    )?;
+
+    // Six parameterizations of ONE delegate's code.
+    let delegates: Vec<DelegateContainer> = (0..6)
+        .map(|i| {
+            DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((
+                &code.clone().into(),
+                &format!("param-{i}").into_bytes().into(),
+            ))))
+        })
+        .collect();
+
+    let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::IncrementCounter)?;
+    for d in &delegates {
+        runtime.delegate_store.store_delegate(d.clone()).unwrap();
+        let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+        let cipher = XChaCha20Poly1305::new(&key);
+        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        runtime
+            .secret_store
+            .register_delegate(d.key().clone(), cipher, nonce)
+            .unwrap();
+        let msg = ApplicationMessage::new(payload.clone());
+        runtime.inbound_app_message(
+            d.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(msg)],
+        )?;
+    }
+
+    let cache = runtime.delegate_modules.lock().unwrap();
+    assert_eq!(
+        cache.len(),
+        1,
+        "6 parameterizations of one delegate's code must share ONE compiled \
+         module, got {} entries",
+        cache.len()
+    );
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
+/// Unregistering one delegate must NOT evict the compiled module its
+/// still-registered siblings share.
+///
+/// The cache is keyed by code hash now, so the old unconditional
+/// `delegate_modules.remove(key)` in `unregister_delegate` would take out the
+/// module every other parameterization of that WASM is running on. Removal is
+/// therefore gated on no remaining indexed delegate referencing the code —
+/// mirroring the check `remove_delegate` already applies to the `.wasm` blob.
+#[tokio::test(flavor = "multi_thread")]
+async fn unregister_keeps_a_module_a_sibling_delegate_still_runs()
+-> Result<(), Box<dyn std::error::Error>> {
+    use super::super::{ContractStore, SecretsStore, delegate_store::DelegateStore};
+    use crate::contract::storages::Storage;
+
+    let temp_dir = get_temp_dir();
+    let db = Storage::new(temp_dir.path()).await?;
+    let contract_store = ContractStore::new(temp_dir.path().join("c"), 10_000, db.clone())?;
+    let delegate_store = DelegateStore::new(temp_dir.path().join("d"), 10_000, db.clone())?;
+    let secret_store = SecretsStore::new(temp_dir.path().join("s"), Default::default(), db)?;
+
+    let code = super::super::tests::get_test_module(TEST_DELEGATE_2)?;
+    let mut runtime = Runtime::build_with_config(
+        contract_store,
+        delegate_store,
+        secret_store,
+        false,
+        super::super::runtime::RuntimeConfig {
+            module_cache_budget_bytes: 512 * 1024 * 1024,
+            ..Default::default()
+        },
+    )?;
+
+    let delegates: Vec<DelegateContainer> = (0..2)
+        .map(|i| {
+            DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(Delegate::from((
+                &code.clone().into(),
+                &format!("sibling-{i}").into_bytes().into(),
+            ))))
+        })
+        .collect();
+
+    let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::IncrementCounter)?;
+    let run = |runtime: &mut Runtime, d: &DelegateContainer| -> RuntimeResult<()> {
+        let msg = ApplicationMessage::new(payload.clone());
+        runtime.inbound_app_message(
+            d.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(msg)],
+        )?;
+        Ok(())
+    };
+
+    for d in &delegates {
+        runtime.delegate_store.store_delegate(d.clone()).unwrap();
+        let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+        let cipher = XChaCha20Poly1305::new(&key);
+        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        runtime
+            .secret_store
+            .register_delegate(d.key().clone(), cipher, nonce)
+            .unwrap();
+    }
+    run(&mut runtime, &delegates[0])?;
+    assert_eq!(runtime.delegate_modules.lock().unwrap().len(), 1);
+
+    // Unregister the FIRST: the second still runs this code, so the module stays.
+    runtime.unregister_delegate(delegates[0].key())?;
+    assert_eq!(
+        runtime.delegate_modules.lock().unwrap().len(),
+        1,
+        "a sibling delegate still runs this code — its module must not be evicted"
+    );
+    // ...and the surviving sibling still executes.
+    run(&mut runtime, &delegates[1])?;
+
+    // Unregister the last one: now nothing references the code, so it goes.
+    runtime.unregister_delegate(delegates[1].key())?;
+    let cache = runtime.delegate_modules.lock().unwrap();
+    assert_eq!(
+        cache.len(),
+        0,
+        "with no delegate left running this code the module must be dropped"
+    );
+    assert_eq!(
+        cache.total_bytes(),
+        0,
+        "dropping the last reference must decrement total_bytes (no byte leak)"
     );
 
     std::mem::drop(temp_dir);

--- a/crates/core/src/wasm_runtime/delegate_store.rs
+++ b/crates/core/src/wasm_runtime/delegate_store.rs
@@ -13,6 +13,47 @@ use super::RuntimeResult;
 /// Registration record version for .reg files
 const REG_FILE_VERSION: u8 = 1;
 
+/// Delegate instance index (`DelegateKey -> CodeHash`) shared across every pool
+/// executor's [`DelegateStore`], so a delegate registered or removed via one
+/// executor is immediately visible to all of them.
+///
+/// The contract side has had this since #4218; the delegate side did not, so each
+/// executor's index froze at whatever ReDb held when it was constructed. That was
+/// survivable only because a warm (shared) compiled-module cache let a sibling
+/// executor run a delegate its own index had never heard of — which stops being
+/// true once the module cache is keyed by an index-resolved code hash (#5268), so
+/// the divergence has to be closed rather than relied upon.
+pub type SharedDelegateIndex = Arc<DashMap<DelegateKey, CodeHash>>;
+
+/// Source-WASM byte cache shared across every pool executor's [`DelegateStore`].
+/// See [`crate::wasm_runtime::SharedCodeCache`] for why these are shared rather
+/// than built per executor.
+pub type SharedDelegateCodeCache = MokaCache<CodeHash, Arc<DelegateCode<'static>>>;
+
+/// Build a source-WASM byte cache bounded by `max_size` bytes.
+pub fn new_code_cache(max_size: u64) -> SharedDelegateCodeCache {
+    MokaCache::builder()
+        .max_capacity(max_size)
+        .weigher(
+            |key: &CodeHash, value: &Arc<DelegateCode<'static>>| -> u32 {
+                // Saturate to u32::MAX on overflow as moka recommends. A delegate
+                // WASM module larger than 4 GiB would indicate a bug in upstream
+                // size validation — log it loudly.
+                let len = value.as_ref().as_ref().len();
+                u32::try_from(len).unwrap_or_else(|_| {
+                    tracing::warn!(
+                        code_hash = %key,
+                        size_bytes = len,
+                        "Delegate code exceeds u32::MAX in cache weigher; \
+                         saturating. This should be impossible."
+                    );
+                    u32::MAX
+                })
+            },
+        )
+        .build()
+}
+
 pub struct DelegateStore {
     delegates_dir: PathBuf,
     delegate_cache: MokaCache<CodeHash, Arc<DelegateCode<'static>>>,
@@ -29,12 +70,30 @@ impl DelegateStore {
     /// - max_size: max size in bytes of the delegates being cached
     /// - db: ReDb storage for persistent index
     pub fn new(delegates_dir: PathBuf, max_size: u64, db: Storage) -> RuntimeResult<Self> {
+        Self::new_with_shared(
+            delegates_dir,
+            db,
+            SharedDelegateIndex::default(),
+            new_code_cache(max_size),
+        )
+    }
+
+    /// Like [`Self::new`] but adopting a caller-owned index and source-byte cache
+    /// so every pool executor's store shares one of each. Both are populated
+    /// idempotently, so it does not matter which executor is constructed first.
+    /// See [`SharedDelegateIndex`] and [`SharedDelegateCodeCache`].
+    pub fn new_with_shared(
+        delegates_dir: PathBuf,
+        db: Storage,
+        shared_index: SharedDelegateIndex,
+        shared_code_cache: SharedDelegateCodeCache,
+    ) -> RuntimeResult<Self> {
         std::fs::create_dir_all(&delegates_dir).map_err(|err| {
             tracing::error!("error creating delegate dir: {err}");
             err
         })?;
 
-        let key_to_code_part = Arc::new(DashMap::new());
+        let key_to_code_part = shared_index;
 
         // Phase 1: Load index from ReDb (primary store)
         match db.load_all_delegate_index() {
@@ -129,30 +188,22 @@ impl DelegateStore {
         }
 
         Ok(Self {
-            delegate_cache: MokaCache::builder()
-                .max_capacity(max_size)
-                .weigher(
-                    |key: &CodeHash, value: &Arc<DelegateCode<'static>>| -> u32 {
-                        // Saturate to u32::MAX on overflow as moka recommends.
-                        // A delegate WASM module larger than 4 GiB would indicate
-                        // a bug in upstream size validation — log it loudly.
-                        let len = value.as_ref().as_ref().len();
-                        u32::try_from(len).unwrap_or_else(|_| {
-                            tracing::warn!(
-                                code_hash = %key,
-                                size_bytes = len,
-                                "Delegate code exceeds u32::MAX in cache weigher; \
-                                 saturating. This should be impossible."
-                            );
-                            u32::MAX
-                        })
-                    },
-                )
-                .build(),
+            delegate_cache: shared_code_cache,
             delegates_dir,
             key_to_code_part,
             db,
         })
+    }
+
+    /// Whether any delegate this node still has indexed runs `code_hash`.
+    ///
+    /// Mirrors the reference check [`Self::remove_delegate`] already applies
+    /// before deleting a shared `.wasm` blob; callers use it to decide whether a
+    /// compiled module keyed by that code hash is still needed.
+    pub fn code_still_referenced(&self, code_hash: &CodeHash) -> bool {
+        self.key_to_code_part
+            .iter()
+            .any(|entry| entry.value() == code_hash)
     }
 
     // Returns a copy of the delegate bytes if available, none otherwise.
@@ -457,6 +508,14 @@ impl DelegateStore {
             .with_extension("wasm"))
     }
 
+    /// The code hash this node recorded for `key`, or `None` when it never
+    /// registered that delegate.
+    ///
+    /// The authoritative resolution the compiled-module cache keys on (#5268),
+    /// for exactly the reason [`Self::fetch_delegate`] documents: the `code_hash`
+    /// a caller's `DelegateKey` carries is unverified serde data, so trusting it
+    /// would let a caller name a delegate while choosing which cached module ran
+    /// for it.
     pub fn code_hash_from_key(&self, key: &DelegateKey) -> Option<CodeHash> {
         self.key_to_code_part.get(key).map(|r| *r.value())
     }

--- a/crates/core/src/wasm_runtime/engine.rs
+++ b/crates/core/src/wasm_runtime/engine.rs
@@ -31,6 +31,14 @@ compile_error!("The wasmtime-backend feature must be enabled.");
 #[cfg(feature = "wasmtime-backend")]
 mod wasmtime_engine;
 
+/// Retired-instance bytes ONE wasmtime Store may hold before it is refreshed, for
+/// a host with `total_ram` bytes and `pool_size` executors. Re-exported because
+/// there is one Store per executor, so it is a per-worker term in the node's
+/// aggregate memory commitment (see
+/// `contract::executor::tests::cache_byte_budgets_are_aggregate_safe`).
+#[cfg(all(test, feature = "wasmtime-backend"))]
+pub(crate) use wasmtime_engine::store_arena_budget_for;
+
 use super::ContractError;
 use super::runtime::RuntimeConfig;
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -303,7 +303,71 @@ const WASM_STACK_SIZE: usize = 8 * 1024 * 1024;
 /// and refresh frequency. With the bounded per-instance reservation
 /// (~256 MiB, see #3986) the per-Store virtual memory budget is ~125 GiB,
 /// well within the address space limits that previously motivated this cap.
+///
+/// This bounds VIRTUAL memory and mapping COUNT only. It does NOT bound the
+/// arena's RESIDENT footprint, which is what OOM-kills a peer — see
+/// [`store_arena_budget_bytes`], the companion byte bound (#5268).
 const STORE_REFRESH_THRESHOLD: u64 = 500;
+
+/// Fraction of the memory the node may use that all Store arenas together may
+/// hold in retired-but-unreclaimed instance memory before refreshing.
+///
+/// The arena is pure slack: every byte in it belongs to an instance that has
+/// already finished. An eighth of the node's memory limit is a generous ceiling
+/// for slack while leaving refreshes infrequent enough not to matter.
+const STORE_ARENA_RAM_DIVISOR: usize = 8;
+
+/// Floor for the per-Store arena byte budget (16 MiB).
+///
+/// Low enough to bind hard on a 2 GiB peer with 16 workers (the shape that OOMs
+/// today), high enough that a Store still retires several instances' worth of
+/// linear memory between refreshes rather than refreshing on every call.
+const STORE_ARENA_MIN_BYTES: usize = 16 * 1024 * 1024;
+
+/// Ceiling for the per-Store arena byte budget (256 MiB).
+///
+/// Past this the count threshold is the binding bound again: at the measured
+/// ~3 MiB of retained linear memory per instance, 256 MiB is reached at roughly
+/// the same point as [`STORE_REFRESH_THRESHOLD`], so a large unconstrained
+/// gateway keeps exactly its current refresh cadence.
+const STORE_ARENA_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Retired-instance bytes ONE Store may accumulate before it is refreshed.
+///
+/// # Why a byte bound is needed at all
+///
+/// wasmtime arena-allocates instances inside a `Store`, so dropping an
+/// `Instance` frees nothing: its linear memory stays resident until the whole
+/// Store is replaced. RSS on a real peer is therefore a SAWTOOTH, not a ramp —
+/// `framework`'s fell 1.46 GiB within one second of a
+/// `Refreshing engine store … lifetime_instances=500` line. Peak height was set
+/// purely by [`STORE_REFRESH_THRESHOLD`], a fixed instance COUNT, so nothing in
+/// the node budgeted the arena's resident bytes; the existing comment budgets
+/// only VIRTUAL memory (~125 GiB, matching nova's `VmSize`). That is why kill
+/// intervals varied so wildly on one node (5.5 h vs 1.1 h): death depended on
+/// where a ramp happened to start. Issue #5268 defect 2.
+///
+/// # Sizing
+///
+/// `clamp(memory_limit / 8 / pool_size, 16 MiB, 256 MiB)`. It is divided by the
+/// pool size because there is one Store PER pool worker (up to 16), so the
+/// node-wide arena slack is the product; the memory limit comes from
+/// [`read_total_ram_bytes`](crate::wasm_runtime::read_total_ram_bytes), which
+/// already resolves `min(MemTotal, cgroup limit)` and so honours the shipped
+/// `MemoryMax=2G`. On a 2 GiB peer with 16 workers this is the 16 MiB floor
+/// (256 MiB node-wide); on an unconstrained gateway it saturates at 256 MiB per
+/// Store, where the count threshold binds first and behaviour is unchanged.
+fn store_arena_budget_bytes() -> usize {
+    let total_ram =
+        crate::wasm_runtime::read_total_ram_bytes().unwrap_or(STORE_ARENA_FALLBACK_TOTAL_RAM_BYTES);
+    let pool_size: usize = crate::config::runtime_pool_size().into();
+    (total_ram / STORE_ARENA_RAM_DIVISOR / pool_size)
+        .clamp(STORE_ARENA_MIN_BYTES, STORE_ARENA_MAX_BYTES)
+}
+
+/// Fallback total-RAM estimate (1 GiB) when the OS query fails, mirroring the
+/// module cache's own fallback.
+const STORE_ARENA_FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
 
 /// Maximum age of a Store before forced refresh, even with live instances.
 ///
@@ -614,6 +678,20 @@ pub(crate) struct WasmtimeEngine {
     /// Instances created in the current Store; reset on `replace_store`.
     /// See [`STORE_REFRESH_THRESHOLD`].
     lifetime_instances: u64,
+    /// Linear-memory bytes belonging to instances that have finished but whose
+    /// allocation the current Store's arena still holds; reset on
+    /// `replace_store`. Measured at `drop_instance` time (memory only grows
+    /// within an instance's life, so the size at drop is its high-water mark)
+    /// and compared against [`Self::arena_budget_bytes`]. See
+    /// [`store_arena_budget_bytes`].
+    ///
+    /// Approximate on purpose: it counts the guest's linear memory, which
+    /// dominates, and misses instances leaked without engine cleanup — those
+    /// stay covered by [`STORE_REFRESH_THRESHOLD`] and [`STORE_MAX_AGE`].
+    retired_instance_bytes: u64,
+    /// Retired-instance bytes this Store may hold before it is refreshed.
+    /// Resolved once per engine from the node's memory limit and pool size.
+    arena_budget_bytes: u64,
     /// When the current Store was created. Used by [`STORE_MAX_AGE`] fallback.
     store_created_at: Instant,
     /// Production opt-in for offloading a cache-miss compile to a blocking
@@ -731,6 +809,8 @@ impl WasmEngine for WasmtimeEngine {
             max_fuel,
             epoch_deadline_ticks,
             lifetime_instances: 0,
+            retired_instance_bytes: 0,
+            arena_budget_bytes: store_arena_budget_bytes() as u64,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
         })
@@ -850,17 +930,32 @@ impl WasmEngine for WasmtimeEngine {
     }
 
     fn drop_instance(&mut self, handle: &InstanceHandle) {
+        // Charge this instance's linear memory to the arena BEFORE dropping the
+        // handle: the allocation outlives the instance (it is reclaimed only by
+        // replacing the whole Store), so this is what makes RSS a sawtooth
+        // rather than a ramp. See `retired_instance_bytes` (#5268).
+        self.retired_instance_bytes = self
+            .retired_instance_bytes
+            .saturating_add(self.instance_memory_bytes(handle.id));
         self.instances.remove(&handle.id);
         MEM_ADDR.remove(&handle.id);
 
         let threshold_exceeded = self.lifetime_instances >= STORE_REFRESH_THRESHOLD;
+        let arena_over_budget = self.retired_instance_bytes >= self.arena_budget_bytes;
         let store_expired = self.store_created_at.elapsed() >= STORE_MAX_AGE;
 
-        if self.instances.is_empty() && threshold_exceeded {
-            // Normal path: all instances dropped and threshold exceeded.
+        if self.instances.is_empty() && (threshold_exceeded || arena_over_budget) {
+            // Normal path: all instances dropped and either bound exceeded.
             tracing::info!(
                 lifetime_instances = self.lifetime_instances,
-                "Refreshing engine store to reclaim virtual memory"
+                retired_instance_bytes = self.retired_instance_bytes,
+                arena_budget_bytes = self.arena_budget_bytes,
+                reason = if arena_over_budget {
+                    "arena_bytes"
+                } else {
+                    "instance_count"
+                },
+                "Refreshing engine store to reclaim memory"
             );
             self.replace_store();
         } else if threshold_exceeded && store_expired {
@@ -1264,6 +1359,8 @@ impl WasmtimeEngine {
             max_fuel,
             epoch_deadline_ticks,
             lifetime_instances: 0,
+            retired_instance_bytes: 0,
+            arena_budget_bytes: store_arena_budget_bytes() as u64,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
         })
@@ -1509,7 +1606,36 @@ impl WasmtimeEngine {
         self.instances.clear();
         self.store = Some(store);
         self.lifetime_instances = 0;
+        self.retired_instance_bytes = 0;
         self.store_created_at = Instant::now();
+    }
+
+    /// Override the arena byte budget so a test can decide which of the two
+    /// refresh bounds is under examination, rather than inheriting the test
+    /// host's RAM and core count. Tests that pin the INSTANCE-COUNT threshold
+    /// set `u64::MAX` (arena bound disarmed); the arena test sets a small value.
+    #[cfg(test)]
+    fn set_arena_budget_for_test(&mut self, bytes: u64) {
+        self.arena_budget_bytes = bytes;
+    }
+
+    /// Current linear-memory size of a live instance, or 0 when it cannot be
+    /// read (already gone, no store, or no `memory` export).
+    ///
+    /// Used to charge a finishing instance's allocation to the Store arena; a
+    /// zero on an unreadable instance only under-counts, and the count/age
+    /// thresholds remain as backstops.
+    fn instance_memory_bytes(&mut self, id: i64) -> u64 {
+        let Some(store) = self.store.as_mut() else {
+            return 0;
+        };
+        let Some(instance) = self.instances.get(&id) else {
+            return 0;
+        };
+        instance
+            .get_memory(&mut *store, "memory")
+            .map(|memory| memory.data_size(&*store) as u64)
+            .unwrap_or(0)
     }
 
     fn compute_max_fuel(config: &RuntimeConfig) -> u64 {
@@ -3432,12 +3558,122 @@ mod tests {
         engine.drop_instance(&handle);
     }
 
+    /// REGRESSION (issue #5268 defect 2): the Store must be refreshed when the
+    /// arena's retained RESIDENT bytes reach the budget, WITHOUT waiting for
+    /// `STORE_REFRESH_THRESHOLD` instance creations.
+    ///
+    /// wasmtime arena-allocates instances, so dropping an `Instance` frees
+    /// nothing until the whole Store is replaced. With the fixed 500-instance
+    /// count as the only bound, peak RSS was set by that count and nothing
+    /// budgeted resident memory: a real peer's RSS fell 1.46 GiB the instant one
+    /// refresh fired, and peers died against the shipped 2 GiB `MemoryMax` long
+    /// before 500 was a sensible number.
+    ///
+    /// Without the byte bound this loop refreshes only at 500, so
+    /// `lifetime_instances` is still counting up when the assertion runs.
+    #[test]
+    fn store_refresh_fires_on_arena_bytes_before_instance_count() {
+        let config = RuntimeConfig::default();
+        let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        let module = engine.compile(SIMPLE_WASM).unwrap();
+
+        // Charge one instance to learn what the arena actually retains per
+        // instance, then set a budget only a few instances wide.
+        let handle = engine.create_instance(&module, 0, 1024).unwrap();
+        engine.drop_instance(&handle);
+        let per_instance = engine.retired_instance_bytes;
+        assert!(
+            per_instance > 0,
+            "an instance's linear memory must be measurable, else the byte bound \
+             can never fire"
+        );
+        engine.set_arena_budget_for_test(per_instance * 4);
+
+        let mut refreshes = 0;
+        let mut previous = engine.lifetime_instances;
+        // Far fewer creations than STORE_REFRESH_THRESHOLD: any refresh seen
+        // here is attributable to the byte bound alone.
+        let creations = 40;
+        assert!(creations < STORE_REFRESH_THRESHOLD);
+        for i in 1..=creations {
+            let handle = engine.create_instance(&module, i as i64, 1024).unwrap();
+            engine.drop_instance(&handle);
+            if engine.lifetime_instances <= previous {
+                refreshes += 1;
+                assert_eq!(
+                    engine.lifetime_instances, 0,
+                    "a refresh must reset the instance counter"
+                );
+                assert_eq!(
+                    engine.retired_instance_bytes, 0,
+                    "a refresh must reset the arena byte counter"
+                );
+            }
+            previous = engine.lifetime_instances;
+        }
+
+        assert!(
+            refreshes >= 5,
+            "a 4-instance arena budget must refresh repeatedly over {creations} \
+             instances, saw {refreshes}"
+        );
+        assert!(
+            engine.is_healthy(),
+            "engine must stay healthy across byte-budget refreshes"
+        );
+        let handle = engine
+            .create_instance(&module, 999_999, 1024)
+            .expect("should create instance after byte-budget refresh");
+        engine.drop_instance(&handle);
+    }
+
+    /// The arena budget must be derived from the memory the node may use divided
+    /// by the number of Stores (one per pool worker), not from a constant — and
+    /// must land at its floor for the shape that OOMs today: a 2 GiB `MemoryMax`
+    /// on a many-core box.
+    #[test]
+    fn arena_budget_is_memory_derived_and_pool_divided() {
+        let budget = store_arena_budget_bytes();
+        assert!(
+            (STORE_ARENA_MIN_BYTES..=STORE_ARENA_MAX_BYTES).contains(&budget),
+            "arena budget {budget} must stay within \
+             [{STORE_ARENA_MIN_BYTES}, {STORE_ARENA_MAX_BYTES}]"
+        );
+
+        // Pure sizing math, independent of the test host (see #5268 defect 3 for
+        // why the pool size must divide it: it is CPU-derived and MemoryMax does
+        // not constrain CPU count).
+        let sized = |total_ram: usize, pool: usize| {
+            (total_ram / STORE_ARENA_RAM_DIVISOR / pool)
+                .clamp(STORE_ARENA_MIN_BYTES, STORE_ARENA_MAX_BYTES)
+        };
+        let two_gib = 2 * 1024 * 1024 * 1024;
+        assert_eq!(
+            sized(two_gib, 16),
+            STORE_ARENA_MIN_BYTES,
+            "a 2 GiB cap across 16 workers must land on the floor"
+        );
+        assert!(
+            sized(two_gib, 16) * 16 <= two_gib / 4,
+            "node-wide arena slack on a 2 GiB peer must stay a modest fraction \
+             of the limit"
+        );
+        // A single-worker 2 GiB peer and a large unconstrained gateway both keep
+        // the generous ceiling, so this only bites the constrained many-core case.
+        assert_eq!(sized(two_gib, 1), STORE_ARENA_MAX_BYTES);
+        assert_eq!(sized(125 * 1024 * 1024 * 1024, 16), STORE_ARENA_MAX_BYTES);
+    }
+
     /// Verify that the Store is refreshed after STORE_REFRESH_THRESHOLD instances,
     /// reclaiming virtual memory from wasmtime's arena allocator.
     #[test]
     fn test_store_refresh_reclaims_virtual_memory() {
         let config = RuntimeConfig::default();
         let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // Pin the arena byte bound OFF: this test examines the
+        // instance-COUNT threshold, which must not depend on the test host's
+        // RAM or core count (#5268).
+        engine.set_arena_budget_for_test(u64::MAX);
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // Create and drop exactly STORE_REFRESH_THRESHOLD instances.
@@ -3472,6 +3708,10 @@ mod tests {
     fn test_store_not_refreshed_with_live_instances() {
         let config = RuntimeConfig::default();
         let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // Pin the arena byte bound OFF: this test examines the
+        // instance-COUNT threshold, which must not depend on the test host's
+        // RAM or core count (#5268).
+        engine.set_arena_budget_for_test(u64::MAX);
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // First, burn through most of the threshold with create/drop cycles
@@ -3518,6 +3758,10 @@ mod tests {
     fn test_recover_store_resets_lifetime_instances() {
         let config = RuntimeConfig::default();
         let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // Pin the arena byte bound OFF: this test examines the
+        // instance-COUNT threshold, which must not depend on the test host's
+        // RAM or core count (#5268).
+        engine.set_arena_budget_for_test(u64::MAX);
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // Create some instances to bump the counter
@@ -3552,6 +3796,10 @@ mod tests {
             ..Default::default()
         };
         let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // Pin the arena byte bound OFF: this test examines the
+        // instance-COUNT threshold, which must not depend on the test host's
+        // RAM or core count (#5268).
+        engine.set_arena_budget_for_test(u64::MAX);
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         // Create and drop enough instances to trigger refresh
@@ -3624,6 +3872,10 @@ mod tests {
 
         let config = RuntimeConfig::default();
         let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // Pin the arena byte bound OFF: this test examines the instance-COUNT
+        // threshold, which must not depend on the test host's RAM or core count
+        // (#5268).
+        engine.set_arena_budget_for_test(u64::MAX);
         let module = engine.compile(SIMPLE_WASM).unwrap();
 
         let baseline_maps = count_maps();

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -317,12 +317,21 @@ const STORE_REFRESH_THRESHOLD: u64 = 500;
 /// for slack while leaving refreshes infrequent enough not to matter.
 const STORE_ARENA_RAM_DIVISOR: usize = 8;
 
-/// Floor for the per-Store arena byte budget (16 MiB).
+/// Floor for the per-Store arena byte budget (4 MiB).
 ///
-/// Low enough to bind hard on a 2 GiB peer with 16 workers (the shape that OOMs
-/// today), high enough that a Store still retires several instances' worth of
-/// linear memory between refreshes rather than refreshing on every call.
-const STORE_ARENA_MIN_BYTES: usize = 16 * 1024 * 1024;
+/// A thrash guard, not a target: at the measured ~3 MiB of linear memory retained
+/// per instance it still lets a Store retire an instance or so between refreshes,
+/// so a refresh never lands on literally every call.
+///
+/// Deliberately small, because it is the term that fights the budget rather than
+/// serving it. `pool_size × this` is a floor on node-wide arena slack that no
+/// memory limit can reduce, so a generous value re-creates in miniature the
+/// defect-3 shape it sits next to (a per-worker constant multiplied by a
+/// CPU-derived count). Where memory is scarce enough for it to bind — below
+/// roughly a 512 MiB limit at 16 workers — more frequent refreshes are the right
+/// trade; above that the RAM-scaled share binds and this is inert (a 2 GiB peer
+/// with 16 workers resolves to 16 MiB from the share, not from here).
+const STORE_ARENA_MIN_BYTES: usize = 4 * 1024 * 1024;
 
 /// Ceiling for the per-Store arena byte budget (256 MiB).
 ///
@@ -360,8 +369,17 @@ const STORE_ARENA_MAX_BYTES: usize = 256 * 1024 * 1024;
 fn store_arena_budget_bytes() -> usize {
     let total_ram =
         crate::wasm_runtime::read_total_ram_bytes().unwrap_or(STORE_ARENA_FALLBACK_TOTAL_RAM_BYTES);
-    let pool_size: usize = crate::config::runtime_pool_size().into();
-    (total_ram / STORE_ARENA_RAM_DIVISOR / pool_size)
+    store_arena_budget_for(total_ram, crate::config::runtime_pool_size().into())
+}
+
+/// Pure sizing math behind [`store_arena_budget_bytes`], split out so
+/// aggregate-commitment tests can ask what a hypothetical host would get instead
+/// of depending on the test machine's own RAM and core count. See
+/// `contract::executor::tests::cache_byte_budgets_are_aggregate_safe`, which has
+/// to include this term: there is one Store per pool worker, so the node-wide
+/// arena slack is `pool_size ×` this.
+pub(crate) fn store_arena_budget_for(total_ram: usize, pool_size: usize) -> usize {
+    (total_ram / STORE_ARENA_RAM_DIVISOR / pool_size.max(1))
         .clamp(STORE_ARENA_MIN_BYTES, STORE_ARENA_MAX_BYTES)
 }
 
@@ -946,7 +964,13 @@ impl WasmEngine for WasmtimeEngine {
 
         if self.instances.is_empty() && (threshold_exceeded || arena_over_budget) {
             // Normal path: all instances dropped and either bound exceeded.
-            tracing::info!(
+            //
+            // `debug!`, not `info!`: with the byte bound this is a routine event
+            // rather than a rare one. On a constrained host (16 MiB arena budget,
+            // ~3 MiB retained per instance) it fires roughly every 5 instances
+            // instead of every 500, which at `info!` would bury the operator log
+            // under a line every few seconds under load.
+            tracing::debug!(
                 lifetime_instances = self.lifetime_instances,
                 retired_instance_bytes = self.retired_instance_bytes,
                 arena_budget_bytes = self.arena_budget_bytes,
@@ -958,13 +982,21 @@ impl WasmEngine for WasmtimeEngine {
                 "Refreshing engine store to reclaim memory"
             );
             self.replace_store();
-        } else if threshold_exceeded && store_expired {
+        } else if (threshold_exceeded || arena_over_budget) && store_expired {
             // Safety net: orphaned instances (leaked without engine cleanup) are
             // preventing is_empty() from being true. After STORE_MAX_AGE, force
-            // a refresh to bound virtual memory growth. The orphaned Instance
-            // handles become invalid but they were already leaked and unusable.
+            // a refresh to bound memory growth. The orphaned Instance handles
+            // become invalid but they were already leaked and unusable.
+            //
+            // This arm takes EITHER bound, like the normal arm above: the leaked
+            // instance is exactly the case `retired_instance_bytes` claims to
+            // cover, and requiring the full 500-instance count here would have
+            // left the arena's resident bytes unbounded on the one path that
+            // reaches this code (#5268 review).
             tracing::warn!(
                 lifetime_instances = self.lifetime_instances,
+                retired_instance_bytes = self.retired_instance_bytes,
+                arena_budget_bytes = self.arena_budget_bytes,
                 orphaned_instances = self.instances.len(),
                 store_age_secs = self.store_created_at.elapsed().as_secs(),
                 "Force-refreshing engine store — orphaned instances preventing normal refresh"
@@ -3643,21 +3675,25 @@ mod tests {
         // Pure sizing math, independent of the test host (see #5268 defect 3 for
         // why the pool size must divide it: it is CPU-derived and MemoryMax does
         // not constrain CPU count).
-        let sized = |total_ram: usize, pool: usize| {
-            (total_ram / STORE_ARENA_RAM_DIVISOR / pool)
-                .clamp(STORE_ARENA_MIN_BYTES, STORE_ARENA_MAX_BYTES)
-        };
+        let sized = store_arena_budget_for;
         let two_gib = 2 * 1024 * 1024 * 1024;
         assert_eq!(
             sized(two_gib, 16),
-            STORE_ARENA_MIN_BYTES,
-            "a 2 GiB cap across 16 workers must land on the floor"
+            two_gib / STORE_ARENA_RAM_DIVISOR / 16,
+            "a 2 GiB cap across 16 workers must resolve from the RAM-scaled \
+             share, with neither clamp binding"
         );
         assert!(
             sized(two_gib, 16) * 16 <= two_gib / 4,
             "node-wide arena slack on a 2 GiB peer must stay a modest fraction \
              of the limit"
         );
+        // The floor binds only where memory is genuinely scarce, and even then
+        // the node-wide slack stays bounded rather than becoming a
+        // per-worker constant times the core count.
+        let tiny = 256 * 1024 * 1024;
+        assert_eq!(sized(tiny, 16), STORE_ARENA_MIN_BYTES);
+        assert!(sized(tiny, 16) * 16 <= tiny / 4);
         // A single-worker 2 GiB peer and a large unconstrained gateway both keep
         // the generous ceiling, so this only bites the constrained many-core case.
         assert_eq!(sized(two_gib, 1), STORE_ARENA_MAX_BYTES);

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -335,10 +335,18 @@ const STORE_ARENA_MIN_BYTES: usize = 4 * 1024 * 1024;
 
 /// Ceiling for the per-Store arena byte budget (256 MiB).
 ///
-/// Past this the count threshold is the binding bound again: at the measured
-/// ~3 MiB of retained linear memory per instance, 256 MiB is reached at roughly
-/// the same point as [`STORE_REFRESH_THRESHOLD`], so a large unconstrained
-/// gateway keeps exactly its current refresh cadence.
+/// On an unconstrained host this is what binds, and it binds BEFORE
+/// [`STORE_REFRESH_THRESHOLD`] does: at the measured ~3 MiB of retained linear
+/// memory per instance it is reached after roughly 85 instances, not 500. That
+/// is the intended outcome — a quarter-gigabyte of memory belonging to instances
+/// that have already finished is enough slack for anyone, and refreshing at 85
+/// rather than 500 costs one extra `Store::new` per ~85 contract calls. The
+/// count threshold stays as the mapping-count backstop
+/// (`vm.max_map_count`), which byte accounting does not measure.
+///
+/// Raising this to ~1.5 GiB WOULD restore the old 500-instance cadence exactly,
+/// and is deliberately not done: the whole point of the byte bound is that an
+/// instance COUNT is the wrong unit for a resident-memory limit.
 const STORE_ARENA_MAX_BYTES: usize = 256 * 1024 * 1024;
 
 /// Retired-instance bytes ONE Store may accumulate before it is refreshed.
@@ -358,14 +366,35 @@ const STORE_ARENA_MAX_BYTES: usize = 256 * 1024 * 1024;
 ///
 /// # Sizing
 ///
-/// `clamp(memory_limit / 8 / pool_size, 16 MiB, 256 MiB)`. It is divided by the
+/// `clamp(memory_limit / 8 / pool_size, 4 MiB, 256 MiB)`. It is divided by the
 /// pool size because there is one Store PER pool worker (up to 16), so the
 /// node-wide arena slack is the product; the memory limit comes from
 /// [`read_total_ram_bytes`](crate::wasm_runtime::read_total_ram_bytes), which
 /// already resolves `min(MemTotal, cgroup limit)` and so honours the shipped
-/// `MemoryMax=2G`. On a 2 GiB peer with 16 workers this is the 16 MiB floor
-/// (256 MiB node-wide); on an unconstrained gateway it saturates at 256 MiB per
-/// Store, where the count threshold binds first and behaviour is unchanged.
+/// `MemoryMax=2G`. A 2 GiB peer with 16 workers resolves to 16 MiB per Store
+/// (256 MiB node-wide) from the RAM-scaled share; an unconstrained gateway
+/// saturates at [`STORE_ARENA_MAX_BYTES`].
+///
+/// # When ONE instance is as large as the whole budget
+///
+/// A contract may declare up to `DEFAULT_MAX_MEMORY_PAGES` (256 MiB) of linear
+/// memory, so a single instance can meet or exceed this budget by itself. Then
+/// every call to that contract ends in a Store refresh rather than a periodic
+/// one. That is deliberate, and it is the RIGHT outcome rather than a
+/// degenerate one: the alternative is retaining an arena already at or past the
+/// limit the node is trying not to exceed, which is the OOM this exists to
+/// prevent. Prompt reclamation is what a memory-constrained peer wants.
+///
+/// It is not free, though — a `Store::new` plus epoch re-arm per call — and it
+/// concentrates on exactly the large-contract, memory-constrained peers this
+/// work targets, so [`WasmtimeEngine::note_refresh_cadence`] makes it visible to
+/// an operator (rate-limited) instead of letting it be a silent CPU cost. The
+/// per-refresh work is small next to instantiating a module with tens of MiB of
+/// linear memory in the first place, which is why it is accepted rather than
+/// worked around with a floor scaled to observed instance size: such a floor
+/// would be `N × (up to 256 MiB) × pool_size` of guaranteed slack that no
+/// memory limit could reduce — reintroducing defect 3's shape to avoid a cost
+/// that is a fraction of the call it accompanies.
 fn store_arena_budget_bytes() -> usize {
     let total_ram =
         crate::wasm_runtime::read_total_ram_bytes().unwrap_or(STORE_ARENA_FALLBACK_TOTAL_RAM_BYTES);
@@ -386,6 +415,11 @@ pub(crate) fn store_arena_budget_for(total_ram: usize, pool_size: usize) -> usiz
 /// Fallback total-RAM estimate (1 GiB) when the OS query fails, mirroring the
 /// module cache's own fallback.
 const STORE_ARENA_FALLBACK_TOTAL_RAM_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Minimum gap between [`WasmtimeEngine::note_refresh_cadence`] warnings, so a
+/// peer running one large contract reports the condition periodically instead of
+/// once per call — which would be the very flood the warning is about.
+const CADENCE_WARN_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Maximum age of a Store before forced refresh, even with live instances.
 ///
@@ -710,6 +744,11 @@ pub(crate) struct WasmtimeEngine {
     /// Retired-instance bytes this Store may hold before it is refreshed.
     /// Resolved once per engine from the node's memory limit and pool size.
     arena_budget_bytes: u64,
+    /// Last time [`Self::note_refresh_cadence`] warned that refreshes are firing
+    /// after a single instance. Real wall-clock `Instant` deliberately: it
+    /// rate-limits an operator log line, not node behavior (same rationale as
+    /// `store_created_at` and the module cache's eviction-warning window).
+    last_cadence_warn: Option<Instant>,
     /// When the current Store was created. Used by [`STORE_MAX_AGE`] fallback.
     store_created_at: Instant,
     /// Production opt-in for offloading a cache-miss compile to a blocking
@@ -829,6 +868,7 @@ impl WasmEngine for WasmtimeEngine {
             lifetime_instances: 0,
             retired_instance_bytes: 0,
             arena_budget_bytes: store_arena_budget_bytes() as u64,
+            last_cadence_warn: None,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
         })
@@ -963,6 +1003,7 @@ impl WasmEngine for WasmtimeEngine {
         let store_expired = self.store_created_at.elapsed() >= STORE_MAX_AGE;
 
         if self.instances.is_empty() && (threshold_exceeded || arena_over_budget) {
+            self.note_refresh_cadence(arena_over_budget);
             // Normal path: all instances dropped and either bound exceeded.
             //
             // `debug!`, not `info!`: with the byte bound this is a routine event
@@ -1393,6 +1434,7 @@ impl WasmtimeEngine {
             lifetime_instances: 0,
             retired_instance_bytes: 0,
             arena_budget_bytes: store_arena_budget_bytes() as u64,
+            last_cadence_warn: None,
             store_created_at: Instant::now(),
             offload_compilation: config.offload_compilation,
         })
@@ -1640,6 +1682,44 @@ impl WasmtimeEngine {
         self.lifetime_instances = 0;
         self.retired_instance_bytes = 0;
         self.store_created_at = Instant::now();
+    }
+
+    /// Warn (rate-limited) when the arena bound is firing after a SINGLE
+    /// instance, i.e. one contract's linear memory alone meets or exceeds this
+    /// Store's whole arena budget, so every call to it now ends in a Store
+    /// refresh rather than a periodic one.
+    ///
+    /// Correct behaviour (see [`store_arena_budget_bytes`]) but not free, and it
+    /// lands on exactly the large-contract, memory-constrained peers this work
+    /// targets. Without a signal it would be an invisible CPU cost that looks
+    /// like "the node got slower after the upgrade" with nothing to point at; the
+    /// refresh line itself is `debug!` precisely because it is too frequent to
+    /// read, so the diagnosis has to come from here. `warn!` and rate-limited to
+    /// one line per [`CADENCE_WARN_INTERVAL`], so it is greppable without
+    /// becoming the flood it reports.
+    fn note_refresh_cadence(&mut self, arena_over_budget: bool) {
+        // `lifetime_instances` counts creations in the CURRENT Store and resets
+        // on every replace, so 1 here means this Store served exactly one call.
+        if !arena_over_budget || self.lifetime_instances > 1 {
+            return;
+        }
+        let now = Instant::now();
+        let due = self
+            .last_cadence_warn
+            .is_none_or(|prev| now.duration_since(prev) >= CADENCE_WARN_INTERVAL);
+        if !due {
+            return;
+        }
+        self.last_cadence_warn = Some(now);
+        tracing::warn!(
+            retired_instance_bytes = self.retired_instance_bytes,
+            arena_budget_bytes = self.arena_budget_bytes,
+            "A single contract instance's memory fills this worker's whole WASM \
+             arena budget, so its Store is being replaced on every call. Memory \
+             stays bounded, but each call pays an extra store rebuild. Raise the \
+             node's memory limit (MemoryMax) or lower FREENET_RUNTIME_POOL_SIZE \
+             to give each worker a larger arena budget."
+        );
     }
 
     /// Override the arena byte budget so a test can decide which of the two
@@ -3657,6 +3737,60 @@ mod tests {
             .create_instance(&module, 999_999, 1024)
             .expect("should create instance after byte-budget refresh");
         engine.drop_instance(&handle);
+    }
+
+    /// A single instance whose linear memory alone meets the arena budget must
+    /// keep WORKING — refreshing the Store on every call, with memory bounded and
+    /// no wedge — rather than looping, erroring, or silently growing.
+    ///
+    /// A contract may declare up to `DEFAULT_MAX_MEMORY_PAGES` (256 MiB), and on
+    /// the 2 GiB / 16-worker shape this PR targets the arena budget is 16 MiB, so
+    /// "one instance is the whole budget" is a reachable production case, not a
+    /// contrived one (#5268 review, 5th lens). This pins that it degrades to
+    /// per-call reclamation — the correct trade for a memory-constrained peer —
+    /// instead of misbehaving.
+    #[test]
+    fn instance_larger_than_the_arena_budget_refreshes_every_call_and_keeps_working() {
+        let config = RuntimeConfig::default();
+        let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        // 160 pages = 10 MiB of linear memory, against a 1 MiB arena budget: one
+        // instance is TEN times the whole budget.
+        let wat = r#"
+        (module
+          (memory (export "memory") 160)
+          (func (export "__frnt__initiate_buffer") (param i32) (result i64)
+            i64.const 0)
+          (func (export "__frnt_set_id") (param i64)))
+        "#;
+        let module = engine.compile(wat.as_bytes()).unwrap();
+        engine.set_arena_budget_for_test(1024 * 1024);
+
+        for i in 0..12 {
+            let handle = engine
+                .create_instance(&module, i as i64, 1024)
+                .unwrap_or_else(|e| panic!("instance {i} must still be creatable: {e}"));
+            assert_eq!(
+                engine.lifetime_instances, 1,
+                "each call starts from a fresh Store, so it is the Store's first \
+                 instance"
+            );
+            engine.drop_instance(&handle);
+            assert_eq!(
+                engine.lifetime_instances, 0,
+                "an instance larger than the budget must trigger a refresh on \
+                 EVERY call"
+            );
+            assert_eq!(
+                engine.retired_instance_bytes, 0,
+                "the refresh must reset the arena accounting, so residue cannot \
+                 accumulate across calls"
+            );
+        }
+
+        assert!(
+            engine.is_healthy(),
+            "the engine must survive per-call store replacement"
+        );
     }
 
     /// The arena budget must be derived from the memory the node may use divided

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -55,17 +55,19 @@ pub(crate) type SharedModuleCache<K> = Arc<Mutex<ModuleCache<K, <Engine as WasmE
 /// themselves rather than from the container's self-declared `code` field
 /// (`ContractCode::hash()` returns a stored field; nothing recomputes it on
 /// deserialization — see `ContractStore::verify_contract_identity`).
-/// The catch-all mirrors the code extraction in `prepare_contract_call_inner`,
-/// which is `unimplemented!()` for the same inputs (both stdlib enums are
-/// `#[non_exhaustive]` but each has exactly one variant), so this adds no
-/// reachable panic: a container that trips this one could never have been
-/// compiled and cached in the first place.
-fn wasm_code_hash(contract: &ContractContainer) -> CodeHash {
+/// Returns an error rather than `unimplemented!()` on the catch-all, matching
+/// `ContractStore::store_contract`'s reasoning for the identical situation:
+/// unreachable today (V1 is `ContractWasmAPIVersion`'s only variant), but the
+/// enum is `#[non_exhaustive]`, and this now runs on the common PUT path, so a
+/// future variant would make that panic reachable from ordinary traffic.
+fn wasm_code_hash(contract: &ContractContainer) -> RuntimeResult<CodeHash> {
     match contract {
         ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => {
-            CodeHash::from_code(contract_v1.code().data())
+            Ok(CodeHash::from_code(contract_v1.code().data()))
         }
-        ContractContainer::Wasm(_) | _ => unimplemented!(),
+        ContractContainer::Wasm(_) | _ => {
+            Err(anyhow::anyhow!("unsupported contract container version").into())
+        }
     }
 }
 
@@ -495,8 +497,10 @@ pub struct Runtime {
 
     pub(super) secret_store: SecretsStore,
     pub(super) delegate_store: DelegateStore,
-    /// LRU cache of compiled delegate modules (shared across pool executors).
-    pub(super) delegate_modules: SharedModuleCache<DelegateKey>,
+    /// LRU cache of compiled delegate modules (shared across pool executors),
+    /// keyed by the CODE hash rather than the delegate key — see
+    /// [`SharedModuleCache`] and `prepare_delegate_call`.
+    pub(super) delegate_modules: SharedModuleCache<CodeHash>,
     /// Persisted `ctx.write()` bytes per delegate, shared across pool
     /// executors so a prompt round-trip routed to a different `Runtime` still
     /// sees the pending state. See `native_api::DelegateContextCache`.
@@ -767,7 +771,7 @@ impl Runtime {
         secret_store: SecretsStore,
         host_mem: bool,
         contract_modules: SharedModuleCache<CodeHash>,
-        delegate_modules: SharedModuleCache<DelegateKey>,
+        delegate_modules: SharedModuleCache<CodeHash>,
         delegate_contexts: super::native_api::DelegateContextCache,
         created_delegates_count: super::native_api::SharedDelegateCounter,
         inherited_origins: super::native_api::SharedInheritedOrigins,
@@ -993,7 +997,7 @@ impl Runtime {
         // instance index, or — for a caller holding a not-yet-indexed container
         // — from hashing the very bytes we are about to compile.
         let code_hash = match already_fetched {
-            Some(contract) => wasm_code_hash(contract),
+            Some(contract) => wasm_code_hash(contract)?,
             None => self
                 .contract_store
                 .code_hash_from_id(key.id())
@@ -1089,14 +1093,32 @@ impl Runtime {
         key: &DelegateKey,
         req_bytes: usize,
     ) -> RuntimeResult<(RunningInstance, DelegateApiVersion)> {
+        // Same defect and same fix as the contract cache above (#5268):
+        // `prepare_delegate_call` compiles `delegate.code()` alone, but
+        // `DelegateKey`'s identity covers `key = BLAKE3(code_hash ‖ params)`, so
+        // keying by it compiled and retained one copy of identical machine code
+        // per PARAMETER SET — the shape per-user / per-room parameterized
+        // delegates hit hardest. The hash is resolved through this node's own
+        // delegate index for the same trust reason: `key.code_hash()` is
+        // unverified serde data, so a caller could otherwise name a delegate
+        // while choosing which cached module ran for it.
+        let code_hash = self
+            .delegate_store
+            .code_hash_from_key(key)
+            .ok_or_else(|| RuntimeInnerError::DelegateNotFound(key.clone()))?;
         // Lock held only for the lookup + Module clone; always dropped before
         // the compile below (never held across the blocking compile).
-        let cached = self.delegate_modules.lock().unwrap().get(key).cloned();
+        let cached = self
+            .delegate_modules
+            .lock()
+            .unwrap()
+            .get(&code_hash)
+            .cloned();
         let module = if let Some(module) = cached {
-            tracing::debug!(delegate = %key, "Module cache hit");
+            tracing::debug!(delegate = %key, %code_hash, "Module cache hit");
             module
         } else {
-            tracing::info!(delegate = %key, "Module cache miss — compiling");
+            tracing::info!(delegate = %key, %code_hash, "Module cache miss — compiling");
             let delegate = self
                 .delegate_store
                 .fetch_delegate(key, params)
@@ -1107,10 +1129,10 @@ impl Runtime {
             // Re-check cache: the lock was released before compilation, so
             // another executor may have compiled and cached this delegate.
             let mut cache = self.delegate_modules.lock().unwrap();
-            if let Some(existing) = cache.get(key).cloned() {
+            if let Some(existing) = cache.get(&code_hash).cloned() {
                 existing
             } else {
-                cache.insert(key.clone(), module.clone(), compiled_size);
+                cache.insert(code_hash, module.clone(), compiled_size);
                 module
             }
         };

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -55,6 +55,11 @@ pub(crate) type SharedModuleCache<K> = Arc<Mutex<ModuleCache<K, <Engine as WasmE
 /// themselves rather than from the container's self-declared `code` field
 /// (`ContractCode::hash()` returns a stored field; nothing recomputes it on
 /// deserialization — see `ContractStore::verify_contract_identity`).
+/// The catch-all mirrors the code extraction in `prepare_contract_call_inner`,
+/// which is `unimplemented!()` for the same inputs (both stdlib enums are
+/// `#[non_exhaustive]` but each has exactly one variant), so this adds no
+/// reachable panic: a container that trips this one could never have been
+/// compiled and cached in the first place.
 fn wasm_code_hash(contract: &ContractContainer) -> CodeHash {
     match contract {
         ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => {

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -39,7 +39,30 @@ use super::ModuleCache;
 ///   *count* cap did (the eviction-recompilation cycle behind issue #4441).
 /// - It bounds the cache's absolute memory footprint regardless of contract
 ///   count, which a count cap could not (1024 large modules ≫ 1024 small ones).
+///
+/// The contract cache is keyed by [`CodeHash`], NOT by `ContractKey`. Compilation
+/// only ever sees the WASM code (`engine.compile(code)`); parameters are written
+/// into linear memory at call time. Keying by `ContractKey` — whose `Hash`/`Eq`
+/// compare `instance = blake3(code_hash ‖ params)` — therefore compiled and
+/// retained one copy of identical machine code per PARAMETER SET: a measured
+/// ~17x duplication on a production gateway (3,746 cached modules for 215
+/// distinct `.wasm` files), which is issue #5268's largest single contributor to
+/// peers being OOM-killed at the shipped 2 GiB `MemoryMax`. The source-bytes
+/// cache one layer down (`ContractStore::contract_cache`) already keys this way.
 pub(crate) type SharedModuleCache<K> = Arc<Mutex<ModuleCache<K, <Engine as WasmEngine>::Module>>>;
+
+/// Content hash of a contract container's WASM code, derived from the bytes
+/// themselves rather than from the container's self-declared `code` field
+/// (`ContractCode::hash()` returns a stored field; nothing recomputes it on
+/// deserialization — see `ContractStore::verify_contract_identity`).
+fn wasm_code_hash(contract: &ContractContainer) -> CodeHash {
+    match contract {
+        ContractContainer::Wasm(ContractWasmAPIVersion::V1(contract_v1)) => {
+            CodeHash::from_code(contract_v1.code().data())
+        }
+        ContractContainer::Wasm(_) | _ => unimplemented!(),
+    }
+}
 
 static INSTANCE_ID: AtomicI64 = AtomicI64::new(0);
 
@@ -486,8 +509,10 @@ pub struct Runtime {
 
     /// Local contract storage.
     pub(crate) contract_store: ContractStore,
-    /// LRU cache of compiled contract modules (shared across pool executors).
-    pub(super) contract_modules: SharedModuleCache<ContractKey>,
+    /// LRU cache of compiled contract modules (shared across pool executors),
+    /// keyed by the CODE hash rather than the contract instance — see
+    /// [`SharedModuleCache`] and `prepare_contract_call_inner`.
+    pub(super) contract_modules: SharedModuleCache<CodeHash>,
 
     /// Optional state storage backend for V2 delegate contract access.
     pub(crate) state_store_db: Option<crate::contract::storages::Storage>,
@@ -736,7 +761,7 @@ impl Runtime {
         delegate_store: DelegateStore,
         secret_store: SecretsStore,
         host_mem: bool,
-        contract_modules: SharedModuleCache<ContractKey>,
+        contract_modules: SharedModuleCache<CodeHash>,
         delegate_modules: SharedModuleCache<DelegateKey>,
         delegate_contexts: super::native_api::DelegateContextCache,
         created_delegates_count: super::native_api::SharedDelegateCounter,
@@ -950,15 +975,46 @@ impl Runtime {
         req_bytes: usize,
         already_fetched: Option<&ContractContainer>,
     ) -> RuntimeResult<RunningInstance> {
+        // Resolve the CODE hash this instance runs, which is what the compiled
+        // module is keyed by (issue #5268). Compilation only ever sees the WASM
+        // code — parameters are written into linear memory at call time — so N
+        // instances of one contract share one compiled module.
+        //
+        // The hash must NOT come from `key.code_hash()`: that is an unverified
+        // serde field which `ContractKey`'s `Hash`/`Eq` never consult, so a
+        // caller naming an instance it is entitled to could otherwise choose
+        // WHICH cached module ran for it (the same reasoning as
+        // `ContractStore::fetch_contract`). Instead it comes from the node's own
+        // instance index, or — for a caller holding a not-yet-indexed container
+        // — from hashing the very bytes we are about to compile.
+        let code_hash = match already_fetched {
+            Some(contract) => wasm_code_hash(contract),
+            None => self
+                .contract_store
+                .code_hash_from_id(key.id())
+                .ok_or_else(|| {
+                    tracing::error!(
+                        contract = %key,
+                        phase = "prepare_contract_call_failed",
+                        "Contract not indexed in store during WASM execution"
+                    );
+                    RuntimeInnerError::ContractNotFound(*key)
+                })?,
+        };
         // Check shared cache first. The lock is held only for the duration of
         // the lookup + Module clone (an Arc bump) and is ALWAYS dropped before
         // the compile below — never held across the blocking compile.
-        let cached = self.contract_modules.lock().unwrap().get(key).cloned();
+        let cached = self
+            .contract_modules
+            .lock()
+            .unwrap()
+            .get(&code_hash)
+            .cloned();
         let module = if let Some(module) = cached {
-            tracing::debug!(contract = %key, "Module cache hit");
+            tracing::debug!(contract = %key, %code_hash, "Module cache hit");
             module
         } else {
-            tracing::info!(contract = %key, "Module cache miss — compiling");
+            tracing::info!(contract = %key, %code_hash, "Module cache miss — compiling");
             // Cache miss — obtain the code and compile with the lock released
             // so the (potentially multi-hundred-millisecond) Cranelift compile
             // never blocks other executors waiting on the shared cache. When
@@ -1002,10 +1058,10 @@ impl Runtime {
             // duplicate Cranelift work, but two distinct misses can still race
             // to this insert). Prefer the already-cached clone if present.
             let mut cache = self.contract_modules.lock().unwrap();
-            if let Some(existing) = cache.get(key).cloned() {
+            if let Some(existing) = cache.get(&code_hash).cloned() {
                 existing
             } else {
-                cache.insert(*key, module.clone(), compiled_size);
+                cache.insert(code_hash, module.clone(), compiled_size);
                 module
             }
         };

--- a/crates/core/src/wasm_runtime/tests.rs
+++ b/crates/core/src/wasm_runtime/tests.rs
@@ -52,6 +52,44 @@ pub(crate) fn get_test_module(name: &str) -> Result<Vec<u8>, Box<dyn std::error:
     Ok(std::fs::read(output_file)?)
 }
 
+/// Append a WASM custom section carrying `tag`, yielding a module that is
+/// byte-distinct (so it compiles to its own `Module` with its own code memory)
+/// but semantically identical to `code`.
+///
+/// Custom sections are `id=0` followed by a LEB128 payload length; the payload
+/// is a name (LEB128 length + bytes) plus arbitrary data, and they may appear
+/// after any other section.
+///
+/// Tests that need N genuinely different modules must go through this. Varying
+/// the PARAMETERS no longer produces distinct compiled modules — that
+/// duplication is exactly what #5268 removed — so a byte-eviction test built on
+/// distinct params would pass while measuring nothing.
+pub(crate) fn code_variant(code: &[u8], tag: &str) -> Vec<u8> {
+    fn leb128(mut value: u32, out: &mut Vec<u8>) {
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    let name = b"freenet-test-variant";
+    let mut payload = Vec::new();
+    leb128(name.len() as u32, &mut payload);
+    payload.extend_from_slice(name);
+    payload.extend_from_slice(tag.as_bytes());
+
+    let mut out = code.to_vec();
+    out.push(0x00); // custom section id
+    leb128(payload.len() as u32, &mut out);
+    out.extend_from_slice(&payload);
+    out
+}
+
 pub(crate) struct TestSetup {
     #[allow(unused)]
     temp_dir: tempfile::TempDir,

--- a/crates/core/src/wasm_runtime/tests/cache.rs
+++ b/crates/core/src/wasm_runtime/tests/cache.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use super::super::Runtime;
 use super::super::contract::ContractRuntimeInterface;
 use super::super::runtime::RuntimeConfig;
-use super::{TestSetup, get_test_module, setup_test_contract};
+use super::{TestSetup, code_variant, get_test_module, setup_test_contract};
 use freenet_stdlib::prelude::*;
 
 /// Loading a contract populates the cache and the cache stays within its byte
@@ -152,42 +152,6 @@ fn distinct_keys_same_code(
         keys.push(key);
     }
     keys
-}
-
-/// Append a WASM custom section carrying `tag`, yielding a module that is
-/// byte-distinct (so it compiles to its own `Module` with its own code memory)
-/// but semantically identical to `code`.
-///
-/// Custom sections are `id=0` followed by a LEB128 payload length; the payload
-/// is a name (LEB128 length + bytes) plus arbitrary data, and they may appear
-/// after any other section. This is how the eviction test below gets many
-/// genuinely different modules out of one compiled test contract — varying the
-/// PARAMETERS would no longer do it, because that is precisely the duplication
-/// #5268 removed.
-fn code_variant(code: &[u8], tag: &str) -> Vec<u8> {
-    fn leb128(mut value: u32, out: &mut Vec<u8>) {
-        loop {
-            let byte = (value & 0x7f) as u8;
-            value >>= 7;
-            if value == 0 {
-                out.push(byte);
-                return;
-            }
-            out.push(byte | 0x80);
-        }
-    }
-
-    let name = b"freenet-test-variant";
-    let mut payload = Vec::new();
-    leb128(name.len() as u32, &mut payload);
-    payload.extend_from_slice(name);
-    payload.extend_from_slice(tag.as_bytes());
-
-    let mut out = code.to_vec();
-    out.push(0x00); // custom section id
-    leb128(payload.len() as u32, &mut out);
-    out.extend_from_slice(&payload);
-    out
 }
 
 /// Build `count` contracts whose WASM code is genuinely distinct (one custom
@@ -484,6 +448,145 @@ async fn test_compiled_module_size_is_in_expected_range() -> Result<(), Box<dyn 
         (10 * 1024..=16 * 1024 * 1024).contains(&measured),
         "compiled module size {measured} bytes outside expected 10KiB..16MiB range; \
          revisit the module cache budget if the toolchain changed"
+    );
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
+/// Many pool executors, on separate threads, driving DIFFERENT instances of the
+/// SAME code through one shared module cache must end with exactly ONE compiled
+/// module and no lost work.
+///
+/// Keying by code hash makes this the common case rather than a rarity: before
+/// #5268 each parameterization had its own cache key, so concurrent calls for
+/// distinct instances never contended on the same entry at all. Now they all
+/// race the one key, and specifically the double-check-after-compile in
+/// `prepare_contract_call_inner` — the lock is released across the (slow)
+/// Cranelift compile, so several threads can miss, compile, and then race to
+/// insert. That must converge on a single cached entry, not N inserts trading
+/// places or a torn byte total.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_calls_on_one_code_converge_to_one_cached_module()
+-> Result<(), Box<dyn std::error::Error>> {
+    use super::super::{
+        ContractStore, DelegateStore, SecretsStore, SharedContractIndex, contract_store,
+        engine::Engine,
+    };
+    use crate::contract::storages::Storage;
+    use crate::util::tests::get_temp_dir;
+    use std::sync::{Barrier, Mutex};
+
+    const EXECUTORS: usize = 4;
+
+    let code = get_test_module("test_contract_1")?;
+    let temp_dir = get_temp_dir();
+    let db = Storage::new(temp_dir.path()).await?;
+
+    // One index and one source-byte cache, exactly as `RuntimePool` wires them.
+    let index = SharedContractIndex::default();
+    let code_cache = contract_store::new_code_cache(10 * 1024 * 1024);
+
+    // EXECUTORS distinct instances of ONE code, stored once through the shared
+    // index so every executor's store resolves them.
+    let mut seed_store = ContractStore::new_with_shared(
+        temp_dir.path().join("contracts"),
+        db.clone(),
+        index.clone(),
+        code_cache.clone(),
+    )?;
+    let keys = distinct_keys_same_code(&mut seed_store, &code, EXECUTORS);
+    drop(seed_store);
+
+    let config = RuntimeConfig {
+        module_cache_budget_bytes: 512 * 1024 * 1024,
+        ..Default::default()
+    };
+    let shared_modules: super::super::runtime::SharedModuleCache<CodeHash> = Arc::new(Mutex::new(
+        super::super::ModuleCache::new(config.module_cache_budget_bytes),
+    ));
+    let shared_delegate_modules: super::super::runtime::SharedModuleCache<CodeHash> =
+        Arc::new(Mutex::new(super::super::ModuleCache::new(
+            config.module_cache_budget_bytes,
+        )));
+    let backend = Engine::create_backend_engine(&config)?;
+    let delegate_contexts = super::super::new_delegate_context_cache();
+    let delegate_counter = super::super::new_delegate_counter();
+    let inherited_origins = super::super::new_inherited_origins();
+
+    let mut runtimes = Vec::with_capacity(EXECUTORS);
+    for i in 0..EXECUTORS {
+        let contract_store = ContractStore::new_with_shared(
+            temp_dir.path().join("contracts"),
+            db.clone(),
+            index.clone(),
+            code_cache.clone(),
+        )?;
+        let delegate_store = DelegateStore::new(
+            temp_dir.path().join(format!("delegates-{i}")),
+            10_000,
+            db.clone(),
+        )?;
+        let secrets_store = SecretsStore::new(
+            temp_dir.path().join(format!("secrets-{i}")),
+            Default::default(),
+            db.clone(),
+        )?;
+        runtimes.push(Runtime::build_with_shared_module_caches(
+            contract_store,
+            delegate_store,
+            secrets_store,
+            false,
+            shared_modules.clone(),
+            shared_delegate_modules.clone(),
+            delegate_contexts.clone(),
+            delegate_counter.clone(),
+            inherited_origins.clone(),
+            backend.clone(),
+            &config,
+        )?);
+    }
+
+    // Release every thread into its first (guaranteed-miss) call at once, so the
+    // compile-then-insert race is actually exercised rather than serialized by
+    // thread startup.
+    let barrier = Arc::new(Barrier::new(EXECUTORS));
+    let mut handles = Vec::with_capacity(EXECUTORS);
+    for (i, mut runtime) in runtimes.into_iter().enumerate() {
+        let key = keys[i];
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            let params = Parameters::from(format!("param-{i}").into_bytes());
+            let state = WrappedState::new(vec![1, 2, 3, 4]);
+            barrier.wait();
+            // Repeat so later iterations exercise the hit path under the same
+            // contention, not just the cold race.
+            for _ in 0..8 {
+                let result = runtime.validate_state(&key, &params, &state, &Default::default());
+                assert!(
+                    matches!(result, Ok(ValidateResult::Valid)),
+                    "instance {i} must validate through the shared module: {result:?}"
+                );
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("executor thread panicked");
+    }
+
+    let cache = shared_modules.lock().unwrap();
+    assert_eq!(
+        cache.len(),
+        1,
+        "{EXECUTORS} concurrent executors on one code must leave exactly ONE \
+         cached module, got {}",
+        cache.len()
+    );
+    assert!(
+        cache.total_bytes() > 0 && cache.total_bytes() <= cache.budget_bytes(),
+        "byte accounting must survive the insert race: {} bytes against a {} budget",
+        cache.total_bytes(),
+        cache.budget_bytes()
     );
 
     std::mem::drop(temp_dir);

--- a/crates/core/src/wasm_runtime/tests/cache.rs
+++ b/crates/core/src/wasm_runtime/tests/cache.rs
@@ -126,9 +126,9 @@ async fn test_module_cache_tiny_budget_still_runs() -> Result<(), Box<dyn std::e
 /// Build `count` distinct `ContractKey`s from the SAME WASM code by varying the
 /// parameters, store/index each in the contract store, and return the keys.
 ///
-/// Each key is a separate cache entry (cache is keyed by the full
-/// `ContractKey`), so loading all of them exercises eviction with real compiled
-/// module sizes without needing many distinct contract source files.
+/// Every key is a distinct contract INSTANCE running byte-identical code, which
+/// is the shape issue #5268 is about: the compiled module is keyed by code hash,
+/// so all `count` instances must share exactly ONE cache entry.
 fn distinct_keys_same_code(
     contract_store: &mut super::super::ContractStore,
     code: &[u8],
@@ -154,6 +154,186 @@ fn distinct_keys_same_code(
     keys
 }
 
+/// Append a WASM custom section carrying `tag`, yielding a module that is
+/// byte-distinct (so it compiles to its own `Module` with its own code memory)
+/// but semantically identical to `code`.
+///
+/// Custom sections are `id=0` followed by a LEB128 payload length; the payload
+/// is a name (LEB128 length + bytes) plus arbitrary data, and they may appear
+/// after any other section. This is how the eviction test below gets many
+/// genuinely different modules out of one compiled test contract — varying the
+/// PARAMETERS would no longer do it, because that is precisely the duplication
+/// #5268 removed.
+fn code_variant(code: &[u8], tag: &str) -> Vec<u8> {
+    fn leb128(mut value: u32, out: &mut Vec<u8>) {
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    let name = b"freenet-test-variant";
+    let mut payload = Vec::new();
+    leb128(name.len() as u32, &mut payload);
+    payload.extend_from_slice(name);
+    payload.extend_from_slice(tag.as_bytes());
+
+    let mut out = code.to_vec();
+    out.push(0x00); // custom section id
+    leb128(payload.len() as u32, &mut out);
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Build `count` contracts whose WASM code is genuinely distinct (one custom
+/// section apart), store/index each, and return the keys.
+fn distinct_code_keys(
+    contract_store: &mut super::super::ContractStore,
+    code: &[u8],
+    count: usize,
+) -> Vec<ContractKey> {
+    let mut keys = Vec::with_capacity(count);
+    for i in 0..count {
+        let variant = code_variant(code, &format!("variant-{i}"));
+        let wrapped = WrappedContract::new(
+            Arc::new(ContractCode::from(variant)),
+            Parameters::from([].as_ref()).into_owned(),
+        );
+        let key = *wrapped.key();
+        let container = ContractContainer::Wasm(ContractWasmAPIVersion::V1(wrapped));
+        contract_store
+            .store_contract(container)
+            .expect("store distinct-code contract");
+        contract_store
+            .ensure_key_indexed(&key)
+            .expect("index distinct-code key");
+        keys.push(key);
+    }
+    keys
+}
+
+/// REGRESSION (issue #5268): instances of the same code that differ only in
+/// their parameters MUST share ONE compiled module.
+///
+/// Compilation never sees parameters — `engine.compile` is handed
+/// `contract_v1.code().data()` alone and parameters are written into linear
+/// memory at call time — so a cache keyed by `ContractKey` (whose `Hash`/`Eq`
+/// compare `instance = blake3(code_hash ‖ params)`) compiled and retained one
+/// copy of identical machine code per parameter set. Measured on a production
+/// gateway: 3,746 cached modules for 215 distinct `.wasm` files, ~94% of the
+/// module-cache budget wasted, and the largest single contributor to peers
+/// being OOM-killed at the shipped 2 GiB `MemoryMax`.
+///
+/// Before the fix this test sees 8 entries and ~8x the bytes; after it, 1.
+#[tokio::test(flavor = "multi_thread")]
+async fn same_code_different_params_share_one_module() -> Result<(), Box<dyn std::error::Error>> {
+    let code = get_test_module("test_contract_1")?;
+
+    let TestSetup {
+        mut contract_store,
+        delegate_store,
+        secrets_store,
+        temp_dir,
+        ..
+    } = setup_test_contract("test_contract_1").await?;
+
+    let keys = distinct_keys_same_code(&mut contract_store, &code, 8);
+
+    let config = RuntimeConfig {
+        module_cache_budget_bytes: 512 * 1024 * 1024,
+        ..Default::default()
+    };
+    let mut runtime =
+        Runtime::build_with_config(contract_store, delegate_store, secrets_store, false, config)
+            .unwrap();
+
+    let state = WrappedState::new(vec![1, 2, 3, 4]);
+    for (i, key) in keys.iter().enumerate() {
+        let params = Parameters::from(format!("param-{i}").into_bytes());
+        drop(runtime.validate_state(key, &params, &state, &Default::default()));
+    }
+
+    let cache = runtime.contract_modules.lock().unwrap();
+    assert_eq!(
+        cache.len(),
+        1,
+        "8 instances of one contract's code must share ONE compiled module, got {} entries",
+        cache.len()
+    );
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
+/// Distinct instances of the same code must still each RUN correctly: the shared
+/// module is parameter-independent, and the parameters a call is executed with
+/// are the ones passed to that call.
+///
+/// Guards the obvious way to get `same_code_different_params_share_one_module`
+/// to pass wrongly — serving one instance's compiled module while silently
+/// running it with another instance's parameters.
+#[tokio::test(flavor = "multi_thread")]
+async fn shared_module_still_honors_per_instance_parameters()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = get_test_module("test_contract_1")?;
+
+    let TestSetup {
+        mut contract_store,
+        delegate_store,
+        secrets_store,
+        temp_dir,
+        ..
+    } = setup_test_contract("test_contract_1").await?;
+
+    let keys = distinct_keys_same_code(&mut contract_store, &code, 3);
+
+    let mut runtime = Runtime::build_with_config(
+        contract_store,
+        delegate_store,
+        secrets_store,
+        false,
+        RuntimeConfig::default(),
+    )
+    .unwrap();
+
+    // test-contract-1 returns Valid for a 4-byte state and Invalid otherwise,
+    // independently of parameters — so every instance must agree on both.
+    for (i, key) in keys.iter().enumerate() {
+        let params = Parameters::from(format!("param-{i}").into_bytes());
+        let valid = runtime.validate_state(
+            key,
+            &params,
+            &WrappedState::new(vec![1, 2, 3, 4]),
+            &Default::default(),
+        );
+        assert!(
+            matches!(valid, Ok(ValidateResult::Valid)),
+            "instance {i} must validate its own state through the shared module: {valid:?}"
+        );
+        // test-contract-1 signals a non-4-byte state by returning an
+        // InvalidState error rather than `ValidateResult::Invalid`; either way
+        // it must NOT come back Valid.
+        let invalid = runtime.validate_state(
+            key,
+            &params,
+            &WrappedState::new(vec![1, 2, 3]),
+            &Default::default(),
+        );
+        assert!(
+            !matches!(invalid, Ok(ValidateResult::Valid)),
+            "instance {i} must reject a bad state through the shared module: {invalid:?}"
+        );
+    }
+
+    std::mem::drop(temp_dir);
+    Ok(())
+}
+
 /// REGRESSION (issue #4441): the cache evicts by BYTES, not by a fixed entry
 /// count. Loading many distinct modules under a byte budget that only holds a
 /// few must keep `total_bytes <= budget` and evict the rest — and crucially the
@@ -177,8 +357,10 @@ async fn test_module_cache_evicts_by_bytes_not_count() -> Result<(), Box<dyn std
         ..
     } = setup_test_contract("test_contract_1").await?;
 
-    // Create 8 distinct-param keys over the same code.
-    let keys = distinct_keys_same_code(&mut contract_store, &code, 8);
+    // Create 8 keys over genuinely DISTINCT code. Distinct parameters over one
+    // code would no longer produce 8 cache entries — that duplication is the
+    // #5268 bug — so eviction has to be driven by real distinct modules.
+    let keys = distinct_code_keys(&mut contract_store, &code, 8);
 
     // First, measure one compiled module's size with a generous budget so we
     // can pick a byte budget that holds only ~2 modules.
@@ -195,10 +377,10 @@ async fn test_module_cache_evicts_by_bytes_not_count() -> Result<(), Box<dyn std
     )
     .unwrap();
     let valid_state = WrappedState::new(vec![1, 2, 3, 4]);
-    let params0 = Parameters::from("param-0".as_bytes().to_vec());
+    let params = Parameters::from([].as_ref());
     // We only care that the module compiled and got cached; the validate
     // outcome is irrelevant here, so explicitly discard the must-use result.
-    drop(probe_runtime.validate_state(&keys[0], &params0, &valid_state, &Default::default()));
+    drop(probe_runtime.validate_state(&keys[0], &params, &valid_state, &Default::default()));
     let per_module = {
         let cache = probe_runtime.contract_modules.lock().unwrap();
         assert_eq!(cache.len(), 1);
@@ -215,7 +397,6 @@ async fn test_module_cache_evicts_by_bytes_not_count() -> Result<(), Box<dyn std
 
     // Load all 8 distinct modules.
     for (i, key) in keys.iter().enumerate() {
-        let params = Parameters::from(format!("param-{i}").into_bytes());
         drop(probe_runtime.validate_state(key, &params, &valid_state, &Default::default()));
 
         let cache = probe_runtime.contract_modules.lock().unwrap();


### PR DESCRIPTION
## Problem

Peers are being OOM-killed against the **2 GiB `MemoryMax`** shipped in the systemd unit (87.5% of peers report exactly that limit). Issue #5268 documents three compounding defects; none of them is legitimate use, so raising the cap fixes nothing.

1. **The compiled-module caches were keyed by contract/delegate INSTANCE, not code hash.** Compilation never sees parameters — `engine.compile` is handed the code alone and parameters are written into linear memory at call time — but the caches were keyed by `ContractKey` / `DelegateKey`, whose identity covers `BLAKE3(code_hash ‖ params)`. Identical machine code was therefore compiled and retained once per parameter set: **3,746 cached modules for 215 distinct `.wasm` files on nova (~17x)**, with 61.1% of samples pinned at ≥99% of the module-cache budget and a median 247 MiB wasted.

2. **The wasmtime Store arena was unbudgeted in resident terms.** wasmtime arena-allocates instances, so dropping an `Instance` frees nothing until the whole Store is replaced. The only bound was a fixed 500-instance count whose comment budgets *virtual* memory (~125 GiB, matching nova's `VmSize`). RSS is a sawtooth, not a ramp — `framework`'s fell **1.46 GiB within one second** of a refresh — and the peak height is set by an instance count, which is why kill intervals varied 5.5 h vs 1.1 h on one node.

3. **Cache ceilings were multiplied by a CPU-derived pool size, never composed against the memory cap.** Declared ceilings at a 2 GiB cgroup sum to ~2.9 GiB, dominated by `pool_size × (32 MiB summary + 64 MiB delta)` = 1.5 GiB, where `pool_size = clamp(cores−1, 1, 16)` comes from CPU count — which `MemoryMax` does not constrain. On top of that, redb was opened bare (silently applying its **1 GiB default page cache**) and each executor built its own 10 MiB source-WASM byte caches (**`pool_size × 2 × 10 MiB` = 320 MiB** at 16 workers) — both uncounted by any budget.

## Approach

**Defect 1 — key the module caches by `CodeHash`** (`wasm_runtime/runtime.rs`, both `prepare_contract_call_inner` and `prepare_delegate_call`).

The hash is resolved from the node's own instance index, or — for a caller holding a container that is not yet indexed, e.g. `validate_state_with_contract` — by hashing the very bytes about to be compiled. It is deliberately **not** taken from `key.code_hash()`: that is an unverified serde field which identity never consults, so trusting it would let a caller naming an instance it is entitled to choose *which* cached module ran for it. This is the same reasoning `ContractStore::fetch_contract` and `DelegateStore::fetch_delegate` already document.

Two consequences the delegate side required:

- **The delegate index is now shared across the pool**, as the contract side has been since #4218. Each executor's `DelegateStore` previously froze its index at construction; that was survivable only because a warm (shared) module cache let a sibling executor run a delegate its own index had never heard of, which stops being true once the cache is keyed by an index-resolved hash.
- **`unregister_delegate` drops the compiled module only when no remaining indexed delegate runs that code**, mirroring the reference check `remove_delegate` already applies to the `.wasm` blob. The old unconditional `remove(key)` would now evict the module its still-registered siblings share.

The contract cache's interest predicate had to be restated at code-hash granularity, since `Ring::contract_in_use` is a per-instance question and the cache no longer holds instances. `InUseCodeHashes` enumerates the in-use set (`Ring::in_use_contract_ids`) and maps it through the shared index, memoized for 10 s so an eviction sweep over thousands of cached modules does not re-derive it per entry.

**Defect 2 — bound the Store arena by resident bytes** (`wasm_runtime/engine/wasmtime_engine.rs`).

`drop_instance` charges the finishing instance's linear memory to `retired_instance_bytes` and refreshes once that reaches `clamp(memory_limit / 8 / pool_size, 4 MiB, 256 MiB)`. The memory limit comes from `read_total_ram_bytes`, which already resolves `min(MemTotal, cgroup limit)` and so honours `MemoryMax=2G`; the pool-size divisor is there because there is one Store *per pool worker*. Both the normal and the **forced** (orphaned-instance) refresh arms take either bound — the leaked instance is precisely the case the byte accounting claims to cover, so requiring the full 500-instance count there would have left it unbounded on the one path that reaches it.

The instance-count and store-age thresholds remain as backstops for instances leaked without engine cleanup, which byte accounting cannot see.

**Defect 3 — compose the ceilings** (`contract/executor.rs`, `contract/storages/redb.rs`, `wasm_runtime.rs`).

Per-executor summary/delta budgets are capped by their share of a node-wide envelope divided by the pool size; the redb page cache is scaled to the memory limit (64 MiB on a 2 GiB peer, unchanged at redb's own 1 GiB default above 32 GiB of RAM); and the two source-WASM byte caches are now **shared across the pool** rather than built per executor, taking that term from 320 MiB to 20 MiB while removing the same duplicate-by-parameterization shape one layer down. The pool-size derivation moved to `config::runtime_pool_size` so the divisor and the pool `RuntimePool::new` actually creates cannot drift.

These bind **only** on memory-constrained many-core hosts. A single-worker 2 GiB peer (vega's shape) and a large gateway keep exactly the budgets they had.

### Known behaviour changes worth watching post-rollout

- **`interested_bytes` / `would_reclassify` change meaning at this release boundary.** Interest is now code-hash-granular, so for a WASM shared by many instances where at least one is always in use (River's room contract), the code hash is permanently "interested" and `lru_cold_key()` will typically return `None` — two-tier eviction degenerates toward plain LRU for those entries. Expect a step change in both gauges at rollout; it is this change, not a regression. The SubscribeHint admission gate reads the same gauges and its freshness comment has been corrected accordingly (the gate is dormant today).
- **A module-cache HIT now requires an index lookup that can miss.** `prepare_contract_call_inner` / `prepare_delegate_call` resolve the code hash through the instance index before consulting the cache, so a warm hit for an instance the node has no index row for now returns `ContractNotFound` / `DelegateNotFound` where it previously served. That is the intended gate (it is what stops a caller choosing which module runs for an instance) and mirrors `fetch_contract`'s own index gating; for delegates the sharing change above is what keeps it from being a cross-executor regression.
- **Store refreshes are much more frequent on constrained hosts** (~every 5 instances at a 16 MiB arena budget vs ~every 500), so that log line dropped from `info!` to `debug!`.
- **A contract whose linear memory alone meets the arena budget now refreshes the Store on EVERY call.** Reachable in production: a contract may declare up to 256 MiB and the 2 GiB / 16-worker shape budgets 16 MiB per worker. This is kept deliberately — the alternative is retaining an arena already at the limit the node is trying not to exceed — but it is no longer silent: `note_refresh_cadence` emits a rate-limited (5 min) `warn!` naming the condition and the two levers (raise `MemoryMax`, lower `FREENET_RUNTIME_POOL_SIZE`). A floor scaled to observed instance size was considered and rejected: it would guarantee `N × (up to 256 MiB) × pool_size` of slack no memory limit could reduce, which is defect 3's shape again, to avoid a `Store::new` that is a fraction of the call it accompanies.

### Judgment calls for review

- **10 s interest staleness** in the code-hash in-use set. Matches the module cache's own `INTEREST_SHADOW_REFRESH_INTERVAL`, but it is a change from the previously-exact per-key predicate.
- **blake3 over the container bytes on the `already_fetched` path**, chosen for unconditional correctness over trusting the index there. Sub-millisecond next to the `validate_state` WASM call it accompanies.
- **The divisors** (arena `/8`, summary+delta envelope `/8`, redb `/32`), the `1:2` summary:delta split, and the 4 MiB arena floor. Sized to fit a 2 GiB peer with headroom, not derived from measurement. The floor is deliberately small because `pool_size × floor` is itself a CPU-multiplied constant — the defect-3 shape in miniature.
- **Compiled modules are not evicted when a code hash becomes unreferenced** on the contract side; they age out by LRU (the delegate side does evict, because `unregister_delegate` is an explicit removal point with a cheap reference check available). Bounded by the budget either way.

## Testing

Every new test was verified to **fail without its fix** by temporarily mutating the code, then reverted.

New:
- `cache::same_code_different_params_share_one_module` and `delegate::test::same_code_different_params_share_one_delegate_module` — 8 (resp. 6) instances of one code under different parameters must produce exactly 1 cache entry. Under per-instance-keying mutations: 8 and 6.
- `cache::shared_module_still_honors_per_instance_parameters` — guards the obvious wrong way to pass those (serving one instance's module while running another's parameters).
- `cache::concurrent_calls_on_one_code_converge_to_one_cached_module` — 4 executors on separate threads, released through a barrier, driving different instances of one code through a shared cache and backend engine. Keying by code hash makes the compile-then-insert race in `prepare_contract_call_inner` the common case rather than a rarity; this asserts it converges on one entry with intact byte accounting.
- `delegate::test::unregister_keeps_a_module_a_sibling_delegate_still_runs` — and drops it once the last reference goes.
- `pool::tests::in_use_code_hashes::*` — four tests covering the many-to-one mapping, index gating (in-use but unindexed resolves to nothing), the memoization window (50 lookups cost one scan; an expired window recomputes rather than latching), and post-window visibility of new demand.
- `wasmtime_engine::tests::store_refresh_fires_on_arena_bytes_before_instance_count` — measures what one instance retains, sets a 4-instance budget, requires repeated refreshes well below `STORE_REFRESH_THRESHOLD`. With the byte bound disarmed: 0 refreshes.
- `wasmtime_engine::tests::instance_larger_than_the_arena_budget_refreshes_every_call_and_keeps_working` — a 10 MiB-memory contract against a 1 MiB budget: twelve calls all succeed, each refreshing, with the arena accounting reset every time so residue cannot accumulate.
- `wasmtime_engine::tests::arena_budget_is_memory_derived_and_pool_divided` and `config::tests::runtime_pool_size_clamps_cores_and_override` — pure sizing/clamp boundaries, the latter exercised through a pure helper rather than the env-reading wrapper, since `FREENET_RUNTIME_POOL_SIZE` is process-global and setting it would race every other test in the binary.
- `executor::tests::per_executor_budgets_shrink_as_the_pool_grows` — pins the mechanism, not just its aggregate consequence.
- `executor::tests::declared_cache_ceiling_names_every_budget` — a source-scrape pin requiring every budget to appear in the aggregate. The bound it feeds is an inequality with headroom, so a dropped term passes silently; that is exactly how the first version of this PR came to omit the arena and the source-byte caches from a sum whose doc comment claimed to include everything.
- `executor::tests::small_host_ceiling_is_dominated_by_floors_this_pr_does_not_own` — states the boundary below ~1 GiB rather than leaving it an untested gap.

Changed:
- `executor::tests::cache_byte_budgets_are_aggregate_safe` modelled only a 7600 MiB gateway with a hardcoded worst-case pool size. It now sums **every** declared ceiling — summary, delta, Store arena (× pool), both module caches, both source-byte caches, redb — for a 1 GiB VPS, a 2 GiB peer and a gateway, across three pool sizes, from **pure sizing functions** rather than the test host's own RAM and core count. Verified to fail against each half of the defect-3 fix independently.
- `test_module_cache_evicts_by_bytes_not_count` and `test_delegate_cache_evicts_by_bytes` both relied on distinct *parameters* producing distinct cache entries — precisely the duplication this PR removes, so both would have silently become vacuous. Rebuilt on genuinely distinct modules (one appended WASM custom section apart).
- The four instance-count engine tests pin the arena budget off, so which of the two refresh bounds each examines is explicit and host-independent.

Runs:
- `cargo test -p freenet --lib` — 4892 passed, 0 failed.
- Because the suite gained tests, it was run **12 times** to check for cross-test interference (the class `.claude/rules/testing.md` warns `cargo nextest` cannot see). Two runs each produced one failure, both **known pre-existing flakes that reproduce on unmodified base commits**: `validate_host_function_delegate` (#5039, which names this exact test) and `fallback_rotation_covers_the_whole_shared_set` (#5181, whose title is its root cause — the rotation re-randomizes mid-cycle). Both pass in isolation; neither is on a path this PR touches.
- `--test operations` 22 passed; `--test persistence_roundtrip` 1 passed; `--test hosted_mode_isolation` 3 passed; `--test hosted_mode_migrate` 4 passed (the last two cover the delegate registration/secret paths this round touched).
- `cargo fmt --all --check` clean; `cargo clippy -p freenet --all-targets --all-features` clean.

Not covered: no test asserts a real peer's RSS stays under 2 GiB — that needs field validation after rollout. The predicted effect is the ~94% module-cache reclaim, a sawtooth peak bounded at 256 MiB node-wide instead of unbounded, and declared ceilings at ~45% of the limit instead of 145% of it.

Closes #5268

[AI-assisted - Claude]
