### PR TITLE
fix(hosting): add a count-derived resident-overhead eviction pressure axis

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1689,6 +1689,22 @@ pub struct HostingSnapshot {
     /// real value — so the panel can distinguish "not yet computed" from a
     /// genuine (if enormous) budget.
     pub disk_budget_bytes: Option<u64>,
+    /// Configured resident-overhead budget (bytes, #5325): the RAM-scaled
+    /// ceiling on `contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`, a
+    /// pressure axis independent of `budget_bytes`/`used_bytes` (which cover
+    /// contract STATE bytes only, not the per-contract resident bookkeeping
+    /// overhead that scales with count). See
+    /// `.claude/rules/hosting-invariants.md` invariant 3.
+    pub resident_overhead_budget_bytes: u64,
+    /// Current estimated resident-overhead bytes (#5325): `contract_count *
+    /// ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`. Compare against
+    /// `resident_overhead_budget_bytes` the same way `used_bytes` is compared
+    /// against `budget_bytes`.
+    pub estimated_resident_overhead_bytes: u64,
+    /// Monotonic count of evictions where resident-overhead pressure was
+    /// active at decision time (#5325); may overlap with
+    /// `budget_evictions_total`.
+    pub resident_overhead_evictions_total: u64,
 }
 
 /// One hosted contract's demand-driven eviction row for the dashboard.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4497,6 +4497,9 @@ impl Ring {
             disk_compile_cache_bytes,
             disk_total_bytes,
             disk_budget_bytes,
+            resident_overhead_budget_bytes: stats.resident_overhead_budget_bytes,
+            estimated_resident_overhead_bytes: stats.estimated_resident_overhead_bytes,
+            resident_overhead_evictions_total: stats.resident_overhead_evictions_total,
         }
     }
 

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -280,6 +280,24 @@ pub(crate) fn resident_overhead_budget_for_ram(total_ram: u64) -> u64 {
     )
 }
 
+/// Minimum CONTINUOUS breach duration required before resident-overhead
+/// pressure contributes to the eviction decision (#5325 PR review, Must-Fix
+/// #1): the raw over-budget reading must persist for at least half of this
+/// window (see [`HostingCache::resident_overhead_over_budget`]) — i.e. 150s
+/// at the current value — before eviction acts on it.
+///
+/// Set equal to [`COST_RATE_MIN_WINDOW`] (the #4861 cost-pressure precedent
+/// this mirrors) for a first cut, but declared as its OWN constant rather
+/// than a reference to that one: the two gate conceptually different things
+/// (a per-contract sampled RATE vs. a per-node exact contract COUNT) and
+/// tuning one should not silently retune the other. 300s / 150s-to-arm is
+/// long enough that the 5s periodic sweep (`CLEANUP_INTERVAL`,
+/// `node/op_state_manager.rs`) observes the breach ~30 times before it can
+/// arm, so a single stale/racy read can't trigger it, and short enough that
+/// a genuinely persistent post-upgrade overage still gets addressed within
+/// a few minutes rather than never.
+pub(crate) const RESIDENT_OVERHEAD_SUSTAINED_WINDOW: Duration = Duration::from_secs(300);
+
 /// Default fraction of the disk capacity *available to Freenet* used to size the
 /// aggregate disk budget (#4683): 50%. Sized against `used + free` (capacity the
 /// node can actually reach), NOT a naive live free-space read that shrinks as it
@@ -1008,10 +1026,21 @@ pub struct HostingCache<T: TimeSource> {
     /// that separates still-wanted contracts from stale ones. Measured in
     /// cache-contention units, not wall-clock.
     eviction_floor: f64,
-    /// Monotonic count of contracts evicted because the cache was over budget.
-    /// Only `evict_over_budget` increments it, so it counts budget-triggered
-    /// evictions specifically (not TTL sweeps that found nothing over budget).
-    /// Exposed via [`HostingCache::stats`] for per-node telemetry.
+    /// Monotonic count of contracts evicted because the cache was over
+    /// budget on EITHER axis: the state-byte budget (`current_bytes >
+    /// budget_bytes`) or, since #5325, the count-derived resident-overhead
+    /// estimate (sustained over `resident_overhead_budget_bytes` — see
+    /// [`HostingCache::resident_overhead_over_budget`]). Only
+    /// `evict_over_budget` increments it, so it counts over-budget-triggered
+    /// evictions specifically (not TTL sweeps that found nothing over
+    /// budget, and not [`Self::evict_cost_pressure`]'s zero-demand cost
+    /// evictions, tracked separately by
+    /// [`Self::cost_evictions_total`]). To isolate the resident-overhead-
+    /// driven subset specifically, see
+    /// [`Self::resident_overhead_evictions_total`] (a subset, not disjoint —
+    /// a single eviction can be counted by both when both axes are over
+    /// budget at once). Exposed via [`HostingCache::stats`] for per-node
+    /// telemetry.
     budget_evictions_total: u64,
     /// Monotonic count of over-budget evictions whose victim had `read_count >= 2`
     /// (genuine repeat demand). The #4338 miscalibration signal — see
@@ -1062,6 +1091,20 @@ pub struct HostingCache<T: TimeSource> {
     /// pressure, not just state bytes, is shaping retention. See
     /// [`HostingCacheStats::resident_overhead_evictions_total`].
     resident_overhead_evictions_total: u64,
+    /// Wall-clock timestamp of when the resident-overhead estimate FIRST
+    /// crossed [`Self::resident_overhead_budget_bytes`], continuously (#5325
+    /// PR review, Must-Fix #1). `None` whenever the raw estimate is at or
+    /// under budget. This is what makes resident-overhead pressure a
+    /// SUSTAINED trigger — mirroring the #4861 cost-pressure precedent
+    /// (`.claude/rules/hosting-invariants.md` invariant 3: "a single burst
+    /// never triggers... sustained across at least half the cost window") —
+    /// rather than a bare instantaneous comparison. Without this, a peer
+    /// upgrading straight into a large pre-existing hosted set (framework:
+    /// 1,057 contracts against a 256-contract budget at its 2 GiB cap) would
+    /// shed the bulk of it in the very first post-upgrade sweep, with no
+    /// grace period for organic (state-byte-driven) shrinkage or operator
+    /// notice. See [`Self::resident_overhead_over_budget`].
+    resident_overhead_breach_since: Option<Instant>,
     eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     /// Monotonic hosting-BEGIN counts by [`HostingCause`]. Incremented ONLY by
@@ -1326,6 +1369,7 @@ impl<T: TimeSource> HostingCache<T> {
             cost_evictions_total: 0,
             resident_overhead_budget_bytes: default_resident_overhead_budget_bytes(),
             resident_overhead_evictions_total: 0,
+            resident_overhead_breach_since: None,
             eviction_victim_counts: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             eviction_victim_bytes: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             hosting_begins: [0; HostingCause::COUNT],
@@ -1438,7 +1482,19 @@ impl<T: TimeSource> HostingCache<T> {
         // to start from short of ad hoc field measurement. Only logged when
         // eviction actually runs (not on every no-op periodic sweep), so this
         // does not spam logs during normal in-budget operation.
-        tracing::debug!(
+        //
+        // `info!`, NOT `debug!` (PR review Must-Fix #2): this crate builds
+        // with `release_max_level_info` (`crates/core/Cargo.toml`), which
+        // statically strips `debug!`/`trace!` out of release binaries
+        // entirely — a `debug!` here would never appear on a deployed node,
+        // silently reopening the exact observability gap #5325 complained
+        // about. Existing precedent for a real, deployed-visible eviction
+        // signal in this file is `warn!` (e.g. the cost-pressure eviction
+        // line below); `info!` is the right level here since this fires once
+        // per SWEEP (not once per evicted contract), so a chronically
+        // over-budget node logs at most once per periodic-sweep cadence
+        // (`CLEANUP_INTERVAL`, currently 5s), not a line per contract.
+        tracing::info!(
             current_bytes = self.current_bytes,
             budget_bytes = self.budget_bytes,
             contract_count = self.contracts.len(),
@@ -1517,8 +1573,11 @@ impl<T: TimeSource> HostingCache<T> {
             // Captured BEFORE removal: `contracts.len()` (and therefore the
             // resident-overhead estimate) changes once this victim is removed,
             // so whether resident pressure was the reason THIS victim was
-            // shed must be read against the pre-removal count.
+            // shed must be read against the pre-removal count. Same reasoning
+            // for the state-byte axis, captured alongside for the per-victim
+            // log line below.
             let resident_pressure_active = self.resident_overhead_over_budget();
+            let state_byte_pressure_active = self.current_bytes > self.budget_bytes;
             if let Some(entry) = self.contracts.remove(&key) {
                 let was_in_use = local + downstream > 0;
                 self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
@@ -1526,6 +1585,36 @@ impl<T: TimeSource> HostingCache<T> {
                 if resident_pressure_active {
                     self.resident_overhead_evictions_total =
                         self.resident_overhead_evictions_total.saturating_add(1);
+                    // Per-eviction observability for the resident-overhead axis
+                    // specifically (#5325 PR review — Ian's soak-test concern):
+                    // Must-Fix #1 controls HOW FAST evictions happen; this line
+                    // is what lets a human watching the upcoming soak tests
+                    // (nova try.freenet.org + framework) judge WHETHER they were
+                    // the right contracts — spot-check that this axis is
+                    // shedding zero/low-demand contracts, not ones other peers
+                    // or users still depend on. The existing subscriber-primary
+                    // `victim_order` is what actually protects demanded
+                    // contracts; this line is purely so that protection is
+                    // externally verifiable, not just trusted. `info!`, not
+                    // `debug!` — same `release_max_level_info` release-strip
+                    // trap as Must-Fix #2 (see the sweep-entry log above).
+                    let last_genuine_access_secs_ago = entry
+                        .last_genuine_access
+                        .map(|at| now.saturating_duration_since(at).as_secs());
+                    tracing::info!(
+                        contract = %key,
+                        local_subscriptions = local,
+                        downstream_subscribers = downstream,
+                        read_count = entry.read_count,
+                        last_genuine_access_secs_ago,
+                        state_bytes = entry.size_bytes,
+                        state_byte_pressure_also_active = state_byte_pressure_active,
+                        "resident-overhead pressure evicted a contract (#5325) — \
+                         local_subscriptions/downstream_subscribers should be 0 \
+                         and last_genuine_access_secs_ago should be large (or \
+                         absent = never accessed this run) for this to be a \
+                         correct, low-demand victim"
+                    );
                 }
                 self.record_eviction_victim(usize::from(was_in_use), entry.size_bytes);
                 // Field falsifier for the single riskiest new behavior: shedding a
@@ -2158,11 +2247,55 @@ impl<T: TimeSource> HostingCache<T> {
         (self.contracts.len() as u64).saturating_mul(ESTIMATED_RESIDENT_BYTES_PER_CONTRACT)
     }
 
-    /// Whether the count-derived resident-overhead estimate exceeds its
-    /// budget (#5325) — the second half of `evict_over_budget`'s "am I over
-    /// budget" predicate, alongside `current_bytes > budget_bytes`.
-    fn resident_overhead_over_budget(&self) -> bool {
+    /// Raw, instantaneous "is the count-derived estimate over its budget
+    /// right now" reading (#5325) — no debounce. Used only to drive the
+    /// SUSTAINED gate below and to report point-in-time state (the dashboard
+    /// tile, tripwire logging); never used directly to decide whether to
+    /// evict — see [`Self::resident_overhead_over_budget`].
+    fn resident_overhead_raw_over_budget(&self) -> bool {
         self.estimated_resident_overhead_bytes() > self.resident_overhead_budget_bytes
+    }
+
+    /// Whether resident-overhead pressure is SUSTAINED enough to act as an
+    /// eviction trigger (#5325 PR review, Must-Fix #1) — the second half of
+    /// `evict_over_budget`'s "am I over budget" predicate, alongside
+    /// `current_bytes > budget_bytes`.
+    ///
+    /// Mirrors the #4861 cost-pressure precedent
+    /// (`.claude/rules/hosting-invariants.md` invariant 3: "SUSTAINED
+    /// pressure... a single burst never triggers... continuously for at
+    /// least half the cost window") applied to a per-NODE scalar (hosted
+    /// contract count) rather than a per-contract rate: the raw estimate
+    /// must stay continuously over budget for at least
+    /// [`RESIDENT_OVERHEAD_SUSTAINED_WINDOW`]`/2` before this axis
+    /// contributes eviction pressure. `resident_overhead_breach_since`
+    /// records when the CURRENT continuous breach started; it resets to
+    /// `None` the instant the raw estimate dips back to or under budget
+    /// (an eviction bringing the count back down "cures" the breach, exactly
+    /// like the raw check would).
+    ///
+    /// This is a per-node scalar debounce, not a per-contract rate sample
+    /// like the cost axes': there is no "report burst" to filter out
+    /// (`contracts.len()` is exact, not sampled), so the risk this closes is
+    /// different but the same shape — a peer upgrading straight into a large
+    /// pre-existing hosted set gets a grace window (for organic, state-byte-
+    /// driven shrinkage, or operator notice) before this brand-new axis can
+    /// evict anything, instead of reacting on the very first sweep after
+    /// deploy.
+    ///
+    /// `&mut self`: every call site is already inside `evict_over_budget`
+    /// (`&mut self`), so recording the breach timer here — rather than as a
+    /// separate "observe" step some caller could forget — keeps the state
+    /// machine's only writer next to its only reader.
+    fn resident_overhead_over_budget(&mut self) -> bool {
+        let raw = self.resident_overhead_raw_over_budget();
+        if !raw {
+            self.resident_overhead_breach_since = None;
+            return false;
+        }
+        let now = self.time_source.now();
+        let since = *self.resident_overhead_breach_since.get_or_insert(now);
+        now.saturating_duration_since(since) >= RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2
     }
 
     /// Snapshot the cache's aggregate resource gauges under a single read for
@@ -2291,8 +2424,11 @@ impl<T: TimeSource> HostingCache<T> {
     /// Sweep for evictable contracts when the cache is over budget, at a given
     /// [`MemoryPressure`].
     ///
-    /// Only evicts when `current_bytes > budget_bytes`. Victims are chosen
-    /// subscriber-primary — ascending
+    /// Only evicts when `current_bytes > budget_bytes` OR the count-derived
+    /// resident-overhead estimate has been SUSTAINED over its own budget
+    /// (#5325 — see [`HostingCache::resident_overhead_over_budget`]); the two
+    /// axes feed the SAME decision, not two separate mechanisms. Victims are
+    /// chosen subscriber-primary — ascending
     /// `(local_subscription_count, downstream_subscriber_count, recency_seq, key)` —
     /// with eligibility governed by `pressure`:
     /// - [`MemoryPressure::AtCapacity`] (production): every entry is eligible (no
@@ -4401,13 +4537,28 @@ mod tests {
     fn resident_overhead_pressure_evicts_even_when_state_bytes_are_negligible() {
         // A generous 1 GiB state-byte budget: with 10-byte contracts this
         // axis could hold over 100 million entries and will never bind.
-        let (mut cache, _clock) = make_cache(GIB);
+        let (mut cache, clock) = make_cache(GIB);
         cache.set_resident_overhead_budget_bytes(10 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
 
         for i in 0..15u32 {
             let key = make_key_u32(i);
             cache.record_access(key, 10, AccessType::Put, 1, |_| (0, 0));
         }
+        assert_eq!(
+            cache.stats().contract_count,
+            15,
+            "the sustained gate (#5325 Must-Fix #1) must not act on an \
+             instantaneous breach — nothing evicts yet"
+        );
+
+        // Advance past the sustained-breach requirement and re-trigger via the
+        // PERIODIC sweep (not another insert) — the real post-deploy path.
+        clock.advance_time(RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2 + Duration::from_secs(1));
+        let evicted = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert!(
+            !evicted.is_empty(),
+            "once sustained past the window, the periodic sweep must evict"
+        );
 
         let stats = cache.stats();
         assert_eq!(
@@ -4470,7 +4621,7 @@ mod tests {
     /// oldest (would be first evicted under plain LRU/insertion order).
     #[test]
     fn resident_overhead_pressure_respects_subscriber_primary_ordering() {
-        let (mut cache, _clock) = make_cache(GIB);
+        let (mut cache, clock) = make_cache(GIB);
         cache.set_resident_overhead_budget_bytes(3 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
 
         let subscribed = make_key_u32(999);
@@ -4483,6 +4634,11 @@ mod tests {
             let key = make_key_u32(i);
             cache.record_access(key, 10, AccessType::Put, 1, counts);
         }
+
+        // Sustained gate (#5325 Must-Fix #1): nothing evicts on the
+        // instantaneous breach; advance past the window and re-sweep.
+        clock.advance_time(RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2 + Duration::from_secs(1));
+        cache.sweep_expired(counts, MemoryPressure::AtCapacity);
 
         assert!(
             cache.get(&subscribed).is_some(),
@@ -4502,7 +4658,7 @@ mod tests {
     /// `sweep_expired`.
     #[test]
     fn resident_overhead_pressure_is_enforced_by_periodic_sweep_after_bulk_load() {
-        let (mut cache, _clock) = make_cache(GIB);
+        let (mut cache, clock) = make_cache(GIB);
         for i in 0..20u32 {
             let key = make_key_u32(i);
             cache.load_persisted_entry(key, 10, AccessType::Get, Duration::from_secs(0), false);
@@ -4515,13 +4671,132 @@ mod tests {
         );
 
         cache.set_resident_overhead_budget_bytes(5 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
+        // First sweep after restart: observes the breach (starts the
+        // sustained-breach timer) but must NOT evict yet (#5325 Must-Fix #1)
+        // — this is the exact post-upgrade instant the review flagged as
+        // dangerous without a sustained gate.
+        let first_sweep = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert!(
+            first_sweep.is_empty(),
+            "a freshly-observed breach must not evict on the very first \
+             post-restart sweep"
+        );
+        assert_eq!(cache.stats().contract_count, 20);
+
+        // Advance past the sustained window; the NEXT periodic sweep (5s
+        // cadence in production — see CLEANUP_INTERVAL) now acts.
+        clock.advance_time(RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2 + Duration::from_secs(1));
         let evicted = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
 
         assert!(
             !evicted.is_empty(),
-            "the periodic sweep must shed down to the resident-overhead budget"
+            "the periodic sweep must shed down to the resident-overhead budget \
+             once the breach has been sustained"
         );
         assert_eq!(cache.stats().contract_count, 5);
+    }
+
+    /// Dedicated regression test for the review's own concrete numbers
+    /// (2 GiB memory limit -> 256-contract resident budget; framework hosts
+    /// 1,057): without the sustained gate, the very first sweep post-deploy
+    /// would shed ~76% of the hosted set in one pass. Confirms that
+    /// specific, previously-verified-dangerous scenario is now throttled.
+    #[test]
+    fn resident_overhead_pressure_does_not_mass_evict_on_first_sweep_at_framework_scale() {
+        let (mut cache, clock) = make_cache(GIB);
+        cache.set_resident_overhead_budget_bytes(resident_overhead_budget_for_ram(2 * GIB));
+        assert_eq!(
+            cache.resident_overhead_budget_bytes(),
+            256 * MIB,
+            "sanity-check the review's own arithmetic: clamp(2GiB/8, ..) = 256MiB"
+        );
+
+        for i in 0..1057u32 {
+            let key = make_key_u32(i);
+            cache.load_persisted_entry(key, 10, AccessType::Get, Duration::from_secs(0), false);
+        }
+        cache.finalize_loading();
+        assert_eq!(cache.stats().contract_count, 1057);
+
+        // The dangerous instant: the very first sweep immediately after
+        // restart/deploy, with zero elapsed sustained time.
+        let first_sweep = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert!(
+            first_sweep.is_empty(),
+            "must NOT mass-evict ~76% of the hosted set on the very first \
+             post-deploy sweep — this is exactly what the sustained gate exists \
+             to prevent"
+        );
+        assert_eq!(cache.stats().contract_count, 1057);
+
+        // Confirm the axis is not simply inert: given enough sustained time,
+        // it does eventually shed down to the budget's contract-count
+        // equivalent (256 contracts at 1 MiB/contract).
+        clock.advance_time(RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2 + Duration::from_secs(1));
+        cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert_eq!(cache.stats().contract_count, 256);
+    }
+
+    /// PR review Should-Fix #5: both budget axes bound AT ONCE, at DIFFERENT
+    /// contract-count targets (byte budget looser at 6 contracts, resident-
+    /// overhead budget stricter at 5) — proves the compound `&&` stop
+    /// condition, not an early exit once either axis alone clears, AND that
+    /// the SUSTAINED gate applies independently per axis: an unsustained
+    /// resident breach must not block byte-driven eviction (which has no
+    /// sustained gate), and once sustained it must drive ADDITIONAL eviction
+    /// beyond what byte pressure alone already achieved.
+    #[test]
+    fn both_budget_axes_bind_simultaneously() {
+        let (mut cache, clock) = make_cache(60); // byte budget: 6 contracts @ 10 bytes
+        cache.set_resident_overhead_budget_bytes(5 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
+        for i in 0..8u32 {
+            let key = make_key_u32(i);
+            cache.load_persisted_entry(key, 10, AccessType::Get, Duration::from_secs(0), false);
+        }
+        cache.finalize_loading();
+        assert_eq!(cache.stats().contract_count, 8);
+
+        // Sweep 1: byte pressure has NO sustained gate, so it acts
+        // immediately; resident pressure is freshly observed this call (not
+        // yet sustained) and must contribute nothing.
+        let sweep1 = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert_eq!(sweep1.len(), 2);
+        assert_eq!(
+            cache.stats().contract_count,
+            6,
+            "byte pressure alone (no sustain gate) evicts down to its own \
+             6-contract target"
+        );
+        assert_eq!(
+            cache.stats().resident_overhead_evictions_total,
+            0,
+            "none of sweep 1's evictions were resident-sustained yet"
+        );
+
+        // Sweep 2, after the resident breach has been sustained: byte
+        // pressure is ALREADY satisfied (6 contracts = 60 bytes = budget),
+        // but resident pressure (still over its own 5-contract budget) must
+        // drive exactly ONE more eviction.
+        clock.advance_time(RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2 + Duration::from_secs(1));
+        let sweep2 = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+        assert_eq!(
+            sweep2.len(),
+            1,
+            "exactly one more eviction, driven by the now-sustained resident axis"
+        );
+
+        let stats = cache.stats();
+        assert_eq!(stats.contract_count, 5);
+        assert_eq!(
+            stats.resident_overhead_evictions_total, 1,
+            "exactly the sweep-2 eviction is attributed to sustained resident pressure"
+        );
+        assert_eq!(
+            stats.budget_evictions_total, 3,
+            "3 total evictions across both sweeps (2 byte-driven + 1 resident-driven)"
+        );
     }
 
     // --- Aggregate disk budget sizing (#4683) ---

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -164,6 +164,122 @@ pub(crate) fn budget_for_ram(total_ram: u64) -> u64 {
     )
 }
 
+// =============================================================================
+// Resident-overhead (count-derived) budget — freenet/freenet-core#5325
+// =============================================================================
+//
+// `budget_bytes` above bounds hosted contract STATE bytes only (its own doc
+// says so). The dominant REAL per-contract memory cost is resident overhead
+// that has nothing to do with state size — subscription/interest bookkeeping,
+// redb/index entries, and other fixed per-contract structures — and it scales
+// with hosted CONTRACT COUNT, not state bytes. #5324 composed the module
+// cache, the wasmtime Store arena, and the per-executor summary/delta/redb
+// caches against the memory limit; this budget closes the remaining gap by
+// giving the hosting cache's OWN eviction decision a count-derived pressure
+// axis, so a peer hosting many small-state contracts (a real 2026-08-14 case:
+// a framework peer hosting 1,057 contracts under a 2 GiB cgroup cap, with
+// ~1 GB of resident memory unaccounted for by any budget) still gets eviction
+// pressure even though its state-byte usage looks comfortably in budget.
+//
+// This is composed into the SAME `evict_over_budget` decision as the
+// state-byte budget — not a new admission gate, not a new OOM valve, not a
+// hard pin (`.claude/rules/hosting-invariants.md` invariant 3: eviction is
+// ONE demand-ordered decision). `evict_over_budget` becomes "over budget" if
+// EITHER axis is exceeded, and the SAME `victim_order` (subscriber-primary,
+// then GET/PUT recency) picks the victim regardless of which axis triggered
+// the sweep. This mirrors the existing cost-pressure axes (#4861) in spirit —
+// "a new cost dimension weighed by the same decision" — but not in mechanism:
+// cost pressure targets a single OFFENDER whose share of a per-contract-
+// variable-rate axis dominates the node's total, whereas resident overhead is
+// (by this estimate) roughly UNIFORM per contract, so there is no "offender"
+// to single out — the fix is a second ceiling on the SAME over-budget
+// predicate, not a share-of-total test.
+
+/// Estimated resident-memory overhead per hosted contract, in bytes,
+/// independent of contract state size — subscription/interest bookkeeping,
+/// redb/index entries, and other per-contract fixed costs that do not show up
+/// in [`HostingCache::current_bytes`].
+///
+/// Value: 1 MiB. Provenance: the 2026-06-30 profiling referenced by
+/// `.claude/rules/hosting-invariants.md`'s "Byte-only eviction as the sole
+/// signal" anti-pattern row measured ~1 MB resident per hosted contract,
+/// uncorrelated with state bytes (~650 KB/contract there, negligible).
+/// Independently re-confirmed by the #5325 field evidence: a framework peer
+/// hosting 1,057 contracts under a 2 GiB cgroup cap had ~1 GB of resident
+/// memory unaccounted for by any budget (module cache, Store arena,
+/// summary/delta, redb — all now composed against the memory limit by
+/// #5324), i.e. ~950 KiB/contract — consistent with the earlier figure.
+///
+/// This is a coarse, UNIFORM-per-contract estimate, not a measured-per-
+/// contract-type figure — it does not distinguish a contract with heavy
+/// subscription fan-out or a large redb index from a quiet, rarely-touched
+/// one. It can be wrong in either direction: a peer hosting many small,
+/// low-fan-out contracts may have real overhead below this figure (pressure
+/// triggers EARLIER than strictly necessary — a retention cost, not a
+/// correctness one); a peer whose hosted set skews toward heavily-subscribed,
+/// high-index-overhead contracts may have real overhead ABOVE it (pressure
+/// triggers LATER than needed — the dangerous direction, since it under-
+/// protects against OOM). Revisit this constant if field telemetry (the
+/// `resident_overhead_*` [`HostingCacheStats`] fields this change adds) shows
+/// measured overhead diverging from the estimate at scale.
+pub const ESTIMATED_RESIDENT_BYTES_PER_CONTRACT: u64 = 1024 * 1024;
+
+/// Lower clamp for the RAM-scaled resident-overhead budget (128 MiB) —
+/// mirrors [`MIN_DEFAULT_HOSTING_BUDGET_BYTES`], same floor rationale applied
+/// to a different resource (resident bookkeeping bytes rather than on-disk
+/// state bytes).
+pub const MIN_RESIDENT_OVERHEAD_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Upper clamp for the RAM-scaled resident-overhead budget (1 GiB) — mirrors
+/// [`MAX_DEFAULT_HOSTING_BUDGET_BYTES`].
+pub const MAX_RESIDENT_OVERHEAD_BUDGET_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Fraction of total system RAM earmarked for per-contract resident overhead:
+/// 1/8, the SAME fraction [`DEFAULT_HOSTING_BUDGET_RAM_DIVISOR`] earmarks for
+/// contract state bytes.
+///
+/// JUDGMENT CALL: the two budgets are deliberately SEPARATE slices of RAM (a
+/// peer effectively reserves `2 * total_ram / 8` for hosting overall: one
+/// eighth for state bytes, a second eighth for the count-derived
+/// resident-overhead ceiling) rather than one budget divided further. A
+/// hosted contract genuinely costs memory on both axes independently, so
+/// halving one slice to carve out room for the other would just move the OOM
+/// risk from one axis to the other rather than closing the gap this issue is
+/// about. The remaining ~3/4 of RAM covers the module cache, the wasmtime
+/// Store arena, the per-executor summary/delta/redb caches (all composed
+/// against the memory limit by #5324), transport buffers, and the OS/runtime
+/// baseline — see `cache_byte_budgets_are_aggregate_safe` in
+/// `contract/executor.rs` for that composition's own accounting. Reviewers:
+/// this divisor (and whether it should instead shrink as those other budgets
+/// grow) is exactly the kind of calibration call worth pushing back on.
+const RESIDENT_OVERHEAD_BUDGET_RAM_DIVISOR: u64 = 8;
+
+/// Default resident-overhead budget (bytes), scaled to the memory the node
+/// may use — the count-derived analogue of [`default_hosting_budget_bytes`].
+/// `hosted_contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` is weighed
+/// against this by [`HostingCache::evict_over_budget`] as an ADDITIONAL
+/// pressure axis alongside the state-byte budget, composed into the SAME
+/// demand-ordered eviction decision (see the module docs above and
+/// `.claude/rules/hosting-invariants.md` invariant 3, "eviction is ONE
+/// demand-ordered decision"). This is NOT a separate admission gate and NOT
+/// a new OOM valve.
+pub fn default_resident_overhead_budget_bytes() -> u64 {
+    let total_ram = read_total_ram_bytes()
+        .map(|v| v as u64)
+        .unwrap_or(FALLBACK_TOTAL_RAM_BYTES);
+    resident_overhead_budget_for_ram(total_ram)
+}
+
+/// Pure clamp math behind [`default_resident_overhead_budget_bytes`], split
+/// out for the same reason [`budget_for_ram`] is: unit-testable without
+/// depending on the test host's real RAM.
+pub(crate) fn resident_overhead_budget_for_ram(total_ram: u64) -> u64 {
+    (total_ram / RESIDENT_OVERHEAD_BUDGET_RAM_DIVISOR).clamp(
+        MIN_RESIDENT_OVERHEAD_BUDGET_BYTES,
+        MAX_RESIDENT_OVERHEAD_BUDGET_BYTES,
+    )
+}
+
 /// Default fraction of the disk capacity *available to Freenet* used to size the
 /// aggregate disk budget (#4683): 50%. Sized against `used + free` (capacity the
 /// node can actually reach), NOT a naive live free-space read that shrinks as it
@@ -332,6 +448,23 @@ pub(crate) struct HostingCacheStats {
     /// means the floors / share threshold are miscalibrated and churning cheap
     /// contracts.
     pub cost_evictions_total: u64,
+    /// Configured resident-overhead budget (bytes, #5325) — the RAM-scaled
+    /// ceiling on `contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`.
+    /// Compare against [`Self::estimated_resident_overhead_bytes`] the same
+    /// way [`Self::budget_bytes`] is compared against
+    /// [`Self::current_bytes`]: headroom = `1 -
+    /// estimated_resident_overhead_bytes / resident_overhead_budget_bytes`.
+    pub resident_overhead_budget_bytes: u64,
+    /// Current estimated resident-overhead bytes (#5325): `contract_count *
+    /// ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`. The count-derived analogue of
+    /// [`Self::current_bytes`] — unlike that field, this is never persisted
+    /// per-contract state, just `contract_count` times a constant.
+    pub estimated_resident_overhead_bytes: u64,
+    /// Monotonic count of evictions where resident-overhead pressure was
+    /// active at decision time (#5325). See
+    /// [`HostingCache::resident_overhead_evictions_total`] for the exact
+    /// semantics (may overlap with [`Self::budget_evictions_total`]).
+    pub resident_overhead_evictions_total: u64,
     /// Monotonic eviction victims by reason × state-size bucket. Reason order:
     /// byte-budget zero-demand, byte-budget in-use, cost pressure.
     pub eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
@@ -913,6 +1046,22 @@ pub struct HostingCache<T: TimeSource> {
     /// #4861). Only [`Self::evict_cost_pressure`] increments it. See
     /// [`HostingCacheStats::cost_evictions_total`].
     cost_evictions_total: u64,
+    /// RAM-scaled ceiling on `contracts.len() *
+    /// ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` (#5325) — the count-derived
+    /// resident-overhead pressure axis, composed into the same over-budget
+    /// decision as `budget_bytes`. Defaults to
+    /// [`default_resident_overhead_budget_bytes`] at construction;
+    /// test-settable via [`Self::set_resident_overhead_budget_bytes`].
+    resident_overhead_budget_bytes: u64,
+    /// Monotonic count of evictions where resident-overhead pressure
+    /// (`estimated_resident_overhead_bytes() > resident_overhead_budget_bytes`)
+    /// was active at decision time (#5325). May overlap with
+    /// [`Self::budget_evictions_total`] when both axes are simultaneously over
+    /// budget — this is a diagnostic overlay, not a disjoint reason code. The
+    /// field falsifier for this axis: nonzero on a peer means COUNT-driven
+    /// pressure, not just state bytes, is shaping retention. See
+    /// [`HostingCacheStats::resident_overhead_evictions_total`].
+    resident_overhead_evictions_total: u64,
     eviction_victim_counts: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     eviction_victim_bytes: [[u64; STATE_SIZE_BUCKET_COUNT]; 3],
     /// Monotonic hosting-BEGIN counts by [`HostingCause`]. Incremented ONLY by
@@ -1149,6 +1298,18 @@ pub(crate) fn cost_eviction_candidate(
 
 impl<T: TimeSource> HostingCache<T> {
     /// Create a new hosting cache with the given byte budget.
+    ///
+    /// The resident-overhead budget (#5325) is NOT threaded through this
+    /// constructor's signature — deliberately, to avoid churning every one of
+    /// this type's call sites for a first cut. It is resolved internally from
+    /// live RAM via [`default_resident_overhead_budget_bytes`], the same
+    /// `min(host RAM, cgroup limit)` basis `budget_bytes`'s caller uses for
+    /// the state-byte default. Tests that need a specific (typically tiny)
+    /// resident-overhead budget call [`Self::set_resident_overhead_budget_bytes`]
+    /// after construction, mirroring [`Self::set_budget_for_test`]. An
+    /// operator override (e.g. a future `--max-hosting-resident-overhead`)
+    /// would thread through the same way `--max-hosting-storage` does today —
+    /// left as a follow-up unless field data shows the default needs tuning.
     pub fn new(budget_bytes: u64, time_source: T) -> Self {
         Self {
             budget_bytes,
@@ -1163,6 +1324,8 @@ impl<T: TimeSource> HostingCache<T> {
             oom_valve_evictions_total: 0,
             subscribed_evictions_total: 0,
             cost_evictions_total: 0,
+            resident_overhead_budget_bytes: default_resident_overhead_budget_bytes(),
+            resident_overhead_evictions_total: 0,
             eviction_victim_counts: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             eviction_victim_bytes: [[0; STATE_SIZE_BUCKET_COUNT]; 3],
             hosting_begins: [0; HostingCause::COUNT],
@@ -1259,9 +1422,30 @@ impl<T: TimeSource> HostingCache<T> {
     where
         G: Fn(&ContractKey) -> (usize, usize),
     {
-        if self.current_bytes <= self.budget_bytes {
+        // "Over budget" is true if EITHER the state-byte budget OR the
+        // count-derived resident-overhead estimate (#5325) is exceeded — two
+        // independent axes feeding the SAME eviction decision, not two
+        // separate mechanisms. `resident_overhead_over_budget()` is O(1)
+        // (just `contracts.len()` against a stored budget), so this early
+        // return stays cheap on the common in-budget path.
+        if self.current_bytes <= self.budget_bytes && !self.resident_overhead_over_budget() {
             return Vec::new();
         }
+
+        // Visibility for the axis this run actually triggered on (#5325):
+        // the hosting cache previously logged neither its budget nor its
+        // current usage at any level, so an OOM investigation had no signal
+        // to start from short of ad hoc field measurement. Only logged when
+        // eviction actually runs (not on every no-op periodic sweep), so this
+        // does not spam logs during normal in-budget operation.
+        tracing::debug!(
+            current_bytes = self.current_bytes,
+            budget_bytes = self.budget_bytes,
+            contract_count = self.contracts.len(),
+            estimated_resident_overhead_bytes = self.estimated_resident_overhead_bytes(),
+            resident_overhead_budget_bytes = self.resident_overhead_budget_bytes,
+            "hosting cache over budget; running eviction sweep"
+        );
 
         // Collect eviction-eligible entries with their ordering keys, then evict
         // lowest-priority first until back under budget. O(n log n) per
@@ -1324,13 +1508,25 @@ impl<T: TimeSource> HostingCache<T> {
         let now = self.time_source.now();
         let mut evicted = Vec::new();
         for (key, local, downstream, _seq) in candidates {
-            if self.current_bytes <= self.budget_bytes {
-                break; // back under budget, stop evicting
+            // Stop as soon as BOTH axes clear (#5325): a resident-overhead-only
+            // sweep must keep evicting past the point where state bytes alone
+            // would already look fine, and vice versa.
+            if self.current_bytes <= self.budget_bytes && !self.resident_overhead_over_budget() {
+                break; // back under budget on both axes, stop evicting
             }
+            // Captured BEFORE removal: `contracts.len()` (and therefore the
+            // resident-overhead estimate) changes once this victim is removed,
+            // so whether resident pressure was the reason THIS victim was
+            // shed must be read against the pre-removal count.
+            let resident_pressure_active = self.resident_overhead_over_budget();
             if let Some(entry) = self.contracts.remove(&key) {
                 let was_in_use = local + downstream > 0;
                 self.current_bytes = self.current_bytes.saturating_sub(entry.size_bytes);
                 self.budget_evictions_total = self.budget_evictions_total.saturating_add(1);
+                if resident_pressure_active {
+                    self.resident_overhead_evictions_total =
+                        self.resident_overhead_evictions_total.saturating_add(1);
+                }
                 self.record_eviction_victim(usize::from(was_in_use), entry.size_bytes);
                 // Field falsifier for the single riskiest new behavior: shedding a
                 // subscribed contract. Counted by the captured subscriber split
@@ -1399,7 +1595,7 @@ impl<T: TimeSource> HostingCache<T> {
         // backstop. Not a `debug_assert!`: the "contract larger than budget" corner
         // is legitimate (the old `min_ttl` age-0 gate left the same state silently),
         // so we surface it as a warning rather than panicking debug builds.
-        if self.current_bytes > self.budget_bytes {
+        if self.current_bytes > self.budget_bytes || self.resident_overhead_over_budget() {
             if let Some(protected_key) = protected {
                 if matches!(pressure, MemoryPressure::AtCapacity)
                     && self.contracts.contains_key(protected_key)
@@ -1408,7 +1604,9 @@ impl<T: TimeSource> HostingCache<T> {
                         contract = %protected_key,
                         current_bytes = self.current_bytes,
                         budget_bytes = self.budget_bytes,
-                        over_by = self.current_bytes - self.budget_bytes,
+                        estimated_resident_overhead_bytes = self.estimated_resident_overhead_bytes(),
+                        resident_overhead_budget_bytes = self.resident_overhead_budget_bytes,
+                        over_by = self.current_bytes.saturating_sub(self.budget_bytes),
                         "op-scoped backstop kept an in-flight contract while still over \
                          budget (pathological — a genuine RAM-overflow signal would pierce \
                          this via Overflow)",
@@ -1933,6 +2131,40 @@ impl<T: TimeSource> HostingCache<T> {
         self.budget_bytes = budget_bytes;
     }
 
+    /// Get the resident-overhead budget in bytes (#5325).
+    #[allow(dead_code)] // Public API for introspection
+    pub fn resident_overhead_budget_bytes(&self) -> u64 {
+        self.resident_overhead_budget_bytes
+    }
+
+    /// Overwrite the resident-overhead budget (#5325). Mirrors
+    /// [`Self::set_budget_bytes`]: O(1), does not itself evict — the next
+    /// `evict_over_budget` (on sweep or cache insert) enforces the new value.
+    /// The production default (installed at construction) is
+    /// [`default_resident_overhead_budget_bytes`]; this setter exists for
+    /// tests that need a small, deterministic value instead of whatever the
+    /// test host's live RAM resolves to, and for a future operator override.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn set_resident_overhead_budget_bytes(&mut self, budget_bytes: u64) {
+        self.resident_overhead_budget_bytes = budget_bytes;
+    }
+
+    /// Current estimated resident-overhead bytes (#5325): `contracts.len() *
+    /// ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`. The count-derived analogue of
+    /// [`Self::current_bytes`] — a coarse estimate, not a measured figure (see
+    /// [`ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`]'s doc for provenance and
+    /// error bounds).
+    fn estimated_resident_overhead_bytes(&self) -> u64 {
+        (self.contracts.len() as u64).saturating_mul(ESTIMATED_RESIDENT_BYTES_PER_CONTRACT)
+    }
+
+    /// Whether the count-derived resident-overhead estimate exceeds its
+    /// budget (#5325) — the second half of `evict_over_budget`'s "am I over
+    /// budget" predicate, alongside `current_bytes > budget_bytes`.
+    fn resident_overhead_over_budget(&self) -> bool {
+        self.estimated_resident_overhead_bytes() > self.resident_overhead_budget_bytes
+    }
+
     /// Snapshot the cache's aggregate resource gauges under a single read for
     /// per-node telemetry. See [`HostingCacheStats`].
     pub fn stats(&self) -> HostingCacheStats {
@@ -1970,6 +2202,9 @@ impl<T: TimeSource> HostingCache<T> {
             evicted_unread_total: self.evicted_unread_total,
             evicted_unread_age_secs_sum: self.evicted_unread_age_secs_sum,
             oom_valve_evictions_total: self.oom_valve_evictions_total,
+            resident_overhead_budget_bytes: self.resident_overhead_budget_bytes,
+            estimated_resident_overhead_bytes: self.estimated_resident_overhead_bytes(),
+            resident_overhead_evictions_total: self.resident_overhead_evictions_total,
         }
     }
 
@@ -4115,6 +4350,178 @@ mod tests {
         // give distinct budgets.
         assert_ne!(budget_for_ram(2 * GIB), budget_for_ram(3 * GIB));
         assert_ne!(budget_for_ram(3 * GIB), budget_for_ram(4 * GIB));
+    }
+
+    // --- Resident-overhead (count-derived) budget (#5325) ---
+
+    /// Same clamp behavior as [`budget_for_ram_scales_and_clamps`], for the
+    /// count-derived resident-overhead budget.
+    #[test]
+    fn resident_overhead_budget_for_ram_scales_and_clamps() {
+        assert_eq!(
+            resident_overhead_budget_for_ram(512 * MIB),
+            MIN_RESIDENT_OVERHEAD_BUDGET_BYTES
+        );
+        assert_eq!(
+            resident_overhead_budget_for_ram(GIB),
+            MIN_RESIDENT_OVERHEAD_BUDGET_BYTES
+        );
+        assert_eq!(resident_overhead_budget_for_ram(2 * GIB), 256 * MIB);
+        assert_eq!(resident_overhead_budget_for_ram(4 * GIB), 512 * MIB);
+        assert_eq!(
+            resident_overhead_budget_for_ram(8 * GIB),
+            MAX_RESIDENT_OVERHEAD_BUDGET_BYTES
+        );
+        assert_eq!(
+            resident_overhead_budget_for_ram(128 * GIB),
+            MAX_RESIDENT_OVERHEAD_BUDGET_BYTES
+        );
+    }
+
+    /// A key-maker with a wider seed space than [`make_key`] (`u8`, 256 max):
+    /// the resident-overhead tests below need well over 256 distinct
+    /// contracts to exceed a small resident budget while keeping
+    /// `ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` at a realistic 1 MiB.
+    fn make_key_u32(seed: u32) -> ContractKey {
+        let mut id_bytes = [0u8; 32];
+        id_bytes[..4].copy_from_slice(&seed.to_le_bytes());
+        let mut code_bytes = [0u8; 32];
+        code_bytes[..4].copy_from_slice(&seed.wrapping_add(1).to_le_bytes());
+        ContractKey::from_id_and_code(ContractInstanceId::new(id_bytes), CodeHash::new(code_bytes))
+    }
+
+    /// The core #5325 regression test: a peer hosting many contracts with
+    /// NEGLIGIBLE state bytes each must still come under eviction pressure
+    /// once `hosted_contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`
+    /// exceeds the resident-overhead budget — even though the state-byte
+    /// budget alone is nowhere close to binding. This is exactly the
+    /// framework-peer shape from the issue: 1,057 contracts, negligible state
+    /// bytes each, ~1 GB of resident overhead no budget accounted for.
+    #[test]
+    fn resident_overhead_pressure_evicts_even_when_state_bytes_are_negligible() {
+        // A generous 1 GiB state-byte budget: with 10-byte contracts this
+        // axis could hold over 100 million entries and will never bind.
+        let (mut cache, _clock) = make_cache(GIB);
+        cache.set_resident_overhead_budget_bytes(10 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
+        for i in 0..15u32 {
+            let key = make_key_u32(i);
+            cache.record_access(key, 10, AccessType::Put, 1, |_| (0, 0));
+        }
+
+        let stats = cache.stats();
+        assert_eq!(
+            stats.contract_count, 10,
+            "resident-overhead pressure must cap the hosted set at the budget's \
+             contract-count equivalent even though state bytes are negligible"
+        );
+        assert!(
+            stats.current_bytes < stats.budget_bytes,
+            "the state-byte budget alone would say this cache is nowhere near \
+             over budget (current={}, budget={})",
+            stats.current_bytes,
+            stats.budget_bytes
+        );
+        assert!(
+            stats.resident_overhead_evictions_total > 0,
+            "eviction must be attributable to resident-overhead pressure"
+        );
+        assert_eq!(
+            stats.resident_overhead_evictions_total, stats.budget_evictions_total,
+            "every eviction in this scenario was resident-pressure-driven \
+             (the byte budget never bound)"
+        );
+        assert_eq!(
+            stats.estimated_resident_overhead_bytes,
+            10 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT
+        );
+    }
+
+    /// Negative/boundary counterpart: resident overhead sitting exactly AT
+    /// the budget must not evict (mirrors
+    /// `evict_cost_pressure_exact_share_boundary_not_shed`'s boundary
+    /// discipline for the cost axes).
+    #[test]
+    fn resident_overhead_at_budget_does_not_evict() {
+        let (mut cache, _clock) = make_cache(GIB);
+        cache.set_resident_overhead_budget_bytes(5 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
+        for i in 0..5u32 {
+            let key = make_key_u32(i);
+            cache.record_access(key, 10, AccessType::Put, 1, |_| (0, 0));
+        }
+
+        let stats = cache.stats();
+        assert_eq!(
+            stats.contract_count, 5,
+            "exactly at budget: nothing evicted"
+        );
+        assert_eq!(stats.resident_overhead_evictions_total, 0);
+        assert_eq!(
+            stats.estimated_resident_overhead_bytes,
+            5 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT
+        );
+    }
+
+    /// Resident-overhead pressure must respect the SAME subscriber-primary
+    /// victim ordering as byte-budget eviction (hosting-invariants invariant
+    /// 3) — a locally-subscribed contract survives while zero-subscriber
+    /// contracts are still eligible, even though it is numerically the
+    /// oldest (would be first evicted under plain LRU/insertion order).
+    #[test]
+    fn resident_overhead_pressure_respects_subscriber_primary_ordering() {
+        let (mut cache, _clock) = make_cache(GIB);
+        cache.set_resident_overhead_budget_bytes(3 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
+        let subscribed = make_key_u32(999);
+        let counts = move |k: &ContractKey| if *k == subscribed { (1, 0) } else { (0, 0) };
+
+        // Insert the locally-subscribed contract FIRST (oldest recency) so a
+        // plain recency/LRU policy would evict it before anything else.
+        cache.record_access(subscribed, 10, AccessType::Put, 1, counts);
+        for i in 0..8u32 {
+            let key = make_key_u32(i);
+            cache.record_access(key, 10, AccessType::Put, 1, counts);
+        }
+
+        assert!(
+            cache.get(&subscribed).is_some(),
+            "a locally-subscribed contract must survive resident-overhead \
+             pressure while zero-subscriber contracts are still eligible \
+             (same victim_order as byte-budget eviction)"
+        );
+        assert_eq!(cache.stats().contract_count, 3);
+    }
+
+    /// Resident-overhead pressure must also be enforced by the PERIODIC sweep,
+    /// not only at insertion time — this is the real-world path #5325
+    /// describes: `load_persisted_entry` (bulk startup reload) deliberately
+    /// does NOT evict ("we may be over budget after loading" — see its doc),
+    /// so a peer restarting with more hosted contracts than its
+    /// resident-overhead budget allows sits over budget until the next
+    /// `sweep_expired`.
+    #[test]
+    fn resident_overhead_pressure_is_enforced_by_periodic_sweep_after_bulk_load() {
+        let (mut cache, _clock) = make_cache(GIB);
+        for i in 0..20u32 {
+            let key = make_key_u32(i);
+            cache.load_persisted_entry(key, 10, AccessType::Get, Duration::from_secs(0), false);
+        }
+        cache.finalize_loading();
+        assert_eq!(
+            cache.stats().contract_count,
+            20,
+            "bulk load does not evict, by design"
+        );
+
+        cache.set_resident_overhead_budget_bytes(5 * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+        let evicted = cache.sweep_expired(|_: &ContractKey| (0, 0), MemoryPressure::AtCapacity);
+
+        assert!(
+            !evicted.is_empty(),
+            "the periodic sweep must shed down to the resident-overhead budget"
+        );
+        assert_eq!(cache.stats().contract_count, 5);
     }
 
     // --- Aggregate disk budget sizing (#4683) ---

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2640,6 +2640,7 @@ mod tests {
             disk_compile_cache_bytes: None,
             disk_total_bytes: None,
             disk_budget_bytes: None,
+            ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         assert!(
@@ -2681,6 +2682,7 @@ mod tests {
             disk_compile_cache_bytes: Some(5 * 1024 * 1024),
             disk_total_bytes: Some(125 * 1024 * 1024),
             disk_budget_bytes: Some(500 * 1024 * 1024),
+            ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         assert!(

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2712,6 +2712,49 @@ mod tests {
         );
     }
 
+    /// #5325 PR review Should-Fix #6: the new "Resident overhead" tile
+    /// (count-derived pressure axis, independent of the RAM used/budget
+    /// tile above) must render the actual snapshot values, not just compile.
+    #[test]
+    fn hosting_card_renders_resident_overhead_tile() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 1024,
+            contract_count: 1,
+            budget_evictions_total: 0,
+            evictions_of_recently_read_total: 0,
+            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            resident_overhead_budget_bytes: 100 * 1024 * 1024,
+            estimated_resident_overhead_bytes: 30 * 1024 * 1024,
+            resident_overhead_evictions_total: 7,
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Resident overhead"),
+            "resident-overhead tile label present — got:\n{html}"
+        );
+        assert!(
+            html.contains("30.0 MB"),
+            "resident-overhead used value — got:\n{html}"
+        );
+        assert!(
+            html.contains("100.0 MB"),
+            "resident-overhead budget value — got:\n{html}"
+        );
+        // Headroom = budget(100) - used(30) = 70 MB.
+        assert!(
+            html.contains("70.0 MB"),
+            "resident-overhead headroom value — got:\n{html}"
+        );
+        assert!(
+            html.contains(">7<"),
+            "resident-overhead eviction counter renders the snapshot value — got:\n{html}"
+        );
+    }
+
     // ─── Contract ban-list card (#4302) ────────────────────────────
 
     use crate::node::network_status::{BanListEntry, BanListSnapshot, BanReasonSnapshot};

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1335,6 +1335,16 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         _ => MEASURING.to_string(),
     };
 
+    // Resident-overhead tile (#5325): the state-byte budget above bounds
+    // contract STATE bytes only. This tile is the count-derived axis —
+    // `contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` — that closes
+    // the gap where many small-state contracts (negligible RAM-used-tile
+    // impact) still exhaust a peer's real resident memory via per-contract
+    // subscription/index bookkeeping.
+    let resident_overhead_headroom = h
+        .resident_overhead_budget_bytes
+        .saturating_sub(h.estimated_resident_overhead_bytes);
+
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2><span class="g-mode g-mode-enforce">piece A</span></div>
@@ -1353,6 +1363,14 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                     <div class="g-norm" title="{disk_breakdown_title}"><div class="g-norm-label">Disk used</div><div class="g-norm-value">{disk_used}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Disk budget</div><div class="g-norm-value">{disk_budget}</div></div>
                     <div class="g-norm"><div class="g-norm-label">Disk headroom</div><div class="g-norm-value">{disk_headroom}</div></div>
+                </div>
+            </div>
+            <div class="g-verdict-row">
+                <div class="g-norms">
+                    <div class="g-norm" title="Estimated, not measured: contract_count × 1 MiB/contract (#5325). Bounds per-contract resident bookkeeping overhead (subscriptions, redb/index entries) that RAM used/budget above does not count."><div class="g-norm-label">Resident overhead (est.)</div><div class="g-norm-value">{resident_overhead_used}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Resident overhead budget</div><div class="g-norm-value">{resident_overhead_budget}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Resident overhead headroom</div><div class="g-norm-value">{resident_overhead_headroom}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Resident overhead evictions</div><div class="g-norm-value">{resident_overhead_evictions}</div></div>
                 </div>
             </div>
             <div class="table-wrap">
@@ -1374,6 +1392,10 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         disk_used = disk_used_value,
         disk_budget = disk_budget_value,
         disk_headroom = disk_headroom_value,
+        resident_overhead_used = format_bytes(h.estimated_resident_overhead_bytes),
+        resident_overhead_budget = format_bytes(h.resident_overhead_budget_bytes),
+        resident_overhead_headroom = format_bytes(resident_overhead_headroom),
+        resident_overhead_evictions = h.resident_overhead_evictions_total,
         rows = rows,
         footer = footer,
     )


### PR DESCRIPTION
## Problem

`ring/hosting/cache.rs::budget_for_ram` bounds hosted contract **STATE bytes
only** (its own docstring says so). The dominant real per-contract memory
cost is resident overhead that has nothing to do with state size —
subscription/interest bookkeeping, redb/index entries, and other fixed
per-contract structures — and it scales with hosted **contract COUNT**, not
state bytes. Nothing bounded that count against available memory.

Field evidence (2026-08-14, framework peer): 1,057 hosted contracts under a
2 GiB cgroup cap, with the state-byte budget at that cap resolving to just
256 MiB. Even after #5324 composed the module cache, wasmtime Store arena,
and per-executor summary/delta/redb caches against the memory limit, this
peer had ~1 GB of resident memory unaccounted for by *any* budget — a
peer can sit comfortably "within" its state-byte budget while its actual
resident footprint is well past the memory cap.

**Magnitude, stated explicitly (review round 1 Must-Fix #3):** at a 2 GiB
memory limit, `resident_overhead_budget_for_ram = clamp(2 GiB / 8, 128 MiB,
1 GiB) = 256 MiB`, i.e. a **256-contract ceiling** at the 1 MiB/contract
estimate. Framework — the real peer this issue's own evidence came from —
hosts **1,057 contracts** at exactly this memory limit. Without the
sustained-gate fix below, deploying the original version of this PR would
have evicted roughly **76% of a peer in framework's situation in a single
sweep**, the very first time eviction ran post-deploy, on every peer network-
wide whose hosted count exceeded its new resident budget at upgrade time
(a release restarts the fleet, so this would have hit synchronously, not
just on framework).

## Approach

Adds a second, RAM-scaled "resident-overhead" budget — `hosted_contract_count
* ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` (1 MiB, cited from the 2026-06-30
profiling in `hosting-invariants.md` and independently re-confirmed by this
issue's own field numbers: ~950 KiB/contract) vs.
`clamp(total_ram / 8, 128 MiB, 1 GiB)` — and composes it into the **same**
`evict_over_budget` decision the existing state-byte budget already drives.

`evict_over_budget` is now "over budget" if **either** axis is exceeded, and
the eviction loop doesn't stop until **both** clear. Victims are still chosen
by the existing subscriber-primary `victim_order` (fewest local
subscriptions, then downstream subscribers, then GET/PUT recency) — the same
ranking used for state-byte pressure and the existing cost-pressure axes
(#4861/PR #4903).

**Which invariants this touches, and how it preserves them**
(`.claude/rules/hosting-invariants.md`):

- **Invariant 3 ("eviction is ONE demand-ordered decision")**: this is
  explicitly why the fix is a second *ceiling* composed into the existing
  over-budget predicate, not a new mechanism. There is no separate admission
  decision, no evict-to-admit rule, no at-capacity NACK, and no OOM valve —
  a newcomer competes in the exact same eviction as everything else, via the
  exact same `victim_order`. This mirrors the #4861 cost-pressure precedent
  ("a new cost dimension weighed by the same decision") in *spirit*, but not
  in *mechanism*: cost pressure targets a single offender whose *share* of a
  variable-rate axis dominates the node total; resident overhead is (by this
  estimate) roughly uniform per contract, so there's no offender to single
  out — it's a second ceiling on the same predicate, not a share-of-total
  test.
- **Anti-pattern "byte-only eviction as the sole signal"**: this is precisely
  the gap the anti-pattern warns about (measuring the wrong resource). The
  fix adds the missing axis rather than tightening the existing one.
- Does **not** touch placement, findability, freshness, or the demand
  definition (invariant 3's subscription/GET/PUT signal is untouched) — pure
  addition to the retention *budget* side.

**Judgment calls flagged for review:**

1. **Where the 1 MiB/contract estimate comes from.** It is the existing
   2026-06-30 profiling figure already codified in `hosting-invariants.md`'s
   anti-pattern table (not a fresh guess), independently re-derived from this
   issue's own field numbers (~950 KiB/contract). It's a coarse, *uniform*
   per-contract estimate — documented in-code with explicit failure
   directions (under-estimate → early eviction, a retention cost; over-estimate →
   late eviction, the dangerous direction for OOM).
2. **Composition with the state-byte budget**: chosen to be an
   *independent* RAM/8 slice (mirroring the module-cache/state-byte
   divisor), not a further split of the existing budget or a literal
   "subtract every other subsystem's budget from the cgroup limit"
   computation. Rationale documented at
   `RESIDENT_OVERHEAD_BUDGET_RAM_DIVISOR`. Open to pushback on the divisor.
3. **Not threaded through `HostingCache::new`'s signature** — computed
   internally from live RAM (same `min(host RAM, cgroup limit)` basis) to
   avoid churning the ~10 test call sites for a first cut. A
   `set_resident_overhead_budget_bytes` setter exists for tests; an operator
   override is a natural, small follow-up if the default needs field tuning.
4. **`RESIDENT_OVERHEAD_SUSTAINED_WINDOW` (300s, half-window = 150s to arm)
   is set equal to `COST_RATE_MIN_WINDOW`** but declared as its own constant
   rather than reusing that one — the two gate conceptually different
   signals (a per-contract sampled rate vs. a per-node exact contract count)
   and tuning one should not silently retune the other. 150s-to-arm was
   chosen because the periodic sweep runs every 5s (`CLEANUP_INTERVAL`), so
   it observes a genuine breach ~30 times before the axis can act — open to
   pushback on the exact duration.

**Observability:**

- The sweep-entry log line is `tracing::info!` (was `tracing::debug!` in the
  first version of this PR — this crate builds with `release_max_level_info`,
  which strips `debug!`/`trace!` from release binaries entirely, so the
  original line would never have appeared on a deployed node; fixed per
  review round 1 Must-Fix #2). Fires once per sweep (not per contract), with
  both axes' budget/usage together.
- **New in review round 1** (Must-Fix #4, Ian's soak-test concern): a
  per-eviction `tracing::info!` line specifically when the resident-overhead
  axis drives an eviction, naming the contract key, local/downstream
  subscriber counts, `read_count`, last-genuine-access age, and state size.
  The subscriber-primary `victim_order` is what actually protects
  high-demand contracts (unchanged by this PR, verified independently by the
  code-first reviewer); this line is what makes that protection externally
  verifiable during a soak test rather than only trusted — a human watching
  the logs can spot-check that `local_subscriptions`/`downstream_subscribers`
  are 0 and `last_genuine_access_secs_ago` is large (or absent) for each
  evicted contract.
- `resident_overhead_evictions_total`, `resident_overhead_budget_bytes`, and
  `estimated_resident_overhead_bytes` added to `HostingCacheStats` and wired
  into the local dashboard's `HostingSnapshot`, with a new "Resident
  overhead" tile in the hosting card (mirrors the existing disk-budget
  tiles).

## Sustained-gate fix (review round 1 Must-Fix #1)

`resident_overhead_over_budget()` was a bare instantaneous comparison with
no debounce — see the Magnitude section above for the concrete blast radius
this created. Fixed to mirror the #4861 cost-pressure precedent
(`hosting-invariants.md` invariant 3: "SUSTAINED... a single burst never
triggers... continuously for at least half the cost window"): the raw
estimate must now stay continuously over its budget for
`RESIDENT_OVERHEAD_SUSTAINED_WINDOW / 2` (150s) before this axis contributes
eviction pressure. `resident_overhead_breach_since: Option<Instant>` tracks
when the current continuous breach started, reset to `None` the instant the
raw estimate clears (an eviction bringing the count back down "cures" the
breach exactly like the raw check would). This is a per-node scalar
debounce, not a per-contract rate sample like the cost axes' — there's no
"report burst" to filter (`contracts.len()` is exact, not sampled) — but the
same shape: a peer upgrading straight into a large pre-existing hosted set
now gets a grace window before this brand-new axis can evict anything.

Note the state-byte budget's own eviction is **unaffected** — it has no
sustained gate (pre-existing behavior, not introduced or changed by this
PR) and continues to act immediately, as it always has.

## Testing

Added to `ring/hosting/cache.rs`'s test module:

- `resident_overhead_budget_for_ram_scales_and_clamps` — clamp math, mirrors
  the existing `budget_for_ram_scales_and_clamps`.
- `resident_overhead_pressure_evicts_even_when_state_bytes_are_negligible` —
  the core regression test: a cache with a 1 GiB state-byte budget (never
  binds) and a tiny resident-overhead budget, fed 15 negligible-state
  zero-subscriber contracts. Confirms the instantaneous breach evicts
  *nothing*, then — after advancing the mock clock past the sustained
  window and re-sweeping — sheds down to exactly the resident budget's
  contract-count equivalent while `current_bytes` stays far under
  `budget_bytes` throughout.
- `resident_overhead_at_budget_does_not_evict` — boundary test: exactly at
  budget must not evict (mirrors the cost-pressure exact-boundary test).
- `resident_overhead_pressure_respects_subscriber_primary_ordering` — a
  locally-subscribed contract (inserted oldest, so LRU would evict it first)
  survives resident-overhead pressure while zero-subscriber contracts are
  still eligible — proves this axis reuses the *same* `victim_order`, not a
  new ranking.
- `resident_overhead_pressure_is_enforced_by_periodic_sweep_after_bulk_load`
  — the real-world path: `load_persisted_entry` (startup bulk reload)
  deliberately does not evict. Confirms the FIRST post-restart sweep
  observes the breach but evicts nothing, and only the sweep after the
  sustained window elapses actually sheds.
- **New:** `resident_overhead_pressure_does_not_mass_evict_on_first_sweep_at_framework_scale`
  — the dedicated regression test for the review's own concrete numbers:
  1,057 loaded contracts against a `resident_overhead_budget_for_ram(2 GiB)`
  = 256-contract budget. Confirms the first post-deploy sweep evicts
  *nothing* (not ~76% of the hosted set), and that the axis is not simply
  inert — given sustained time it does shed down to exactly 256.
- **New:** `both_budget_axes_bind_simultaneously` — both axes bound at once,
  at *different* contract-count targets (byte budget looser at 6 contracts,
  resident-overhead budget stricter at 5). Proves the compound `&&` stop
  condition (not an early exit once either axis alone clears) and that the
  sustained gate applies independently per axis: an unsustained resident
  breach doesn't block byte-driven eviction (which has no sustained gate),
  and once sustained it drives exactly one more eviction beyond what byte
  pressure alone already achieved, correctly attributed by
  `resident_overhead_evictions_total` (a strict subset of
  `budget_evictions_total`, not double-counted).
- **New:** `hosting_card_renders_resident_overhead_tile` (`home_page.rs`) —
  the dashboard "Resident overhead" tile renders the actual snapshot values
  (used/budget/headroom/eviction-counter), not just compiles.

Also fixed two stale doc comments flagged in review (`sweep_expired`'s
predicate description now mentions both axes; `budget_evictions_total`'s
field doc now clarifies it covers both axes and how to isolate the
resident-driven subset).

All 235 tests in `ring::hosting::*` pass (0 failed, 10 pre-existing
`#[ignore]`d, unrelated), plus the 7 `home_page::tests::hosting_card_*`
dashboard tests. `cargo fmt` clean. `cargo clippy -p freenet --lib --tests
-- -D warnings` clean.

Closes #5325

[AI-assisted - Claude]
