### PR TITLE
fix(connect): log routine terminus rejections at debug, not info

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -396,6 +396,46 @@ pub(crate) struct AcceptOutcome {
     pub joiner: PeerKeyLocation,
 }
 
+/// Why a relay at terminus could not accept and rejected the request.
+///
+/// These are diagnostically different conditions and must stay
+/// distinguishable downstream: [`NoUphillPeers`](Self::NoUphillPeers) is a
+/// topology/connectivity condition (nothing unvisited left to route to),
+/// while [`UphillBudgetOrTtlExhausted`](Self::UphillBudgetOrTtlExhausted) is
+/// the amplification bound working as designed.
+///
+/// Carried *inside* [`RelayActions::rejected`] rather than as a second field
+/// beside a bool, so that a call site cannot consume the fact of a rejection
+/// without also getting its cause. That is the same reasoning as
+/// [`AcceptOutcome`] (#3838): paired fields which are only meaningful
+/// together drift apart at different call sites, and the type system should
+/// forbid it rather than a comment asking callers to remember.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RejectReason {
+    /// At terminus, cannot accept, and `select_uphill_hop` found no
+    /// unvisited strictly-uphill candidate.
+    NoUphillPeers,
+    /// At terminus, cannot accept, and the uphill budget or TTL is spent.
+    UphillBudgetOrTtlExhausted,
+}
+
+impl RejectReason {
+    /// Stable reason string for the `connect_rejected` telemetry event.
+    ///
+    /// This is the ONLY thing that distinguishes the two causes in a release
+    /// build: the corresponding log lines are `debug!` (#5335) and
+    /// `release_max_level_info` compiles them out entirely, so a constant
+    /// reason string here would erase the distinction in production. Keep
+    /// the two strings distinct, and keep them aligned with the log message
+    /// wording so a log and an event about one rejection agree.
+    pub(crate) fn as_event_reason(self) -> &'static str {
+        match self {
+            Self::NoUphillPeers => "no uphill peers available",
+            Self::UphillBudgetOrTtlExhausted => "uphill budget or TTL exhausted",
+        }
+    }
+}
+
 /// Result of processing a request at a relay.
 #[derive(Debug, Default)]
 pub(crate) struct RelayActions {
@@ -405,9 +445,11 @@ pub(crate) struct RelayActions {
     pub accept: Option<AcceptOutcome>,
     pub forward: Option<(PeerKeyLocation, ConnectRequest)>,
     pub observed_address: Option<(PeerKeyLocation, SocketAddr)>,
-    /// True when at terminus, cannot accept, and has no routing options.
-    /// Signals that an explicit Rejected message should be sent back.
-    pub rejected: bool,
+    /// `Some` exactly when at terminus, cannot accept, and there are no
+    /// routing options — signalling that an explicit Rejected message should
+    /// be sent back. The payload is *why*, so the cause travels with the
+    /// decision instead of in a parallel field. See [`RejectReason`].
+    pub rejected: Option<RejectReason>,
 }
 
 #[derive(Debug, Clone)]
@@ -758,7 +800,7 @@ impl RelayState {
                         visited = ?self.request.visited,
                         "connect: at terminus, cannot accept, no uphill peers available — rejecting"
                     );
-                    actions.rejected = true;
+                    actions.rejected = Some(RejectReason::NoUphillPeers);
                 }
             } else {
                 // debug!, not info!: exhausting the uphill budget or TTL is the
@@ -771,7 +813,7 @@ impl RelayState {
                     visited = ?self.request.visited,
                     "connect: at terminus, cannot accept, uphill budget or TTL exhausted — rejecting"
                 );
-                actions.rejected = true;
+                actions.rejected = Some(RejectReason::UphillBudgetOrTtlExhausted);
             }
         } else if is_terminus && self.forwarded_to.is_some() {
             tracing::debug!(
@@ -3516,7 +3558,11 @@ mod tests {
             actions.forward.is_none(),
             "should not forward uphill when budget is exhausted"
         );
-        assert!(actions.rejected, "should reject when budget is exhausted");
+        assert_eq!(
+            actions.rejected,
+            Some(RejectReason::UphillBudgetOrTtlExhausted),
+            "should reject with the budget-exhausted cause when budget is exhausted"
+        );
     }
 
     // NOTE: A test for joiner_known = None was considered, but this edge case cannot
@@ -3707,7 +3753,11 @@ mod tests {
             Instant::now(),
         );
 
-        assert!(actions.rejected, "should reject when no uphill peers");
+        assert_eq!(
+            actions.rejected,
+            Some(RejectReason::NoUphillPeers),
+            "should reject with the no-uphill-peers cause"
+        );
         assert!(actions.accept.is_none());
         assert!(actions.forward.is_none());
     }
@@ -3745,7 +3795,11 @@ mod tests {
             Instant::now(),
         );
 
-        assert!(actions.rejected, "should reject when TTL exhausted");
+        assert_eq!(
+            actions.rejected,
+            Some(RejectReason::UphillBudgetOrTtlExhausted),
+            "should reject with the budget-or-TTL cause when TTL is exhausted"
+        );
         assert!(actions.accept.is_none());
         assert!(actions.forward.is_none());
     }
@@ -3786,7 +3840,10 @@ mod tests {
             Instant::now(),
         );
 
-        assert!(!actions.rejected, "should not reject when uphill available");
+        assert!(
+            actions.rejected.is_none(),
+            "should not reject when uphill available"
+        );
         assert!(actions.forward.is_some(), "should forward uphill");
         assert!(actions.accept.is_none());
         assert!(
@@ -3915,9 +3972,10 @@ mod tests {
             &estimator,
             Instant::now(),
         );
-        assert!(
+        assert_eq!(
             retry_actions.rejected,
-            "should reject when no uphill peers on retry"
+            Some(RejectReason::NoUphillPeers),
+            "should reject with the no-uphill-peers cause on retry"
         );
         assert!(retry_actions.forward.is_none());
         assert!(retry_actions.accept.is_none());
@@ -4474,7 +4532,7 @@ mod tests {
     fn fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
         let start = source
             .find(signature_prefix)
-            .unwrap_or_else(|| panic!("{signature_prefix} not found in connect.rs"));
+            .unwrap_or_else(|| panic!("anchor not found in scraped source: {signature_prefix}"));
         // Refuse an anchor that landed inside this test module: from there the
         // scraped region could only contain the pin's own literals, so every
         // assertion below would pass without reading production code.
@@ -4508,6 +4566,148 @@ mod tests {
             i += 1;
         }
         panic!("unbalanced braces while scanning {signature_prefix}");
+    }
+
+    /// Drive `handle_request` into the "no unvisited uphill candidate"
+    /// rejection and return the resulting actions.
+    fn reject_actions_no_uphill_peers() -> RelayActions {
+        let self_loc = make_peer(4000);
+        let joiner = make_peer(5000);
+        let mut state = RelayState {
+            upstream_addr: joiner.socket_addr().expect("test peer must have address"),
+            request: ConnectRequest {
+                desired_location: Location::random(),
+                joiner,
+                ttl: 3,
+                visited: VisitedPeers::default(),
+                uphill_budget: DEFAULT_UPHILL_BUDGET,
+            },
+            forwarded_to: None,
+            forwarded_at: None,
+            observed_sent: false,
+            accepted_locally: false,
+            response_forwarded: false,
+        };
+        let ctx = TestRelayContext::new(self_loc)
+            .accept(false)
+            .uphill_hop(None);
+        state.handle_request(
+            &ctx,
+            &HashMap::new(),
+            &mut HashMap::new(),
+            &ConnectForwardEstimator::new(),
+            Instant::now(),
+        )
+    }
+
+    /// Drive `handle_request` into the "uphill budget / TTL spent" rejection
+    /// and return the resulting actions.
+    fn reject_actions_budget_or_ttl_exhausted() -> RelayActions {
+        let self_loc = make_peer(4000);
+        let joiner = make_peer(5000);
+        let mut state = RelayState {
+            upstream_addr: joiner.socket_addr().expect("test peer must have address"),
+            request: ConnectRequest {
+                desired_location: Location::random(),
+                joiner,
+                ttl: 0, // TTL exhausted
+                visited: VisitedPeers::default(),
+                uphill_budget: DEFAULT_UPHILL_BUDGET,
+            },
+            forwarded_to: None,
+            forwarded_at: None,
+            observed_sent: false,
+            accepted_locally: false,
+            response_forwarded: false,
+        };
+        let ctx = TestRelayContext::new(self_loc).accept(false);
+        state.handle_request(
+            &ctx,
+            &HashMap::new(),
+            &mut HashMap::new(),
+            &ConnectForwardEstimator::new(),
+            Instant::now(),
+        )
+    }
+
+    /// #5335: each terminus-rejection cause must reach the structured
+    /// `connect_rejected` event under its OWN distinct reason string.
+    ///
+    /// This is what makes the log downgrade lossless rather than a trade.
+    /// The two causes are diagnostically different — "no uphill peers
+    /// available" is a topology/connectivity condition, "uphill budget or TTL
+    /// exhausted" is the amplification bound working as designed — and once
+    /// the log lines are `debug!` (compiled out of release builds by
+    /// `release_max_level_info`) this event's reason is the ONLY thing that
+    /// tells them apart in production. Before this, both arrived as the
+    /// constant `"rejected by handle_request"`.
+    ///
+    /// Asserts the specific mapping, not merely that the two differ: a test
+    /// that only checked `a != b` would stay green if the two arms of
+    /// `as_event_reason` were swapped.
+    #[test]
+    fn each_terminus_rejection_cause_reaches_the_event_with_its_own_reason() {
+        let no_uphill = reject_actions_no_uphill_peers()
+            .rejected
+            .expect("no-uphill-candidate scenario must reject");
+        let budget_spent = reject_actions_budget_or_ttl_exhausted()
+            .rejected
+            .expect("budget/TTL-exhausted scenario must reject");
+
+        assert_eq!(no_uphill, RejectReason::NoUphillPeers);
+        assert_eq!(budget_spent, RejectReason::UphillBudgetOrTtlExhausted);
+
+        assert_eq!(
+            no_uphill.as_event_reason(),
+            "no uphill peers available",
+            "the no-uphill-candidate cause must carry its own event reason"
+        );
+        assert_eq!(
+            budget_spent.as_event_reason(),
+            "uphill budget or TTL exhausted",
+            "the budget/TTL cause must carry its own event reason"
+        );
+        assert_ne!(
+            no_uphill.as_event_reason(),
+            budget_spent.as_event_reason(),
+            "the two causes must remain distinguishable in telemetry"
+        );
+    }
+
+    /// #5335: the CONNECT relay driver must pass the carried cause to
+    /// `NetEventLog::connect_rejected`, never a constant.
+    ///
+    /// The behavioural test above proves `handle_request` produces the right
+    /// `RejectReason`; this proves the driver actually forwards it into the
+    /// event, which is the step that would silently undo the whole point.
+    /// Reaching the real emit requires a live `OpManager` and ring, so this
+    /// is a source scrape — but a CROSS-FILE one (it lives in `connect.rs`
+    /// and reads `connect/op_ctx_task.rs`), so it structurally cannot be
+    /// satisfied by its own assertion literals.
+    #[test]
+    fn relay_driver_passes_the_specific_reject_cause_to_the_event() {
+        const DRIVER_SOURCE: &str = include_str!("connect/op_ctx_task.rs");
+        let branch = fn_body(
+            DRIVER_SOURCE,
+            "if let Some(reject_reason) = initial_actions.rejected",
+        );
+
+        assert!(
+            branch.contains("NetEventLog::connect_rejected("),
+            "the rejected branch must still emit the structured event"
+        );
+        assert!(
+            branch.contains("reject_reason.as_event_reason()"),
+            "the rejected branch must pass the CARRIED cause to \
+             connect_rejected (#5335) — a constant reason string erases the \
+             difference between 'no uphill peers available' and 'uphill \
+             budget or TTL exhausted' in release builds, where the \
+             corresponding debug! log lines are compiled out entirely"
+        );
+        assert!(
+            !branch.contains("\"rejected by handle_request\""),
+            "the constant reason string must not come back (#5335)"
+        );
     }
 
     /// #5335: the two terminus-rejection arms of `RelayState::handle_request`

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -398,11 +398,14 @@ pub(crate) struct AcceptOutcome {
 
 /// Why a relay at terminus could not accept and rejected the request.
 ///
-/// These are diagnostically different conditions and must stay
-/// distinguishable downstream: [`NoUphillPeers`](Self::NoUphillPeers) is a
+/// Three diagnostically different conditions that must stay distinguishable
+/// downstream: [`NoUphillPeers`](Self::NoUphillPeers) is a
 /// topology/connectivity condition (nothing unvisited left to route to),
-/// while [`UphillBudgetOrTtlExhausted`](Self::UphillBudgetOrTtlExhausted) is
-/// the amplification bound working as designed.
+/// [`UphillBudgetExhausted`](Self::UphillBudgetExhausted) is the
+/// amplification bound working as designed, and
+/// [`TtlExhausted`](Self::TtlExhausted) is the request running out of network
+/// reach. The latter two have different remedies, which is why they are
+/// separate variants rather than one.
 ///
 /// Carried *inside* [`RelayActions::rejected`] rather than as a second field
 /// beside a bool, so that a call site cannot consume the fact of a rejection
@@ -4573,6 +4576,19 @@ mod tests {
     /// inside an `impl` — its closing brace is indented, so that anchor would
     /// find the enclosing `impl RelayState` brace and silently widen the
     /// region across every sibling method.
+    ///
+    /// Two properties callers rely on, both worth knowing before reusing it:
+    ///
+    /// - The `handle_request` anchor matches the TRAIT method signature as
+    ///   well as the inherent one, so it resolves by file order rather than
+    ///   uniquely. That is safe here only because a mis-slice fails LOUDLY —
+    ///   the wrong region lacks the asserted literals — rather than passing
+    ///   vacuously. Do not assume a new anchor has that property.
+    /// - It slices from the first `{` AFTER the anchor, which is right for a
+    ///   signature and wrong for a STATEMENT: the first brace then belongs to
+    ///   whatever follows, so the statement's own text is excluded and an
+    ///   assertion about it can never see it. Match statements
+    ///   whitespace-stripped against the file instead.
     fn fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
         let start = source
             .find(signature_prefix)
@@ -4705,6 +4721,65 @@ mod tests {
             &ConnectForwardEstimator::new(),
             Instant::now(),
         )
+    }
+
+    /// Drive `handle_request` into the case where the uphill budget AND the
+    /// TTL are BOTH spent — the overlap the else-if precedence decides.
+    fn reject_actions_budget_and_ttl_both_exhausted() -> RelayActions {
+        let self_loc = make_peer(4000);
+        let joiner = make_peer(5000);
+        let uphill = make_peer(6000);
+        let mut state = RelayState {
+            upstream_addr: joiner.socket_addr().expect("test peer must have address"),
+            request: ConnectRequest {
+                desired_location: Location::random(),
+                joiner,
+                ttl: 0,           // reach spent
+                uphill_budget: 0, // budget spent
+                visited: VisitedPeers::default(),
+            },
+            forwarded_to: None,
+            forwarded_at: None,
+            observed_sent: false,
+            accepted_locally: false,
+            response_forwarded: false,
+        };
+        let ctx = TestRelayContext::new(self_loc)
+            .accept(false)
+            .next_hop(None)
+            .uphill_hop(Some(uphill));
+        state.handle_request(
+            &ctx,
+            &HashMap::new(),
+            &mut HashMap::new(),
+            &ConnectForwardEstimator::new(),
+            Instant::now(),
+        )
+    }
+
+    /// #5335: when the uphill budget AND the TTL are both spent, the reported
+    /// cause is BUDGET.
+    ///
+    /// The two single-condition fixtures each isolate one half of the
+    /// `uphill_budget > 0 && ttl >= 2` gate, so neither exercises the overlap
+    /// — swapping the else-if to test TTL first leaves both of them green.
+    /// This pins the documented precedence itself, which is a real decision:
+    /// budget is decremented once per uphill retry while TTL also falls on
+    /// ordinary forwards, so budget is the tighter and more actionable bound
+    /// on this path.
+    #[test]
+    fn budget_is_reported_when_budget_and_ttl_are_both_exhausted() {
+        let both_spent = reject_actions_budget_and_ttl_both_exhausted()
+            .rejected
+            .expect("budget+TTL-exhausted scenario must reject");
+
+        assert_eq!(
+            both_spent,
+            RejectReason::UphillBudgetExhausted,
+            "with BOTH spent the budget is reported, not the TTL — the \
+             else-if checks `uphill_budget == 0` first, deliberately (#5335)"
+        );
+        assert_eq!(both_spent.as_event_reason(), "uphill budget exhausted");
     }
 
     /// #5335: each terminus-rejection cause must reach the structured
@@ -4939,7 +5014,13 @@ mod tests {
     /// - the local `_EVENT_LOG` register is opt-in and off by default on
     ///   network nodes;
     /// - telemetry upload is user-disableable;
-    /// - the enqueue is a `try_send`, so events are dropped on a full channel.
+    /// - the enqueue is a `try_send`, so events are dropped on a full channel;
+    /// - **the event is coarser than the line it replaces.** The `debug!`
+    ///   carries `ttl`, `uphill_budget` and `visited`; `connect_rejected`
+    ///   carries only `desired_location` and a reason string. Splitting
+    ///   budget from TTL in [`RejectReason`] recovers WHICH bound bound, but
+    ///   not the values — and `visited`, the actual dead-end evidence, has no
+    ///   replacement on any path.
     ///
     /// On a node with telemetry disabled, a release build records terminus
     /// rejections nowhere at all. That is judged an acceptable trade for a

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -413,25 +413,42 @@ pub(crate) struct AcceptOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RejectReason {
     /// At terminus, cannot accept, and `select_uphill_hop` found no
-    /// unvisited strictly-uphill candidate.
+    /// unvisited strictly-uphill candidate. A topology/connectivity
+    /// condition — there is nowhere left to route.
     NoUphillPeers,
-    /// At terminus, cannot accept, and the uphill budget or TTL is spent.
-    UphillBudgetOrTtlExhausted,
+    /// At terminus, cannot accept, and the uphill budget is spent. The
+    /// amplification bound working as designed; the knob is
+    /// `DEFAULT_UPHILL_BUDGET`.
+    UphillBudgetExhausted,
+    /// At terminus, cannot accept, and the TTL is spent. The request ran
+    /// out of network reach; the knob is `max_hops_to_live`.
+    TtlExhausted,
 }
 
 impl RejectReason {
     /// Stable reason string for the `connect_rejected` telemetry event.
     ///
-    /// This is the ONLY thing that distinguishes the two causes in a release
+    /// This is the ONLY thing that distinguishes the causes in a release
     /// build: the corresponding log lines are `debug!` (#5335) and
     /// `release_max_level_info` compiles them out entirely, so a constant
-    /// reason string here would erase the distinction in production. Keep
-    /// the two strings distinct, and keep them aligned with the log message
-    /// wording so a log and an event about one rejection agree.
+    /// reason string here would erase the distinction in production.
+    ///
+    /// Budget and TTL are SEPARATE variants deliberately. They are the two
+    /// halves of the `uphill_budget > 0 && ttl >= 2` gate below and have
+    /// different remedies, but the `debug!` line that used to carry `ttl`
+    /// and `uphill_budget` as structured fields no longer reaches
+    /// production — so merging them would leave an operator unable to tell
+    /// which knob to reach for.
+    ///
+    /// Keep these strings distinct, and keep each aligned with the log
+    /// message in the branch that produces it, so a log line and an event
+    /// describing the same rejection never disagree. That pairing is pinned
+    /// by `each_reject_branch_logs_the_message_matching_its_reason`.
     pub(crate) fn as_event_reason(self) -> &'static str {
         match self {
             Self::NoUphillPeers => "no uphill peers available",
-            Self::UphillBudgetOrTtlExhausted => "uphill budget or TTL exhausted",
+            Self::UphillBudgetExhausted => "uphill budget exhausted",
+            Self::TtlExhausted => "TTL exhausted",
         }
     }
 }
@@ -445,10 +462,21 @@ pub(crate) struct RelayActions {
     pub accept: Option<AcceptOutcome>,
     pub forward: Option<(PeerKeyLocation, ConnectRequest)>,
     pub observed_address: Option<(PeerKeyLocation, SocketAddr)>,
-    /// `Some` exactly when at terminus, cannot accept, and there are no
-    /// routing options — signalling that an explicit Rejected message should
-    /// be sent back. The payload is *why*, so the cause travels with the
+    /// `Some` when this call reached terminus, could not accept, and had no
+    /// routing option left — carrying *why*, so the cause travels with the
     /// decision instead of in a parallel field. See [`RejectReason`].
+    ///
+    /// This states what `handle_request` PRODUCES, not what the drivers do
+    /// with it, and the two are deliberately not the same shape — do not
+    /// read `Some` as "an explicit Rejected is sent" or `None` as "one is
+    /// not". In `connect/op_ctx_task.rs`, the retry-on-`Rejected` path sends
+    /// `Rejected` upstream whenever neither a forward nor an accept came
+    /// back, `rejected` being `None` included; and the
+    /// retry-on-`ConnectFailed` path propagates `ConnectFailed` upstream
+    /// even when this is `Some`. Both predate this field carrying a payload.
+    /// In particular, do NOT "tidy" either site into an `if let Some(..)`
+    /// gate on this field — that would silently change which message the
+    /// upstream peer receives.
     pub rejected: Option<RejectReason>,
 }
 
@@ -802,18 +830,34 @@ impl RelayState {
                     );
                     actions.rejected = Some(RejectReason::NoUphillPeers);
                 }
-            } else {
-                // debug!, not info!: exhausting the uphill budget or TTL is the
-                // amplification bound doing its job, not a fault. Same #5335
-                // rationale as the sibling arm above.
+            } else if self.request.uphill_budget == 0 {
+                // debug!, not info!: a spent uphill budget is the amplification
+                // bound doing its job, not a fault. Same #5335 rationale as the
+                // sibling arm above.
+                //
+                // Budget is checked FIRST, so when BOTH are spent this reports
+                // budget. Deliberate: budget is decremented once per uphill
+                // retry while TTL also falls on ordinary forwards, so the
+                // budget is the tighter bound on this path and the more
+                // actionable of the two.
                 tracing::debug!(
                     target = %self.request.desired_location,
                     ttl = self.request.ttl,
                     uphill_budget = self.request.uphill_budget,
                     visited = ?self.request.visited,
-                    "connect: at terminus, cannot accept, uphill budget or TTL exhausted — rejecting"
+                    "connect: at terminus, cannot accept, uphill budget exhausted — rejecting"
                 );
-                actions.rejected = Some(RejectReason::UphillBudgetOrTtlExhausted);
+                actions.rejected = Some(RejectReason::UphillBudgetExhausted);
+            } else {
+                // Reaching here means `ttl < 2` (the other half of the gate).
+                tracing::debug!(
+                    target = %self.request.desired_location,
+                    ttl = self.request.ttl,
+                    uphill_budget = self.request.uphill_budget,
+                    visited = ?self.request.visited,
+                    "connect: at terminus, cannot accept, TTL exhausted — rejecting"
+                );
+                actions.rejected = Some(RejectReason::TtlExhausted);
             }
         } else if is_terminus && self.forwarded_to.is_some() {
             tracing::debug!(
@@ -3560,7 +3604,7 @@ mod tests {
         );
         assert_eq!(
             actions.rejected,
-            Some(RejectReason::UphillBudgetOrTtlExhausted),
+            Some(RejectReason::UphillBudgetExhausted),
             "should reject with the budget-exhausted cause when budget is exhausted"
         );
     }
@@ -3797,8 +3841,8 @@ mod tests {
 
         assert_eq!(
             actions.rejected,
-            Some(RejectReason::UphillBudgetOrTtlExhausted),
-            "should reject with the budget-or-TTL cause when TTL is exhausted"
+            Some(RejectReason::TtlExhausted),
+            "should reject with the TTL-exhausted cause when TTL is exhausted"
         );
         assert!(actions.accept.is_none());
         assert!(actions.forward.is_none());
@@ -4600,9 +4644,9 @@ mod tests {
         )
     }
 
-    /// Drive `handle_request` into the "uphill budget / TTL spent" rejection
-    /// and return the resulting actions.
-    fn reject_actions_budget_or_ttl_exhausted() -> RelayActions {
+    /// Drive `handle_request` into the "TTL spent" rejection and return the
+    /// resulting actions.
+    fn reject_actions_ttl_exhausted() -> RelayActions {
         let self_loc = make_peer(4000);
         let joiner = make_peer(5000);
         let mut state = RelayState {
@@ -4630,32 +4674,69 @@ mod tests {
         )
     }
 
+    /// Drive `handle_request` into the "uphill budget spent" rejection.
+    fn reject_actions_budget_exhausted() -> RelayActions {
+        let self_loc = make_peer(4000);
+        let joiner = make_peer(5000);
+        let uphill = make_peer(6000);
+        let mut state = RelayState {
+            upstream_addr: joiner.socket_addr().expect("test peer must have address"),
+            request: ConnectRequest {
+                desired_location: Location::random(),
+                joiner,
+                ttl: 5,           // TTL is fine
+                uphill_budget: 0, // budget spent
+                visited: VisitedPeers::default(),
+            },
+            forwarded_to: None,
+            forwarded_at: None,
+            observed_sent: false,
+            accepted_locally: false,
+            response_forwarded: false,
+        };
+        let ctx = TestRelayContext::new(self_loc)
+            .accept(false)
+            .next_hop(None)
+            .uphill_hop(Some(uphill));
+        state.handle_request(
+            &ctx,
+            &HashMap::new(),
+            &mut HashMap::new(),
+            &ConnectForwardEstimator::new(),
+            Instant::now(),
+        )
+    }
+
     /// #5335: each terminus-rejection cause must reach the structured
     /// `connect_rejected` event under its OWN distinct reason string.
     ///
-    /// This is what makes the log downgrade lossless rather than a trade.
-    /// The two causes are diagnostically different — "no uphill peers
-    /// available" is a topology/connectivity condition, "uphill budget or TTL
-    /// exhausted" is the amplification bound working as designed — and once
+    /// This is what makes the log downgrade a cleanup rather than a trade.
+    /// The three causes are diagnostically different — no uphill candidate is
+    /// a topology/connectivity condition, a spent budget is the amplification
+    /// bound working as designed, a spent TTL is exhausted reach — and once
     /// the log lines are `debug!` (compiled out of release builds by
-    /// `release_max_level_info`) this event's reason is the ONLY thing that
-    /// tells them apart in production. Before this, both arrived as the
+    /// `release_max_level_info`) this event's reason is the only thing that
+    /// tells them apart in production. Before this, all three arrived as the
     /// constant `"rejected by handle_request"`.
     ///
-    /// Asserts the specific mapping, not merely that the two differ: a test
-    /// that only checked `a != b` would stay green if the two arms of
+    /// Asserts the specific mapping, not merely that they differ: a test
+    /// checking only `a != b` would stay green if the arms of
     /// `as_event_reason` were swapped.
     #[test]
     fn each_terminus_rejection_cause_reaches_the_event_with_its_own_reason() {
         let no_uphill = reject_actions_no_uphill_peers()
             .rejected
             .expect("no-uphill-candidate scenario must reject");
-        let budget_spent = reject_actions_budget_or_ttl_exhausted()
+        let budget_spent = reject_actions_budget_exhausted()
             .rejected
-            .expect("budget/TTL-exhausted scenario must reject");
+            .expect("budget-exhausted scenario must reject");
+        let ttl_spent = reject_actions_ttl_exhausted()
+            .rejected
+            .expect("TTL-exhausted scenario must reject");
 
         assert_eq!(no_uphill, RejectReason::NoUphillPeers);
-        assert_eq!(budget_spent, RejectReason::UphillBudgetOrTtlExhausted);
+        assert_eq!(budget_spent, RejectReason::UphillBudgetExhausted);
+        assert_eq!(ttl_spent, RejectReason::TtlExhausted);
 
         assert_eq!(
             no_uphill.as_event_reason(),
@@ -4664,69 +4745,216 @@ mod tests {
         );
         assert_eq!(
             budget_spent.as_event_reason(),
-            "uphill budget or TTL exhausted",
-            "the budget/TTL cause must carry its own event reason"
+            "uphill budget exhausted",
+            "the budget cause must carry its own event reason"
         );
-        assert_ne!(
+        assert_eq!(
+            ttl_spent.as_event_reason(),
+            "TTL exhausted",
+            "the TTL cause must carry its own event reason — budget and TTL \
+             have DIFFERENT remedies and must not be merged (#5335 F2)"
+        );
+
+        // All three distinct: a merge would make one indistinguishable from
+        // another in production, which is the whole failure mode here.
+        let reasons = [
             no_uphill.as_event_reason(),
             budget_spent.as_event_reason(),
-            "the two causes must remain distinguishable in telemetry"
+            ttl_spent.as_event_reason(),
+        ];
+        let unique: std::collections::HashSet<_> = reasons.iter().collect();
+        assert_eq!(
+            unique.len(),
+            reasons.len(),
+            "every cause must remain distinguishable in telemetry, got {reasons:?}"
         );
     }
 
-    /// #5335: the CONNECT relay driver must pass the carried cause to
-    /// `NetEventLog::connect_rejected`, never a constant.
+    /// #5335: within each rejection branch, the `debug!` message must match
+    /// the `RejectReason` that branch assigns.
     ///
-    /// The behavioural test above proves `handle_request` produces the right
-    /// `RejectReason`; this proves the driver actually forwards it into the
-    /// event, which is the step that would silently undo the whole point.
-    /// Reaching the real emit requires a live `OpManager` and ring, so this
-    /// is a source scrape — but a CROSS-FILE one (it lives in `connect.rs`
-    /// and reads `connect/op_ctx_task.rs`), so it structurally cannot be
-    /// satisfied by its own assertion literals.
+    /// The log line and the telemetry event describe the SAME rejection, so
+    /// if their wording drifts apart an operator correlating a debug-build
+    /// log against a production event gets two different stories. Nothing
+    /// else pins this: asserting each message merely appears SOMEWHERE in
+    /// `handle_request` passes vacuously when two messages are swapped
+    /// between arms, since both are still present.
+    ///
+    /// Anchors on the assignment (`actions.rejected = Some(..)`) and looks
+    /// BACKWARD to the nearest `tracing::debug!(`, so it reads the message
+    /// belonging to that specific branch.
     #[test]
-    fn relay_driver_passes_the_specific_reject_cause_to_the_event() {
+    fn each_reject_branch_logs_the_message_matching_its_reason() {
+        const SOURCE: &str = include_str!("connect.rs");
+        let body = fn_body(SOURCE, "pub(crate) fn handle_request<C: RelayContext>(");
+
+        for (variant, expected_message) in [
+            ("RejectReason::NoUphillPeers", "no uphill peers available"),
+            (
+                "RejectReason::UphillBudgetExhausted",
+                "uphill budget exhausted",
+            ),
+            ("RejectReason::TtlExhausted", "TTL exhausted"),
+        ] {
+            let assignment = format!("actions.rejected = Some({variant});");
+            let occurrences = body.matches(assignment.as_str()).count();
+            assert_eq!(
+                occurrences, 1,
+                "expected exactly one `{assignment}` in handle_request, found \
+                 {occurrences}"
+            );
+            let at = body.find(assignment.as_str()).expect("checked above");
+            let macro_start = body[..at]
+                .rfind("tracing::debug!(")
+                .expect("each rejection branch must log before assigning its cause");
+            let branch = &body[macro_start..at];
+            assert!(
+                branch.contains(expected_message),
+                "the branch assigning `{variant}` must log the matching \
+                 message `{expected_message}` (#5335) — a log and an event \
+                 describing one rejection must not disagree. Branch was: \
+                 {branch}"
+            );
+        }
+    }
+
+    /// #5335: EVERY `connect_rejected` emit reachable from a
+    /// `handle_request` result must pass that result's carried cause, never
+    /// a constant.
+    ///
+    /// The behavioural tests above prove `handle_request` produces the right
+    /// `RejectReason`; this proves the driver actually forwards it into the
+    /// event, the step that would silently undo the whole point. Reaching
+    /// the real emit needs a live `OpManager` and ring, so it is a source
+    /// scrape — but a CROSS-FILE one (lives in `connect.rs`, reads
+    /// `connect/op_ctx_task.rs`), so it structurally cannot be satisfied by
+    /// its own assertion literals.
+    ///
+    /// It enumerates ALL THREE `handle_request` call sites rather than the
+    /// first one. The original version of this pin scraped only the
+    /// `initial_actions` branch, and so was blind to the retry-on-`Rejected`
+    /// path — which re-runs the same `handle_request` and emitted a single
+    /// constant covering every cause, i.e. exactly the conflation this issue
+    /// is about, on roughly half of live rejections. Deriving the site list
+    /// from the calls (not from the emits) is what makes a NEW call site
+    /// fail this test rather than slip past it.
+    #[test]
+    fn every_reject_emit_from_handle_request_passes_the_carried_cause() {
         const DRIVER_SOURCE: &str = include_str!("connect/op_ctx_task.rs");
-        let branch = fn_body(
+
+        // Anchor on the CALLS, so a fourth one cannot be added without
+        // either binding its result here or failing the count below.
+        let call_sites = DRIVER_SOURCE.matches("state.handle_request(").count();
+        assert_eq!(
+            call_sites, 3,
+            "handle_request has {call_sites} call sites in the driver, not the \
+             3 this pin enumerates. A new call site must decide what its \
+             rejection reason is before this pin can pass (#5335)."
+        );
+
+        // Every binding of a handle_request result, and how that branch must
+        // reach `connect_rejected` — or why it legitimately does not.
+        let initial = fn_body(
             DRIVER_SOURCE,
             "if let Some(reject_reason) = initial_actions.rejected",
         );
+        assert!(
+            initial.contains("NetEventLog::connect_rejected("),
+            "the initial-actions branch must still emit the structured event"
+        );
+        assert!(
+            initial.contains("reject_reason.as_event_reason()"),
+            "the initial-actions branch must pass the CARRIED cause (#5335)"
+        );
 
+        // Retry after a downstream `Rejected`: same handle_request, so the
+        // same causes — a constant here is the F1 regression.
+        //
+        // Matched whitespace-stripped so a rustfmt reflow cannot disarm it,
+        // and NOT via `fn_body`: that helper slices from the first `{` AFTER
+        // its anchor, which is correct for a signature but silently excludes
+        // a STATEMENT anchor's own text (the first `{` here belongs to the
+        // following `if let`). Anchoring a pin on a statement and then
+        // asserting about that statement is a way to test nothing.
+        let squashed: String = DRIVER_SOURCE
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
         assert!(
-            branch.contains("NetEventLog::connect_rejected("),
-            "the rejected branch must still emit the structured event"
+            squashed.contains("retry.rejected.map(RejectReason::as_event_reason)"),
+            "the retry-on-Rejected path must map the carried cause into the \
+             event reason (#5335 F1) — it re-runs the SAME handle_request, so \
+             a constant string there reintroduces exactly the multi-cause \
+             conflation this issue removed, on about half of live rejections"
         );
         assert!(
-            branch.contains("reject_reason.as_event_reason()"),
-            "the rejected branch must pass the CARRIED cause to \
-             connect_rejected (#5335) — a constant reason string erases the \
-             difference between 'no uphill peers available' and 'uphill \
-             budget or TTL exhausted' in release builds, where the \
-             corresponding debug! log lines are compiled out entirely"
+            squashed.contains("connect_rejected(&incoming_tx,&op_manager.ring,dl,reason)"),
+            "the retry-on-Rejected emit must pass the mapped `reason` binding, \
+             not a literal (#5335 F1)"
+        );
+
+        // The generic string survives ONLY as the no-cause fallback, never
+        // as the sole reason argument.
+        assert!(
+            squashed.contains(".unwrap_or(\"relaynoretrypeersavailable\")"),
+            "the generic reason must remain reachable only as the \
+             `unwrap_or` fallback for a handle_request result that carried no \
+             cause at all"
         );
         assert!(
-            !branch.contains("\"rejected by handle_request\""),
+            !DRIVER_SOURCE.contains("\"rejected by handle_request\""),
             "the constant reason string must not come back (#5335)"
+        );
+
+        // Third call site (retry after ConnectFailed) deliberately emits no
+        // connect_rejected — see the KNOWN GAP comment at that branch. Pin
+        // the deliberateness so a future reader does not "fix" it silently,
+        // and so deleting the rationale fails here.
+        assert!(
+            DRIVER_SOURCE.contains("KNOWN GAP (#5335)"),
+            "the ConnectFailed-propagation branch must keep its explicit \
+             KNOWN GAP rationale for emitting no connect_rejected event; if \
+             that branch starts emitting one, update this pin deliberately"
         );
     }
 
     /// #5335: the two terminus-rejection arms of `RelayState::handle_request`
     /// must log at `debug!`, never `info!`.
     ///
-    /// Both describe a routine, expected outcome of CONNECT routing — no
+    /// All describe a routine, expected outcome of CONNECT routing — no
     /// unvisited uphill candidate, or the uphill budget / TTL bound doing its
     /// job. On a moderately busy peer they fired 25-65 times a minute as
     /// standing baseline, ~22% of all log lines, drowning genuinely rare
     /// connect failures at the level meant for things an operator should
-    /// notice by default. Nothing is lost by the downgrade: the rejection is
-    /// still emitted as a structured `NetEventLog::connect_rejected` event by
-    /// the caller in `connect/op_ctx_task.rs`, and aggregated into the
-    /// `connect_rejects_emitted` snapshot counter.
+    /// notice by default.
+    ///
+    /// What replaces them: the rejection is emitted as a structured
+    /// `NetEventLog::connect_rejected` event by the caller in
+    /// `connect/op_ctx_task.rs`, carrying the specific cause, and aggregated
+    /// into the `connect_rejects_emitted` snapshot counter.
+    ///
+    /// That is a REPLACEMENT, not a guarantee of preservation, and the limits
+    /// are worth stating rather than claiming "nothing is lost":
+    ///
+    /// - the local `_EVENT_LOG` register is opt-in and off by default on
+    ///   network nodes;
+    /// - telemetry upload is user-disableable;
+    /// - the enqueue is a `try_send`, so events are dropped on a full channel.
+    ///
+    /// On a node with telemetry disabled, a release build records terminus
+    /// rejections nowhere at all. That is judged an acceptable trade for a
+    /// line at ~22% of log volume whose per-occurrence value is nil, but it
+    /// is a trade.
     ///
     /// Note `crates/core/Cargo.toml` enables tracing's
     /// `release_max_level_info`, so `debug!` is compiled out of release
     /// builds entirely rather than merely filtered — which is the point here,
     /// but means a future marker anyone greps for must NOT live at this level.
+    ///
+    /// See also the retirement TODO at `tracing/telemetry.rs` on the
+    /// per-event `connect_rejected` firehose: retiring it in favour of
+    /// snapshot counters, which have no reason dimension, would remove this
+    /// PR's entire output while these lines stay compiled out.
     #[test]
     fn terminus_rejection_log_sites_use_debug_not_info() {
         const SOURCE: &str = include_str!("connect.rs");
@@ -4748,7 +4976,8 @@ mod tests {
 
         for marker in [
             "\"connect: at terminus, cannot accept, no uphill peers available",
-            "\"connect: at terminus, cannot accept, uphill budget or TTL exhausted",
+            "\"connect: at terminus, cannot accept, uphill budget exhausted",
+            "\"connect: at terminus, cannot accept, TTL exhausted",
         ] {
             let occurrences = body.matches(marker).count();
             assert_eq!(

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -743,7 +743,15 @@ impl RelayState {
                     self.request.uphill_budget = self.request.uphill_budget.saturating_sub(1);
                     actions.forward = Some((peer, fwd_req));
                 } else {
-                    tracing::info!(
+                    // debug!, not info!: reaching terminus with no unvisited
+                    // uphill candidate is a routine, expected outcome of ring
+                    // routing, not an anomaly — it fires 25-65 times/minute as
+                    // standing baseline on a moderately busy peer (#5335), and
+                    // the rejection is already carried as structured telemetry
+                    // by `NetEventLog::connect_rejected` at the caller plus the
+                    // aggregate `connect_rejects_emitted` snapshot counter.
+                    // Matches the sibling already-forwarded arm below.
+                    tracing::debug!(
                         target = %self.request.desired_location,
                         ttl = self.request.ttl,
                         uphill_budget = self.request.uphill_budget,
@@ -753,7 +761,10 @@ impl RelayState {
                     actions.rejected = true;
                 }
             } else {
-                tracing::info!(
+                // debug!, not info!: exhausting the uphill budget or TTL is the
+                // amplification bound doing its job, not a fault. Same #5335
+                // rationale as the sibling arm above.
+                tracing::debug!(
                     target = %self.request.desired_location,
                     ttl = self.request.ttl,
                     uphill_budget = self.request.uphill_budget,
@@ -4444,5 +4455,121 @@ mod tests {
             gap_median < 0.05,
             "gap_target median ({gap_median:.4}) should be < 0.05 (Kleinberg-optimal produces short connections)"
         );
+    }
+
+    /// Return just the body of the item whose signature starts with
+    /// `signature_prefix`, bounded by brace depth.
+    ///
+    /// A bare `SOURCE[start..].find(needle)` does not stop at the function's
+    /// closing brace: it matches a *later* occurrence, very often this test
+    /// module's own assertion literal, and the pin then passes vacuously
+    /// under a name saying the case is covered. See AGENTS.md, "WHEN writing
+    /// a source-scrape pin test".
+    ///
+    /// Brace counting rather than the `\n}\n` end anchor used by
+    /// `commands::auto_update`'s helper, because `handle_request` is a method
+    /// inside an `impl` — its closing brace is indented, so that anchor would
+    /// find the enclosing `impl RelayState` brace and silently widen the
+    /// region across every sibling method.
+    fn fn_body<'a>(source: &'a str, signature_prefix: &str) -> &'a str {
+        let start = source
+            .find(signature_prefix)
+            .unwrap_or_else(|| panic!("{signature_prefix} not found in connect.rs"));
+        // Refuse an anchor that landed inside this test module: from there the
+        // scraped region could only contain the pin's own literals, so every
+        // assertion below would pass without reading production code.
+        let tests_at = source
+            .find("\n#[cfg(test)]\nmod ")
+            .map(|i| i + 1)
+            .expect("test module not located — this guard cannot verify anything");
+        assert!(
+            start < tests_at,
+            "`{signature_prefix}` matched inside the test module — this pin \
+             would be scraping its own source and pass vacuously"
+        );
+        let brace = source[start..]
+            .find('{')
+            .unwrap_or_else(|| panic!("{signature_prefix} must have a body"));
+        let body_start = start + brace + 1;
+        let bytes = source.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_start;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        panic!("unbalanced braces while scanning {signature_prefix}");
+    }
+
+    /// #5335: the two terminus-rejection arms of `RelayState::handle_request`
+    /// must log at `debug!`, never `info!`.
+    ///
+    /// Both describe a routine, expected outcome of CONNECT routing — no
+    /// unvisited uphill candidate, or the uphill budget / TTL bound doing its
+    /// job. On a moderately busy peer they fired 25-65 times a minute as
+    /// standing baseline, ~22% of all log lines, drowning genuinely rare
+    /// connect failures at the level meant for things an operator should
+    /// notice by default. Nothing is lost by the downgrade: the rejection is
+    /// still emitted as a structured `NetEventLog::connect_rejected` event by
+    /// the caller in `connect/op_ctx_task.rs`, and aggregated into the
+    /// `connect_rejects_emitted` snapshot counter.
+    ///
+    /// Note `crates/core/Cargo.toml` enables tracing's
+    /// `release_max_level_info`, so `debug!` is compiled out of release
+    /// builds entirely rather than merely filtered — which is the point here,
+    /// but means a future marker anyone greps for must NOT live at this level.
+    #[test]
+    fn terminus_rejection_log_sites_use_debug_not_info() {
+        const SOURCE: &str = include_str!("connect.rs");
+        let body = fn_body(SOURCE, "pub(crate) fn handle_request<C: RelayContext>(");
+
+        // Bracket the scraped region so a mis-slice fails loudly instead of
+        // asserting against the wrong text: the sibling already-forwarded arm
+        // is inside `handle_request`, `impl RelayContext for RelayEnv` is the
+        // next item after it.
+        assert!(
+            body.contains("connect: at terminus but already forwarded"),
+            "scraped the wrong region — handle_request's body must contain the \
+             sibling already-forwarded arm"
+        );
+        assert!(
+            !body.contains("impl RelayContext for RelayEnv"),
+            "scraped region overran handle_request's closing brace"
+        );
+
+        for marker in [
+            "\"connect: at terminus, cannot accept, no uphill peers available",
+            "\"connect: at terminus, cannot accept, uphill budget or TTL exhausted",
+        ] {
+            let occurrences = body.matches(marker).count();
+            assert_eq!(
+                occurrences, 1,
+                "expected exactly one `{marker}...` log site in handle_request, \
+                 found {occurrences}. If the message was deliberately reworded, \
+                 update this pin — do not delete it (#5335)."
+            );
+            let at = body.find(marker).expect("checked by the count above");
+            let macro_start = body[..at]
+                .rfind("tracing::")
+                .expect("the log site must be a `tracing::` macro invocation");
+            let invocation = &body[macro_start..];
+            let found: String = invocation.chars().take(16).collect();
+            assert!(
+                invocation.starts_with("tracing::debug!("),
+                "`{marker}...` must be logged at debug!, not info! (#5335) — it \
+                 is a routine terminus outcome, not an anomaly, and the \
+                 rejection is already carried by NetEventLog::connect_rejected. \
+                 Found `{found}`."
+            );
+        }
     }
 }

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -37,7 +37,7 @@ use crate::ring::{ConnectionFailureReason, Location, PeerKeyLocation};
 use crate::tracing::NetEventLog;
 
 use super::{
-    ConnectMsg, ConnectRequest, ForwardAttempt, RelayEnv, RelayState,
+    ConnectMsg, ConnectRequest, ForwardAttempt, RejectReason, RelayEnv, RelayState,
     dispatch_expect_connection_from,
 };
 
@@ -1087,12 +1087,24 @@ async fn drive_relay_connect(
                         failed_peer = ?failed_peer,
                         "CONNECT relay: forwarding rejection upstream (no retry peers)"
                     );
-                    if let Some(event) = NetEventLog::connect_rejected(
-                        &incoming_tx,
-                        &op_manager.ring,
-                        dl,
-                        "relay no retry peers available",
-                    ) {
+                    // This `else` is reached by re-running the SAME
+                    // `handle_request` whose terminus arms carry a specific
+                    // cause, so a constant here would reintroduce exactly the
+                    // conflation #5335 removed from the initial path — and on
+                    // live traffic this retry path is roughly half of this
+                    // driver's rejections, so it is not a corner case. Fall
+                    // back to the generic string only when `handle_request`
+                    // produced no cause at all (it returned neither a forward
+                    // nor an accept nor a rejection — e.g. the already-
+                    // forwarded arm), which is a different situation and
+                    // deserves its own wording.
+                    let reason = retry
+                        .rejected
+                        .map(RejectReason::as_event_reason)
+                        .unwrap_or("relay no retry peers available");
+                    if let Some(event) =
+                        NetEventLog::connect_rejected(&incoming_tx, &op_manager.ring, dl, reason)
+                    {
                         op_manager.ring.register_events(Either::Left(event)).await;
                     }
                     let mut ctx = op_manager.op_ctx(incoming_tx);
@@ -1232,10 +1244,29 @@ async fn drive_relay_connect(
                     )
                     .await?;
                 } else {
+                    // KNOWN GAP (#5335): `retry.rejected` may carry a specific
+                    // cause here, and this branch deliberately emits NO
+                    // `connect_rejected` event — so in a release build, where
+                    // this `debug!` is compiled out by `release_max_level_info`,
+                    // that cause is not recorded anywhere.
+                    //
+                    // Not fixed by emitting `connect_rejected`: the terminal
+                    // outcome here is ConnectFailed PROPAGATION, not a
+                    // rejection. The upstream relay retries on receiving it and
+                    // emits its own rejection if the chain dead-ends, so
+                    // emitting one here would both double-count and make a
+                    // single event name cover two different decisions —
+                    // inflating `connect_rejects_emitted` and breaking its
+                    // comparability across this release boundary. There is no
+                    // existing event variant for "propagated ConnectFailed",
+                    // and adding one is a telemetry schema change beyond the
+                    // scope of #5335. Recorded in the PR rather than silently
+                    // left; revisit if this path is ever sized in production.
                     tracing::debug!(
                         tx = %incoming_tx,
                         %upstream_addr,
                         failed_acceptor = %failed_acceptor_addr,
+                        reject_reason = ?retry.rejected,
                         "CONNECT relay: propagating ConnectFailed upstream (no re-route)"
                     );
                     let mut ctx = op_manager.op_ctx(incoming_tx);

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -908,12 +908,18 @@ async fn drive_relay_connect(
         .await?;
     }
 
-    if initial_actions.rejected {
+    if let Some(reject_reason) = initial_actions.rejected {
+        // Pass the SPECIFIC cause, never a constant: the two terminus-rejection
+        // log lines are `debug!` (#5335) and `release_max_level_info` compiles
+        // them out of release builds, so this event's reason string is the only
+        // thing distinguishing "no uphill peers available" (a connectivity
+        // condition) from "uphill budget or TTL exhausted" (the amplification
+        // bound working) in production.
         if let Some(event) = NetEventLog::connect_rejected(
             &incoming_tx,
             &op_manager.ring,
             state.request.desired_location,
-            "rejected by handle_request",
+            reject_reason.as_event_reason(),
         ) {
             op_manager.ring.register_events(Either::Left(event)).await;
         }

--- a/crates/core/src/operations/connect/op_ctx_task.rs
+++ b/crates/core/src/operations/connect/op_ctx_task.rs
@@ -909,12 +909,13 @@ async fn drive_relay_connect(
     }
 
     if let Some(reject_reason) = initial_actions.rejected {
-        // Pass the SPECIFIC cause, never a constant: the two terminus-rejection
-        // log lines are `debug!` (#5335) and `release_max_level_info` compiles
-        // them out of release builds, so this event's reason string is the only
-        // thing distinguishing "no uphill peers available" (a connectivity
-        // condition) from "uphill budget or TTL exhausted" (the amplification
-        // bound working) in production.
+        // Pass the SPECIFIC cause, never a constant: the terminus-rejection log
+        // lines are `debug!` (#5335) and `release_max_level_info` compiles them
+        // out of release builds, so this event's reason string is the only
+        // thing distinguishing the three causes in production — "no uphill
+        // peers available" (connectivity), "uphill budget exhausted" (the
+        // amplification bound), and "TTL exhausted" (reach). See
+        // `RejectReason::as_event_reason`, which owns those strings.
         if let Some(event) = NetEventLog::connect_rejected(
             &incoming_tx,
             &op_manager.ring,
@@ -1092,12 +1093,20 @@ async fn drive_relay_connect(
                     // cause, so a constant here would reintroduce exactly the
                     // conflation #5335 removed from the initial path — and on
                     // live traffic this retry path is roughly half of this
-                    // driver's rejections, so it is not a corner case. Fall
-                    // back to the generic string only when `handle_request`
-                    // produced no cause at all (it returned neither a forward
-                    // nor an accept nor a rejection — e.g. the already-
-                    // forwarded arm), which is a different situation and
-                    // deserves its own wording.
+                    // driver's rejections, so it is not a corner case.
+                    //
+                    // The generic fallback is for the case where
+                    // `handle_request` returned no forward, no accept AND no
+                    // rejection. That is genuinely reachable, but NOT via the
+                    // already-forwarded arm: `forwarded_to.take()` above sets
+                    // it to `None` before the call, and that arm is gated on
+                    // `forwarded_to.is_some()`. The reachable path is
+                    // `accepted_locally == true` — near-terminus acceptance
+                    // accepts while ALSO forwarding, so when that forward is
+                    // later rejected we re-enter here with every terminus arm
+                    // gated off by `!accepted_locally` and nothing set. A
+                    // different situation from a terminus rejection, so it
+                    // keeps its own wording rather than borrowing a cause.
                     let reason = retry
                         .rejected
                         .map(RejectReason::as_event_reason)
@@ -1246,22 +1255,30 @@ async fn drive_relay_connect(
                 } else {
                     // KNOWN GAP (#5335): `retry.rejected` may carry a specific
                     // cause here, and this branch deliberately emits NO
-                    // `connect_rejected` event — so in a release build, where
-                    // this `debug!` is compiled out by `release_max_level_info`,
-                    // that cause is not recorded anywhere.
+                    // `connect_rejected` event. In a release build this
+                    // `debug!` is compiled out by `release_max_level_info`, so
+                    // on this path the cause is recorded NOWHERE — not in a
+                    // log, not in an event, on this node or any other. State
+                    // that plainly rather than implying it is relocated: a
+                    // `ConnectFailed` is handled in exactly one place (the arm
+                    // this branch belongs to) and its outcomes are forward
+                    // downstream, re-route, accept locally, or propagate
+                    // further upstream. At NO hop does it turn into a
+                    // `Rejected` or emit `connect_rejected`, so there is
+                    // nothing upstream that re-records this.
                     //
-                    // Not fixed by emitting `connect_rejected`: the terminal
-                    // outcome here is ConnectFailed PROPAGATION, not a
-                    // rejection. The upstream relay retries on receiving it and
-                    // emits its own rejection if the chain dead-ends, so
-                    // emitting one here would both double-count and make a
-                    // single event name cover two different decisions —
-                    // inflating `connect_rejects_emitted` and breaking its
-                    // comparability across this release boundary. There is no
-                    // existing event variant for "propagated ConnectFailed",
-                    // and adding one is a telemetry schema change beyond the
-                    // scope of #5335. Recorded in the PR rather than silently
-                    // left; revisit if this path is ever sized in production.
+                    // It is nonetheless deliberate, for a reason that survives
+                    // the above: the terminal outcome here is ConnectFailed
+                    // PROPAGATION, which is a different decision from a
+                    // rejection. Folding it into `connect_rejected` would make
+                    // one event name cover two decisions and inflate
+                    // `connect_rejects_emitted` across this release boundary,
+                    // breaking comparability of the counter. No event variant
+                    // exists for "propagated ConnectFailed" and adding one is a
+                    // telemetry schema change beyond the scope of #5335.
+                    //
+                    // So: an accepted, documented loss on this path, not a
+                    // covered case. Revisit if it is ever sized in production.
                     tracing::debug!(
                         tx = %incoming_tx,
                         %upstream_addr,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -808,6 +808,15 @@ impl NetEventRegister for TelemetryReporter {
                 // consumes the per-event stream (topology / rejection panels).
                 // Retiring here (skip the two variants) would make net telemetry
                 // volume NEGATIVE.
+                //
+                // BEFORE retiring connect_rejected, read #5335. The terminus-
+                // rejection log lines in operations/connect.rs are `debug!`,
+                // which `release_max_level_info` compiles out of release
+                // builds, so this per-event stream's `reason` field is now the
+                // ONLY thing that distinguishes those causes in production.
+                // The snapshot counters have no reason dimension, so retiring
+                // the per-event stream without adding one would silently
+                // delete that signal entirely rather than relocate it.
                 match event_type.as_str() {
                     "connect_connected" => {
                         crate::node::network_status::record_connect_accept_emitted()


### PR DESCRIPTION
## Problem

The two terminus-rejection arms of `RelayState::handle_request`
(`crates/core/src/operations/connect.rs`) log at `info!`:

```
"connect: at terminus, cannot accept, no uphill peers available — rejecting"
"connect: at terminus, cannot accept, uphill budget or TTL exhausted — rejecting"
```

On a real, moderately busy peer they fire 25-65 times/minute as standing
baseline — in a ~34 minute sample this single line-type was ~1560 of ~6966 log
lines (~22%), by far the largest single contributor and 2-4x the next most
frequent operational line.

Neither is an anomaly. The first means a CONNECT reached terminus with no
unvisited strictly-uphill candidate; the second means the `uphill_budget` /
TTL amplification bound did its job. Both are ordinary outcomes of the CONNECT
routing algorithm, and neither is actionable per occurrence — but at `info!`,
the level meant for events an operator should notice by default, they are
indistinguishable from genuinely rare connect failures. The codebase already
documents this as expected: three simulation-harness doc comments cite "at
terminus, no uphill peers available — rejecting" as the routine reason a small
star topology cannot bootstrap organically, and `tracing/telemetry.rs`
describes the corresponding `connect_rejected` event stream as a firehose
(~92k events / 18 min).

## Solution

### 1. Downgrade the terminus-rejection sites to `debug!`

Matching the sibling arm below ("connect: at terminus but already forwarded -
waiting for response"), which is already `debug!`.

This is stronger than a level filter and that matters for everything below:
`crates/core/Cargo.toml` enables tracing's `release_max_level_info`, so
`debug!` is compiled **out** of release builds rather than merely filtered.
These lines disappear entirely from production. (It is also why a marker any
CI gate greps for must never live at this level — see
`.claude/rules/bug-prevention-patterns.md`.)

### 2. Carry the rejection CAUSE into the structured event

Because of that, the downgrade alone would have left a diagnostic gap. The
rejection is independently recorded as a structured
`NetEventLog::connect_rejected` event — but that call passed the **constant**
reason `"rejected by handle_request"`, so release builds would retain *that* a
rejection happened and lose *which cause* fired.

The cause now travels **with** the decision rather than beside it:

```rust
pub enum RejectReason { NoUphillPeers, UphillBudgetExhausted, TtlExhausted }

// RelayActions.rejected: bool  ->  Option<RejectReason>
```

A parallel `reason` field beside the bool would have been the exact shape
`.claude/rules/bug-prevention-patterns.md` records as a repeat offender (the
`AcceptOutcome` / #3838 row): paired fields only meaningful together drift
apart at different call sites and one half gets silently dropped.

**Budget and TTL are separate variants.** The removed `info!` carried `ttl`
and `uphill_budget` as structured fields; the event carries only a reason
string. Merging them would leave an operator unable to tell "raise
`DEFAULT_UPHILL_BUDGET`" from "raise `max_hops_to_live`" — different remedies.
Budget is checked first, so when both are spent the budget is reported; it is
decremented once per uphill retry and is the tighter bound on this path.

### 3. All three `handle_request` call sites, not one

`handle_request` has **three** call sites in the relay driver, and the first
version of this PR fixed only the first:

| Call site | Emit | Status |
|---|---|---|
| initial | `connect_rejected` | passes the carried cause |
| retry on `Rejected` | `connect_rejected` | **now** passes the carried cause |
| retry on `ConnectFailed` | none | deliberate, see below |

The retry-on-`Rejected` path re-runs the **same** `handle_request` whose arms
this PR just separated, then emitted the single constant `"relay no retry
peers available"` — reproducing exactly the conflation the PR exists to
remove. On live collector data that path is roughly **half** of this driver's
rejections (60 vs 67 in a 3 MB sample), so with the log lines compiled out the
PR as first written was a net information **loss** on that traffic. It now
passes the carried cause, keeping the generic string only as the `unwrap_or`
fallback for a result that carried no cause at all.

The `ConnectFailed` retry still emits no `connect_rejected`, deliberately —
but the reason is narrower than an earlier revision of this description
claimed, and the difference matters. `ConnectFailed` is handled in exactly one
arm, whose outcomes are forward downstream, re-route, accept locally, or
propagate further upstream; **at no hop does it become a `Rejected` or emit
`connect_rejected`**. So nothing upstream re-records it: on that path the
cause is unrecorded network-wide, and this PR made it so, since the `info!`
line there did print in release builds before.

The decision stands on its other leg: propagation is a genuinely different
decision from a rejection, and folding it into `connect_rejected` would make
one event name cover two decisions and inflate `connect_rejects_emitted`
across this release boundary. No event variant exists for "propagated
ConnectFailed" and adding one is a telemetry schema change beyond this issue.
The cause is added to that branch's `debug!`, and the branch carries a KNOWN
GAP comment stating the loss plainly rather than implying the signal is merely
relocated.

**Scope — two explicit deferrals, both decisions rather than misses.**

#5335 asks for a sweep and names two other candidates. Neither is changed
here:

1. `"connect driver: updated own_addr and location from ObservedAddress"` —
   **deliberately left at `info!`**. At ~150 lines / 34 min it is ~10% of the
   volume of the pair above, so it is not the offender; and unlike them it
   reports a genuine node state change (the node learning its NAT-observed
   external address and ring location) that has **no** structured-event
   equivalent. Given `release_max_level_info`, downgrading it would delete the
   operator's primary NAT-traversal signal from release builds outright rather
   than relocate it. Deferred as not worth the trade.
2. The `contract_handling` / `DelegateRequest` lines — tied 1:1 to real client
   activity, so their volume is a function of real work rather than routing
   noise. Out of scope for this PR.

`"gateway overloaded"` at the admission-refusal site is also unchanged: one
condition, one specific constant, no conflation to fix.

## Testing

Four tests, all mutation-verified.

**`terminus_rejection_log_sites_use_debug_not_info`** — each message literal
occurs exactly once in `handle_request` and its nearest enclosing macro is
`tracing::debug!(`.

**`each_terminus_rejection_cause_reaches_the_event_with_its_own_reason`** —
drives `handle_request` into all three rejection scenarios and asserts each
maps to its own event string. Asserts the specific mapping, not merely that
they differ: a test checking only `a != b` stays green under a swap.

**`each_reject_branch_logs_the_message_matching_its_reason`** — within each
branch, the `debug!` message matches the `RejectReason` that branch assigns,
so a debug-build log and a production event never tell different stories.
Anchors on the assignment and looks backward to the nearest `tracing::debug!(`,
because asserting each message merely appears *somewhere* passes vacuously
when two are swapped between arms.

**`budget_is_reported_when_budget_and_ttl_are_both_exhausted`** — pins the
documented precedence. Both single-condition fixtures isolate one half of the
`uphill_budget > 0 && ttl >= 2` gate, so neither exercises the overlap and
swapping the else-if left every one of them green. Confirmed by mutation: with
the precedence reversed this is the only failing test in the file.

**`every_reject_emit_from_handle_request_passes_the_carried_cause`** —
enumerates all three call sites. It derives the site list from the
`handle_request` **calls**, not from the emits, so a fourth call site fails
the test rather than slipping past. The earlier version of this pin scraped
only the initial branch and was blind to the retry path by construction; that
blindness is what let the retry-path bug through.

Pin hygiene per AGENTS.md: a `fn_body()` helper bounds scrapes by brace depth
and rejects an anchor that resolved inside the test module; the level pin
brackets its region at both ends. Two traps worth recording, both hit here:
`fn_body` slices from the first `{` *after* its anchor, which is right for a
signature but silently excludes a **statement** anchor's own text — so the
retry-path assertion is matched whitespace-stripped against the file instead,
which also survives a rustfmt reflow. And `handle_request` is a method inside
an `impl`, so the `\n}\n` end anchor used by `commands::auto_update` would
find the `impl` block's brace and widen across every sibling method.

**Mutation results** — each a separate build; every mutation was confirmed to
actually apply, since an unapplied mutation is an unexplained observation, not
a pass:

| Mutation | Result |
|---|---|
| site 1 (`no uphill peers`) → `info!` | FAILS, naming site 1 |
| site 2 (budget/TTL) → `info!` | FAILS, naming site 2 |
| reword a message literal | FAILS on the count assertion |
| swap the two `as_event_reason` arms | FAILS with both values printed |
| driver initial branch → constant reason | FAILS |
| **retry path → constant reason (the F1 bug)** | **FAILS** |
| merge the TTL reason into the budget string | FAILS |
| swap the two branch log messages | FAILS |
| add a 4th `handle_request` call site | FAILS (4 vs 3) |
| **swap the else-if precedence to TTL-first** | **FAILS — and is the ONLY test that does; all 58 others stay green, which is exactly the gap it closes** |
| unmutated tree | 59 connect tests pass |

Nothing depended on these lines being `info!`: the message strings appear
nowhere else in freenet-core except three prose doc comments in the simulation
harness, no test captures or asserts on them, and nothing in the wider tree
(scripts, dashboard, telemetry config) greps for them.

`cargo fmt` applied; `cargo clippy --all-targets -- -D warnings` clean on
`crates/core`.

### What this trades, stated plainly

The structured event is a *replacement* for the log lines, not a guarantee of
preservation. Four limits, stated because the earlier claim that "nothing is
lost" was too strong:

- the local `_EVENT_LOG` register is opt-in and off by default on network
  nodes;
- telemetry upload is user-disableable;
- the enqueue is a `try_send` that drops on a full channel;
- **the event is coarser than the line it replaces.** The `debug!` carries
  `ttl`, `uphill_budget` and `visited`; `connect_rejected` carries only
  `desired_location` and a reason string. Splitting budget from TTL recovers
  *which* bound bound, but not the values — and `visited`, the actual dead-end
  evidence and arguably the most diagnostically useful of the three, has no
  replacement on any path.

**On a node with telemetry disabled, a release build after this PR records
terminus rejections nowhere at all.** That is judged an acceptable trade for a
line at ~22% of log volume whose per-occurrence value is nil — but it is a
trade.

**Reason-string values change at this boundary.** `"rejected by
handle_request"` and `"relay no retry peers available"` are replaced by the
three specific strings on the paths described above, so any external dashboard
grouping `connect_rejected` by reason will see a discontinuity at this
release. Nothing in-repo consumes these values.

Related: `tracing/telemetry.rs` carries a live TODO to retire the per-event
`connect_rejected` firehose in favour of snapshot counters, which have no
reason dimension. If that lands as written it would delete this PR's entire
output while the `debug!` lines stay compiled out, so a cross-reference note is
left at that TODO.

Closes #5335

[AI-assisted - Claude]
