### PR TITLE
fix(ci): make Gate A assert WHICH decision the updater reached

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -509,34 +509,78 @@ caught by Gate B one release later, when that binary becomes the previous one.
 Gate B is also post-publish and non-blocking, so even then it reports rather
 than stops.
 
-**Gate A cannot see a wrong COMPARISON of correct values.** Since #5236 it
-checks the version the node says it observed (`latest=`) against the tag
+**Gate A checks the COMPARISON in one direction only.** Since #5236 it checks
+the version the node says it observed (`latest=`) against the tag
 `releases/latest` actually resolves to, so a fetch or normaliser that returns
-the wrong string is caught. The comparison that follows it is not covered.
-Mutate `compare_versions_for_startup`'s `latest_ver > current_ver`
-(`crates/core/src/bin/commands/auto_update.rs`) to `<` and Gate A stays green:
-the fetch is right, the parse is right, the observed value is right, and every
-marker the gate reads is exactly what a healthy run produces.
+the wrong string is caught. Since #5340 it also asserts WHICH decision the
+updater reached, which closes the half of the comparison Gate A is able to
+exercise.
 
-This is structural, not something the gate is failing to do properly. Gate A's
-subject is by construction NEWER than `releases/latest` — the release it
-belongs to is still a draft — so there is no newer release for it to find and
-"decided not to update" is the correct outcome of a healthy run. A gate whose
-input can only produce one answer cannot distinguish comparators by their
-answer.
+The half it closes. Gate A's subject is by construction NEWER than
+`releases/latest` — the release it belongs to is still a draft — so a healthy
+updater must find nothing newer and stay put. Anything else is a defect, and
+the obvious reading of the failure is the wrong way round: inverting
+`compare_versions_for_startup`'s `latest_ver > current_ver`
+(`crates/core/src/bin/commands/auto_update.rs`) does not make the node quietly
+do nothing. `latest < current` is TRUE for a Gate A run, so the node returns the
+OLDER release, requests an update to it, and exits 42 — a self-downgrade, and a
+supervisor loop that repeats it on every restart. Gate A used to report green on
+that, because a trigger was one of the outcomes `assert_detection_healthy`
+accepts. It now blocks on it, from two independent observers: a trigger line
+appearing in the log, and `NODE_EXIT` being 42. (A healthy run has neither.)
 
-Worth being precise about the direction, because the obvious reading is the
-wrong way round: inverting that operator does not make the node quietly do
-nothing. `latest < current` is TRUE for a Gate A run, so the node returns the
-OLDER release and requests an update to it — a self-downgrade. Gate A reports
-green on it, because a trigger is one of the outcomes it accepts. (Gate A's
-verdict comes only from `assert_detection_healthy`; it does not assert that
-the shipping binary declined to update. Adding that assertion would close this
-particular hole, at the cost of failing any release cut from a branch whose
-version is genuinely below `releases/latest` — a hotfix on an older line. It
-has not been added.)
+The two are independent in the way that matters, and the exit-code observer is
+what covers the log check's blind spot rather than merely duplicating it. If a
+trigger site's wording drifts out of `MARKER_TRIGGERED_RE`, or the line is
+dropped, the node logs no matched trigger *and* no completion line either —
+`freenet.rs` returns as soon as it sends — so the log assertion can only report
+INDETERMINATE. The exit-code observer is therefore evaluated whenever the log
+assertion has not already found a definite fault, not only when it passed;
+gating it on "passed" made it unreachable on exactly that input, which an
+external review pass caught and reproduced.
 
-What does cover the comparison is the Rust unit tests on
+The second observer is qualified — 42 is also `FATAL_LISTENER_EXIT_CODE`
+(`crates/core/src/node/p2p_impl.rs`), which a healthy binary emits when its
+network event listener dies or redb is poisoned, and the canary does not opt
+into the distinct code 45. So an exit 42 whose node output carries one of those
+`CRITICAL:` lines is classified environmental and retried rather than blocking
+the release. (A healthy Gate A run ends at 143 — the canary SIGTERMs a node that
+is still going — so a 42 at all means the node exited on its own.)
+
+Gate A also blocks a `is_version_pinned_bad` / `is_version_install_gated` gate
+(`crates/core/src/bin/commands/rollback.rs`) that matches when it should not:
+the canary node has a fresh isolated HOME with no crash-loop pin and no
+install-failure history, so that refusal has nothing it could legitimately
+match, and a node that refuses every release it is offered is stranded as
+thoroughly as one that cannot parse the tag. That check is worth having and is
+close to unreachable on the normal path, which is not a contradiction — the node
+only reaches the #4073 branch from inside
+`if let Some(new_version) = startup_update_check(…)`, so entering it during a
+draft-release run already requires an inverted comparator, and the trigger check
+above would catch that first. Where it earns its keep is the older-binary arm
+and Gate B.
+
+The half it does not close, and cannot. A comparator that answers "nothing
+newer" when something newer DOES exist is invisible on the normal path, because
+on the normal path nothing newer exists. Gate A only asserts that direction when
+it is genuinely running an older binary, which it detects by comparing the
+shipping binary's `--version` against the resolved latest tag; it says which arm
+it took in the job log. That arm is narrow, and narrower than it first looks:
+`cross-compile.yml` sparse-checks-out the canary script at the tag it is gating,
+so re-running an *older* release's workflow runs that tag's copy of the script,
+which predates this check entirely. What is left is a hotfix branch cut on an
+older line and tagged after a newer release has published, a re-run of a tag cut
+after #5340 landed, and a manual `preflight` run. The conditional exists to stop
+a blocking gate from failing those for being right, not because they are common.
+
+If the two versions cannot be compared at all, Gate A skips the decision check
+and the exit-code check with it, and emits a `::warning::` annotation saying so.
+That is the one input that returns Gate A to its pre-#5340 strength while still
+reporting green, so the `--version` output format is source-pinned in
+`auto-update-canary_test.sh` — a change to it fails there rather than widening
+that arm quietly.
+
+What does cover the comparison in both directions is the Rust unit tests on
 `compare_versions_for_startup` (same file, `mod tests`), which assert both
 directions and the equal case. Gate B covers it end-to-end for real, but only
 for the PREVIOUS release's binary.
@@ -579,9 +623,10 @@ job log before concluding anything about auto-update. Closing this needs a
 runtime test with a stubbed release archive; it is a known gap, deliberately
 deferred, not an oversight.
 
-Net: the installer half of a shipping binary has no blocking gate, and neither
-does its comparison logic. Treat a green Gate A as "this binary can still fetch
-and read new release tags", not as "auto-update works".
+Net: the installer half of a shipping binary has no blocking gate, and its
+comparison logic is gated in one direction only. Treat a green Gate A as "this
+binary can still fetch and read new release tags, and did not ask to be
+replaced by an older one", not as "auto-update works".
 
 ### If Gate A fails
 

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -202,6 +202,38 @@ MARKER_LATEST_SEEN='Startup update check: GitHub reports latest release'
 # REWORDED and this constant was not moved with it (fix it here).
 MARKER_LATEST_SEEN_SINCE='0.2.125'
 
+# p2p_impl.rs -- the two OTHER ways a node exits 42, and the reason Gate A cannot
+# read an exit 42 as "it asked to be updated" on its own.
+#
+# 42 is OVERLOADED. It is `FATAL_LISTENER_EXIT_CODE` (`crates/core/src/node/
+# p2p_impl.rs`) as well as the update-requested code, and BOTH producers are
+# enabled in the real binary: `enable_abort_on_fatal_listener_exit` and
+# `enable_abort_on_redb_poison` are called unconditionally at the top of
+# `freenet.rs`'s node path. The distinct `FAST_CRASH_EXIT_CODE` (45) is opted
+# into only when `SYSTEMD_FAST_CRASH_ENV_VAR` is set, which the canary does not
+# export -- so `fatal_listener_exit_code` returns 42 at EVERY uptime here,
+# including the ~40s window a canary run occupies.
+#
+# So a perfectly healthy binary that declines the update and then loses its
+# network event listener (a CI-runner transport error, a monitored task exiting)
+# or poisons redb (disk EIO) exits 42 for a reason that has nothing to do with
+# the updater. Without these markers the gate would BLOCK that release and send
+# the operator to `compare_versions_for_startup`, which is fine.
+#
+# The overlap is not incidental to the exit-42 assertion, it is exactly
+# coincident with it: when the comparator IS inverted the trigger line is in the
+# log and `assert_gate_a_decision` already blocks, so exit 42 adds nothing there.
+# Exit 42 is load-bearing ONLY when there is no trigger line -- and "42 with no
+# trigger line" is precisely the fatal-listener / redb signature. Hence the
+# corroboration rather than a bare code test.
+#
+# Both are `eprintln!`, so they land in `node.out` (the subshell in
+# `run_node_until_check` redirects stdout+stderr there) and NOT in the log dir.
+# That is why the predicate below takes a WORKDIR and the log predicates take a
+# log dir.
+MARKER_FATAL_LISTENER='CRITICAL: Network event listener exited (fatal)'
+MARKER_REDB_POISONED='CRITICAL: contract storage (redb) is poisoned'
+
 MUSL_ASSET='freenet-x86_64-unknown-linux-musl.tar.gz'
 RELEASE_BASE='https://github.com/freenet/freenet-core/releases/download'
 # The endpoint the NODE uses for its startup check (the 302 from
@@ -334,6 +366,14 @@ fail() { printf '::error::%s\n' "$*" >&2; }
 # annotating an unreachable GitHub as a workflow error trains people to ignore
 # the annotation, and the caller decides whether to retry or fail.
 note() { printf '%s\n' "$*" >&2; }
+# A real GitHub ANNOTATION for something that is not a failure but must not be
+# scrolled past. `note` is plain text, and a release job's log runs to several
+# thousand lines -- which is fine for a line the caller is about to act on
+# (a retry, a classification) and not fine for one saying an ASSERTION WAS
+# SKIPPED. A skipped assertion that only whispers is the vacuous-pass shape this
+# file keeps having to remove; `::warning::` puts it in the run summary where
+# somebody sees it without reading the log.
+warn() { printf '::warning::%s\n' "$*" >&2; }
 
 # True when the logs show the node DECIDED to update. See the marker comments
 # above for why this is a subtraction rather than a single grep.
@@ -351,6 +391,48 @@ node_decided_to_update() {
   hits="$(grep -ahE "$MARKER_TRIGGERED_RE" "$logdir"/freenet.*.log 2>/dev/null \
     | grep -vF "$MARKER_NOT_TRIGGERED")"
   [ -n "$hits" ]
+}
+
+# True when the node REFUSED to update because the newer version is locally
+# blocked -- the #4073 gate (`is_version_pinned_bad` / `is_version_install_gated`,
+# crates/core/src/bin/commands/rollback.rs).
+#
+# A named predicate rather than an inline `log_has`, for the reason
+# `prev_emits_latest_seen` is one: the DECISION it feeds is what a mutation would
+# break, and a decision that has no name has nothing to test.
+#
+# WHY THIS IS A FAULT SIGNAL AND NOT MERELY INFORMATION. Both gates run the node
+# under a HOME created fresh by `run_node_until_check` and wiped between
+# attempts, and both of those #4073 predicates read their state from under
+# `$HOME/.local/state`. A canary node therefore has no crash-loop pin and no
+# install-failure history by construction, so neither predicate has anything it
+# could legitimately match. If this line appears, the gating logic matched
+# something that is not there -- which strands a node exactly as effectively as
+# a parse bug, and looks identical to a healthy run in every marker the gate
+# read before.
+#
+# No pipe, for the SIGPIPE reason documented on `node_decided_to_update`.
+node_refused_locally_gated() {
+  local logdir="$1"
+  grep -aqF -- "$MARKER_NOT_TRIGGERED" "$logdir"/freenet.*.log 2>/dev/null
+}
+
+# True when the node exited 42 for one of the two NON-UPDATE reasons -- a fatal
+# network-event-listener exit, or a poisoned redb. See the marker comments above
+# for why 42 cannot be read as "an update was requested" without this.
+#
+# Takes the WORKDIR, not the log dir: both are `eprintln!`, so they are in
+# `node.out`. A `pure` function still -- file in, boolean out -- so
+# `auto-update-canary_test.sh` drives it from fixtures like its neighbours.
+#
+# Reads BOTH markers rather than one: the redb path was added separately
+# (#4604) and reuses the listener path's exit-code decision, so a version of
+# this that knew only about the listener would hard-block a healthy release on
+# a disk error. No pipe, for the SIGPIPE reason on `node_decided_to_update`.
+node_exited_on_fatal_abort() {
+  local work="$1"
+  grep -aqF -- "$MARKER_FATAL_LISTENER" "$work/node.out" 2>/dev/null && return 0
+  grep -aqF -- "$MARKER_REDB_POISONED" "$work/node.out" 2>/dev/null
 }
 
 # True when the startup check reached a TERMINAL outcome -- any outcome, healthy
@@ -625,6 +707,160 @@ assert_detection_healthy() {
 
   log "OK: startup update check ran to completion and parsed GitHub's response."
   log_lines "$logdir" "$MARKER_CHECK_RAN" | head -2
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# gate_a_expected_decision <shipping-version> <observed-latest>
+#
+# WHICH DECISION a healthy updater is obliged to reach, given the two versions
+# it is comparing. Echoes exactly one of:
+#
+#   decline  -- shipping >= latest. Nothing newer exists, so the only correct
+#               outcome is to stay put. This is the normal release path: Gate A
+#               runs while its own release is still a DRAFT, so the binary under
+#               test is newer than `/releases/latest` by construction.
+#   update   -- shipping <  latest. Something newer really does exist, so the
+#               only correct outcome is to request it. RARE, and worth being
+#               exact about how rare, because the obvious framing overstates
+#               it: `cross-compile.yml` sparse-checks-out this script at the
+#               TAG being gated ("the script version matches the release it is
+#               gating"), so re-running an OLDER release's workflow runs THAT
+#               tag's copy of this file, which does not contain this code at
+#               all. What is actually left is a hotfix branch cut on an older
+#               line and tagged after a newer release has published (the branch
+#               carries this script, and its binary really is behind
+#               `/releases/latest`), a re-run of a tag cut after this landed,
+#               and a manual `preflight` run on an older binary -- the
+#               local-debugging path this file's header invites.
+#   unknown  -- one of the two is not a bare dotted version, so the direction
+#               cannot be established.
+#
+# THE DIRECTION IS THE WHOLE REASON THIS EXISTS. Asserting "must have declined"
+# unconditionally would be right on the normal path and WRONG on the paths
+# above, where it would block a release for the correct behaviour of a healthy
+# updater. A blocking gate that false-fails does not merely cost one release: it
+# teaches people to override it, and an overridden gate catches nothing. That
+# those paths are narrow is a reason to keep the conditional cheap, not a reason
+# to drop it -- the cost of getting it wrong is paid on a release nobody expected
+# to be blocked, which is the worst moment to be debugging the gate.
+#
+# `version_at_least` is the comparator because it is `sort -V` (0.2.9 < 0.2.10,
+# which a lexical compare gets wrong) and because it is already tested. The
+# `is_dotted_version` guard runs FIRST so the `unknown` case is decided here
+# rather than by `version_at_least`'s own refusal, which would also emit its
+# malformed-input note for an input we are choosing to handle.
+#
+# EQUAL counts as `decline`, matching `compare_versions_for_startup`: it returns
+# Some(latest) only for latest STRICTLY greater than current.
+# ---------------------------------------------------------------------------
+gate_a_expected_decision() {
+  if ! is_dotted_version "$1" || ! is_dotted_version "$2"; then
+    printf 'unknown'
+  elif version_at_least "$1" "$2"; then
+    printf 'decline'
+  else
+    printf 'update'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# assert_gate_a_decision <log-dir> <expected-decision>
+#
+# WHICH DECISION the updater actually reached, asserted positively.
+#
+# `assert_detection_healthy` deliberately does not do this, and the gap is not
+# an oversight there -- it is shared by both gates, which require OPPOSITE
+# decisions, so it can only assert the parts common to both. What it leaves
+# uncovered is the decision itself:
+#
+#   * `node_check_settled` accepts a completion line OR a trigger, so a node
+#     that decided to UPDATE counts as settled;
+#   * the positive-equality check validates the version the node compared
+#     AGAINST, not what it did with it;
+#   * the #4073 refusal reaches the completion line too, so it reads as an
+#     ordinary healthy ending.
+#
+# So a shipping binary with an inverted comparison passes all seven checks and
+# ships. That is the mirror image of #5221 and strands peers identically:
+# `latest < current` is TRUE for a Gate A run, so an inverted comparator returns
+# the OLDER release and the node requests a self-DOWNGRADE. `docs/RELEASING.md`
+# has described this hole since #5236.
+#
+# PURE, like `assert_detection_healthy` and for the same reason: log dir and a
+# decision word in, verdict out, so it is driven by fixtures in
+# `auto-update-canary_test.sh`. The expected decision is passed in rather than
+# computed here because computing it needs the shipping binary's version, which
+# is caller state. `NODE_EXIT` is caller state too, and its assertion therefore
+# lives in `cmd_preflight`.
+#
+# Exit: 0 the node reached the decision it had to, 1 it did not.
+# There is deliberately no 2: this runs only after `assert_detection_healthy`
+# has returned 0, so the check is already KNOWN to have started, parsed and
+# settled. Nothing left here is indeterminate, and a wrong decision is not a
+# thing a re-run fixes.
+# ---------------------------------------------------------------------------
+assert_gate_a_decision() {
+  local logdir="$1" expect="$2"
+
+  # DIRECTION-INDEPENDENT, and checked first because it is the sharper finding.
+  # It rests only on the canary's fresh isolated HOME (see
+  # `node_refused_locally_gated`), which holds in every arm, so no version
+  # relationship can make this refusal legitimate.
+  #
+  # WHERE IT ACTUALLY EARNS ITS KEEP, stated honestly rather than sold: the
+  # `update` and `unknown` arms, plus Gate B (which names it separately). In the
+  # `decline` arm it is close to unreachable, because the node only reaches the
+  # #4073 branch at all from inside
+  # `if let Some(new_version) = startup_update_check(...)` -- so entering it on
+  # the normal path already requires an inverted comparator, and with a fresh
+  # HOME the pin/gate would then not match either, so the TRIGGER fires and the
+  # decline arm below catches it first. Two independent defects, not one. It is
+  # kept in every arm regardless because it is free, it cannot false-positive
+  # (the premise holds unconditionally), and it is genuinely reached where it
+  # matters: the refusal falls through to the completion line, so
+  # `assert_detection_healthy` returns 0 and this function runs.
+  if node_refused_locally_gated "$logdir"; then
+    fail "the node REFUSED to update because it treated the newer version as locally blocked (#4073) -- but this canary node has a fresh, isolated HOME with no crash-loop pin and no install-failure history, so there is nothing for that gate to have matched. The locally-blocked check (is_version_pinned_bad / is_version_install_gated in crates/core/src/bin/commands/rollback.rs) is matching wrongly. A node that refuses every release it is offered is stranded exactly as thoroughly as one that cannot parse the tag."
+    log_lines "$logdir" "$MARKER_NOT_TRIGGERED" | head -2 >&2
+    return 1
+  fi
+
+  case "$expect" in
+    decline)
+      if node_decided_to_update "$logdir"; then
+        fail "the shipping binary DECIDED TO UPDATE, and there is nothing for it to update to: its own release is still a draft, so it is at or ahead of everything GitHub publishes. A healthy updater stays put here. This is the mirror image of #5221 -- detection did not fail, it reached the WRONG ANSWER, which is why every other check passed. An inverted comparison in compare_versions_for_startup (crates/core/src/bin/commands/auto_update.rs) produces exactly this, and it makes the node request a self-DOWNGRADE to the older release, then exit 42 and do it again on every restart. If you are running \`preflight\` by hand on a binary that really IS older than the latest release, that is the other explanation, and the log line above this one says which versions were compared."
+        grep -ahE "$MARKER_TRIGGERED_RE" "$logdir"/freenet.*.log 2>/dev/null \
+          | grep -vF "$MARKER_NOT_TRIGGERED" | head -2 >&2
+        return 1
+      fi
+      log "OK: the node declined to update, which is the only correct outcome when nothing newer than the shipping binary is published."
+      ;;
+    update)
+      if ! node_decided_to_update "$logdir"; then
+        fail "the binary under test is genuinely OLDER than GitHub's latest release and did NOT decide to update to it. A node in that position must request the update; one that stays put can never leave the version it is on, which is the #5221 outcome reached by a different route. (Gate A is running in its off-normal arm here -- a re-run of an older release's workflow, or a hotfix cut on an older line -- and the log line above says which versions were compared.)"
+        return 1
+      fi
+      log "OK: the node decided to update, which is the correct outcome for a binary older than GitHub's latest release."
+      ;;
+    *)
+      # LOUD, and never silent. A skipped arm that printed nothing would be the
+      # vacuous escape hatch this gate family keeps having to remove: a reader
+      # of a green log could not tell an asserted decision from an unasserted
+      # one. The refusal check above still ran, so this is a partial skip, not
+      # a skipped function.
+      #
+      # `warn`, not `note`, and the difference is the whole point of the branch.
+      # This arm disables the decision check AND (because that check is scoped to
+      # the `decline` arm in `cmd_preflight`) the exit-42 check with it, so
+      # reaching it silently reverts Gate A to its pre-decision-check strength
+      # while the job stays green. One change to the shape of `--version`'s
+      # output is all it takes. `::warning::` surfaces in the run summary rather
+      # than in line 4,000 of a release log; the source pin on the `--version`
+      # format in auto-update-canary_test.sh is the other half.
+      warn "the canary could not establish whether the shipping binary is newer or older than GitHub's latest release, so it did NOT assert which decision the updater had to reach, and the exit-42 check is skipped with it. The #4073 refusal check above still ran. This run does not prove the comparator answered correctly -- see the version line logged by cmd_preflight for the two values it could not compare."
+      ;;
+  esac
   return 0
 }
 
@@ -1063,7 +1299,27 @@ cmd_preflight() {
   mkdir -p "$work"
 
   log "=== Gate A: auto-update pre-flight on the binary about to ship ==="
-  "$binary" --version
+  # Captured rather than just printed: the version is now an INPUT to the gate
+  # (it decides which decision the updater is obliged to reach), not decoration.
+  local version_output version_line shipping_version gate_a_expect
+  version_output="$("$binary" --version)"
+  log "$version_output"
+  # Selected BY ITS MARKER, not by line position, and that is deliberate.
+  # `--version` already prints a second line (`Build timestamp: ...`), so the
+  # output is not one line and never was; taking `head -1` would make the gate's
+  # input depend on nothing more than the ORDER of two `println!`s. Add a banner
+  # line ahead of the version -- a deprecation notice, a build warning -- and a
+  # positional read silently yields an unparseable field, which sends the whole
+  # gate down the `unknown` arm and skips both new assertions while the job stays
+  # green. Matching the line that identifies itself costs nothing and removes
+  # that class outright.
+  #
+  # `| head -1` is used for its stdout, not its status, which is what keeps it
+  # clear of the SIGPIPE ban documented in auto-update-canary_test.sh.
+  version_line="$(printf '%s\n' "$version_output" | grep -F 'Freenet version:' | head -1)"
+  # Field 3 of `Freenet version: 0.2.127 (deadbeefcafe)`, the same split
+  # cmd_selfupdate uses on the same output.
+  shipping_version="$(printf '%s' "$version_line" | awk '{print $3}')"
 
   # Resolve what the node SHOULD see before booting it, so the log assertion can
   # be a positive equality rather than an absence-of-error. Failing to resolve
@@ -1093,10 +1349,33 @@ cmd_preflight() {
   export CANARY_EXPECTED_LATEST
   log "GitHub's latest published release is '$CANARY_EXPECTED_LATEST'; the node must compare against exactly that."
 
+  # Which DECISION the updater is obliged to reach, decided once here because
+  # neither version changes across attempts. Logged in every arm, so a reader of
+  # a green job can tell which assertion actually ran -- an unstated arm is how
+  # a gate comes to be trusted for something it did not check.
+  gate_a_expect="$(gate_a_expected_decision "$shipping_version" "$CANARY_EXPECTED_LATEST")"
+  case "$gate_a_expect" in
+    decline)
+      log "the binary under test (v$shipping_version) is at or ahead of GitHub's latest (v$CANARY_EXPECTED_LATEST) -- the normal Gate A shape, since this release is still a draft. A healthy updater MUST decline to update, and that is what is asserted."
+      ;;
+    update)
+      log "the binary under test (v$shipping_version) is BEHIND GitHub's latest (v$CANARY_EXPECTED_LATEST). This is NOT the normal release path -- a re-run of an older release's workflow, or a hotfix cut on an older line, produces it. A healthy updater MUST decide to update, so that is what is asserted instead."
+      ;;
+    *)
+      warn "could not compare the shipping version ('$shipping_version') with GitHub's latest ('$CANARY_EXPECTED_LATEST') -- at least one is not a bare dotted version. Gate A will NOT assert which decision the updater reached, nor check its exit code. Every other check still runs; the arms skipped are the ones that catch an inverted comparator."
+      ;;
+  esac
+
   # Retry only the INDETERMINATE case. A parse failure is deterministic and
   # retrying it just burns release time; a GitHub blip is worth a second look
   # before we stall a release on it.
-  local attempt rc
+  # `saw_fatal_abort` LATCHES, for the reason Gate B's `saw_unexplained` does:
+  # it changes only the WORDING of the final blocking message, and a run where
+  # one attempt died on a fatal abort must not be described as "GitHub
+  # unreachable, or the check never logged an outcome" just because a later
+  # attempt was. It never makes the gate greener -- every path below is still a
+  # blocked release.
+  local attempt rc saw_fatal_abort=0
   for attempt in $(seq 1 "$CANARY_ATTEMPTS"); do
     log "--- attempt $attempt/$CANARY_ATTEMPTS ---"
     # Wipe the WHOLE tree, not just the logs. The node persists its GitHub
@@ -1128,6 +1407,98 @@ cmd_preflight() {
     else
       assert_detection_healthy "$work/logs"
       rc=$?
+      # WHICH DECISION, asserted only once the log assertion is happy: that one
+      # localises the failure, and a node whose parse failed reaches no decision
+      # worth reporting on. See `assert_gate_a_decision` for why the seven
+      # checks above cannot see this.
+      if [ "$rc" -eq 0 ]; then
+        assert_gate_a_decision "$work/logs" "$gate_a_expect"
+        rc=$?
+      fi
+      # The SECOND, independent observer of the same decision, and the reason it
+      # is worth having both: the log check reads a phrase this repo chooses,
+      # while exit 42 is the supervisor contract itself (see "NOTE ON
+      # AUTO-UPDATE" at the top of crates/core/src/bin/freenet.rs) -- what
+      # actually makes the fleet restart onto another binary.
+      #
+      # `-ne 1`, NOT `-eq 0`, AND THAT IS THE WHOLE POINT OF THE OBSERVER.
+      # It was `-eq 0`, which made the observer unreachable on precisely the
+      # input it exists for. A trigger site whose wording `MARKER_TRIGGERED_RE`
+      # misses -- or a dropped trigger line -- means the node logs NO matched
+      # trigger, and `freenet.rs` `return`s immediately after `update_tx.send`,
+      # so the completion line is never emitted either. `node_check_settled` is
+      # then false, `assert_detection_healthy` returns 2, and an `-eq 0` gate
+      # skips. Gate A burned both attempts and reported "produced no verdict --
+      # GitHub unreachable, or the check never logged an outcome" for a
+      # deterministic self-downgrade. Reproduced on both variants.
+      #
+      # rc=1 is deliberately left alone: `assert_detection_healthy` has already
+      # found a definite fault (an unparseable tag, a disabled updater, a node
+      # that never started), and those localise better than "it exited 42". That
+      # is also what keeps this off the "check never started" case the exit code
+      # alone cannot explain.
+      #
+      # `-ne 1` ADMITS TWO rc=2 ROUTES, not one, and the second is worth naming.
+      # `assert_detection_healthy` also returns 2 for `MARKER_FETCH_FAIL`. If the
+      # node could not reach GitHub it cannot have learned of a newer release, so
+      # a 42 on that run must be the fatal listener -- which
+      # `node_exited_on_fatal_abort` catches, giving rc=2 and a retry. The gap is
+      # narrow but real: if the CRITICAL wording drifts, this branch hard-blocks
+      # with a message asserting "the only release available is OLDER than
+      # itself" about a run where the node never learned what was available. It
+      # needs BOTH conditions at once and the wording is pinned, so it is
+      # recorded rather than guarded. Under `-eq 0` it was unreachable.
+      #
+      # It covers ONE of the log check's two blind directions, not both, and the
+      # OTHER one is worth stating exactly because the obvious guess is wrong.
+      # In the `decline` arm a reworded or missing trigger is caught here. In the
+      # `update` arm it is NOT caught, and it does NOT surface as "did NOT decide
+      # to update": every trigger site `return`s straight after `update_tx.send`,
+      # so a node that triggered emits no completion line either, `rc` is 2, and
+      # `assert_gate_a_decision` is never reached at all (it is gated on rc=0
+      # above). The run burns both attempts and blocks as UNVERIFIED with
+      # "produced no verdict" -- the same wrong-subsystem diagnosis this observer
+      # removes from the `decline` arm, on a node that behaved correctly. Still a
+      # false BLOCK, so still fail-closed; the mechanism is just not the decision
+      # check. Not fixed here because the exit-42 observer must stay scoped to
+      # `decline` (exiting 42 is CORRECT in the update arm, so the code cannot
+      # discriminate), and that arm is off the normal release route.
+      # Latent rather than live -- `run_node_until_check` exports
+      # FREENET_DISABLE_LOG_RATE_LIMIT=1 for exactly this class, and Gate B
+      # depends on the same line anyway -- but the asymmetry is worth knowing
+      # before treating the pair as a full cross-check.
+      #
+      # Only in the `decline` arm. In the `update` arm exiting 42 is the CORRECT
+      # behaviour, and asserting it there instead would add a false-block risk
+      # (a node that triggers late may still be alive when the canary stops it)
+      # for a path that is off the normal release route anyway.
+      #
+      # AND ONLY WITH CORROBORATION, because 42 is overloaded: it is also
+      # `FATAL_LISTENER_EXIT_CODE` (see the marker comments at the top of this
+      # file), which a HEALTHY binary emits when its network event listener dies
+      # or redb is poisoned -- neither of which says anything about the updater.
+      # Blocking a release on that would send the operator to
+      # `compare_versions_for_startup`, code that is fine, which is how a
+      # blocking gate earns the reputation that gets it overridden.
+      #
+      # So the node's own CRITICAL line decides which it was:
+      #   present -> ENVIRONMENTAL. rc=2, retried on a fresh tree, and a run
+      #              that only ever produces this fails as UNVERIFIED rather
+      #              than as an updater fault.
+      #   absent  -> the updater really did ask to be replaced. rc=1, no retry:
+      #              deterministic, and no re-run changes it.
+      # Both messages name the other cause. A gate that confidently blames the
+      # wrong subsystem is worse than one that says it is unsure.
+      if [ "$rc" -ne 1 ] && [ "$gate_a_expect" = "decline" ] && [ "$NODE_EXIT" = "42" ]; then
+        if node_exited_on_fatal_abort "$work"; then
+          note "INDETERMINATE: the node exited 42, but its output carries a CRITICAL fatal-abort line (network event listener exited, or redb poisoned). 42 is ALSO FATAL_LISTENER_EXIT_CODE (crates/core/src/node/p2p_impl.rs), and the canary does not set SYSTEMD_FAST_CRASH_ENV_VAR, so that path uses 42 at every uptime. This is NOT an auto-update fault and NOT evidence the updater is healthy -- the node died for an unrelated reason. Retrying on a fresh tree."
+          saw_fatal_abort=1
+          rc=2
+        else
+          fail "the shipping binary exited 42 (the update-requested code the supervisor acts on) -- it asked its supervisor to replace it, and the only release available is OLDER than itself. A healthy Gate A run ends at 143, because the canary SIGTERMs a node that is still going; reaching 42 means this node exited on its own. Publishing this strands the fleet in a downgrade-and-restart loop: the supervisor installs the older binary, that binary detects this one as newer, and the cycle repeats. Check compare_versions_for_startup in crates/core/src/bin/commands/auto_update.rs for an inverted comparison. (42 is also FATAL_LISTENER_EXIT_CODE, but the canary looked for the CRITICAL fatal-abort line in the node output below and did not find one, so this is not a listener or redb exit.) If you cannot find a 'triggering auto-update' line in the log below, that is expected and is NOT evidence against this verdict: a trigger site whose wording MARKER_TRIGGERED_RE no longer matches produces exactly this shape -- no matched trigger, and no completion line either, because freenet.rs returns as soon as it sends. Check MARKER_TRIGGERED_RE against the trigger sites in freenet.rs before concluding the exit code is wrong."
+          rc=1
+        fi
+      fi
     fi
     # Keep the evidence before the next attempt wipes the tree, or the EXIT trap
     # deletes it. Only on a non-zero verdict, so a healthy release stays quiet.
@@ -1139,6 +1510,10 @@ cmd_preflight() {
     fi
   done
 
+  if [ "$saw_fatal_abort" -eq 1 ]; then
+    fail "the shipping binary's update check produced no verdict in $CANARY_ATTEMPTS attempts, and on at least one of them the node exited 42 after a CRITICAL fatal abort (network event listener exited, or redb poisoned -- see the node output above). That is NOT the update-requested exit and NOT an auto-update fault: 42 is also FATAL_LISTENER_EXIT_CODE (crates/core/src/node/p2p_impl.rs), and the canary does not opt into the distinct code 45. Nothing was learned about the updater, so this is an UNVERIFIED result rather than a detected bug: re-run this job, and if it recurs look at why the node's listener or storage is dying on this runner. Do NOT un-draft the release by hand -- an unverified gate is not a passed gate."
+    return 1
+  fi
   fail "the shipping binary's update check produced no verdict in $CANARY_ATTEMPTS attempts -- GitHub unreachable, or the check never logged an outcome. Cannot confirm its updater works. This is an UNVERIFIED result, not a detected bug: re-run this job. Do NOT un-draft the release by hand to work around it -- an unverified gate is not a passed gate."
   return 1
 }
@@ -1384,7 +1759,18 @@ cmd_selfupdate() {
   fi
   [ "$rc" -eq 0 ] || return 1
 
+  # Gate B needs no mirror of `assert_gate_a_decision`: it already asserts its own
+  # direction, here and at the exit-42 check below, and its direction is fixed
+  # (the release IS published by now, so the previous binary must always decide
+  # to update). What it did not do is say WHY it stayed put when the node told
+  # it -- so the #4073 refusal, the one non-obvious cause, gets named. Message
+  # only; the verdict is unchanged either way.
   if ! node_decided_to_update "$work/logs"; then
+    if node_refused_locally_gated "$work/logs"; then
+      fail "v$prev_version saw v$expected_version and REFUSED it as locally blocked (#4073: crash-loop known-bad pin or repeated install failures). The canary runs it under a fresh, isolated HOME with no such history, so there is nothing for that gate to have matched -- is_version_pinned_bad / is_version_install_gated (crates/core/src/bin/commands/rollback.rs) is matching wrongly, and every node on v$prev_version will refuse this release the same way. Do NOT read this as the ordinary 'stayed put' case."
+      log_lines "$work/logs" "$MARKER_NOT_TRIGGERED" | head -2 >&2
+      return 1
+    fi
     fail "v$prev_version parsed GitHub's response but did NOT decide to update to v$expected_version. The release is published and visible, so a node on the previous version is choosing to stay put -- the fleet will not converge."
     return 1
   fi

--- a/scripts/auto-update-canary_lifecycle_test.sh
+++ b/scripts/auto-update-canary_lifecycle_test.sh
@@ -96,8 +96,16 @@ export CANARY_EXPECTED_LATEST=0.2.121
 # outcome line. It models the only variable a real node has here: how long
 # GitHub takes to answer. Production bounds that at PROBE_CHAIN_TIMEOUT (10s),
 # and the whole of case 5 is a value inside that bound.
+# `stderr-line` (arg 6) models an `eprintln!` rather than a `tracing` event, and
+# the distinction is the whole reason it exists: the node's two fatal-abort
+# CRITICAL lines are `eprintln!`, so they land in `node.out` (via the subshell's
+# `2>&1` in run_node_until_check) and NEVER in the log dir. The exit-42
+# classification reads them from there, and until this parameter existed that
+# premise was asserted only by inspection -- every behavioural case wrote
+# `node.out` itself through the stub.
 make_fake_node() {
     local path="$1" exit_code="$2" extra="$3" linger="${4:-0}" delay="${5:-0}"
+    local stderr_line="${6:-}"
     cat > "$path" <<FAKE
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
@@ -117,6 +125,13 @@ echo "2026-08-08T02:00:00.000000Z  $CHECK_LINE" >> "\$logdir/freenet.2026-08-08-
 if [ -n "$extra" ]; then
     sleep $delay
     echo "2026-08-08T02:00:00.100000Z  $extra" >> "\$logdir/freenet.2026-08-08-02.log"
+fi
+if [ -n "$stderr_line" ]; then
+    # To STDERR, exactly as the node's eprintln! does. run_node_until_check
+    # redirects the node's stdout AND stderr into node.out; if that redirect were
+    # ever split or dropped, this line would stop arriving and the fatal-abort
+    # classification would silently turn every environmental 42 into a hard block.
+    echo "$stderr_line" >&2
 fi
 sleep $linger
 exit $exit_code
@@ -188,6 +203,61 @@ elif [[ "$WRONG_OUT" == *"compared against the WRONG release"* ]]; then
     ok "cmd_preflight fails a node that compared against the wrong release, with the right diagnosis"
 else
     bad "cmd_preflight failed the wrong-release node but with the wrong diagnosis: $WRONG_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2c. Exit 42 is OVERLOADED, and the discrimination must work through the REAL
+#     harness -- not just through a stub that writes node.out itself.
+#
+#     `FATAL_LISTENER_EXIT_CODE` is also 42 (crates/core/src/node/p2p_impl.rs),
+#     and both of its producers `eprintln!` a CRITICAL line before exiting. The
+#     canary treats "42 + CRITICAL" as environmental (retryable) and "42 without
+#     it" as a real downgrade bug, so the whole distinction rests on a premise
+#     nothing was testing: that the node's STDERR reaches `node.out`.
+#
+#     auto-update-canary_test.sh cannot test that. Its stub writes node.out
+#     directly, so it asserts the classification while ASSUMING the plumbing --
+#     the same shape as the retry-attempts gap found in review, and as the #5271
+#     fixture that wrapped a real log string in a type the system cannot emit:
+#     the assertion was fine, the fixture could not produce the fault.
+#
+#     Here the fake node writes the line to fd 2 and the REAL run_node_until_check
+#     captures it. A refactor that splits node stderr into its own file, or drops
+#     the `2>&1`, turns every environmental 42 into a hard block on a healthy
+#     release -- and would leave the other suite entirely green.
+#
+#     CANARY_ATTEMPTS is 1 here, so the environmental verdict exhausts the budget
+#     and the gate returns non-zero; what is asserted is the DIAGNOSIS, which is
+#     what differs between the two branches.
+# ---------------------------------------------------------------------------
+FAKE_FATAL42="$TMPROOT/fake-fatal-abort-42"
+make_fake_node "$FAKE_FATAL42" 42 "$LATEST_SEEN_LINE
+2026-08-08T02:00:00.200000Z  $COMPLETE_LINE" 0 0 \
+    "CRITICAL: Network event listener exited (fatal): transport error: connection reset by peer"
+FATAL42_OUT="$(cmd_preflight "$FAKE_FATAL42" 2>&1)"
+FATAL42_RC=$?
+if [ "$FATAL42_RC" -eq 0 ]; then
+    bad "cmd_preflight returned OK for a node that exited 42 -- the exit-code observer is not running at all"
+elif [[ "$FATAL42_OUT" == *"CRITICAL fatal abort"* ]]; then
+    ok "a fatal-abort CRITICAL on the node's STDERR reaches node.out and is classified environmental (real harness)"
+else
+    bad "cmd_preflight blocked on exit 42 without seeing the fatal-abort CRITICAL the node printed to stderr. Either run_node_until_check no longer captures the node's stderr into node.out, or the marker drifted -- every environmental 42 is now a hard block on a HEALTHY release, blaming compare_versions_for_startup. Got: $FATAL42_OUT"
+fi
+
+# ...and the discriminating twin, through the same real harness: exit 42 with NO
+# CRITICAL line is a genuine downgrade bug and must be named as one. Without this
+# the case above is satisfied by a classifier that calls everything environmental.
+FAKE_BARE42="$TMPROOT/fake-bare-exit-42"
+make_fake_node "$FAKE_BARE42" 42 "$LATEST_SEEN_LINE
+2026-08-08T02:00:00.200000Z  $COMPLETE_LINE" 0 0
+BARE42_OUT="$(cmd_preflight "$FAKE_BARE42" 2>&1)"
+BARE42_RC=$?
+if [ "$BARE42_RC" -eq 0 ]; then
+    bad "cmd_preflight returned OK for a node that exited 42 with a clean log and no fatal-abort line -- that is a self-downgrade request and must block"
+elif [[ "$BARE42_OUT" == *"downgrade-and-restart loop"* ]]; then
+    ok "exit 42 with no fatal-abort line is blocked as a self-downgrade (real harness)"
+else
+    bad "cmd_preflight blocked the bare exit-42 node but with the wrong diagnosis; got: $BARE42_OUT"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -126,6 +126,31 @@ SEEN_CONSTANT='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check a
 2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.0.0
 2026-08-08T02:00:00.412000Z  INFO freenet: Startup update check complete: staying on the current version current="0.2.123"'
 
+# --- fixtures for the DECISION check ----------------------------------------
+#
+# All three pass every one of `assert_detection_healthy`'s seven checks. That is
+# the point: the decision the node reached is not one of the things those checks
+# look at, so these are the logs a broken comparator produces and the old gate
+# called healthy.
+#
+# The binary under test in Gate A is NEWER than `releases/latest` by
+# construction (its own release is still a draft), so this node found something
+# newer than itself that does not exist. An inverted `latest_ver > current_ver`
+# in compare_versions_for_startup produces exactly it, and the update requested
+# is a self-DOWNGRADE to 0.2.122 from 0.2.123.
+SEEN_TRIGGERED='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.123" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.122
+2026-08-08T02:00:00.412000Z  INFO freenet: Startup check: newer version on GitHub, triggering auto-update new_version=0.2.122'
+
+# The #4073 refusal, verbatim from freenet.rs. It reaches the completion line
+# like every other non-triggering outcome, so before the decision check this log
+# was indistinguishable from an ordinary healthy one -- and it means the node
+# will refuse EVERY release it is ever offered.
+SEEN_REFUSED_4073='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.123" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.122
+2026-08-08T02:00:00.350000Z  WARN freenet: Startup check: newer version is locally blocked (crash-loop known-bad pin or repeated install failures); not triggering auto-update (#4073)
+2026-08-08T02:00:00.412000Z  INFO freenet: Startup update check complete: staying on the current version current="0.2.123"'
+
 # --- the positive cases -----------------------------------------------------
 check "healthy: check ran, parsed, triggered -> pass" 0 "$HEALTHY"
 check "healthy: check ran and completed up-to-date -> pass" 0 "$HEALTHY_UP_TO_DATE"
@@ -353,6 +378,159 @@ $BULK"
 check "volume: #5221 parse failure behind >64KB of later output -> still fail" \
     1 "$BROKEN
 $BULK" "could not parse the version GitHub returned"
+
+# --- WHICH DECISION the updater reached -------------------------------------
+#
+# Every assertion above this point is satisfied by a node that reached the WRONG
+# DECISION. `assert_detection_healthy` never looks at one: `node_check_settled`
+# accepts a completion line OR a trigger, the equality check validates the
+# version compared AGAINST rather than what was done with it, and the #4073
+# refusal reaches the completion line like any other non-triggering outcome. So
+# a shipping binary with an inverted `latest_ver > current_ver` passes all seven
+# checks and ships -- and it does not quietly do nothing, it requests a
+# self-DOWNGRADE to the older release, exits 42, and the supervisor loop repeats
+# it forever. `docs/RELEASING.md` has described this hole since #5236.
+#
+# TWO functions, tested separately, because they fail differently:
+#   gate_a_expected_decision -- WHICH decision is obliged, from the two versions
+#   assert_gate_a_decision   -- whether the node reached it
+#
+# The split is what keeps the gate from false-BLOCKING. Gate A's subject is
+# newer than `releases/latest` on the normal release path, but `cross-compile.yml`
+# is checked out AT THE TAG, so re-running an older release's workflow (or a
+# hotfix cut on an older line) puts a genuinely older binary under the gate,
+# where deciding to update is CORRECT. A blocking gate that fails a healthy
+# release does not cost one release; it teaches people to override it.
+expect_case() {
+    # expect_case <shipping> <latest> <expected: decline|update|unknown>
+    local got
+    got="$(gate_a_expected_decision "$1" "$2")"
+    if [[ "$got" == "$3" ]]; then
+        echo "ok   - gate_a_expected_decision '$1' vs '$2' -> $3"
+    else
+        echo "FAIL - gate_a_expected_decision '$1' vs '$2' said '$got', expected '$3'" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+expect_case "0.2.127" "0.2.126" decline   # the normal release path: draft, so newer
+expect_case "0.2.126" "0.2.126" decline   # equal is NOT newer -- compare_versions_for_startup
+                                          # returns Some only for STRICTLY greater
+expect_case "0.2.126" "0.2.127" update    # a workflow re-run at an older tag
+# Numeric, not lexical, and this is the load-bearing pair: a lexical compare puts
+# 0.2.9 ABOVE 0.2.10, so it would demand a DECLINE from a node that must update
+# and block the release for being right.
+expect_case "0.2.9"   "0.2.10"  update
+expect_case "0.2.10"  "0.2.9"   decline
+# Undecidable rather than guessed. Guessing either way risks blocking a healthy
+# release on a version string nobody can read, with a message about auto-update.
+expect_case ""              "0.2.126" unknown
+expect_case "not-a-version" "0.2.126" unknown
+expect_case "0.2.126"       ""        unknown
+
+# The optional <want-stdout> is separate from <msg> because the two streams carry
+# different things and only one of them was ever asserted. Failures go to STDERR
+# via `fail`/`note`/`warn`; the `OK:` CONFIRMATIONS go to STDOUT via `log`.
+#
+# Those confirmations are what the PR describes as letting a reader of a green job
+# tell WHICH assertion actually ran -- and they were themselves unasserted:
+# deleting `log "OK: the node declined to update, ..."` outright left every suite
+# GREEN, because the green-side cases matched "MUST decline to update", which
+# `cmd_preflight` logs from its OWN arm-selection `case`. A borrowed neighbour
+# again, in the one direction that makes a blocking gate less legible rather than
+# less correct. Message-only severity, but the whole purpose of those lines is
+# that a human can see them, so they get an anchor at the site that emits them.
+decision_case() {
+    # decision_case <desc> <expected-decision-arg> <expected-exit> <log> [msg] [want-stdout]
+    local desc="$1" expect="$2" want_rc="$3" content="$4" want_msg="${5:-}" want_out="${6:-}"
+    local dir actual stderr stdout outfile
+    dir="$(mktemp -d "$TMPROOT/dec.XXXXXX")"
+    outfile="$(mktemp "$TMPROOT/decout.XXXXXX")"
+    if [[ -n "$content" ]]; then
+        printf '%s\n' "$content" > "$dir/freenet.2026-08-08-02.log"
+    fi
+    stderr="$(assert_gate_a_decision "$dir" "$expect" 2>&1 >"$outfile")"
+    actual=$?
+    stdout="$(cat "$outfile")"
+    rm -f "$outfile"
+    if [[ "$actual" != "$want_rc" ]]; then
+        echo "FAIL - decision: $desc (got exit $actual, expected $want_rc)" >&2
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if [[ -n "$want_msg" && "$stderr" != *"$want_msg"* ]]; then
+        echo "FAIL - decision: $desc (exit $actual correct, but diagnosis wrong)" >&2
+        echo "       wanted message containing: $want_msg" >&2
+        echo "       got: ${stderr:-<nothing on stderr>}" >&2
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if [[ -n "$want_out" && "$stdout" != *"$want_out"* ]]; then
+        echo "FAIL - decision: $desc (exit $actual correct, but the OK confirmation is missing)" >&2
+        echo "       wanted stdout containing: $want_out" >&2
+        echo "       got: ${stdout:-<nothing on stdout>}" >&2
+        echo "       These 'OK:' lines are how a reader of a GREEN job tells which assertion" >&2
+        echo "       ran. Without them a passing gate and a skipped one look identical." >&2
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "ok   - decision: $desc"
+}
+
+# The GREEN side first, and it matters as much as the red ones: this gate BLOCKS
+# publication, so a version of it that could only fail would stall the first
+# release that ran it and be indistinguishable from a working one until then.
+# The 6th argument anchors the OK: confirmation on STDOUT at the site that emits
+# it. Without it the green side asserted only cmd_preflight's arm-selection log,
+# and both `log "OK: ..."` lines could be deleted with every suite still green.
+decision_case "healthy Gate A run declines, as it must -> pass" \
+    decline 0 "$SEEN_OK" "" "OK: the node declined to update"
+# ...and the two red ones, which are the whole reason the check exists.
+decision_case "decided to UPDATE with nothing newer to update to -> fail" \
+    decline 1 "$SEEN_TRIGGERED" "DECIDED TO UPDATE"
+decision_case "refused via the #4073 local gate on a fresh HOME -> fail" \
+    decline 1 "$SEEN_REFUSED_4073" "locally blocked (#4073)"
+
+# The OTHER direction, so the conditional is tested rather than assumed. Here the
+# binary really is older than the latest release and updating is correct.
+decision_case "older binary decides to update, as it must -> pass" \
+    update 0 "$SEEN_TRIGGERED" "" "OK: the node decided to update"
+decision_case "older binary stays put on a published newer release -> fail" \
+    update 1 "$SEEN_OK" "did NOT decide to update"
+
+# The #4073 check is DIRECTION-INDEPENDENT: it rests only on the canary's fresh
+# isolated HOME, which holds in every arm. These two are what pin that -- delete
+# the refusal check and the `decline` case above still fails on the trigger, so
+# on its own it does not prove the refusal check runs at all.
+decision_case "the #4073 refusal is a fault in the update arm too" \
+    update 1 "$SEEN_REFUSED_4073" "locally blocked (#4073)"
+decision_case "the #4073 refusal is a fault even when the direction is unknown" \
+    unknown 1 "$SEEN_REFUSED_4073" "locally blocked (#4073)"
+
+# An undecidable direction skips ONE arm, and says so. Silence here would be the
+# vacuous escape hatch this gate family keeps having to remove: a reader of a
+# green log could not tell an asserted decision from an unasserted one.
+decision_case "an unknown direction skips the decision arm LOUDLY" \
+    unknown 0 "$SEEN_TRIGGERED" "did NOT assert which decision"
+# ...as a GitHub ANNOTATION, asserted HERE rather than only through cmd_preflight.
+# Measured: with the annotation pinned only on the end-to-end case, swapping this
+# arm's `warn` back to a plain `note` left the whole suite GREEN -- because
+# cmd_preflight emits its own `::warning::` when it picks the unknown arm, so the
+# end-to-end assertion was satisfied by the CALLER's annotation and never looked
+# at this one. The pure function has no such neighbour to borrow from, which is
+# what makes this the anchor that can actually fail.
+decision_case "the unknown-arm skip is a ::warning:: annotation, not a plain line" \
+    unknown 0 "$SEEN_TRIGGERED" "::warning::"
+
+# Volume-resistance, for the reason the block above this one exists: the real
+# Gate A log is megabytes, and a status-consuming pipe that short-circuits reads
+# a marker that IS present as ABSENT once it passes the 64 KB pipe buffer. Both
+# directions, because a false GREEN here ships the downgrade loop.
+decision_case "volume: a trigger behind >64KB of later output still fails" \
+    decline 1 "$SEEN_TRIGGERED
+$BULK" "DECIDED TO UPDATE"
+decision_case "volume: a healthy decline behind >64KB of later output still passes" \
+    decline 0 "$SEEN_OK
+$BULK"
 
 # --- numeric-override validation (review finding 36) ------------------------
 # A non-numeric CANARY_TIMEOUT_SECS reaches an arithmetic context and, under
@@ -610,25 +788,41 @@ eval "$real_runner_can_reach_github"
 # `curl`/`tar` are shadowed so the
 # download preamble is a no-op. Same shape as
 # `release_wait_for_binaries_test.sh`'s `check_call_count`.
-GATE_B_ATTEMPT=0
-GATE_B_SCRIPT=()
+#
+# The stub and its two globals are SHARED with the Gate A driver further down --
+# the gates differ in which command they drive, not in how a scripted sequence of
+# node boots is faked. Hence the neutral names.
+CANARY_STUB_ATTEMPT=0
+CANARY_STUB_SCRIPT=()
 run_node_until_check_stub() {
-    local work="$2" spec exit_code logvar
-    GATE_B_ATTEMPT=$((GATE_B_ATTEMPT + 1))
+    local work="$2" spec exit_code logvar rest outvar
+    CANARY_STUB_ATTEMPT=$((CANARY_STUB_ATTEMPT + 1))
     # Past the end of the script means the loop ran more times than the case
     # expects; repeat the last entry so the attempt-COUNT assertion is what
     # reports it, with a number, rather than an unbound-variable abort.
-    if [[ "$GATE_B_ATTEMPT" -le "${#GATE_B_SCRIPT[@]}" ]]; then
-        spec="${GATE_B_SCRIPT[$((GATE_B_ATTEMPT - 1))]}"
+    if [[ "$CANARY_STUB_ATTEMPT" -le "${#CANARY_STUB_SCRIPT[@]}" ]]; then
+        spec="${CANARY_STUB_SCRIPT[$((CANARY_STUB_ATTEMPT - 1))]}"
     else
-        spec="${GATE_B_SCRIPT[$((${#GATE_B_SCRIPT[@]} - 1))]}"
+        spec="${CANARY_STUB_SCRIPT[$((${#CANARY_STUB_SCRIPT[@]} - 1))]}"
     fi
+    # "<node-exit>:<log-fixture>" or "<node-exit>:<log-fixture>:<node.out-fixture>".
+    # The third field exists because `node.out` is a SEPARATE observation surface
+    # from the log dir: the node's fatal-abort CRITICAL lines are `eprintln!`, so
+    # they land there and nowhere else, and the exit-42 classification reads them.
     exit_code="${spec%%:*}"
-    logvar="${spec#*:}"
+    rest="${spec#*:}"
+    logvar="${rest%%:*}"
+    outvar="${rest#*:}"
+    # No colon in `rest` leaves it unchanged by the strip, which is how a
+    # two-field spec is told from a three-field one.
+    [[ "$outvar" == "$rest" ]] && outvar=""
     NODE_EXIT="$exit_code"
     mkdir -p "$work/logs"
     if [[ -n "$logvar" ]]; then
         printf '%s\n' "${!logvar}" > "$work/logs/freenet.2026-08-08-02.log"
+    fi
+    if [[ -n "$outvar" ]]; then
+        printf '%s\n' "${!outvar}" > "$work/node.out"
     fi
 }
 
@@ -652,12 +846,12 @@ gate_b_case() {
     # Each <spec> is "<node-exit>:<fixture-variable-name>" for one attempt.
     local desc="$1" want_rc="$2" want_attempts="$3" reachable="$4" want_msg="$5"
     shift 5
-    GATE_B_SCRIPT=("$@")
-    GATE_B_ATTEMPT=0
+    CANARY_STUB_SCRIPT=("$@")
+    CANARY_STUB_ATTEMPT=0
     local got_rc got_attempts out err errfile
     errfile="$(mktemp "$TMPROOT/gateb.XXXXXX")"
     out="$(
-        CANARY_ATTEMPTS="${#GATE_B_SCRIPT[@]}"
+        CANARY_ATTEMPTS="${#CANARY_STUB_SCRIPT[@]}"
         CANARY_RETRY_SLEEP=0
         curl() { :; }
         tar()  { :; }
@@ -672,7 +866,7 @@ gate_b_case() {
             > "$CANARY_WORKDIR/selfupdate/bin/freenet"
         chmod +x "$CANARY_WORKDIR/selfupdate/bin/freenet"
         cmd_selfupdate 0.2.121 0.2.122 2>"$errfile" >/dev/null
-        printf '%s %s' "$?" "$GATE_B_ATTEMPT"
+        printf '%s %s' "$?" "$CANARY_STUB_ATTEMPT"
     )"
     got_rc="${out%% *}"
     got_attempts="${out##* }"
@@ -753,6 +947,435 @@ gate_b_case "ports THEN github with the runner DOWN is quiet, and counts honestl
 gate_b_case "github THEN ports with the runner DOWN is quiet, and counts honestly" 75 2 no \
     "could not reach GitHub on 1 of 2 attempt(s), and this runner cannot reach it either" \
     "0:FETCH_FAIL" "43:"
+
+# --- Gate B's own decision assertion, past the log check --------------------
+# Gate B does NOT need Gate A's decision gate: its direction is fixed (the
+# release is published by the time it runs, so the previous binary must always
+# decide to update) and it already asserts that, plus exit 42. These two cases
+# reach that assertion for the first time -- every case above fails earlier --
+# and pin the ONE thing that was missing: which of the two causes it names.
+#
+# Both are a real failure and both are red. The distinction is the diagnosis,
+# and it is the same reason `check()` at the top of this file asserts messages:
+# "the node stayed put" sends the reader after the comparator, while the #4073
+# refusal is a wrongly-matching local gate in rollback.rs. Sending an on-call
+# reader at the wrong subsystem on a post-publish alarm is the cost.
+#
+# A spare attempt each, for the reason documented on `gate_a_case` below: these
+# are the only Gate B cases whose verdict comes from a loop that exited on rc=0,
+# so with one spec nothing would notice if that break stopped working. Asserting
+# one consumed attempt out of two available pins it.
+gate_b_case "the previous release simply stayed put -> loud, named as such" 1 1 yes \
+    "did NOT decide to update to v0.2.122" "0:SEEN_OK" "0:SEEN_OK"
+gate_b_case "the previous release refused via the #4073 local gate -> named as THAT" 1 1 yes \
+    "REFUSED it as locally blocked (#4073" "0:SEEN_REFUSED_4073" "0:SEEN_REFUSED_4073"
+
+# --- Gate A END TO END, driven per attempt ----------------------------------
+# The Gate A counterpart of the block above, sharing its stub. Two properties
+# cannot be observed anywhere else:
+#
+#   1. THE EXIT-CODE ASSERTION. `NODE_EXIT` is caller state, so it is asserted in
+#      `cmd_preflight` rather than in the pure function, and no fixture-driven
+#      test of `assert_gate_a_decision` can reach it. It is a SECOND, independent
+#      observer of the same decision: the log check reads a phrase this repo
+#      chooses, while exit 42 is the supervisor contract itself, so a trigger site
+#      worded past `MARKER_TRIGGERED_RE` is invisible to one and caught by the
+#      other.
+#   2. THAT THE CONDITIONAL IS WIRED AT ALL. The pure function is told which arm
+#      to take; only cmd_preflight decides it, from the shipping binary's
+#      `--version` and the resolved latest tag. A gate that always demanded a
+#      DECLINE would block a re-run of an older release's workflow -- healthy
+#      behaviour, blocked -- and nothing below the wiring can see that.
+#
+# The shipping version is given as a whole `--version` LINE so the unreadable
+# case is driven through the same field split the real gate uses, rather than
+# around it.
+# --- node.out fixtures: the OTHER two producers of exit 42 -------------------
+#
+# 42 is overloaded. `FATAL_LISTENER_EXIT_CODE` (crates/core/src/node/p2p_impl.rs)
+# is the same number, both of its producers are enabled unconditionally in the
+# real binary (`enable_abort_on_fatal_listener_exit` / `enable_abort_on_redb_poison`
+# at the top of freenet.rs's node path), and the distinct code 45 is opted into
+# only via SYSTEMD_FAST_CRASH_ENV_VAR, which the canary does not export -- so 42
+# is used at every uptime, including the ~40s a canary run lasts.
+#
+# These are `eprintln!`, so they appear in node.out and NOT in the log dir, which
+# is why the predicate that reads them takes a workdir.
+# shellcheck disable=SC2034
+FATAL_LISTENER_OUT='2026-08-08T02:00:05Z  INFO freenet: node running
+CRITICAL: Network event listener exited (fatal): transport error: connection reset by peer'
+# shellcheck disable=SC2034
+REDB_POISON_OUT='CRITICAL: contract storage (redb) is poisoned by an I/O error and cannot recover in-process: Io(Custom { kind: Other, error: "input/output error" }). Exiting with code 42 so the service manager restarts the node with a fresh database handle (#4604).'
+# The ordinary shape: a node that was stopped by the canary says nothing special.
+# shellcheck disable=SC2034
+CLEAN_OUT='2026-08-08T02:00:05Z  INFO freenet: node running
+2026-08-08T02:00:09Z  INFO freenet: received SIGTERM, shutting down'
+
+# Read BY NAME through the stub's `${!logvar}`, so shellcheck cannot see the use.
+# shellcheck disable=SC2034
+SEEN_TRIGGERED_OLD='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.122" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.123
+2026-08-08T02:00:00.412000Z  INFO freenet: Startup check: newer version on GitHub, triggering auto-update new_version=0.2.123'
+
+# A CASE THAT ASSERTS A HARD BLOCK MUST SUPPLY MORE SPECS THAN IT EXPECTS TO
+# CONSUME. This is a rule about the fixture, not about style, and getting it
+# wrong silently disarms the case:
+#
+# `CANARY_ATTEMPTS` is set below to the NUMBER OF SPECS. With exactly one spec it
+# is 1, and then rc=1 (a real defect, returns immediately) and rc=2 (an
+# environmental verdict, retried until the budget runs out and the tail `fail`
+# returns 1) produce the SAME exit code after the SAME one attempt. Every
+# discriminator between "block" and "retry" becomes invisible to the outcome, and
+# only the message text is left to notice it.
+#
+# That is not a hypothetical: mutation R-a (`node_exited_on_fatal_abort` stuck
+# TRUE, the escape-hatch direction that launders a real downgrade bug into
+# "environmental") was caught by NO outcome assertion in this file, because every
+# hard-block case here supplied one spec. The REAL gate defaults to
+# `CANARY_ATTEMPTS=2` (auto-update-canary.sh), so with a retry available the same
+# mutation returns 0 and the release publishes. The fixture could not produce the
+# fault because its environment differed from production in exactly the dimension
+# the fault needed -- the same shape as the #5271 fixture that wrapped a real log
+# string in a type the system cannot emit.
+#
+# So: give a hard-block case a spare attempt it must NOT reach, and assert the
+# attempt COUNT. `gate_b_case "a real #5221 failure is never retried"` above is
+# the existing precedent, and it had this right all along.
+#
+# rc=0 cases are exempt: rc=0 leaves the loop immediately, so any mutation that
+# turns one into rc=1 or rc=2 changes the exit code at one attempt.
+gate_a_case() {
+    # gate_a_case <desc> <version-line> <expected-latest> <want-rc> \
+    #             <want-attempts> <want-message-substring> <spec...>
+    # Each <spec> is "<node-exit>:<fixture-variable-name>" for one attempt.
+    local desc="$1" version_line="$2" latest="$3" want_rc="$4" want_attempts="$5" want_msg="$6"
+    shift 6
+    CANARY_STUB_SCRIPT=("$@")
+    CANARY_STUB_ATTEMPT=0
+    local got_rc got_attempts out output outfile bindir
+    outfile="$(mktemp "$TMPROOT/gatea.XXXXXX")"
+    bindir="$(mktemp -d "$TMPROOT/gateabin.XXXXXX")"
+    # BASH, not `/bin/sh`: `%q` renders a string containing a newline as bash's
+    # ANSI-C `$'...'` form, which dash does not understand -- it would emit the
+    # quoting syntax literally and the multi-line case below would fail for a
+    # reason that has nothing to do with the gate.
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" %q\n' "$version_line" > "$bindir/freenet"
+    chmod +x "$bindir/freenet"
+    out="$(
+        CANARY_ATTEMPTS="${#CANARY_STUB_SCRIPT[@]}"
+        CANARY_RETRY_SLEEP=0
+        # Pinned so cmd_preflight does not reach GitHub from a test. It cannot
+        # DISARM anything: an empty value is treated as unset and sends the gate
+        # to `resolve_expected_latest`, so every case here supplies a real one.
+        export CANARY_EXPECTED_LATEST="$latest"
+        run_node_until_check() { run_node_until_check_stub "$@"; }
+        cmd_preflight "$bindir/freenet" >"$outfile" 2>&1
+        printf '%s %s' "$?" "$CANARY_STUB_ATTEMPT"
+    )"
+    got_rc="${out%% *}"
+    got_attempts="${out##* }"
+    output="$(cat "$outfile")"
+    rm -f "$outfile"
+    if [[ "$got_rc" != "$want_rc" || "$got_attempts" != "$want_attempts" ]]; then
+        echo "FAIL - Gate A: $desc" >&2
+        echo "         got exit $got_rc after $got_attempts attempt(s);" >&2
+        echo "         wanted exit $want_rc after $want_attempts" >&2
+        echo "         output: ${output:-<nothing>}" >&2
+        FAILURES=$((FAILURES + 1))
+    elif [[ "$want_msg" == '!'* && "$output" == *"${want_msg#!}"* ]]; then
+        # A `!`-prefixed needle asserts ABSENCE. Needed because `fail` writes to
+        # stderr and does not replace what an earlier `fail` already wrote, so a
+        # branch that should NOT have run is invisible to a presence check --
+        # both messages simply appear. Measured: dropping the `rc -ne 1` guard on
+        # the exit-42 observer lets it overwrite a parse-failure verdict, and the
+        # positive form of this case stayed GREEN because the parse-failure text
+        # was still in the output alongside it.
+        echo "FAIL - Gate A: $desc (exit $got_rc correct, but a message that should NOT appear did)" >&2
+        echo "         must NOT contain: ${want_msg#!}" >&2
+        echo "         got: ${output:-<nothing>}" >&2
+        FAILURES=$((FAILURES + 1))
+    elif [[ "$want_msg" != '!'* && "$output" != *"$want_msg"* ]]; then
+        echo "FAIL - Gate A: $desc (exit $got_rc correct, but the operator sees the wrong text)" >&2
+        echo "         wanted a message containing: $want_msg" >&2
+        echo "         got: ${output:-<nothing>}" >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "ok   - Gate A: $desc"
+    fi
+}
+
+# THE GREEN SIDE, and for a BLOCKING gate it carries as much weight as the red
+# ones: a version of this check that could only fail would stall the first
+# release that ran it, and the first person to hit that learns to override the
+# gate. The message assertion pins that the arm taken is stated in the log --
+# a reader of a green job must be able to tell WHICH assertion ran.
+gate_a_case "healthy release: newer than latest, declines -> pass" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 0 1 \
+    "MUST decline to update" "0:SEEN_OK"
+
+# The version line is found BY ITS MARKER, not by position. `--version` already
+# prints a second line (`Build timestamp: ...`), so anything that printed a line
+# BEFORE the version -- a deprecation banner, a build warning -- would make a
+# positional read return an unparseable field, send the gate down the `unknown`
+# arm, and skip both new assertions while the job stayed green. The format pin
+# further down cannot see that: the format is untouched, only its line moved.
+#
+# The `\n` in the version-line argument is what makes this a real multi-line
+# `--version`; `gate_a_case` writes it through `printf`, so the fake binary emits
+# two lines exactly as the node does.
+gate_a_case "a banner line before the version does not disarm the gate" \
+    "NOTE: this build is unsupported
+Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 0 1 \
+    "MUST decline to update" "0:SEEN_OK"
+
+# The hole this closes. Everything `assert_detection_healthy` reads is exactly
+# what a healthy run produces; the node simply reached the wrong answer.
+#
+# Two specs, one expected attempt, per the rule on `gate_a_case`: the spare
+# attempt is what makes "blocked" distinguishable from "retried into the same
+# exit code".
+gate_a_case "inverted comparator: decides to update with nothing newer -> BLOCK" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "DECIDED TO UPDATE" "0:SEEN_TRIGGERED" "0:SEEN_OK"
+
+# The exit-code observer on its own. The log here is a HEALTHY decline -- no
+# trigger line at all -- so every log-based check passes and only NODE_EXIT
+# speaks. This is the case a log-only assertion cannot reach. No `node.out` at
+# all, so it also covers the fail-closed reading of a missing one.
+gate_a_case "exit 42 with a clean log still blocks (the second observer)" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "exited 42" "42:SEEN_OK" "0:SEEN_OK"
+
+# A real defect is deterministic, so it must not be retried -- which is what the
+# spare attempt asserts, and what a one-spec fixture could not.
+gate_a_case "the #4073 refusal blocks, and names rollback.rs" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "rollback.rs" "0:SEEN_REFUSED_4073" "0:SEEN_OK"
+
+# THE OTHER ARM. `cross-compile.yml` is checked out AT THE TAG, so re-running an
+# older release's workflow after newer releases have published puts a genuinely
+# older binary under Gate A. Deciding to update is then CORRECT, and exiting 42
+# is correct with it -- both of these would be blocked by an unconditional
+# "must have declined" assertion, on a release with nothing wrong.
+gate_a_case "older binary than latest: decides to update -> pass" \
+    "Freenet version: 0.2.122 (deadbeefcafe)" 0.2.123 0 1 \
+    "MUST decide to update" "0:SEEN_TRIGGERED_OLD"
+gate_a_case "older binary than latest: exit 42 is correct there, not a block" \
+    "Freenet version: 0.2.122 (deadbeefcafe)" 0.2.123 0 1 \
+    "MUST decide to update" "42:SEEN_TRIGGERED_OLD"
+
+# An unreadable version skips ONE arm and says so, rather than guessing a
+# direction and blocking a release on the guess. The exit-42 assertion is scoped
+# to the `decline` arm, so it must not fire here either.
+#
+# `::warning::` and not a plain line: this arm disables BOTH new assertions, so
+# reaching it silently returns Gate A to its pre-decision-check strength while the
+# job stays green. A release log runs to thousands of lines; an annotation is seen
+# without reading it. (The `--version` format pin further down is the other half
+# -- it makes a change to that output shape fail LOUDLY here rather than widen
+# this arm quietly.)
+gate_a_case "unreadable shipping version: skips the decision arm LOUDLY" \
+    "Freenet" 0.2.122 0 1 \
+    "::warning::" "42:SEEN_OK"
+gate_a_case "unreadable shipping version: the warning says WHAT was skipped" \
+    "Freenet" 0.2.122 0 1 \
+    "did NOT assert which decision" "42:SEEN_OK"
+# ...and cmd_preflight's OWN annotation, anchored on the PREFIX AND the
+# caller-unique text TOGETHER.
+#
+# Both needles above are produced by `assert_gate_a_decision`, so they were
+# satisfied by the pure function and said nothing about the caller: reverting
+# cmd_preflight's `warn` to a plain `note` left the whole suite GREEN, measured.
+# That is the borrowed anchor this file's own comment (on the unknown-arm
+# decision case) describes, running in the opposite direction -- the pure
+# function was pinned against the caller and the caller against nothing.
+#
+# THE FIRST ATTEMPT AT THIS CASE ALSO FAILED TO CATCH IT, and the reason is worth
+# keeping: it asserted only the caller-unique TEXT, which `note` prints just as
+# `warn` does. Neither half is sufficient alone -- `::warning::` alone is
+# borrowable from the pure function, and the text alone survives the downgrade.
+# The needle must therefore span the boundary between them, which is only
+# possible because the annotation prefix is immediately followed by the message.
+gate_a_case "unreadable shipping version: cmd_preflight raises its OWN annotation" \
+    "Freenet" 0.2.122 0 1 \
+    "::warning::could not compare the shipping version" "42:SEEN_OK"
+
+# --- exit 42 is OVERLOADED, and must not false-block a healthy release -------
+#
+# `FATAL_LISTENER_EXIT_CODE` is also 42 (crates/core/src/node/p2p_impl.rs). Both of
+# its producers run in the real binary, and the distinct code 45 is opted into only
+# via SYSTEMD_FAST_CRASH_ENV_VAR, which the canary does not set -- so a HEALTHY
+# binary that declines the update and then loses its network event listener (a
+# CI-runner transport error) or poisons redb (disk EIO) exits 42 for a reason that
+# has nothing to do with the updater.
+#
+# THE OVERLAP IS EXACTLY COINCIDENT WITH THE CHECK'S VALUE, which is why this is a
+# fix and not a note: when the comparator IS inverted the trigger line is in the
+# log and the decision check already blocks, so exit 42 adds nothing there. Exit 42
+# is load-bearing ONLY when there is no trigger line -- and "42 with no trigger
+# line" is precisely the fatal-abort signature. So the code alone cannot carry it;
+# the node's own CRITICAL line is what separates them.
+#
+# ENVIRONMENTAL means rc=2, which is RETRIED. With one attempt that ends as a
+# blocked release (unverified is not verified) but with the right diagnosis.
+#
+# These two DELIBERATELY supply one spec -- they are asserting the exhaustion
+# path and its tail message, so the budget must run out. They therefore cannot
+# discriminate rc=2 from rc=1 by exit code; the retry case below is what does
+# that, and the hard-block cases after it are what stop rc=2 from being handed
+# to a real defect.
+gate_a_case "exit 42 after a fatal listener abort is environmental, not an updater fault" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "CRITICAL fatal abort" "42:SEEN_OK:FATAL_LISTENER_OUT"
+# ...and the redb path separately, because it was added later (#4604) and reuses
+# the listener path's exit-code decision. A version of this that knew only about
+# the listener would hard-block a healthy release on a disk error.
+gate_a_case "exit 42 after a redb poison is environmental too" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "CRITICAL fatal abort" "42:SEEN_OK:REDB_POISON_OUT"
+# THE ONE THAT MATTERS: retried, and a healthy release is NOT blocked by one bad
+# attempt. This is the whole point of classifying it as 2 rather than 1 -- and it
+# is the case a hard block would have failed.
+gate_a_case "a fatal abort is RETRIED and the healthy retry passes" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 0 2 \
+    "MUST decline to update" "42:SEEN_OK:FATAL_LISTENER_OUT" "0:SEEN_OK:CLEAN_OUT"
+# THE OTHER DIRECTION, AND THE STRONGEST ATTACK ON THIS WHOLE PATH. 42 with node
+# output carrying NO fatal-abort line is a real downgrade bug and must block on
+# attempt 1, with the retry budget untouched.
+#
+# The spare attempt is the entire assertion. The rc=2 path introduced above is an
+# escape hatch by construction: anything that makes the discriminator answer
+# "environmental" for a genuine defect converts a blocked release into a
+# published one. With one spec that conversion is INVISIBLE -- rc=1 and rc=2 both
+# exit 1 after one attempt -- and mutation R-a (the discriminator stuck TRUE) was
+# caught here by message text alone. With the spare attempt R-a yields
+# `exit 0 after 2 attempts`: the release publishes. The real gate runs
+# CANARY_ATTEMPTS=2, so 2 is also the production shape.
+gate_a_case "a real exit-42 downgrade blocks on attempt 1 even when a retry is available" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "downgrade-and-restart loop" "42:SEEN_OK:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+# ...and it names the alternative cause rather than confidently blaming the
+# comparator. A blocking gate that points at the wrong subsystem is how people
+# learn to override it.
+gate_a_case "the hard block names the fatal-abort alternative it ruled out" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "42 is also FATAL_LISTENER_EXIT_CODE" "42:SEEN_OK:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+
+# --- the exit-42 observer must survive an INDETERMINATE log verdict ----------
+#
+# Found by an external (Codex) review pass, reproduced twice, and it made the
+# observer unreachable on the one input it exists for.
+#
+# `freenet.rs` `return`s immediately after `update_tx.send`, so the completion
+# line is NEVER emitted on the trigger path. If the trigger's wording drifts out
+# of `MARKER_TRIGGERED_RE`, or the line is dropped, the log then has no matched
+# trigger AND no completion -- `node_check_settled` is false and
+# `assert_detection_healthy` returns 2 (INDETERMINATE). The observer was gated on
+# `rc -eq 0`, so it skipped; Gate A burned both attempts and reported "produced no
+# verdict -- GitHub unreachable, or the check never logged an outcome" for a
+# deterministic self-downgrade. Fail-closed, so no false green -- but the
+# diagnosis named the wrong subsystem, and the file CLAIMED this case was covered.
+#
+# The gate is now `rc -ne 1`, so an INDETERMINATE log verdict no longer disarms
+# it while a definite fault (rc=1, which localises better) still wins.
+# shellcheck disable=SC2034  # read BY NAME through the stub's `${!logvar}`
+SEEN_TRIGGER_REWORDED='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.123" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.122
+2026-08-08T02:00:00.412000Z  INFO freenet: Startup check: newer release found, starting auto-update new_version=0.2.122'
+# shellcheck disable=SC2034  # read BY NAME through the stub's `${!logvar}`
+SEEN_TRIGGER_DROPPED='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.123" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.122'
+
+# Both must BLOCK, on attempt 1, with the self-downgrade diagnosis -- not with
+# the "no verdict" message, and not by consuming the retry budget.
+gate_a_case "reworded trigger + exit 42 blocks despite an INDETERMINATE log" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "downgrade-and-restart loop" "42:SEEN_TRIGGER_REWORDED:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+gate_a_case "dropped trigger line + exit 42 blocks despite an INDETERMINATE log" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "downgrade-and-restart loop" "42:SEEN_TRIGGER_DROPPED:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+# ...and the operator is told why there is no trigger line to find, so the
+# missing line does not read as evidence against the verdict.
+gate_a_case "the block explains the absent trigger line" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "no matched trigger, and no completion line either" \
+    "42:SEEN_TRIGGER_REWORDED:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+# THE UPDATE ARM'S BEHAVIOUR ON THE SAME DEFECT, pinned because the comment
+# describing it in auto-update-canary.sh was WRONG twice and a reader has no way
+# to check it without this.
+#
+# The intuitive answer -- "the update arm catches it as 'did NOT decide to
+# update'" -- is false. Every trigger site `return`s straight after
+# `update_tx.send`, so a node that triggered emits no completion line either;
+# `rc` is 2 and `assert_gate_a_decision` is never reached (it is gated on rc=0).
+# The run burns BOTH attempts and blocks as UNVERIFIED, with the same
+# wrong-subsystem "produced no verdict" text this observer removes from the
+# decline arm -- on a node that behaved correctly. Fail-closed, and not fixed
+# here: the exit-42 observer cannot be extended to this arm, because exiting 42
+# is CORRECT when the binary really is older.
+#
+# Two specs and two expected attempts, because burning the retry budget is the
+# behaviour being asserted.
+# shellcheck disable=SC2034  # read BY NAME through the stub's `${!logvar}`
+SEEN_TRIGGER_REWORDED_OLD='2026-08-08T02:00:00.000000Z  INFO freenet: Startup update check against GitHub current="0.2.122" jitter_secs=7
+2026-08-08T02:00:00.300000Z  INFO freenet::commands::auto_update: Startup update check: GitHub reports latest release latest=0.2.123
+2026-08-08T02:00:00.412000Z  INFO freenet: Startup check: newer release found, starting auto-update new_version=0.2.123'
+gate_a_case "update arm + reworded trigger blocks as UNVERIFIED, not as a decision failure" \
+    "Freenet version: 0.2.122 (deadbeefcafe)" 0.2.123 1 2 \
+    "produced no verdict" "42:SEEN_TRIGGER_REWORDED_OLD:CLEAN_OUT" "42:SEEN_TRIGGER_REWORDED_OLD:CLEAN_OUT"
+gate_a_case "...and NOT with the decision-failure diagnosis" \
+    "Freenet version: 0.2.122 (deadbeefcafe)" 0.2.123 1 2 \
+    '!did NOT decide to update' "42:SEEN_TRIGGER_REWORDED_OLD:CLEAN_OUT" "42:SEEN_TRIGGER_REWORDED_OLD:CLEAN_OUT"
+
+# The corroboration still governs this path: same INDETERMINATE log, but a
+# fatal-abort CRITICAL present means the 42 is explained and must stay
+# environmental rather than becoming a hard block.
+gate_a_case "an INDETERMINATE log + exit 42 + fatal abort stays environmental" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "CRITICAL fatal abort" "42:SEEN_TRIGGER_DROPPED:FATAL_LISTENER_OUT"
+# And rc=1 must still win: a parse failure localises better than "it exited 42",
+# so the observer must not run on top of it. TWO cases, and the second is the
+# load-bearing one -- `fail` appends to stderr rather than replacing, so the
+# positive check below passes even when the observer DID overwrite the verdict
+# (both messages are present). Only the absence assertion can see it; measured,
+# the positive form alone left the guard-removal mutation GREEN.
+gate_a_case "a parse failure still outranks the exit-42 observer" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    "could not parse the version GitHub returned" "42:BROKEN:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+gate_a_case "...and the exit-42 diagnosis is NOT also emitted over it" \
+    "Freenet version: 0.2.123 (deadbeefcafe)" 0.2.122 1 1 \
+    '!downgrade-and-restart loop' "42:BROKEN:CLEAN_OUT" "0:SEEN_OK:CLEAN_OUT"
+
+# The pure predicate underneath all of that.
+fatal_out_case() {
+    # fatal_out_case <desc> <expect yes|no> <node.out content>
+    local desc="$1" expect="$2" content="$3" dir got
+    dir="$(mktemp -d "$TMPROOT/fatal.XXXXXX")"
+    if [[ -n "$content" ]]; then
+        printf '%s\n' "$content" > "$dir/node.out"
+    fi
+    if node_exited_on_fatal_abort "$dir"; then got=yes; else got=no; fi
+    if [[ "$got" == "$expect" ]]; then
+        echo "ok   - fatal-abort detection: $desc"
+    else
+        echo "FAIL - fatal-abort detection: $desc (got '$got', expected '$expect')" >&2
+        if [[ "$expect" == no ]]; then
+            echo "       Reading this as a fatal abort downgrades a REAL downgrade-loop bug to" >&2
+            echo "       'environmental' and retries it -- the direction that ships the bug." >&2
+        else
+            echo "       Not reading this as a fatal abort blocks a healthy release and blames" >&2
+            echo "       compare_versions_for_startup, which is fine." >&2
+        fi
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+fatal_out_case "the network-event-listener CRITICAL"   yes "$FATAL_LISTENER_OUT"
+fatal_out_case "the redb-poison CRITICAL"              yes "$REDB_POISON_OUT"
+fatal_out_case "an ordinary SIGTERM shutdown is NOT one" no "$CLEAN_OUT"
+# A missing node.out must read as "no fatal abort", i.e. the hard block stands.
+# The opposite would hand every exit 42 the environmental path the moment the
+# harness stopped capturing output.
+fatal_out_case "a missing node.out is NOT a fatal abort" no ""
 
 eval "$real_run_node_until_check"
 
@@ -1163,6 +1786,148 @@ else
 fi
 pin_marker "source pin: #4073 refusal phrase"   "$SRC"    "$MARKER_NOT_TRIGGERED"
 pin_marker "source pin: disabled marker"        "$SRC"    "$MARKER_DISABLED"
+
+# --- WHY THERE ARE NO SOURCE PINS ON THE TWO FATAL-ABORT MARKERS -------------
+#
+# There were, briefly. `MARKER_FATAL_LISTENER` and `MARKER_REDB_POISONED` decide
+# whether an exit 42 is a genuine self-downgrade bug (block the release) or a
+# fatal-listener / redb abort (environmental, retry), so a reword that the canary
+# does not follow is worth warning about, and two pins were added to do it by
+# scraping `p2p_impl.rs` for text inside `println!`/`eprintln!` bodies.
+#
+# THEY WERE REMOVED, and the reason is not that they were imperfect -- it is that
+# a line-oriented approximation of Rust lexing produced BOTH failure directions.
+# Five review rounds each closed the shape they were shown (whole-line comments,
+# trailing comments, `#[cfg(test)]` modules, blob-vs-line matching, single-line
+# string literals) and each round produced a NEW verified defect rather than a
+# diminishing one:
+#
+#   FALSE PASSES (text the binary never prints satisfying the pin): multi-line
+#   string literals, plain and raw, defeat string masking entirely, since the
+#   masker resets per line; `#[cfg(all(test, ...))]` / `#[cfg(any(test, ...))]`
+#   bypass the test-module cut; the span cap admits an unprinted `const` near a
+#   macro that does not terminate on `);`; `/* */` blocks are not handled at all.
+#
+#   FALSE BLOCKS (a CORRECT tree failing the gate), which is what settled it.
+#   Two independent routes. One: the `#[cfg(test)]` cut matched the TEXT, so a
+#   doc comment merely MENTIONING the attribute truncated the file and produced
+#   two blocking failures on a tree whose binary still printed the markers. Two,
+#   and this is the one no reordering fixes: `sed 's/\\$//'` strips a
+#   continuation backslash WITHOUT JOINING THE LINES, so a marker split across a
+#   `\`-continuation goes red -- while Rust joins the literal, the binary prints
+#   ONE line, and the canary's `grep -aqF` matches it perfectly. Verified by
+#   compiling and running the binary. An earlier version of this file justified
+#   per-line matching as "a single source line is a requirement of the runtime
+#   grep"; for that form the claim is simply false, and it is recorded here so
+#   nobody re-derives the same half-fix.
+#
+# A blocking gate that a doc comment or a line wrap can turn red trains people to
+# override it, and the limits comment warns the next AUTHOR while the cost is
+# paid by the release engineer standing in front of a red gate. So the pins went
+# rather than the release-blocking risk.
+#
+# WHAT THIS COSTS: an early warning if someone rewords either CRITICAL line
+# without updating the marker here. The canary then hard-blocks on the next
+# environmental exit 42 and names the wrong subsystem -- loud and fail-closed,
+# but with no pointer. That is the trade, taken deliberately.
+#
+# THE FIX THAT CLOSES THE CLASS is freenet/freenet-core#5345: lift each marker
+# into a `const` in the Rust source, interpolate it at the emission site, and
+# assert it from a Rust `#[test]`. The compiler, not a tokenizer, becomes the
+# oracle -- no comment, doc comment, string literal, test module or `cfg`
+# spelling can fool it -- and the canary's marker and the node's output get a
+# single source of truth so they cannot drift. #5345 also carries the fallback
+# options if that turns out bigger than expected, and the ranking of the five
+# whole-file `pin_marker` scrapes that remain in this file.
+#
+# DO NOT re-add a scrape-based pin for these two markers without reading #5345.
+
+P2P_SRC="$SCRIPT_DIR/../crates/core/src/node/p2p_impl.rs"
+
+# ...and that 42 really is still the code those paths use. If FATAL_LISTENER_EXIT_CODE
+# ever moves off 42 the corroboration above becomes dead weight that quietly
+# weakens the exit-42 assertion -- an exit 42 could then only mean "update
+# requested", and the environmental branch would be an escape hatch with no
+# legitimate input. Pinned so that change forces a decision here.
+# Whole-line `//` comments dropped first, so a historical `// was: ... = 42;`
+# cannot satisfy it. (A const declaration is not inside a macro, so the
+# emitted-text helper above does not apply here.)
+#
+# Same `/* */` gap as that helper, and stated for the same reason: a
+# `/* const FATAL_LISTENER_EXIT_CODE: i32 = 42; */` left beside a changed const
+# keeps this green. Symmetric with the disclosed limit above rather than a
+# separate defect, and closing it properly means parsing Rust.
+p2p_code_only="$(grep -v '^[[:space:]]*//' "$P2P_SRC" | tr -d '[:space:]')"
+if [[ "$p2p_code_only" == *"constFATAL_LISTENER_EXIT_CODE:i32=42;"* ]]; then
+    echo "ok   - source pin: FATAL_LISTENER_EXIT_CODE is still 42 (so the overload is real)"
+else
+    echo "FAIL - source pin: FATAL_LISTENER_EXIT_CODE is no longer 42 in p2p_impl.rs." >&2
+    echo "       The canary treats an exit 42 with a CRITICAL fatal-abort line as ENVIRONMENTAL" >&2
+    echo "       because that code is shared with the update-requested exit. If they are no" >&2
+    echo "       longer the same number, that branch has no legitimate input and is now an" >&2
+    echo "       escape hatch on a BLOCKING gate -- delete it rather than leaving it." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+# --- the `--version` output format ------------------------------------------
+# cmd_preflight reads the shipping version from field 3 of the `Freenet version:`
+# line and uses it to choose WHICH decision to assert. A change to that output
+# shape does not fail anything on its own: the field split yields something
+# unparseable, the direction becomes `unknown`, and BOTH new assertions silently
+# stop running while the job stays green. So the format is pinned to the
+# `println!` that produces it.
+#
+# SCOPE, stated accurately rather than sold: this pins the FORMAT, and
+# cmd_preflight selects the line by its `Freenet version:` marker rather than by
+# position, so a banner line printed ahead of it no longer shifts the field read.
+# Between them the class is closed; neither alone closes it, and the `::warning::`
+# on the `unknown` arm is the backstop if some third thing gets past both.
+# `cmd_selfupdate` reads the same field of the same output, so this protects both.
+#
+# A WHOLE-FILE scrape, like the five `tracing::` pins above and unlike the
+# emitted-macro extraction that was removed (see the note further up). It is
+# WEAKER -- a comment quoting the old format satisfies it -- and it is kept
+# because its failure direction is safe: adding text to the file can only make a
+# containment check PASS, so no comment, doc comment or line wrap can turn this
+# red on a correct tree. That is the whole reason the extraction went and this
+# stayed. #5345 replaces both.
+#
+# THE WHITESPACE STRIPPING ALSO BLINDS IT TO A MISSING SEPARATOR INSIDE THE
+# LITERAL, which is worth naming because it is the ONE edit that actually
+# defeats what this pin protects. Delete the space after the colon --
+# `"Freenet version:{} ({}{})"` -- and `tr -d '[:space:]'` normalises the change
+# away, so the pin stays green while `awk '{print $3}'` yields `(deadbeefcafe)`,
+# `gate_a_expected_decision` answers `unknown`, and BOTH of Gate A's new
+# assertions are skipped. Found by an external review pass, on code two earlier
+# passes had examined.
+#
+# NOT FIXED HERE, and the rejected fix is recorded so it is not re-proposed.
+# Squeezing instead of deleting (`tr -s '[:space:]' ' '`) does catch it -- and
+# reintroduces a false-BLOCK route, which is the trade this file must never
+# make. Measured: with the needle reduced to the format string alone, a rustfmt
+# reflow and a deeper indent both stay green, but a `\`-continuation splitting
+# the literal mid-word goes RED while the binary prints the text correctly. That
+# is the exact shape that forced the removal of the other three source pins.
+# Preserving "semantic" whitespace is worse still -- it restores the rustfmt
+# fragility the stripping exists to prevent.
+#
+# So this stays a known blind spot, tracked in #5345, which replaces the pin
+# with a marker const plus a Rust test that asserts against real `--version`
+# OUTPUT rather than scraping source. The degradation is LOUD in the meantime:
+# the `unknown` arm it leads to emits a `::warning::` naming both unparseable
+# values, which is exactly the backstop that arm was added for.
+if [[ "$(sed 's/\\$//' "$SRC" | tr -d '[:space:]')" == *'println!("Freenetversion:{}({}{})",'* ]]; then
+    echo "ok   - source pin: --version still prints 'Freenet version: X (sha)' (field 3 is the version)"
+else
+    echo "FAIL - source pin: freenet.rs no longer prints 'Freenet version: {} ({}{})'." >&2
+    echo "       cmd_preflight takes the shipping version from field 3 of that line and uses it" >&2
+    echo "       to pick which decision to assert. A different shape makes the direction" >&2
+    echo "       'unknown', which skips the decision check AND the exit-42 check -- Gate A" >&2
+    echo "       silently returns to its pre-decision-check strength, green. cmd_selfupdate's" >&2
+    echo "       final version comparison reads the same field. Update BOTH awk splits, or the" >&2
+    echo "       gate is weaker than it looks." >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 # --- the (marker text, first release that shipped it) PAIR ------------------
 # Gate B's version gate is pinned in both directions (the behavioural cases on


### PR DESCRIPTION
## Problem

Gate A of the auto-update canary (`scripts/auto-update-canary.sh`) is the **blocking pre-publish** check: it boots the binary about to ship and asserts the auto-updater is healthy *before* `gh release edit --draft=false` publishes the release. It exists because 0.2.120/0.2.121 shipped a broken auto-updater and stranded a large cohort of the network permanently.

**Gate A could not distinguish which decision the updater reached.** `assert_detection_healthy` runs seven checks and not one of them looks at the decision:

- `node_check_settled` is satisfied by a completion line **or a trigger**, so a node that decides to UPDATE counts as settled;
- the positive-equality check validates the version the node compared *against*, not what it did with it;
- the #4073 "locally blocked" refusal reaches the completion line like every other non-triggering outcome, so it reads as an ordinary healthy ending;
- `cmd_preflight` reads `NODE_EXIT` only to test for 43 (already-running). The `!= 42` assertion lives in `cmd_selfupdate` — Gate B, which is post-publish and runs the *previous* release's binary, one release too late.

So a shipping binary with an inverted comparison passes Gate A green and ships. That is not a quiet no-op. `latest < current` is TRUE for a Gate A run, so an inverted `compare_versions_for_startup` returns the OLDER release, the node requests a self-**downgrade** to it and exits 42, and the supervisor repeats that on every restart. `docs/RELEASING.md` has documented this hole as open since #5236 ("Gate A reports green on it, because a trigger is one of the outcomes it accepts … It has not been added").

## Approach

During Gate A the shipping binary's own release is still a **draft**, so the correct behaviour is known: find nothing newer, decline, log completion. Assert that positively instead of merely "did not complain".

- **`assert_gate_a_decision <log-dir> <expected-decision>`** — new, and **pure** like its neighbour (log dir and a decision word in, verdict out), so it stays unit-testable against fixtures. Exit 0/1 only; it runs after `assert_detection_healthy` has returned 0, so the check is already known to have started, parsed and settled — a wrong decision is not something a re-run fixes.
- **`node_refused_locally_gated`** — a named predicate so the decision has something to test.
- **`NODE_EXIT != 42` in `cmd_preflight`**, not in the pure function, because it is caller state. It is a *second, independent* observer: the log check reads a phrase this repo chooses, exit 42 is the supervisor contract itself.

### exit 42 is overloaded, so the second observer needs corroboration

`FATAL_LISTENER_EXIT_CODE` is **also 42** (`crates/core/src/node/p2p_impl.rs:48`). Both of its producers are enabled unconditionally in the real binary (`freenet.rs:322`, `:343`), and the distinct `FAST_CRASH_EXIT_CODE = 45` is opted into only via `SYSTEMD_FAST_CRASH_ENV_VAR`, which the canary does not export — so that path returns 42 at every uptime, including the ~40 s a canary run occupies. A healthy binary that declines the update and then loses its network event listener (CI-runner transport error) or poisons redb (disk EIO) would have been blocked, with the operator sent to `compare_versions_for_startup` — code that is fine.

The overlap is *exactly coincident with the check's value*: when the comparator is inverted the trigger line is in the log and the decision check already blocks, so exit 42 adds nothing there. Exit 42 is load-bearing **only** when there is no trigger line — and "42 with no trigger line" is precisely the fatal-abort signature. So the node's own `CRITICAL:` output decides which it was: present → **rc=2, environmental, retried**; absent → the hard block stands. Both messages name the other cause, and the block notes that a healthy run ends at 143 (the canary SIGTERMs a node still running), so reaching 42 means the node self-exited.

### The direction is conditional

An unconditional "must have declined" would be wrong whenever the binary genuinely is older than `/releases/latest`, and blocking a healthy release is how a blocking gate earns the reputation that gets it overridden. `gate_a_expected_decision` compares the shipping `--version` against the resolved latest tag and yields `decline` / `update` / `unknown`:

- `decline` (shipping ≥ latest, the normal path): must not have triggered, plus the corroborated exit-42 check.
- `update` (shipping < latest): must have triggered. Exit-42 is deliberately not mirrored — exiting 42 is correct here.
- `unknown`: both arms skipped, with a `::warning::` annotation.

**How narrow the `update` arm really is**, since the obvious framing overstates it: `cross-compile.yml` sparse-checks-out this script **at the tag it is gating** ("the script version matches the release it is gating"), so re-running an *older* release's workflow runs that tag's copy of the file, which does not contain this code at all. What remains is a hotfix branch cut on an older line and tagged after a newer release published, a re-run of a tag cut after this lands, and a manual `preflight` run. Narrow — which is a reason to keep the conditional cheap, not to drop it.

**Honest scope of the #4073 check.** It is direction-independent and free, but in the `decline` arm it is close to unreachable: the node only reaches that branch from inside `if let Some(new_version) = startup_update_check(...)`, so entering it on the normal path already requires an inverted comparator, and with a fresh HOME the pin/gate would then not match — the trigger fires and the decline arm catches it first. Two independent defects, not one. Where it earns its keep is the `update`/`unknown` arms and Gate B. It is genuinely reached where it runs: the refusal falls through to the completion line, so `assert_detection_healthy` returns 0.

**Gate B is deliberately not given the mirror**: it already asserts its own fixed direction. It only gained a #4073-naming diagnostic on its existing stayed-put failure. Message only.

## Testing

New fixture-driven cases in `scripts/auto-update-canary_test.sh`, plus a Gate A end-to-end driver sharing the Gate B stub (globals renamed to `CANARY_STUB_*`; the spec grew an optional third field so a case can supply `node.out`, a separate observation surface from the log dir):

- `gate_a_expected_decision`: both directions, the equal case, the numeric-not-lexical pair (`0.2.9` vs `0.2.10`), three undecidable inputs.
- `assert_gate_a_decision`: healthy decline passes; trigger-when-declining and the refusal fail; the update arm both ways; the refusal fails in the **update** and **unknown** arms (pinning direction-independence); the unknown arm skips loudly **and as an annotation**; both >64 KB volume cases.
- `node_exited_on_fatal_abort`: both CRITICAL markers, an ordinary SIGTERM shutdown, and a missing `node.out` (which must read as "not a fatal abort", so the hard block stands).
- `cmd_preflight` end to end: the healthy green case, the inverted-comparator block, exit 42 with an otherwise-clean log, the refusal, both older-binary cases, an unreadable version, and five exit-42 classification cases — including **a fatal abort being retried with the healthy retry passing** (rc=0 after 2 attempts), which is the case a hard block would have failed.
- Gate B: two cases reaching its stayed-put assertion for the first time.
- **Two lifecycle cases driving the REAL `run_node_until_check`** (not the stub): a fake node that writes the fatal-abort CRITICAL to *stderr* and exits 42 must be classified environmental, and one that exits 42 without it must be blocked as a self-downgrade. Until these existed, the premise the whole discriminator rests on — that the node's `eprintln!` reaches `node.out` — was asserted only by inspection. Verified non-vacuous: splitting node stderr out of `node.out` fails these while the stub-based suite reports **0 failures**.
- Source pins on `FATAL_LISTENER_EXIT_CODE == 42` (so the environmental branch cannot become an escape hatch with no legitimate input) and on the `--version` output format. **Pins on the two fatal-abort marker strings were attempted and then removed** — see below.
- Both `OK:` confirmations — the lines that let a reader of a green job tell which assertion ran — are anchored on **stdout** at the site that emits them. They were previously unasserted: the green-side cases matched text `cmd_preflight` logs from its own arm selection.
- `cmd_preflight` now selects the version line **by its `Freenet version:` marker rather than by position**, so a banner line printed ahead of it cannot shift the field read and silently send the gate down the `unknown` arm. Pinned by a case that supplies a two-line `--version`.

All suites green, `shellcheck -x` clean, no Rust touched.

### Mutations run

Each is applied by an exact-string replacement that **refuses unless the pattern occurs exactly once** (an unapplied mutation is a false pass), the suite is run, and the tree restored from git. **28 mutations, 28 killed, 0 survivors on the final tree**, plus Rust-source mutations covering ten distinct attack shapes against the pins.

| # | Mutation | Result |
|---|---|---|
| M1 | `cmd_preflight` stops calling `assert_gate_a_decision` | RED — 3 |
| M2 | delete the #4073 refusal check | RED — 4 |
| M3 | invert the `decline` arm | RED — 13 |
| M4 | delete the `NODE_EXIT != 42` assertion | RED — 6 |
| M5 | invert `gate_a_expected_decision` | RED — 16 |
| M6 | always answer `unknown` | RED — 16 |
| M7 | delete the `update` arm's assertion | RED — 1 |
| M8 | unscope exit-42 from the `decline` arm | RED — 4 |
| M9 | silence the unknown-direction warning | RED — 3 |
| M10 | drop Gate B's #4073 diagnosis | RED — 1 |
| M11 | `node_refused_locally_gated` matches nothing | RED — 5 |
| R1 | delete the fatal-abort corroboration (hard-block everything) | RED — 3 |
| R2 | **invert** the corroboration (real fault → environmental) | RED — 6 |
| R3 | classify the abort but block anyway (rc=1 not 2) | RED — 3 |
| R4 | drop the redb marker from the predicate | RED — 2 |
| R5 | read the log dir instead of `node.out` | RED — 3 |
| R6 | hard-block message stops naming the alternative | RED — 1 |
| R7 | downgrade the unknown-arm warning to a plain note | RED — 1 |
| R8 | `warn()` loses its `::warning::` prefix | RED — 3 |
| R9 | drop the `saw_fatal_abort` latch | RED — 2 |
| **R-a** | **discriminator stuck TRUE — a real defect laundered into "environmental"** | **RED — 5** |
| OK-1 | delete the decline-arm `OK:` confirmation | RED — 1 |
| OK-2 | delete the update-arm `OK:` confirmation | RED — 1 |
| C-1 | revert the exit-42 gate to `-eq 0` (the Codex regression) | RED — 4 |
| C-2 | drop the `rc` guard entirely (parse failure misdiagnosed) | RED — 1 *(survived first attempt)* |
| C-3 | unscope the widened gate from the `decline` arm | RED — 4 |
| C-4 | drop the fatal-abort corroboration on the widened gate | RED — 4 |
| C-5 | drop the absent-trigger-line explanation | RED — 1 |

Rust-side mutations, each failing its intended pin: rewording the fatal-listener `eprintln!`; the same reword **with the old text left in a preceding comment**; `FATAL_LISTENER_EXIT_CODE` 42→44, also with a historical comment; changing the `--version` format, likewise with the old form in a comment; splitting node stderr out of `node.out`; and reverting version-line selection from marker-based to positional.

### Findings that survived a first fix

Recorded because in each case the assertion was fine and the *fixture* could not produce the fault — the class this PR kept hitting. Five instances, four of them found by mutation rather than by reading.

**The first `emitted_macro_text` had the hole it exists to close.** It dropped only whole-line comments and closed its region on a line ending in `);`, so the most natural reword — `eprintln!("FATAL: ..."); // CRITICAL: <old text>` — both kept the old text and stopped the line ending in `);`, leaving the region open. Measured: pin GREEN while the binary no longer printed the marker. Now fixed by a quote-aware stripper, a `#[cfg(test)]` cut, a string-masked left-anchored opener, and a bounded region.

**Per-line matching, because the runtime detector is line-oriented.** Squeezing all emitted lines into one blob made a `\`-continued literal indistinguishable from a raw multi-line one, so re-wrapping a marker across a line break without the continuation backslash left the pin green while `grep -aqF` in the canary could no longer match the text the running binary printed. Matching per line makes the pin agree with the detector it protects. This also correctly exposed that the `--version` needle had been spanning two source lines and only matched via the blob.

### Three earlier findings that survived a first fix

Recorded because in each case the assertion was fine and the *fixture* could not produce the fault — the class this PR kept hitting.

**R-a was caught only by message text.** Every `gate_a_case` sets `CANARY_ATTEMPTS` to its spec count, so a one-spec hard-block fixture cannot tell rc=1 (block) from rc=2 (retry-until-exhausted): both exit 1 after one attempt. The real gate defaults to `CANARY_ATTEMPTS=2`, where the same mutation returns **exit 0 and the release publishes**. Fixed by giving every hard-block case a spare attempt it must not reach and asserting the attempt count — the shape `gate_b_case "a real #5221 failure is never retried"` already had. Audited the whole file; the two new Gate B cases had the same shape and were upgraded too. The rule is now documented on `gate_a_case` itself.

**The `--version` and CRITICAL source pins were satisfiable by a comment.** Now bounded to `println!`/`eprintln!` bodies via `emitted_macro_text`, so a historical comment cannot satisfy them (AGENTS.md requires region-bounding; measured green before the fix).

**The first caller-side anchor for F2 did not work either.** Asserting cmd_preflight's unique *text* still passed when its `warn` was reverted to `note`, because `note` prints the same text. `::warning::` alone is borrowable from the pure function; the text alone survives the downgrade. The needle now spans both: `::warning::could not compare the shipping version`.

Beyond going red, a genuinely healthy Gate A run is asserted to return **0** at the pure level, end-to-end through `cmd_preflight`, on the fatal-abort retry, with a banner line ahead of the version, and in two lifecycle cases that boot a real fake-node process. For a blocking gate, proving it goes green matters as much as proving it can go red.

## The exit-42 observer had to be reachable to be true

An external (Codex) review pass found that the observer was gated on the log assertion having *passed* (`rc -eq 0`), which made it unreachable on exactly the input it exists for.

`freenet.rs` returns immediately after `update_tx.send`, so the completion line is never emitted on the trigger path. If a trigger site's wording drifts out of `MARKER_TRIGGERED_RE` — or the line is dropped — the log carries no matched trigger *and* no completion line, `node_check_settled` is false, and `assert_detection_healthy` returns 2 (INDETERMINATE). Both `rc -eq 0` gates then skipped, Gate A burned its retry budget, and it reported *"produced no verdict — GitHub unreachable, or the check never logged an outcome"* for a deterministic self-downgrade. Reproduced on both variants.

Fail-closed — Gate A still returned 1 and the release stayed a draft — so this was never a false green. What made it blocking is that three statements in the tree claimed the case *was* covered, and they were false. Rather than retract the claims, the observer now does what they say: the gate is `rc -ne 1`, so an INDETERMINATE verdict no longer disarms it while a definite fault (rc=1, which localises better) still wins. Both review-flagged hazards are preserved — it stays scoped to the `decline` arm, and it keeps the fatal-abort corroboration. The failure message also now explains why there may be no trigger line in the log, so its absence does not read as evidence against the verdict.

This also answers the sharper form of the finding: the hard-block arm previously had no reachable real input at all (a matched trigger returns 1 first, a `#4073` refusal returns 1, the 6h periodic re-poll cannot fire inside a ≤240s window), so it was reachable only from a synthetic fixture. It now has one.

Five mutations cover it, including reverting the gate to `-eq 0`. One of them, **C-2**, initially survived: `fail` appends to stderr rather than replacing, so a case asserting the parse-failure message was still *present* passed even when the observer had overwritten the verdict. `gate_a_case` grew `!`-prefixed absence assertions to close it — the same borrowed-signal shape as R7 and F2, arriving a third time.

## A removal worth explaining

An earlier revision of this PR added source pins on the two fatal-abort marker strings, scraping `p2p_impl.rs` for text inside `println!`/`eprintln!` bodies so that a reword could not silently break the exit-42 discrimination. **They were removed**, and the reason is not that they were imperfect: a line-oriented approximation of Rust lexing produced *both* failure directions.

Independent mutation review found four surviving false-pass classes (multi-line string literals plain and raw, `#[cfg(all(test, …))]`/`#[cfg(any(test, …))]`, span-cap over-emission, `/* */` blocks) and — decisively — **two ways for a correct tree to block a release**: a doc comment merely *mentioning* `#[cfg(test)]` truncated the file, and a marker split across a `\`-continuation went red while the binary printed one line that `grep -aqF` matched perfectly (confirmed by compiling and running it). The second invalidated the justification the pin was resting on.

A blocking gate that a doc comment or a line wrap can turn red trains people to override it, and a limits comment warns the next *author* while the cost falls on the release engineer standing in front of a red gate. So the pins went rather than the release-blocking risk. What that costs is an early warning on a marker reword; the canary then hard-blocks on the next environmental exit 42 with no pointer — loud and fail-closed. The trade is recorded in the file at the point where someone would be tempted to re-add them.

**#5345** is the fix that closes the class: lift each marker into a `const`, interpolate it at the emission site, assert it from a Rust `#[test]`, so the compiler rather than a tokenizer is the oracle and the canary and node share one source of truth. It carries the full findings list, the ranking of the remaining whole-file pins (`MARKER_FETCH_FAIL` is the only one whose drift produces a false *green*), and the archived review report.

## Docs

`docs/RELEASING.md` described this hole as open and is updated in the same PR — including the half that stays open (a comparator answering "nothing newer" when something newer *does* exist is invisible on the normal path), the narrowness of the `update` arm, the near-unreachability of the #4073 check on the normal path, and the `unknown` arm being the one input that returns Gate A to its pre-#5340 strength while still reporting green.

One blind spot noted in the code but deliberately not built for: a *dropped* trigger log line makes the `decline` arm pass (false green, caught by the exit-42 observer) and the `update` arm fail (false block, not caught). Latent — the harness sets `FREENET_DISABLE_LOG_RATE_LIMIT=1` for exactly this class, and Gate B depends on the same line anyway.

[AI-assisted - Claude]
