### PR TITLE
fix(release): drop the crates.io token probe that blocked every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,23 +52,62 @@ jobs:
       # The crates.io credential is checked HERE, in the first job, because the
       # publish that needs it now runs at the very END of the pipeline -- after
       # the bump PR, the tag, ~30 minutes of cross-compilation and macOS
-      # notarization, and Gate A. Discovering a missing or dead token at that
-      # point costs the whole run and a tag, which is F3's shape reappearing one
-      # step further down. Fail before anything has been created.
+      # notarization, and Gate A. Discovering a missing token at that point
+      # costs the whole run and a tag, which is F3's shape reappearing one step
+      # further down. Fail before anything has been created.
       #
-      # Precedent: cross-compile.yml's `verify-signing-key` job, which likewise
-      # proves a release credential works before a release depends on it.
+      # PRESENCE ONLY. Deliberately no live-validity probe -- do NOT add one.
       #
-      # Two distinct outcomes, deliberately not collapsed:
-      #   missing        -> ERROR. Deterministic, and the release cannot finish.
-      #   present, 401/403 -> ERROR. A dead or wrong-scope token; equally fatal
-      #                     and equally actionable, and a real check rather than
-      #                     mere presence.
-      #   unreachable    -> WARNING only. crates.io being down is infrastructure,
-      #                     and failing a release on it would be a failure that
-      #                     is not a bug -- the same reasoning the canary uses
-      #                     for INDETERMINATE.
-      # The token is never echoed; only the HTTP status is.
+      # #5342 added exactly that: a probe of `https://crates.io/api/v1/me` with
+      # the token in an `Authorization` header, treating 401/403 as "expired,
+      # revoked, or lacks publish scope" and exiting 1. It fired unconditionally
+      # and blocked EVERY release, including the 0.2.128 cut, because
+      # `/api/v1/me` is a session-COOKIE endpoint that never accepts API tokens
+      # at all. Measured directly against crates.io:
+      #
+      #   /api/v1/me  with a VALID token   -> HTTP 403
+      #   /api/v1/me  with NO auth header  -> HTTP 403
+      #   body: {"errors":[{"detail":"this action can only be performed on the
+      #          crates.io website"}]}
+      #
+      # So the probe could not distinguish a good token from a bad one from no
+      # token at all: a gate no input could turn green.
+      #
+      # And there is no replacement endpoint. Every read endpoint on the API was
+      # measured with a valid token ("good") and an invalid one ("bad"):
+      #
+      #   /api/v1/me                     good=403 bad=403
+      #   /api/v1/me/updates             good=403 bad=403
+      #   /api/v1/me/tokens              good=403 bad=403
+      #   /api/v1/tokens                 good=404 bad=404
+      #   /api/v1/me/crates              good=404 bad=404
+      #   /api/v1/crates/freenet/owners  good=200 bad=200   <- PUBLIC endpoint
+      #   /api/private/session           good=405 bad=405
+      #
+      # NONE discriminates. In particular do not "fix" this by switching to
+      # `/api/v1/crates/<crate>/owners`: it answers 200 for an invalid token and
+      # for no auth, which is the same defect inverted -- a gate no input can
+      # turn RED, which is worse, because it reports success it never checked.
+      #
+      # What that costs us, stated plainly: a token that is PRESENT but expired
+      # or wrong-scope is no longer detected here. It surfaces at the publish
+      # step, which under the #5342 ordering is after Gate A and after the full
+      # build -- expensive, and exactly the cost the probe was meant to avoid.
+      # That is a real loss. It is strictly better than a gate that blocks every
+      # release, and until crates.io exposes a token-authenticated read endpoint
+      # there is no third option. `cargo publish` itself is the only operation
+      # that validates the credential, and it is not idempotent, so it cannot be
+      # run as a probe.
+      #
+      # The remaining check is still worth its place: a missing secret is the
+      # common real failure (an unset or rotated-away repo secret), it is
+      # deterministic, and it costs nothing to catch here.
+      #
+      # Sibling, same shape, already correct: cross-compile.yml's "Check the
+      # crates.io credential is present" is presence-only for these reasons.
+      #
+      # Pinned by scripts/release_canary_wiring_test.sh (assertion 2b-quater),
+      # which fails if a validity probe is re-added or the refusal is removed.
       - name: Verify the crates.io token before anything is created
         if: ${{ !inputs.dry_run }}
         env:
@@ -79,25 +118,7 @@ jobs:
             echo "::error title=CARGO_REGISTRY_TOKEN not set::The crates.io publish runs at the END of the release (in cross-compile.yml, after Gate A), so without this secret the release would fail after the tag, the binaries and ~30 minutes of cross-compilation. Set the CARGO_REGISTRY_TOKEN repo secret and re-run. See AGENTS.md and docs/RELEASING.md."
             exit 1
           fi
-          # `/api/v1/me` is read-only and is the cheapest thing that actually
-          # exercises the credential rather than its presence.
-          STATUS="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-            --retry 2 --retry-all-errors \
-            -H "Authorization: $CARGO_REGISTRY_TOKEN" \
-            -A 'freenet-release-ci' \
-            'https://crates.io/api/v1/me' || echo '000')"
-          case "$STATUS" in
-            200)
-              echo "✅ CARGO_REGISTRY_TOKEN is present and accepted by crates.io."
-              ;;
-            401|403)
-              echo "::error title=CARGO_REGISTRY_TOKEN rejected::crates.io answered HTTP $STATUS for this token. It is expired, revoked, or lacks publish scope. The release would fail at the publish step, after the tag and the full build. Rotate the secret and re-run."
-              exit 1
-              ;;
-            *)
-              echo "::warning title=Could not verify CARGO_REGISTRY_TOKEN::crates.io returned HTTP $STATUS, so the token could not be checked. This is NOT evidence that it is bad -- proceeding. If the publish later fails on authentication, this is why."
-              ;;
-          esac
+          echo "✅ CARGO_REGISTRY_TOKEN is present. Its live validity is NOT checked here; see the comment above this step for why crates.io offers no endpoint that could."
 
       - name: Resolve + validate version
         id: validate

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -804,8 +804,31 @@ else
         # Scoped to this STEP, never to the job: the `validate` job legitimately
         # curls crates.io elsewhere (the auto-bump reads the latest published
         # version), so a job-wide scan would fail on a correct tree.
-        CRED_PROBE="$(printf '%s\n' "$CRED_CODE" \
-            | grep -nE 'curl|wget|https?://|api/v1|/api/')"
+        #
+        # TWO needle sets against two different texts, because they have
+        # different false-positive profiles.
+        #
+        # The URL-ish needles are applied to a copy with `echo` lines elided.
+        # The step's operator message already says "Set the CARGO_REGISTRY_TOKEN
+        # repo secret", and adding a docs link to it is a plausible, correct
+        # edit -- which against the raw body produced `FAIL ... probes the
+        # network` quoting an `echo`. A pin that makes a false accusation on a
+        # correct edit is the one that gets deleted rather than fixed, which is
+        # the same reasoning that drops comment lines above.
+        #
+        # `curl`/`wget`/`cargo` stay matched on the RAW text, so `echo $(curl
+        # ...)` is still caught: eliding echo lines for those would open the
+        # hole the elision is meant to avoid opening.
+        #
+        # `cargo` is in the set because a probe need not spell a URL at all:
+        # `cargo owner --list freenet` has no curl, no wget and no `api/v1`, and
+        # since `owners` is public it exits 0 for a bogus token, so the executed
+        # half below passes too -- a gate nothing can turn red, re-entering
+        # through a gap in the needles. The step invokes no cargo, so this costs
+        # nothing.
+        CRED_NOECHO="$(printf '%s\n' "$CRED_CODE" | sed 's/^[[:space:]]*echo .*//')"
+        CRED_PROBE="$( { printf '%s\n' "$CRED_NOECHO" | grep -nE 'https?://|api/v1|/api/'
+                         printf '%s\n' "$CRED_CODE"   | grep -nE 'curl|wget|\bcargo\b'; } | sort -u)"
         if [[ -n "$CRED_PROBE" ]]; then
             fail "release.yml's crates.io credential step probes the network" \
                 "$CRED_PROBE" \
@@ -830,11 +853,24 @@ else
             # that matters in production; the fully-unset case is what `set -u`
             # would abort on if the `${VAR:-}` guard were dropped, and that is
             # a real regression with a different cause.
-            CRED_EMPTY_OUT="$(CARGO_REGISTRY_TOKEN='' bash -c "$CRED_RUN" 2>&1)"
+            #
+            # `-e` IS LOAD-BEARING, and its absence was this pin's own instance
+            # of the defect the PR fixes. A step with no `shell:` key runs under
+            # Actions as `bash -e {0}`: `-e` comes from the INVOCATION, and the
+            # body only sets `-uo pipefail`. A plain `bash -c` therefore runs the
+            # step under weaker options than production, so any unguarded
+            # non-zero command -- `printf %s "$CARGO_REGISTRY_TOKEN" | grep -q
+            # "^cio_"` before the final echo is the demonstration -- aborts the
+            # real step and blocks every release while this suite reports all
+            # assertions passed. Measured on that mutated body with a present
+            # token: real shell rc=1, `bash -c` rc=0. Re-running the three cases
+            # below under `-e` on the correct body gives 1, 1, 0 -- identical --
+            # so matching production costs nothing and buys the whole class.
+            CRED_EMPTY_OUT="$(CARGO_REGISTRY_TOKEN='' bash -e -c "$CRED_RUN" 2>&1)"
             CRED_EMPTY_RC=$?
-            CRED_UNSET_OUT="$(env -u CARGO_REGISTRY_TOKEN bash -c "$CRED_RUN" 2>&1)"
+            CRED_UNSET_OUT="$(env -u CARGO_REGISTRY_TOKEN bash -e -c "$CRED_RUN" 2>&1)"
             CRED_UNSET_RC=$?
-            CRED_OK_OUT="$(CARGO_REGISTRY_TOKEN='cio-not-a-real-token' bash -c "$CRED_RUN" 2>&1)"
+            CRED_OK_OUT="$(CARGO_REGISTRY_TOKEN='cio-not-a-real-token' bash -e -c "$CRED_RUN" 2>&1)"
             CRED_OK_RC=$?
 
             if [[ "$CRED_EMPTY_RC" -eq 0 ]]; then

--- a/scripts/release_canary_wiring_test.sh
+++ b/scripts/release_canary_wiring_test.sh
@@ -418,7 +418,11 @@ extract_step_run() {
     # describe is the same defect waiting. See the consistency check at the
     # PC_RUN call site, which asserts the two extractors agree rather than
     # trusting that they do.
-    local job="$1" name="$2"
+    #
+    # The optional third argument is the FILE to read, defaulting to `$WF`
+    # (cross-compile.yml) so every existing call site is unchanged. 2b-quater
+    # passes release.yml, because the credential step it executes lives there.
+    local job="$1" name="$2" file="${3:-$WF}"
     awk -v jobre="^  $job:[[:space:]]*\$" -v want="      - name: $name" '
         $0 ~ jobre                       { injob = 1; next }
         injob && /^  [A-Za-z_.-]+:/      { injob = 0 }
@@ -431,7 +435,7 @@ extract_step_run() {
             sub(/^          /, "")
             print
         }
-    ' "$WF"
+    ' "$file"
 }
 
 PC_RUN="$(extract_step_run attach-to-release 'Publish crates to crates.io')"
@@ -737,6 +741,133 @@ else
                 "this deliberately does not count them."
         else
             pass "release.yml's crates.io token check is present in 'validate' and can refuse"
+        fi
+    fi
+fi
+
+# --- 2b-quater. that check is PRESENCE-ONLY, and still REFUSES ---------------
+#
+# The gap this closes is not the probe itself, it is that a BLOCKING GATE
+# SHIPPED WITH NO WAY TO EXERCISE IT. #5342 added a live-validity probe to that
+# step -- `curl` to `https://crates.io/api/v1/me` with the token in an
+# `Authorization` header, 401/403 -> `exit 1` -- and it blocked every release,
+# including the 0.2.128 cut, while 2b-ter and 2c-bis above stayed green. They
+# pin that the step EXISTS and CAN refuse; neither could see that it now
+# refused unconditionally.
+#
+# `/api/v1/me` is a session-COOKIE endpoint that never accepts API tokens.
+# Measured against the live API:
+#
+#   /api/v1/me  with a VALID token   -> HTTP 403
+#   /api/v1/me  with NO auth header  -> HTTP 403
+#   body: {"errors":[{"detail":"this action can only be performed on the
+#          crates.io website"}]}
+#
+# and no other read endpoint discriminates either -- good token vs bad token:
+# /api/v1/me 403/403, /api/v1/me/updates 403/403, /api/v1/me/tokens 403/403,
+# /api/v1/tokens 404/404, /api/v1/me/crates 404/404, /api/private/session
+# 405/405, and /api/v1/crates/freenet/owners 200/200 because it is PUBLIC.
+# That last one is the tempting "fix" and it is the same defect inverted: a
+# gate no input can turn RED, which is worse than one nothing turns green,
+# because it reports a success it never checked.
+#
+# So the invariant is BOTH halves, and they fail in opposite directions:
+#   - re-add a validity probe  -> the release is blocked unconditionally
+#   - drop the refusal         -> a missing secret is discovered at the publish,
+#                                 after the tag, the full build and Gate A.
+#
+# The no-probe half is STATIC and the refusal half is EXECUTED, deliberately.
+# Executing cannot see a re-added probe: a runner with no network gets curl's
+# `000`, which the #5342 code treated as a warning and passed. That is the
+# environment-cannot-fail shape -- an assertion that is fine while the
+# environment cannot produce the fault. Scanning is what actually discriminates
+# here, so the scan runs FIRST and the execution only happens once it has
+# established the step makes no network calls at all.
+if [[ ! -f "$RELEASE_YML" ]]; then
+    fail "release.yml not found at $RELEASE_YML"
+else
+    CRED_RUN="$(extract_step_run validate \
+        'Verify the crates.io token before anything is created' "$RELEASE_YML")"
+    if [[ -z "$CRED_RUN" || "$CRED_RUN" != *'CARGO_REGISTRY_TOKEN'* ]]; then
+        fail "could not extract release.yml's crates.io credential step's run: block" \
+            "Both halves below read and EXECUTE it, so an empty or wrong extraction" \
+            "would make all of them pass vacuously. Expected a step in the 'validate'" \
+            "job named 'Verify the crates.io token before anything is created' whose" \
+            "'run: |' body mentions CARGO_REGISTRY_TOKEN."
+    else
+        # Shell comments dropped before scanning: the step's own prose is
+        # allowed to quote the endpoints (it does, at length, so the next
+        # person does not re-add the probe), and a pin that fails on the
+        # comment explaining it is a pin that gets deleted rather than fixed.
+        # A commented-out probe is also inert, so ignoring it is correct.
+        CRED_CODE="$(printf '%s\n' "$CRED_RUN" | grep -vE '^[[:space:]]*#')"
+        # Scoped to this STEP, never to the job: the `validate` job legitimately
+        # curls crates.io elsewhere (the auto-bump reads the latest published
+        # version), so a job-wide scan would fail on a correct tree.
+        CRED_PROBE="$(printf '%s\n' "$CRED_CODE" \
+            | grep -nE 'curl|wget|https?://|api/v1|/api/')"
+        if [[ -n "$CRED_PROBE" ]]; then
+            fail "release.yml's crates.io credential step probes the network" \
+                "$CRED_PROBE" \
+                "crates.io exposes NO read endpoint that answers differently for a" \
+                "valid and an invalid API token -- see the measurements in the" \
+                "comment above, and in the step itself. A probe is therefore either" \
+                "a gate nothing turns green (#5342 blocked every release with" \
+                "/api/v1/me) or a gate nothing turns red (/crates/<name>/owners is" \
+                "public and answers 200 with no auth at all). Keep it presence-only." \
+                "The cost is accepted and documented: a present-but-dead token now" \
+                "surfaces at the publish instead."
+        else
+            pass "release.yml's crates.io credential step is presence-only (no network probe)"
+
+            # The refusal, EXECUTED. 2b-ter and 2c-bis scan the step for
+            # `exit 1`; neither shows that the exit is REACHED, or reached for
+            # the right input. Running it does, and it is safe to run precisely
+            # because the scan above established it makes no network calls.
+            #
+            # Both spellings of "missing" are exercised. Actions sets the env
+            # var to the EMPTY STRING for an unset secret, which is the case
+            # that matters in production; the fully-unset case is what `set -u`
+            # would abort on if the `${VAR:-}` guard were dropped, and that is
+            # a real regression with a different cause.
+            CRED_EMPTY_OUT="$(CARGO_REGISTRY_TOKEN='' bash -c "$CRED_RUN" 2>&1)"
+            CRED_EMPTY_RC=$?
+            CRED_UNSET_OUT="$(env -u CARGO_REGISTRY_TOKEN bash -c "$CRED_RUN" 2>&1)"
+            CRED_UNSET_RC=$?
+            CRED_OK_OUT="$(CARGO_REGISTRY_TOKEN='cio-not-a-real-token' bash -c "$CRED_RUN" 2>&1)"
+            CRED_OK_RC=$?
+
+            if [[ "$CRED_EMPTY_RC" -eq 0 ]]; then
+                fail "release.yml's credential step ACCEPTS an empty CARGO_REGISTRY_TOKEN" \
+                    "Exit status 0. Output: ${CRED_EMPTY_OUT:-(none)}" \
+                    "An unset repo secret reaches the step as the empty string, so this" \
+                    "is the common real failure. Unrefused, it is discovered at the" \
+                    "crates.io publish -- after the bump PR, the tag, ~30 minutes of" \
+                    "cross-compilation and Gate A. That cost is the whole reason the" \
+                    "check sits in the first job."
+            elif [[ "$CRED_EMPTY_OUT" != *'::error title=CARGO_REGISTRY_TOKEN not set'* ]]; then
+                fail "release.yml's credential step fails on an empty token for the WRONG reason" \
+                    "Exit status $CRED_EMPTY_RC. Output: ${CRED_EMPTY_OUT:-(none)}" \
+                    "It refused, but without the ::error:: annotation naming the missing" \
+                    "secret -- so the non-zero exit is more likely a syntax error in the" \
+                    "step than the intended refusal, and the operator gets no actionable" \
+                    "message in the Actions summary."
+            elif [[ "$CRED_UNSET_RC" -eq 0 ]]; then
+                fail "release.yml's credential step ACCEPTS a fully-unset CARGO_REGISTRY_TOKEN" \
+                    "Exit status 0. Output: ${CRED_UNSET_OUT:-(none)}" \
+                    "Same consequence as the empty case."
+            elif [[ "$CRED_OK_RC" -ne 0 ]]; then
+                fail "release.yml's credential step REFUSES a present token" \
+                    "Exit status $CRED_OK_RC. Output: ${CRED_OK_OUT:-(none)}" \
+                    "The token above is syntactically fine and merely not real, so the" \
+                    "step must accept it: this check cannot tell a live token from a" \
+                    "dead one and must not pretend to. A step that refuses a present" \
+                    "token blocks EVERY release, which is exactly what #5342 shipped." \
+                    "If this started failing after adding a validity check, the check" \
+                    "is the bug."
+            else
+                pass "release.yml's credential step refuses a missing token (empty and unset) and accepts a present one"
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
## Problem

`.github/workflows/release.yml` gained a step in #5342 (merged today), **"Verify the crates.io token before anything is created"**, in the `validate` job. It probes `https://crates.io/api/v1/me` with `CARGO_REGISTRY_TOKEN` in an `Authorization` header and treats HTTP 401/403 as "expired, revoked, or lacks publish scope", then `exit 1`.

**It fires unconditionally and blocks every release.** It blocked the 0.2.128 cut.

`/api/v1/me` is a **session-cookie endpoint that never accepts API tokens**. Its own error body says so. Measured against the live API:

```
/api/v1/me  with a VALID token   -> HTTP 403
/api/v1/me  with NO auth header  -> HTTP 403
body: {"errors":[{"detail":"this action can only be performed on the crates.io website"}]}
```

So the probe cannot distinguish a good token from a bad one from no token at all. It is a gate no input can turn green.

**And there is no replacement endpoint.** Every candidate read endpoint was measured with a valid token ("good") and an invalid one ("bad"):

| endpoint | good | bad |
|---|---|---|
| `/api/v1/me` | 403 | 403 |
| `/api/v1/me/updates` | 403 | 403 |
| `/api/v1/me/tokens` | 403 | 403 |
| `/api/v1/tokens` | 404 | 404 |
| `/api/v1/me/crates` | 404 | 404 |
| `/api/v1/crates/freenet/owners` | 200 | 200 (**public** — 200 with no auth at all) |
| `/api/private/session` | 405 | 405 |

**None discriminates.** In particular this must not be "fixed" by switching to `/api/v1/crates/<crate>/owners`: it returns 200 for an invalid token and for no auth, which is the same defect inverted — a gate no input can turn **red**, which is worse, because it reports a success it never checked.

## Approach

**Remove the live-validity probe. Keep the presence check.** The presence check (`-z "${CARGO_REGISTRY_TOKEN:-}"` → `::error::` + `exit 1`) is correct and stays: a missing or rotated-away repo secret is the common real failure, it is deterministic, and it costs nothing to catch in the first job.

The step now carries the measurements above in a comment, stating explicitly that a probe must not be re-added and why every candidate endpoint fails, so the next person does not spend the same afternoon on it.

**What this costs, stated plainly:** a token that is *present but expired or wrong-scope* is no longer detected here. It surfaces at the publish step, which under #5342's new ordering is after Gate A and after the full build — expensive, and exactly the cost the probe was meant to avoid. That is a real loss. It is strictly better than a gate that blocks every release, and until crates.io exposes a token-authenticated read endpoint there is no third option: `cargo publish` is the only operation that validates the credential, and it is not idempotent, so it cannot be run as a probe.

**Sibling check:** `grep -rn "api/v1/me" .github/ scripts/` returns two hits, both in this one step. `cross-compile.yml`'s sibling — "Check the crates.io credential is present" — was already presence-only, and its existing comment already gives this reasoning verbatim ("Presence only, no network call -- deterministic, so it cannot fail a release for a reason that is not a bug"). No change needed there.

## Testing

The real defect is not the endpoint choice. It is that **a blocking gate shipped with nothing able to exercise it.** The existing pins (`2b-ter`, `2c-bis` in `scripts/release_canary_wiring_test.sh`) assert the step *exists* and *contains* `exit 1`; both stayed green while the step refused unconditionally.

New assertion **2b-quater** pins both halves of the invariant, which fail in opposite directions:

- **no-probe — STATIC.** The step's comment-stripped `run:` body must contain no `curl`, `wget`, URL, or `api/v1`. Scoped to the *step*, never the job (the `validate` job legitimately curls crates.io for the auto-bump). Static rather than executed on purpose: a runner with no network gets curl's `000`, which #5342's code treated as a warning and passed — an assertion whose environment cannot produce the fault. Scanning is what actually discriminates here, so it runs first and gates the execution below.
- **refusal — EXECUTED.** The step's `run:` block is extracted and run. Empty token → non-zero exit carrying the `::error title=CARGO_REGISTRY_TOKEN not set` annotation; fully-unset token → non-zero (the `${VAR:-}` guard); present-but-bogus token → exit 0, which is precisely what a validity probe breaks.

`extract_step_run` gained an optional file argument so it can read `release.yml`; every existing call site is unchanged.

### Mutation testing — five mutations, all confirmed RED

| # | Mutation | Result |
|---|---|---|
| 1 | Re-add the `/api/v1/me` probe | **RED** — `FAIL - release.yml's crates.io credential step probes the network` |
| 2 | Probe `/api/v1/crates/freenet/owners` instead (the tempting wrong fix) | **RED** — same assertion |
| 3 | Replace the refusal's `exit 1` with `echo "proceeding without it"`, leaving the `::error::` line | **RED** — 2 failures, incl. the new `ACCEPTS an empty CARGO_REGISTRY_TOKEN` |
| 4 | Rename the step | **RED** — fails closed on the extraction, no vacuous pass |
| 5 | Make the refusal **unreachable** (`if false; then …`) while a literal `exit 1` stays in the step | **RED — and only by the new assertion** |
| 6 | Add an unguarded non-zero command (`printf %s "$CARGO_REGISTRY_TOKEN" \| grep -q "^cio_"`) before the final echo — blocks every release under Actions' `-e` | **RED** (was GREEN before the `bash -e -c` fix below; counterfactual measured) |
| 7 | Probe via `cargo owner --list freenet` — no curl, no wget, no URL, no `api/v1` | **RED** — `probes the network` |

And one direction that must stay **green**: adding a docs URL to the operator's `echo` message, a plausible correct edit, no longer trips the scan.

### Review round: three findings folded in

- **F1 (the important one).** The executed half used `bash -c`, but a step with no `shell:` key runs under Actions as `bash -e {0}` — `-e` comes from the *invocation*, and the step body only sets `-uo pipefail`. The pin was therefore running the step under weaker options than production, so an unguarded non-zero command would abort the real step and block every release while this suite printed all-assertions-passed. That is this PR's own defect class sitting inside the test that guards it. Now `bash -e -c`; the three existing cases give 1, 1, 0 under `-e` exactly as before, so it costs nothing. Mutation 6 is its demonstration, and the counterfactual was measured: the pre-fix pin exits 0 with zero failures on that same mutated body.
- **F2.** The no-probe scan applied its URL needles to the whole body including `echo` lines, so adding a docs link to the operator message produced `FAIL … probes the network` quoting an `echo`. A pin that makes a false accusation on a correct edit is the one that gets deleted rather than fixed. URL needles now run against a copy with `echo` lines elided; `curl`/`wget` stay on raw text so `echo $(curl …)` is still caught.
- **F3.** A probe need not spell a URL: `cargo owner --list freenet` evaded both halves, and since `owners` is public it exits 0 for a bogus token so the executed half passed too. `\bcargo\b` added to the needle set; the step invokes no cargo, so there is no false-positive cost.

Mutation 5 is the one that shows the executed half is not redundant. Under it the pre-existing scrapes still report `ok - release.yml's crates.io token check is present in 'validate' and can refuse` about a check that can no longer refuse; the executed assertion is the only thing that catches it.

Suite restored and re-run after every mutation. All nine release/canary shell suites pass on the final tree (`release_canary_wiring_test.sh`, `release_driver_test.sh`, `release_mergequeue_test.sh`, `release_state_restore_test.sh`, `release_wait_for_binaries_test.sh`, `rule_lint_shell_assertion_counter_test.sh`, `auto-update-canary_test.sh`, `auto-update-canary_lifecycle_test.sh`, `merge_group_concurrency_test.sh`), `shellcheck -x` is clean with CI's exact flag set, and `release.yml` parses as YAML.

## Scope

One logical change. #5341, #5343, #5345 and #5348 are deliberately not touched.

[AI-assisted - Claude]
