### PR TITLE
test(conformance): cover the never-settles shape found on the live network

### DIFF
--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -226,6 +226,18 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
         ),
         ConformanceProperty::StateIdempotence,
     );
+    // Associativity breaks too, which the mode's documentation claims and this
+    // asserts rather than leaving in prose. Needs three states by definition.
+    assert_violates(
+        verify_case(
+            &mut never_settles,
+            &ConformanceCase::new(
+                ConformanceProperty::StateAssociativity,
+                vec![bytes(&[1, 2]), bytes(&[2, 3]), bytes(&[5, 6])],
+            ),
+        ),
+        ConformanceProperty::StateAssociativity,
+    );
     // Commutativity still HOLDS for this arm: the rewrite is applied to a union, and
     // a union is symmetric. Asserting it keeps the mode's description honest rather
     // than leaving a reader to redo the algebra — the same self-check the

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -226,6 +226,24 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
         ),
         ConformanceProperty::StateIdempotence,
     );
+    // Commutativity still HOLDS for this arm: the rewrite is applied to a union, and
+    // a union is symmetric. Asserting it keeps the mode's description honest rather
+    // than leaving a reader to redo the algebra — the same self-check the
+    // capped-collection mode carries, and the reason review caught the doc claiming
+    // otherwise.
+    let commutativity_still_holds = verify_case(
+        &mut never_settles,
+        &ConformanceCase::new(
+            ConformanceProperty::StateCommutativity,
+            vec![bytes(&[1, 2]), bytes(&[2, 3])],
+        ),
+    );
+    assert!(
+        !commutativity_still_holds.is_violation(),
+        "this mode should break idempotence and associativity only; a commutativity \
+         finding means the arm no longer isolates what its documentation claims: \
+         {commutativity_still_holds:?}"
+    );
 
     // ---------------------------------- same code, different params, different instance
     let a = RuntimeOracle::standalone(wasm.clone(), vec![CONFORMING]).await?;

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -24,6 +24,7 @@ const MUTUAL_REJECTION: u8 = 2;
 const NON_IDEMPOTENT_DELTA: u8 = 3;
 const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
+const NEVER_SETTLES: u8 = 6;
 
 fn bytes(values: &[u8]) -> Bytes {
     Arc::from(values)
@@ -209,6 +210,22 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
             pairwise.property
         );
     }
+
+    // ------------------------------------------------ mode 6: never settles
+    //
+    // Regression cover for the worst shape found on the live network: a contract
+    // whose merge rewrote its state on every apply, so `merge(A, A)` never reached a
+    // fixpoint. Under at-least-once delivery such a contract can never converge, and
+    // it is covered here by shape rather than by committing the third-party WASM it
+    // was observed in.
+    let mut never_settles = RuntimeOracle::standalone(wasm.clone(), vec![NEVER_SETTLES]).await?;
+    assert_violates(
+        verify_case(
+            &mut never_settles,
+            &ConformanceCase::new(ConformanceProperty::StateIdempotence, vec![bytes(&[1, 2])]),
+        ),
+        ConformanceProperty::StateIdempotence,
+    );
 
     // ---------------------------------- same code, different params, different instance
     let a = RuntimeOracle::standalone(wasm.clone(), vec![CONFORMING]).await?;

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -26,6 +26,12 @@
 //!                                Commutative and idempotent; only a three-state
 //!                                case reveals it. The one mode the pairwise laws
 //!                                cannot catch.
+//!   6 NEVER_SETTLES            — merge rewrites the state in place on every apply,
+//!                                so merge(A, A) never reaches a fixpoint. Observed in
+//!                                the wild: a live contract whose states were all a
+//!                                fixed 3488 bytes and whose content changed on every
+//!                                re-apply, breaking idempotence, commutativity and
+//!                                associativity at once.
 //!
 //! State is always a canonical byte set: sorted, strictly ascending, no
 //! duplicates. `validate_state` accepts exactly that canonical form.
@@ -55,6 +61,7 @@ const MUTUAL_REJECTION: u8 = 2;
 const NON_IDEMPOTENT_DELTA: u8 = 3;
 const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
+const NEVER_SETTLES: u8 = 6;
 
 /// How many entries [`CAPPED_SET`] keeps. Small so a three-state case overflows it.
 const CAP: usize = 3;
@@ -85,6 +92,28 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
     match m {
         LAST_WRITE_WINS => incoming.to_vec(),
         MUTUAL_REJECTION => current.to_vec(),
+        // Rewrite in place on every apply: same length, different content, and no
+        // fixpoint. Deterministic, so it is not mistaken for nondeterminism — the
+        // shape seen in the wild, where a contract that keeps a derived field
+        // (a running digest, a sequence number) recomputes it on every merge.
+        //
+        // At-least-once delivery makes this fatal rather than untidy: the same state
+        // redelivered mutates the result again, so the peer never stops producing
+        // "new" state to gossip and can never agree with anyone.
+        NEVER_SETTLES => {
+            let mut out = union(current, incoming);
+            if out.is_empty() {
+                return out;
+            }
+            // Rotate the byte values within the set's own alphabet, keeping the
+            // state canonical (sorted, deduplicated) and the same length, so the
+            // change cannot be dismissed as a serialization artifact.
+            let rotated: Vec<u8> = out.iter().map(|b| b.wrapping_add(1)).collect();
+            out = rotated;
+            out.sort_unstable();
+            out.dedup();
+            out
+        }
         // Union, then evict down to CAP entries.
         //
         // This is the "cap the collection at N" rule real applications write, and

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -26,12 +26,15 @@
 //!                                Commutative and idempotent; only a three-state
 //!                                case reveals it. The one mode the pairwise laws
 //!                                cannot catch.
-//!   6 NEVER_SETTLES            — merge rewrites the state in place on every apply,
-//!                                so merge(A, A) never reaches a fixpoint. Observed in
-//!                                the wild: a live contract whose states were all a
-//!                                fixed 3488 bytes and whose content changed on every
-//!                                re-apply, breaking idempotence, commutativity and
-//!                                associativity at once.
+//!   6 NEVER_SETTLES            — merge rewrites the state on every apply, so
+//!                                merge(A, A) never reaches a fixpoint. Idempotence
+//!                                and associativity break; commutativity still HOLDS
+//!                                here, because the rewrite is applied to a union and
+//!                                a union is symmetric. Modelled on a live contract
+//!                                whose states were all a fixed 3488 bytes and whose
+//!                                content changed on every re-apply — that one broke
+//!                                commutativity too, for reasons this arm does not
+//!                                reproduce.
 //!
 //! State is always a canonical byte set: sorted, strictly ascending, no
 //! duplicates. `validate_state` accepts exactly that canonical form.
@@ -100,6 +103,13 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
         // At-least-once delivery makes this fatal rather than untidy: the same state
         // redelivered mutates the result again, so the peer never stops producing
         // "new" state to gossip and can never agree with anyone.
+        //
+        // Adding one is a bijection on the byte alphabet, so the rotation can never
+        // collapse two entries into one and the state never settles — EXCEPT for the
+        // two sets that are invariant under a 256-cycle: the empty set (returned
+        // early below) and the full 0..=255 alphabet. Neither is reachable from the
+        // small states this fixture is driven with, but anyone reusing this arm with
+        // a generated corpus should know the second one exists.
         NEVER_SETTLES => {
             let mut out = union(current, incoming);
             if out.is_empty() {


### PR DESCRIPTION
## Problem

RFC #5320's offline-validation phase requires every shape found against a real contract to become a permanent regression case. Replaying the merged verifier against a corpus captured from the live network (21 contracts across two peers) surfaced four violating contracts. Three of their shapes were already covered by fixture modes — last-write-wins, mutual rejection, capped collection. The fourth was not, and it is the worst of them.

## Approach

A merge that rewrites its state on every apply, so `merge(A, A)` never reaches a fixpoint. Under at-least-once delivery such a contract can never converge: each redelivery of the same state mutates the result again, so the peer keeps producing "new" state to gossip and cannot agree with anyone, however healthy the network is. The live instance broke idempotence, commutativity and associativity together, with every state a fixed 3488 bytes and different content on each re-apply.

Covered by **shape** rather than by committing the third-party WASM it was observed in. Replaying the original would mean vendoring someone else's compiled application into this repo, and the regression value is in the detector continuing to catch the shape, not in re-running that particular contract. The captured corpus stays outside the tree for re-verification.

The mode is deliberately deterministic, so it cannot be mistaken for nondeterminism and escalated to `UpdateDeterminism`, and it keeps the state canonical and the same length, so a finding against it cannot be dismissed as a serialization artifact.

## Testing

Wired into `verifier_matches_real_wasm_for_every_planted_defect`, which drives it through real wasmtime and asserts a `StateIdempotence` violation. `cargo test`, `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check` clean.

Part of #5320.

[AI-assisted - Claude]
