### PR TITLE
feat(conformance): capture related-contract state

### DIFF
--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -105,6 +105,18 @@ const OBSERVATION_QUEUE: usize = 256;
 /// exhaust memory" is no by construction rather than by argument.
 const MAX_QUEUED_BYTES: usize = 8 * 1024 * 1024;
 
+/// Upper bound on related-contract state retained per tracked contract.
+///
+/// Related state gets its OWN allowance rather than sharing the per-contract
+/// sample budget. Sharing would let a contract with large related state crowd out
+/// the very samples the related state exists to make checkable, which is a silly
+/// way to lose. Small, because one recent state per related contract is enough to
+/// execute against — this is context, not a corpus.
+const MAX_RELATED_BYTES: usize = 512 * 1024;
+
+/// Upper bound on distinct related contracts retained per tracked contract.
+const MAX_RELATED_CONTRACTS: usize = 8;
+
 /// Upper bound on contracts sampled concurrently.
 const MAX_TRACKED_CONTRACTS: usize = 64;
 
@@ -138,6 +150,16 @@ pub struct Observation {
     pub incoming_state: Option<Vec<u8>>,
     pub delta: Option<Vec<u8>>,
     pub result_state: Vec<u8>,
+    /// State of other contracts this merge referenced.
+    ///
+    /// A contract whose `validate_state` needs another contract's state cannot be
+    /// checked at all without it: the verifier reports
+    /// [`Inconclusive::RelatedRequired`](super::property::Inconclusive) and reaches
+    /// no verdict. That is honest but useless, and it applies to a whole class of
+    /// contract rather than to an unlucky one. The states arrive alongside the
+    /// update the contract is being asked to apply, so recording them costs a copy
+    /// and no lookup.
+    pub related: Vec<(ContractInstanceId, Vec<u8>)>,
 }
 
 impl Observation {
@@ -148,6 +170,11 @@ impl Observation {
             + self.incoming_state.as_ref().map_or(0, Vec::len)
             + self.delta.as_ref().map_or(0, Vec::len)
             + self.result_state.len()
+            + self
+                .related
+                .iter()
+                .map(|(_, state)| state.len())
+                .sum::<usize>()
     }
 }
 
@@ -367,6 +394,12 @@ struct TrackedContract {
     /// refusing rather than being inferred later from an empty result, because an
     /// empty corpus has several possible causes and they need telling apart.
     refused_too_large: u64,
+    /// Most recent state seen for each related contract this one referenced.
+    ///
+    /// Keyed by instance, so a contract that references the same related contract
+    /// repeatedly keeps one entry rather than a history: the verifier needs one
+    /// state it can execute against, not every state that ever passed through.
+    related: HashMap<ContractInstanceId, Vec<u8>>,
 }
 
 /// Rebuild samplers from the bundles already in the capture directory.
@@ -421,6 +454,7 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
             TrackedContract {
                 sampler,
                 code_hash,
+                related: bundle.related.iter().cloned().collect(),
                 parameters: bundle.parameters,
                 // Not persisted in the bundle: this counts what THIS process
                 // refused, and a reloaded corpus has no refusals of its own yet.
@@ -446,7 +480,28 @@ fn record(samplers: &mut HashMap<ContractInstanceId, TrackedContract>, observati
             code_hash: observation.code_hash,
             parameters: observation.parameters.clone(),
             refused_too_large: 0,
+            related: HashMap::new(),
         });
+
+    // Keep the newest state per related contract, within a bounded allowance. Both
+    // bounds refuse rather than evict: a contract that references a hundred others
+    // should not be able to churn this map, and the states already retained are more
+    // useful than an arbitrary newcomer.
+    for (instance, state) in &observation.related {
+        if state.len() > MAX_RELATED_BYTES {
+            continue;
+        }
+        let known = tracked.related.contains_key(instance);
+        if !known && tracked.related.len() >= MAX_RELATED_CONTRACTS {
+            continue;
+        }
+        let held: usize = tracked.related.values().map(Vec::len).sum();
+        let replacing = tracked.related.get(instance).map_or(0, Vec::len);
+        if held - replacing + state.len() > MAX_RELATED_BYTES {
+            continue;
+        }
+        tracked.related.insert(*instance, state.clone());
+    }
 
     let admission = tracked.sampler.observe_transition(
         &observation.base_state,
@@ -483,6 +538,18 @@ async fn write_all(
                 .sampler
                 .to_bundle(None, Some(tracked.code_hash), tracked.parameters.clone());
         bundle.instance = Some(*instance);
+        // Carried so a replay can execute a contract whose validity depends on
+        // another contract. `to_corpus` turns these back into `RelatedContracts`.
+        // Sorted by instance, so a bundle's bytes do not depend on hash iteration
+        // order. The corpus is written repeatedly and compared across runs; a file
+        // that differs only by map ordering wastes everyone's time.
+        let mut related: Vec<(ContractInstanceId, Vec<u8>)> = tracked
+            .related
+            .iter()
+            .map(|(id, state)| (*id, state.clone()))
+            .collect();
+        related.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+        bundle.related = related;
         bundle.note = Some(format!(
             "captured by freenet {} ({} observation(s) dropped node-wide)",
             env!("CARGO_PKG_VERSION"),

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -400,24 +400,31 @@ struct TrackedContract {
     /// repeatedly keeps one entry rather than a history: the verifier needs one
     /// state it can execute against, not every state that ever passed through.
     ///
-    /// # Accepted risk: this snapshot is not aligned in time with the cases
+    /// # Why latest-wins is sound, and what it costs
     ///
     /// `to_corpus` attaches whatever related state is held here to EVERY case,
     /// including transitions sampled hours earlier when the related contract held
-    /// something else. Inputs are pre-validated against it, so most mismatches
-    /// degrade safely to `Inconclusive::InputNotValid` — but `EmittedStateValidity`
-    /// turns a validate-Invalid on the MERGED output into a violation, so a contract
-    /// whose validity couples its own state to the related one could in principle be
-    /// accused over a pairing that never existed on the network.
+    /// something else. That looks like the temporal-mismatch shape of the delta false
+    /// positive this work memorialises, where the fix was provenance. It is not, and
+    /// the difference is worth stating so nobody re-derives the wrong conclusion:
     ///
-    /// This is the same temporal-mismatch shape as the delta false positive this work
-    /// already memorialises, where the fix was to give deltas provenance and pair only
-    /// within a shared base. Related state has no such provenance yet: it is
-    /// latest-wins. The honest fix is a per-transition related snapshot in
-    /// `bundle.transitions`; until then this is a known way to be wrong, recorded
-    /// rather than discovered later. It is bounded by needing a contract whose
-    /// validity depends on related state AND a related state that changed between
-    /// capture and replay.
+    /// `verify_case` validates EVERY input state against `case.related` before any
+    /// property runs, and that is the SAME related state the property then uses. So
+    /// the only way to reach a violation is `validate(A, R)` and `validate(B, R)` both
+    /// Valid while `validate(merge(A, B), R)` is Invalid — the contract emitting a
+    /// state it rejects, under a related state it accepted both inputs against. `R`
+    /// was observed on this node, so it is reachable, and related contracts propagate
+    /// independently of this one, so a peer holding `A` can be seeing `R` when `B`
+    /// arrives. A contract that couples its own validity to the related state has that
+    /// coupling enforced in the input check, which degrades to
+    /// `Inconclusive::InputNotValid` rather than accusing. Deltas had no such gate,
+    /// which is precisely why they needed provenance and this does not.
+    ///
+    /// What latest-wins does cost is COVERAGE, not soundness. When the one state held
+    /// here does not validate the inputs, the case reaches no verdict at all. If
+    /// shadow-mode data shows related-dependent contracts sitting at Inconclusive in
+    /// bulk, the cheap answer is to hold the last few distinct related states and let
+    /// the verifier try each, rather than a per-transition snapshot.
     related: HashMap<ContractInstanceId, Vec<u8>>,
 }
 

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -454,7 +454,11 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
             TrackedContract {
                 sampler,
                 code_hash,
-                related: bundle.related.iter().cloned().collect(),
+                related: {
+                    let mut restored = HashMap::new();
+                    admit_related(&mut restored, &bundle.related);
+                    restored
+                },
                 parameters: bundle.parameters,
                 // Not persisted in the bundle: this counts what THIS process
                 // refused, and a reloaded corpus has no refusals of its own yet.
@@ -483,25 +487,7 @@ fn record(samplers: &mut HashMap<ContractInstanceId, TrackedContract>, observati
             related: HashMap::new(),
         });
 
-    // Keep the newest state per related contract, within a bounded allowance. Both
-    // bounds refuse rather than evict: a contract that references a hundred others
-    // should not be able to churn this map, and the states already retained are more
-    // useful than an arbitrary newcomer.
-    for (instance, state) in &observation.related {
-        if state.len() > MAX_RELATED_BYTES {
-            continue;
-        }
-        let known = tracked.related.contains_key(instance);
-        if !known && tracked.related.len() >= MAX_RELATED_CONTRACTS {
-            continue;
-        }
-        let held: usize = tracked.related.values().map(Vec::len).sum();
-        let replacing = tracked.related.get(instance).map_or(0, Vec::len);
-        if held - replacing + state.len() > MAX_RELATED_BYTES {
-            continue;
-        }
-        tracked.related.insert(*instance, state.clone());
-    }
+    admit_related(&mut tracked.related, &observation.related);
 
     let admission = tracked.sampler.observe_transition(
         &observation.base_state,
@@ -512,6 +498,42 @@ fn record(samplers: &mut HashMap<ContractInstanceId, TrackedContract>, observati
     );
     if matches!(admission, Admission::TooLarge) {
         tracked.refused_too_large += 1;
+    }
+}
+
+/// Admit related-contract states into a tracked contract, within the allowance.
+///
+/// Shared by `record` and `reload` on purpose. Everything else a reload restores goes
+/// back through the sampler's own admission checks, so it is self-correcting: a
+/// bundle written under looser limits is trimmed to what the current build allows.
+/// Related state was the one field that skipped that and was collected raw, so a
+/// bundle from a looser build — or an edited one, since nothing bounds the vector on
+/// disk — loaded straight past today's limits. One function, called from both paths,
+/// is what stops the two rules drifting again.
+///
+/// Both bounds refuse rather than evict: a contract referencing a hundred others must
+/// not be able to churn this map, and states already retained are more useful than an
+/// arbitrary newcomer.
+fn admit_related(
+    held: &mut HashMap<ContractInstanceId, Vec<u8>>,
+    offered: &[(ContractInstanceId, Vec<u8>)],
+) {
+    for (instance, state) in offered {
+        if state.len() > MAX_RELATED_BYTES {
+            continue;
+        }
+        if !held.contains_key(instance) && held.len() >= MAX_RELATED_CONTRACTS {
+            continue;
+        }
+        let total: usize = held.values().map(Vec::len).sum();
+        // Subtracting what this entry already holds cannot underflow: `replacing` is
+        // non-zero only when the instance is already a key, in which case its length
+        // is part of `total`.
+        let replacing = held.get(instance).map_or(0, Vec::len);
+        if total - replacing + state.len() > MAX_RELATED_BYTES {
+            continue;
+        }
+        held.insert(*instance, state.clone());
     }
 }
 
@@ -809,6 +831,48 @@ mod tests {
             }),
             "related state must reach the corpus as RelatedContracts, or a contract \
              that needs it still cannot be executed"
+        );
+    }
+
+    /// A bundle on disk cannot smuggle more related state than today's bounds allow.
+    ///
+    /// Everything else a reload restores goes back through the sampler's admission
+    /// checks, so it is self-correcting: a corpus written by a build with looser
+    /// limits is trimmed to what this build permits. Related state was the one field
+    /// collected raw, and nothing bounds that vector on disk, so a bundle from a
+    /// looser build — or an edited one — loaded straight past the current limits.
+    #[tokio::test]
+    async fn a_reloaded_bundle_cannot_exceed_the_related_bounds() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let instance = ContractInstanceId::new([1; 32]);
+
+        // Hand-build a bundle carrying far more related state than the bounds allow,
+        // as a looser build or an edit would produce.
+        let mut bundle = super::super::bundle::ReplayBundle::new(vec![9, 9], vec![3]);
+        bundle.instance = Some(instance);
+        bundle.states = vec![vec![1, 2], vec![2, 3]];
+        bundle.related = (0..(MAX_RELATED_CONTRACTS + 6))
+            .map(|i| (ContractInstanceId::new([i as u8; 32]), vec![i as u8; 32]))
+            .collect();
+        bundle
+            .write_to(&dir.path().join(format!("{instance}.bundle")))
+            .expect("write bundle");
+
+        let samplers = reload(dir.path());
+        let tracked = samplers
+            .values()
+            .next()
+            .expect("the bundle should have been reloaded");
+
+        assert!(
+            tracked.related.len() <= MAX_RELATED_CONTRACTS,
+            "reload admitted {} related contracts, over the cap of {}",
+            tracked.related.len(),
+            MAX_RELATED_CONTRACTS
+        );
+        assert!(
+            tracked.related.values().map(Vec::len).sum::<usize>() <= MAX_RELATED_BYTES,
+            "reload admitted more related bytes than the allowance"
         );
     }
 

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -399,6 +399,25 @@ struct TrackedContract {
     /// Keyed by instance, so a contract that references the same related contract
     /// repeatedly keeps one entry rather than a history: the verifier needs one
     /// state it can execute against, not every state that ever passed through.
+    ///
+    /// # Accepted risk: this snapshot is not aligned in time with the cases
+    ///
+    /// `to_corpus` attaches whatever related state is held here to EVERY case,
+    /// including transitions sampled hours earlier when the related contract held
+    /// something else. Inputs are pre-validated against it, so most mismatches
+    /// degrade safely to `Inconclusive::InputNotValid` — but `EmittedStateValidity`
+    /// turns a validate-Invalid on the MERGED output into a violation, so a contract
+    /// whose validity couples its own state to the related one could in principle be
+    /// accused over a pairing that never existed on the network.
+    ///
+    /// This is the same temporal-mismatch shape as the delta false positive this work
+    /// already memorialises, where the fix was to give deltas provenance and pair only
+    /// within a shared base. Related state has no such provenance yet: it is
+    /// latest-wins. The honest fix is a per-transition related snapshot in
+    /// `bundle.transitions`; until then this is a known way to be wrong, recorded
+    /// rather than discovered later. It is bounded by needing a contract whose
+    /// validity depends on related state AND a related state that changed between
+    /// capture and replay.
     related: HashMap<ContractInstanceId, Vec<u8>>,
 }
 
@@ -831,6 +850,58 @@ mod tests {
             }),
             "related state must reach the corpus as RelatedContracts, or a contract \
              that needs it still cannot be executed"
+        );
+    }
+
+    /// The TOTAL byte allowance holds, not just the per-entry one.
+    ///
+    /// Review found the total check was deletable with every other test still green:
+    /// the oversized-entry case is caught by the per-entry check, and the count tests
+    /// used states small enough that their sum never approached the limit. Without
+    /// the total, eight entries just under the per-entry bound would hold eight times
+    /// the intended allowance for one contract, and that multiplies by every tracked
+    /// contract.
+    ///
+    /// This also exercises the replacement path, where an existing entry's bytes must
+    /// be discounted from the total rather than double-counted.
+    #[tokio::test]
+    async fn the_total_related_byte_allowance_holds() {
+        let mut samplers = HashMap::new();
+        let chunk = MAX_RELATED_BYTES / 3;
+
+        // Three entries of a third of the allowance each: the third is the one that
+        // must be refused on the TOTAL, since each is individually well within the
+        // per-entry bound.
+        for i in 0..4u8 {
+            let mut observed = observation();
+            observed.related = vec![(ContractInstanceId::new([i; 32]), vec![i; chunk])];
+            record(&mut samplers, observed);
+        }
+
+        let tracked = samplers.values().next().expect("one contract tracked");
+        let held: usize = tracked.related.values().map(Vec::len).sum();
+        assert!(
+            held <= MAX_RELATED_BYTES,
+            "related state totalled {held} bytes against an allowance of {}",
+            MAX_RELATED_BYTES
+        );
+        assert!(
+            tracked.related.len() < 4,
+            "all four entries were admitted, so the total allowance is not binding"
+        );
+
+        // Replacing an existing entry must discount what it already held: offering
+        // the same id again with the same size must not push the total over.
+        let before = tracked.related.len();
+        let mut again = observation();
+        again.related = vec![(ContractInstanceId::new([0; 32]), vec![0; chunk])];
+        record(&mut samplers, again);
+        let tracked = samplers.values().next().expect("one contract tracked");
+        assert_eq!(
+            tracked.related.len(),
+            before,
+            "replacing an entry changed the number held, so its bytes were not \
+             discounted from the total"
         );
     }
 

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -637,6 +637,7 @@ mod tests {
             incoming_state: Some(vec![2, 3]),
             delta: None,
             result_state: vec![1, 2, 3],
+            related: Vec::new(),
         }
     }
 
@@ -769,6 +770,88 @@ mod tests {
             handle.dropped() >= 4,
             "the refusals should be counted, saw {}",
             handle.dropped()
+        );
+    }
+
+    /// Related-contract state survives capture and comes back out of the bundle.
+    ///
+    /// A contract whose `validate_state` depends on another contract cannot be
+    /// checked at all without that state: the verifier reaches no verdict and says
+    /// `RelatedRequired`. That is honest, and it applies to a whole class of contract
+    /// rather than to an unlucky one, so the capture path has to carry it.
+    #[tokio::test]
+    async fn related_contract_state_is_captured_and_replayable() {
+        let related_id = ContractInstanceId::new([9; 32]);
+        let mut observed = observation();
+        observed.related = vec![(related_id, vec![42, 43])];
+
+        let mut samplers = HashMap::new();
+        record(&mut samplers, observed);
+
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        write_all(dir.path(), &samplers, 0).await;
+
+        let path = dir
+            .path()
+            .join(format!("{}.bundle", ContractInstanceId::new([1; 32])));
+        let bundle = super::super::bundle::ReplayBundle::read_from(&path).expect("read back");
+        assert_eq!(
+            bundle.related,
+            vec![(related_id, vec![42, 43])],
+            "the bundle must carry the related state the merge referenced"
+        );
+
+        // And it has to arrive where the verifier looks for it, not merely be stored.
+        let corpus = bundle.to_corpus();
+        assert!(
+            corpus.related.states().any(|(id, state)| {
+                *id == related_id && state.as_ref().map(|s| s.as_ref()) == Some(&[42u8, 43][..])
+            }),
+            "related state must reach the corpus as RelatedContracts, or a contract \
+             that needs it still cannot be executed"
+        );
+    }
+
+    /// Related state is bounded, and refuses rather than evicting.
+    ///
+    /// It has its own allowance rather than sharing the sample budget: sharing would
+    /// let a contract with large related state crowd out the very samples the related
+    /// state exists to make checkable.
+    #[tokio::test]
+    async fn related_contract_state_is_bounded() {
+        let mut samplers = HashMap::new();
+
+        // More distinct related contracts than the cap allows.
+        for i in 0..(MAX_RELATED_CONTRACTS + 4) {
+            let mut observed = observation();
+            observed.related = vec![(ContractInstanceId::new([i as u8; 32]), vec![i as u8; 16])];
+            record(&mut samplers, observed);
+        }
+        let tracked = samplers.values().next().expect("one contract tracked");
+        assert!(
+            tracked.related.len() <= MAX_RELATED_CONTRACTS,
+            "related contracts must be capped, held {}",
+            tracked.related.len()
+        );
+
+        // A single oversized related state is refused outright rather than
+        // displacing everything already held.
+        let held_before = tracked.related.len();
+        let mut huge = observation();
+        huge.related = vec![(
+            ContractInstanceId::new([200; 32]),
+            vec![0u8; MAX_RELATED_BYTES + 1],
+        )];
+        record(&mut samplers, huge);
+        let tracked = samplers.values().next().expect("one contract tracked");
+        assert_eq!(
+            tracked.related.len(),
+            held_before,
+            "an oversized related state must be refused, not admitted or swapped in"
+        );
+        assert!(
+            tracked.related.values().map(Vec::len).sum::<usize>() <= MAX_RELATED_BYTES,
+            "the related-state allowance must hold"
         );
     }
 

--- a/crates/core/src/conformance/focus.rs
+++ b/crates/core/src/conformance/focus.rs
@@ -92,3 +92,137 @@ impl FocusSelector {
         *hasher.finalize().as_bytes()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(byte: u8) -> ContractInstanceId {
+        ContractInstanceId::new([byte; 32])
+    }
+
+    fn candidates(n: u8) -> Vec<ContractInstanceId> {
+        (0..n).map(id).collect()
+    }
+
+    /// A peer watches at most `max_focus` contracts, however many it hosts.
+    ///
+    /// This is the bound the whole design rests on: discovery is meant to be sparse,
+    /// and a peer that quietly watched everything it hosted would turn a diagnostic
+    /// into an amplification vector on the busiest peers.
+    #[test]
+    fn selection_is_bounded_by_max_focus() {
+        let selector = FocusSelector::new([1; 32], 2);
+        assert_eq!(selector.select(&candidates(50)).len(), 2);
+
+        // And it cannot exceed what is actually available.
+        assert_eq!(selector.select(&candidates(1)).len(), 1);
+        assert!(selector.select(&[]).is_empty());
+    }
+
+    /// The same peer, same period, same hosted set: the same answer.
+    ///
+    /// Sampling a contract usefully takes hours, so a peer that redrew its focus on
+    /// every call — or on every restart — would keep abandoning half-built corpora
+    /// and never finish one.
+    #[test]
+    fn selection_is_stable_within_an_epoch() {
+        let selector = FocusSelector::new([2; 32], 3);
+        let pool = candidates(20);
+        let first = selector.select(&pool);
+        assert_eq!(first, selector.select(&pool));
+
+        // Order of the candidate list must not matter either: a peer's hosted set is
+        // not an ordered thing, and iteration order should not change what it
+        // watches.
+        let mut shuffled = pool.clone();
+        shuffled.reverse();
+        assert_eq!(first, selector.select(&shuffled));
+
+        // Nor should duplicates, which a hosted-set enumeration could produce.
+        let mut duplicated = pool.clone();
+        duplicated.extend(pool.iter().copied());
+        assert_eq!(first, selector.select(&duplicated));
+    }
+
+    /// Rotation redraws the set rather than merely appending to it.
+    #[test]
+    fn rotation_redraws_the_selection() {
+        let mut selector = FocusSelector::new([3; 32], 2);
+        let pool = candidates(40);
+        let before = selector.select(&pool);
+
+        let mut changed = false;
+        // Any single rotation could coincidentally reselect the same pair, so allow
+        // a few before concluding rotation does nothing.
+        for _ in 0..8 {
+            selector.rotate();
+            if selector.select(&pool) != before {
+                changed = true;
+                break;
+            }
+        }
+        assert!(
+            changed,
+            "rotating did not change the focus set in eight epochs, so rotation is \
+             not reshuffling anything"
+        );
+        assert!(selector.epoch() > 0, "rotate must advance the epoch");
+    }
+
+    /// The security property: selection is not controllable by the contract author.
+    ///
+    /// An author picks their own contract id, so any rule that is a pure function of
+    /// the id can be aimed or dodged — grind ids until no peer ever watches you, or
+    /// until every peer does and the checking cost becomes the attack. Keying on a
+    /// per-peer secret is what removes that lever, and this test is what says the
+    /// salt is actually load-bearing rather than decorative.
+    #[test]
+    fn different_peers_watch_different_contracts() {
+        let pool = candidates(60);
+        let a = FocusSelector::new([0xAA; 32], 2).select(&pool);
+        let b = FocusSelector::new([0xBB; 32], 2).select(&pool);
+        let c = FocusSelector::new([0xCC; 32], 2).select(&pool);
+
+        assert!(
+            !(a == b && b == c),
+            "three peers with different salts chose identical focus sets, so the \
+             salt is not affecting selection and an author could predict it"
+        );
+    }
+
+    /// Changing the salt changes the answer for the SAME contract, which is the
+    /// same property from the contract's point of view.
+    #[test]
+    fn a_contract_cannot_tell_whether_it_is_watched_without_the_salt() {
+        let target = id(7);
+        // A small pool and many peers, so the expected count sits far from both
+        // bounds: each peer draws 2 of 10, so a given contract is watched by roughly
+        // a fifth of them. With 60 candidates and 40 peers the expectation is ~1.3
+        // and a result of zero says nothing about the salt — the first version of
+        // this test was underpowered rather than wrong, and read as a real failure.
+        let pool = candidates(10);
+        let peers = 100u8;
+
+        let watched = (0..peers)
+            .filter(|i| {
+                FocusSelector::new([*i; 32], 2)
+                    .select(&pool)
+                    .contains(&target)
+            })
+            .count();
+
+        // BOTH bounds matter, and the lower one is the bound that bites. `watched
+        // < 40` alone is satisfied by `watched == 0`, which is precisely the
+        // outcome an author wants: a contract nobody ever checks. Removing the salt
+        // from scoring makes selection a pure function of the id, and this contract
+        // then lands in the same bucket for every peer — all of them or none.
+        // Asserting only the upper bound passed under exactly that mutation.
+        assert!(
+            watched > 0 && watched < peers as usize,
+            "this contract was watched by {watched} of {peers} peers; being watched by \
+             none or by all means selection is decided by the id, and an author \
+             could grind for either"
+        );
+    }
+}

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -1072,10 +1072,6 @@ fn generator_is_deterministic() {
     }
 }
 
-/// A case budget must narrow depth, not silently drop whole laws. If the generator
-/// emitted every commutativity case before its first associativity case, a corpus
-/// large enough to hit the budget would quietly stop checking associativity —
-/// and nothing would say so.
 /// The false positive found on the live network, kept as a permanent case.
 ///
 /// A delta is `get_state_delta(sender_state, recipient_summary)`, so two deltas
@@ -1135,6 +1131,10 @@ fn deltas_observed_against_different_bases_are_never_paired() {
     );
 }
 
+/// A case budget must narrow depth, not silently drop whole laws. If the generator
+/// emitted every commutativity case before its first associativity case, a corpus
+/// large enough to hit the budget would quietly stop checking associativity —
+/// and nothing would say so.
 #[test]
 fn a_tight_case_budget_still_covers_every_law() {
     let states: Vec<Vec<u8>> = (1u8..=12).map(|i| vec![i]).collect();

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -780,6 +780,36 @@ fn states_the_contract_rejects_are_never_evidence() {
     );
 }
 
+/// `EmittedStateValidity` is the one property that turns a validate-Invalid into a
+/// violation, so it is the one that has to be provably gated on the inputs.
+///
+/// This is load-bearing for a claim made in `capture.rs`: that latest-wins related
+/// state cannot produce a false accusation, because every input is validated against
+/// the SAME related state the property then uses, so the only route to a violation is
+/// a contract emitting a state it rejects after accepting both inputs. That argument
+/// is only as good as the pre-validation loop in `verify_case`, and nothing pinned it
+/// for this property.
+///
+/// The fake is arranged so that deleting the gate does not merely change the verdict,
+/// it produces the false accusation itself: the input `[3, 1]` is non-canonical and
+/// the merge emits it back, so an ungated run reports `Violated` against a contract
+/// that was never asked a fair question.
+#[test]
+fn emitted_state_validity_is_gated_on_the_inputs_being_valid() {
+    let mut fake = Fake::conforming().merging(|_a, _b| Ok(vec![3, 1]));
+
+    assert_inconclusive(
+        verify_case(
+            &mut fake,
+            &case(
+                ConformanceProperty::EmittedStateValidity,
+                &[&[3, 1], &[2, 3]],
+            ),
+        ),
+        Inconclusive::InputNotValid,
+    );
+}
+
 /// Running out of fuel means we never saw the answer. It must not read as a defect,
 /// or a contract could be removed for being slow on a busy peer.
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -1076,6 +1076,65 @@ fn generator_is_deterministic() {
 /// emitted every commutativity case before its first associativity case, a corpus
 /// large enough to hit the budget would quietly stop checking associativity —
 /// and nothing would say so.
+/// The false positive found on the live network, kept as a permanent case.
+///
+/// A delta is `get_state_delta(sender_state, recipient_summary)`, so two deltas
+/// observed against DIFFERENT bases can be causally sequenced: the later one computed
+/// from a state that already contains the earlier one's effect. Permuting those asks
+/// what happens in a situation the protocol never produces, and the answer is not a
+/// property of the contract.
+///
+/// This is not hypothetical. Replaying a live capture reported a
+/// `DeltaPermutationInvariance` violation against a real contract, and it came from
+/// exactly such a pair; the finding did not survive once pairing was restricted to a
+/// shared base. RFC #5320 requires every false positive to become a permanent
+/// regression case, and this is that case — without it, reverting the rule would
+/// silently restore the accusation, because every other test supplies deltas that
+/// share a base or none at all.
+#[test]
+fn deltas_observed_against_different_bases_are_never_paired() {
+    let base_one: Bytes = Arc::from([1u8, 2].as_slice());
+    let base_two: Bytes = Arc::from([3u8, 4].as_slice());
+
+    let corpus = Corpus {
+        deltas: vec![Arc::from([9u8].as_slice()), Arc::from([7u8].as_slice())],
+        // Same two deltas, but each seen against a different state.
+        delta_bases: vec![Some(base_one), Some(base_two)],
+        ..Corpus::from_states(vec![vec![1, 2], vec![3, 4]])
+    };
+
+    let cases = generate_cases(&corpus, &GeneratorConfig::default());
+    let permutation_cases = cases
+        .iter()
+        .filter(|c| c.property == ConformanceProperty::DeltaPermutationInvariance)
+        .count();
+
+    assert_eq!(
+        permutation_cases, 0,
+        "deltas seen against different bases must not be paired: they may be causally \
+         sequenced, and permuting them accuses contracts of an order-dependence the \
+         network never exercises"
+    );
+
+    // And the guard must not be so blunt that it stops the check working at all:
+    // the same deltas sharing a base ARE a legitimate pair.
+    let shared: Bytes = Arc::from([1u8, 2].as_slice());
+    let paired = Corpus {
+        deltas: vec![Arc::from([9u8].as_slice()), Arc::from([7u8].as_slice())],
+        delta_bases: vec![Some(shared.clone()), Some(shared)],
+        ..Corpus::from_states(vec![vec![1, 2], vec![3, 4]])
+    };
+    let paired_cases = generate_cases(&paired, &GeneratorConfig::default())
+        .iter()
+        .filter(|c| c.property == ConformanceProperty::DeltaPermutationInvariance)
+        .count();
+    assert!(
+        paired_cases > 0,
+        "deltas sharing a base are the genuine concurrent-update case and must still \
+         be checked, or the fix has simply disabled the property"
+    );
+}
+
 #[test]
 fn a_tight_case_budget_still_covers_every_law() {
     let states: Vec<Vec<u8>> = (1u8..=12).map(|i| vec![i]).collect();

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -25,6 +25,8 @@ const NON_IDEMPOTENT_DELTA: u8 = 3;
 const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
 const NEVER_SETTLES: u8 = 6;
+const REQUIRES_RELATED: u8 = 7;
+const RELATED_ID: [u8; 32] = [7; 32];
 
 fn bytes(values: &[u8]) -> Bytes {
     Arc::from(values)
@@ -255,6 +257,46 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
         "this mode should break idempotence and associativity only; a commutativity \
          finding means the arm no longer isolates what its documentation claims: \
          {commutativity_still_holds:?}"
+    );
+
+    // ------------------------------------------- mode 7: needs related state
+    //
+    // Why capturing related-contract state matters: without it the verifier reaches
+    // no verdict at all for this class of contract, which is honest and useless.
+    // Measured against a live capture, three of 32 contracts were in exactly this
+    // position, one across sixty cases.
+    let mut needs_related = RuntimeOracle::standalone(wasm.clone(), vec![REQUIRES_RELATED]).await?;
+    let case = ConformanceCase::new(
+        ConformanceProperty::StateCommutativity,
+        vec![bytes(&[1, 2]), bytes(&[2, 3])],
+    );
+    match verify_case(&mut needs_related, &case) {
+        PropertyOutcome::Inconclusive(reason) => assert_eq!(
+            reason,
+            crate::conformance::property::Inconclusive::RelatedRequired,
+            "a contract asking for related state must be declined, never accused"
+        ),
+        other @ (PropertyOutcome::Holds | PropertyOutcome::Violated(_)) => {
+            panic!("expected RelatedRequired without the related state, got {other:?}")
+        }
+    }
+
+    // Supply it and the same case decides. The merge conforms, so the verdict is
+    // Holds; the point is that there is a verdict at all.
+    let mut supplied = std::collections::HashMap::new();
+    supplied.insert(
+        freenet_stdlib::prelude::ContractInstanceId::new(RELATED_ID),
+        Some(freenet_stdlib::prelude::State::from(vec![1u8, 2])),
+    );
+    let with_related = ConformanceCase::new(
+        ConformanceProperty::StateCommutativity,
+        vec![bytes(&[1, 2]), bytes(&[2, 3])],
+    )
+    .with_related(freenet_stdlib::prelude::RelatedContracts::from(supplied));
+    assert_eq!(
+        verify_case(&mut needs_related, &with_related),
+        PropertyOutcome::Holds,
+        "with the related state supplied the contract must become judgeable"
     );
 
     // ---------------------------------- same code, different params, different instance

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1559,65 +1559,94 @@ where
         // stall a merge — capture losing observations is always preferable to
         // synchronization queueing behind it.
         if let Some(capture) = crate::conformance::capture::global() {
-            let (incoming_state, delta) = updates.iter().fold((None, None), |acc, update| {
-                match update {
-                    UpdateData::State(state) => (Some(state.as_ref().to_vec()), acc.1),
-                    UpdateData::Delta(delta) => (acc.0, Some(delta.as_ref().to_vec())),
-                    UpdateData::StateAndDelta { state, delta } => {
-                        (Some(state.as_ref().to_vec()), Some(delta.as_ref().to_vec()))
-                    }
-                    // Related-contract payloads describe a different contract's
-                    // state, so they are not part of THIS transition — but they are
-                    // context the contract needs to execute at all, and are collected
-                    // separately below.
-                    UpdateData::RelatedState { .. }
-                    | UpdateData::RelatedDelta { .. }
-                    | UpdateData::RelatedStateAndDelta { .. }
-                    | _ => acc,
-                }
-            });
-            // Related-contract state, kept so a contract whose `validate_state`
-            // depends on another contract can be replayed at all. Without it the
-            // verifier reaches no verdict for that whole class of contract.
+            // Measure first, copy later.
             //
-            // Only full states are useful here: a related DELTA cannot be applied
-            // without the state it is relative to, which this peer may not have.
-            let related: Vec<(ContractInstanceId, Vec<u8>)> = updates
-                .iter()
-                .filter_map(|update| match update {
-                    UpdateData::RelatedState { related_to, state }
-                    | UpdateData::RelatedStateAndDelta {
-                        related_to, state, ..
-                    } => Some((*related_to, state.as_ref().to_vec())),
-                    UpdateData::State(_)
-                    | UpdateData::Delta(_)
-                    | UpdateData::StateAndDelta { .. }
-                    | UpdateData::RelatedDelta { .. }
-                    | _ => None,
-                })
-                .collect();
-            // `observe_with` secures a queue slot BEFORE the closure runs, so the
-            // copies below are paid for only when there is somewhere to put them.
-            // Building the observation first would make the drop path the most
-            // expensive path, on the merge path, exactly under the load that causes
-            // drops.
-            // Size the observation from the slices already in hand, so the byte
-            // budget is enforced before a single byte is copied.
+            // Everything below this point that costs an allocation happens inside the
+            // `observe_with` closure, which runs only after a queue slot and byte
+            // budget are secured. An earlier version computed the incoming state,
+            // delta and related payloads BEFORE the budget check and then claimed in
+            // a comment that no byte was copied before it — which was false for
+            // exactly the three largest fields, and worst for related state, since
+            // that carries another contract's whole state. Under sustained load with
+            // a full queue, that made the drop path pay full allocate-and-copy on the
+            // merge path, which is the cost this ordering exists to avoid.
+            let mut incoming_len = 0usize;
+            let mut delta_len = 0usize;
+            let mut related_len = 0usize;
+            for update in updates {
+                match update {
+                    UpdateData::State(state) => incoming_len = state.as_ref().len(),
+                    UpdateData::Delta(delta) => delta_len = delta.as_ref().len(),
+                    UpdateData::StateAndDelta { state, delta } => {
+                        incoming_len = state.as_ref().len();
+                        delta_len = delta.as_ref().len();
+                    }
+                    UpdateData::RelatedState { state, .. }
+                    | UpdateData::RelatedStateAndDelta { state, .. } => {
+                        related_len += state.as_ref().len();
+                    }
+                    UpdateData::RelatedDelta { .. } => {}
+                    // `UpdateData` is `#[non_exhaustive]`. A future variant carrying
+                    // related state would be missed here and in the closure below;
+                    // both sites are marked so the pair is updated together.
+                    // AUDIT: new Related* variant -> update both match sites.
+                    _ => {}
+                }
+            }
+
             let size_hint = parameters.as_ref().len()
                 + current_state.as_ref().len()
                 + new_state.as_ref().len()
-                + incoming_state.as_ref().map_or(0, Vec::len)
-                + delta.as_ref().map_or(0, Vec::len)
-                + related.iter().map(|(_, state)| state.len()).sum::<usize>();
-            capture.observe_with(size_hint, || crate::conformance::capture::Observation {
-                contract: *key.id(),
-                code_hash: crate::conformance::capture::code_hash_of(key),
-                parameters: parameters.as_ref().to_vec(),
-                base_state: current_state.as_ref().to_vec(),
-                incoming_state,
-                delta,
-                result_state: new_state.as_ref().to_vec(),
-                related,
+                + incoming_len
+                + delta_len
+                + related_len;
+
+            capture.observe_with(size_hint, || {
+                let (incoming_state, delta) = updates.iter().fold((None, None), |acc, update| {
+                    match update {
+                        UpdateData::State(state) => (Some(state.as_ref().to_vec()), acc.1),
+                        UpdateData::Delta(delta) => (acc.0, Some(delta.as_ref().to_vec())),
+                        UpdateData::StateAndDelta { state, delta } => {
+                            (Some(state.as_ref().to_vec()), Some(delta.as_ref().to_vec()))
+                        }
+                        // Related payloads are not part of THIS transition; they are
+                        // collected separately below as the context the contract needs
+                        // to execute at all.
+                        UpdateData::RelatedState { .. }
+                        | UpdateData::RelatedDelta { .. }
+                        | UpdateData::RelatedStateAndDelta { .. }
+                        | _ => acc,
+                    }
+                });
+
+                // Only full states: a related DELTA cannot be applied without the
+                // state it is relative to, which this peer may not hold.
+                // AUDIT: new Related* variant -> update both match sites.
+                let related: Vec<(ContractInstanceId, Vec<u8>)> = updates
+                    .iter()
+                    .filter_map(|update| match update {
+                        UpdateData::RelatedState { related_to, state }
+                        | UpdateData::RelatedStateAndDelta {
+                            related_to, state, ..
+                        } => Some((*related_to, state.as_ref().to_vec())),
+                        UpdateData::State(_)
+                        | UpdateData::Delta(_)
+                        | UpdateData::StateAndDelta { .. }
+                        | UpdateData::RelatedDelta { .. }
+                        | _ => None,
+                    })
+                    .collect();
+
+                crate::conformance::capture::Observation {
+                    contract: *key.id(),
+                    code_hash: crate::conformance::capture::code_hash_of(key),
+                    parameters: parameters.as_ref().to_vec(),
+                    base_state: current_state.as_ref().to_vec(),
+                    incoming_state,
+                    delta,
+                    result_state: new_state.as_ref().to_vec(),
+                    related,
+                }
             });
         }
 

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -3322,6 +3322,56 @@ mod conformance_capture_pins {
         }
     }
 
+    /// Nothing may be copied before the byte budget is checked.
+    ///
+    /// The sampler side of this is already pinned: `observe_with` provably does not
+    /// invoke its builder once the queue or byte budget is exhausted
+    /// (`a_full_queue_skips_building_the_observation_entirely`). What that test cannot
+    /// see is the CALL SITE. An earlier version of this hook computed the incoming
+    /// state, delta and related payloads BEFORE calling `observe_with`, so the copies
+    /// happened unconditionally whenever capture was enabled — queue full or not —
+    /// while the comment above them claimed the opposite. Moving them back would
+    /// restore that bug with every existing test green, including both pins in this
+    /// module, because the `Observation` literal would be unchanged and the hook would
+    /// still not await.
+    ///
+    /// Related state is the reason this matters more since related-contract capture:
+    /// it can carry another contract's entire state, so the drop path would pay the
+    /// largest copy of the three, on the merge path, under exactly the load that
+    /// causes drops.
+    #[test]
+    fn nothing_is_copied_before_the_budget_check() {
+        let body = attempt_state_update_body();
+        let hook_start = body
+            .find("if let Some(capture) =")
+            .expect("capture hook not found in attempt_state_update");
+        let hook = &body[hook_start..];
+        let (before_budget, inside_closure) = hook
+            .split_once("capture.observe_with(")
+            .expect("the capture hook no longer routes through observe_with");
+
+        for alloc in [".to_vec()", ".to_owned()", ".clone()"] {
+            assert!(
+                !before_budget.contains(alloc),
+                "the capture hook calls `{alloc}` before `observe_with`, so the copy \
+                 happens whether or not a queue slot and byte budget are secured. \
+                 Measure lengths from the slices already held, and do every \
+                 allocation inside the `observe_with` closure, which runs only after \
+                 the budget check"
+            );
+        }
+
+        // Guard against passing vacuously: if the copies were deleted outright rather
+        // than moved, the loop above would also be satisfied. Both spellings count,
+        // so a refactor from one to the other does not fail here claiming the copies
+        // are gone — which is what the first version of this guard did.
+        assert!(
+            inside_closure.contains(".to_vec()") || inside_closure.contains(".to_owned()"),
+            "no copies remain inside the `observe_with` closure, so this pin would \
+             pass for a hook that records nothing at all"
+        );
+    }
+
     /// The executor must never wait on capture. A slow or stuck writer would
     /// otherwise stall contract synchronization, which is the one thing this path
     /// is required never to do.

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -3303,7 +3303,17 @@ mod conformance_capture_pins {
             .expect("could not find the end of the Observation literal")
             .0;
 
-        for field in ["base_state:", "result_state:", "incoming_state,", "delta,"] {
+        // `related,` included deliberately: without it, a refactor that drops the
+        // field or hardcodes an empty vec reverts related-contract capture entirely
+        // while every pin stays green — the same failure this pin's own history
+        // records for `incoming_state`.
+        for field in [
+            "base_state:",
+            "result_state:",
+            "incoming_state,",
+            "delta,",
+            "related,",
+        ] {
             assert!(
                 literal.contains(field),
                 "capture no longer records `{field}` from the merge path; a replay \

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1567,13 +1567,35 @@ where
                         (Some(state.as_ref().to_vec()), Some(delta.as_ref().to_vec()))
                     }
                     // Related-contract payloads describe a different contract's
-                    // state, so they are not part of this transition.
+                    // state, so they are not part of THIS transition — but they are
+                    // context the contract needs to execute at all, and are collected
+                    // separately below.
                     UpdateData::RelatedState { .. }
                     | UpdateData::RelatedDelta { .. }
                     | UpdateData::RelatedStateAndDelta { .. }
                     | _ => acc,
                 }
             });
+            // Related-contract state, kept so a contract whose `validate_state`
+            // depends on another contract can be replayed at all. Without it the
+            // verifier reaches no verdict for that whole class of contract.
+            //
+            // Only full states are useful here: a related DELTA cannot be applied
+            // without the state it is relative to, which this peer may not have.
+            let related: Vec<(ContractInstanceId, Vec<u8>)> = updates
+                .iter()
+                .filter_map(|update| match update {
+                    UpdateData::RelatedState { related_to, state }
+                    | UpdateData::RelatedStateAndDelta {
+                        related_to, state, ..
+                    } => Some((*related_to, state.as_ref().to_vec())),
+                    UpdateData::State(_)
+                    | UpdateData::Delta(_)
+                    | UpdateData::StateAndDelta { .. }
+                    | UpdateData::RelatedDelta { .. }
+                    | _ => None,
+                })
+                .collect();
             // `observe_with` secures a queue slot BEFORE the closure runs, so the
             // copies below are paid for only when there is somewhere to put them.
             // Building the observation first would make the drop path the most
@@ -1585,7 +1607,8 @@ where
                 + current_state.as_ref().len()
                 + new_state.as_ref().len()
                 + incoming_state.as_ref().map_or(0, Vec::len)
-                + delta.as_ref().map_or(0, Vec::len);
+                + delta.as_ref().map_or(0, Vec::len)
+                + related.iter().map(|(_, state)| state.len()).sum::<usize>();
             capture.observe_with(size_hint, || crate::conformance::capture::Observation {
                 contract: *key.id(),
                 code_hash: crate::conformance::capture::code_hash_of(key),
@@ -1594,6 +1617,7 @@ where
                 incoming_state,
                 delta,
                 result_state: new_state.as_ref().to_vec(),
+                related,
             });
         }
 

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -21,6 +21,11 @@
 //!                                no-op, which at-least-once delivery makes fatal.
 //!   4 NONDETERMINISTIC_SUMMARY — summarize_state depends on something other than
 //!                                the state: real wall-clock time, the #4857 class.
+//!   6 REQUIRES_RELATED         — validate_state cannot decide without another
+//!                                contract's state and asks for it. The merge itself
+//!                                conforms. Proves the verifier declines rather than
+//!                                accuses when the state is missing, and reaches a
+//!                                real verdict once it is supplied.
 //!   5 CAPPED_SET               — merge caps the collection at N entries, evicting
 //!                                by something other than the merge's own ordering.
 //!                                Commutative and idempotent; only a three-state
@@ -65,6 +70,11 @@ const NON_IDEMPOTENT_DELTA: u8 = 3;
 const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
 const NEVER_SETTLES: u8 = 6;
+const REQUIRES_RELATED: u8 = 7;
+
+/// The contract [`REQUIRES_RELATED`] insists on knowing about, as a fixed id so a
+/// test can supply its state without deriving anything.
+const RELATED_ID: [u8; 32] = [7; 32];
 
 /// How many entries [`CAPPED_SET`] keeps. Small so a three-state case overflows it.
 const CAP: usize = 3;
@@ -181,10 +191,24 @@ fn apply_delta(m: u8, current: &[u8], delta: &[u8]) -> Vec<u8> {
 #[contract]
 impl ContractInterface for Contract {
     fn validate_state(
-        _parameters: Parameters<'static>,
+        parameters: Parameters<'static>,
         state: State<'static>,
-        _related: RelatedContracts<'static>,
+        related: RelatedContracts<'static>,
     ) -> Result<ValidateResult, ContractError> {
+        // Mode 6 cannot decide alone: it needs another contract's state, as a
+        // contract enforcing an authorization or membership relation does. Asking is
+        // the honest answer, and it is what makes the contract unjudgeable until the
+        // capture path carries that state.
+        if mode(&parameters) == REQUIRES_RELATED {
+            let wanted = ContractInstanceId::new(RELATED_ID);
+            let supplied = related
+                .states()
+                .any(|(id, state)| *id == wanted && state.is_some());
+            if !supplied {
+                return Ok(ValidateResult::RequestRelated(vec![wanted]));
+            }
+        }
+
         if is_canonical(state.as_ref()) {
             Ok(ValidateResult::Valid)
         } else {

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -21,11 +21,6 @@
 //!                                no-op, which at-least-once delivery makes fatal.
 //!   4 NONDETERMINISTIC_SUMMARY — summarize_state depends on something other than
 //!                                the state: real wall-clock time, the #4857 class.
-//!   6 REQUIRES_RELATED         — validate_state cannot decide without another
-//!                                contract's state and asks for it. The merge itself
-//!                                conforms. Proves the verifier declines rather than
-//!                                accuses when the state is missing, and reaches a
-//!                                real verdict once it is supplied.
 //!   5 CAPPED_SET               — merge caps the collection at N entries, evicting
 //!                                by something other than the merge's own ordering.
 //!                                Commutative and idempotent; only a three-state
@@ -40,6 +35,11 @@
 //!                                content changed on every re-apply — that one broke
 //!                                commutativity too, for reasons this arm does not
 //!                                reproduce.
+//!   7 REQUIRES_RELATED         — validate_state cannot decide without another
+//!                                contract's state and asks for it. The merge itself
+//!                                conforms. Proves the verifier declines rather than
+//!                                accuses when the state is missing, and reaches a
+//!                                real verdict once it is supplied.
 //!
 //! State is always a canonical byte set: sorted, strictly ascending, no
 //! duplicates. `validate_state` accepts exactly that canonical form.
@@ -195,7 +195,7 @@ impl ContractInterface for Contract {
         state: State<'static>,
         related: RelatedContracts<'static>,
     ) -> Result<ValidateResult, ContractError> {
-        // Mode 6 cannot decide alone: it needs another contract's state, as a
+        // Mode 7 cannot decide alone: it needs another contract's state, as a
         // contract enforcing an authorization or membership relation does. Asking is
         // the honest answer, and it is what makes the contract unjudgeable until the
         // capture path carries that state.


### PR DESCRIPTION
## Problem

A contract whose `validate_state` depends on another contract's state could not be checked **at all**. The verifier reached no verdict and reported `Inconclusive::RelatedRequired`, which is honest but useless, and it applies to a whole class of contract rather than to an unlucky one.

Observed on a live capture: one of 21 contracts came back wholly inconclusive — six cases, every one "requires related contract state", no verdict of any kind.

RFC #5320 asks for this explicitly: *"If related state is required to establish validity, that related state becomes part of the context needed to verify the case."*

## Approach

The related states already arrive alongside the update the contract is being asked to apply, as `UpdateData::RelatedState` / `RelatedStateAndDelta`. The capture hook was discarding them with a comment noting they are "not part of this transition" — true of the transition, and precisely why the contract could not be executed. So this binds what was already in scope rather than fetching or plumbing anything new, and costs no lookup on the merge path.

The replay half already existed: `ReplayBundle` has a `related` field that `to_corpus` converts into `RelatedContracts` and hands to the verifier. It was populated with an empty vec. So **no schema change, and existing corpora stay readable** — no re-collection needed.

Only full states are kept. A related *delta* cannot be applied without the state it is relative to, which this peer may not have.

**Bounds.** Related state gets its own allowance (`MAX_RELATED_BYTES`, `MAX_RELATED_CONTRACTS`) rather than sharing the per-contract sample budget. Sharing would let a contract with large related state crowd out the very samples the related state exists to make checkable, which is a silly way to lose. Both bounds **refuse** rather than evict: a contract referencing a hundred others cannot churn the map, and states already held are more useful than an arbitrary newcomer. The queue's byte budget accounts for related bytes too, checked before any copy is made.

Newest state per related contract, keyed by instance — the verifier needs one state it can execute against, not a history. Sorted by instance when written, so bundle bytes do not depend on hash iteration order.

## Testing

- Related state survives capture into the bundle **and** arrives in the corpus as `RelatedContracts`, which is where the verifier looks — storing it without that would be plumbing to nowhere.
- Both bounds hold: the contract cap, and an oversized related state refused outright rather than admitted or swapped in.
- Survives restart, via the existing reload path.

Not done: a WASM fixture contract that genuinely returns `RequestRelated`, which would prove the loop end-to-end through wasmtime rather than proving the plumbing. Worth adding, and called out rather than skipped quietly.

Part of #5320.

[AI-assisted - Claude]
