### PR TITLE
test(delegate): pin that a delegate hop is not a privacy boundary

### DIFF
--- a/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
@@ -60,14 +60,63 @@ enum OutboundAppMessage {
 }
 
 /// Does `haystack` contain `needle` as a contiguous subsequence?
-///
-/// Used to scan RAW returned bytes rather than decoded messages, so a leak is
-/// caught regardless of how the leaking delegate happened to frame it.
 fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
     if needle.is_empty() || haystack.len() < needle.len() {
         return false;
     }
     haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Every raw byte the runtime hands back to the driving client, concatenated.
+///
+/// Two variants reach the client from a delegate hop. `contract.rs` filters only
+/// `SendDelegateMessage` from the target's output; both `ApplicationMessage` and
+/// `ContextUpdated` pass through into the client's `values`. Scanning only the
+/// first would leave the second as an unchecked channel.
+///
+/// `ContextUpdated` is ORDER-DEPENDENT, which is easy to get wrong when writing a
+/// test for it. Emitted BEFORE a terminal message it is consumed by
+/// `process_outbound` to update the delegate's own stored context
+/// (`wasm_runtime/delegate/execution.rs:393`) and never reaches the client.
+/// Emitted AFTER one it goes out through the drain path (`execution.rs:69-74`)
+/// and does reach the client. Only the second ordering is a leak, and a mutation
+/// written the first way passes while proving nothing.
+///
+/// Concatenating matters too: scanning each message separately misses a payload
+/// split across two messages, since no single one then holds the whole run.
+fn client_visible_bytes(values: &[OutboundDelegateMsg]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for m in values {
+        match m {
+            OutboundDelegateMsg::ApplicationMessage(msg) => out.extend_from_slice(&msg.payload),
+            OutboundDelegateMsg::ContextUpdated(ctx) => out.extend_from_slice(ctx.as_ref()),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Smallest run of secret bytes whose appearance counts as a leak.
+///
+/// Requiring the WHOLE secret would pass a receiver that leaked half of it, so
+/// the check is on any window of this length. The secret below is high-entropy
+/// precisely so a window this size cannot collide with unrelated bytes.
+const LEAK_WINDOW: usize = 8;
+
+/// Does any `LEAK_WINDOW`-sized run of `secret` appear in `haystack`?
+///
+/// LIMIT, stated rather than implied: this catches a secret that is leaked
+/// verbatim, whole or in part, contiguously or split across messages. It CANNOT
+/// catch one that is transformed first (hex, base64, XOR, reversed). No byte
+/// scan can. Ruling that out is the receiving delegate's own responsibility and
+/// this test does not prove it.
+fn leaks_any_window(haystack: &[u8], secret: &[u8]) -> bool {
+    if secret.len() < LEAK_WINDOW {
+        return contains_subsequence(haystack, secret);
+    }
+    secret
+        .windows(LEAK_WINDOW)
+        .any(|w| contains_subsequence(haystack, w))
 }
 
 /// E2E test for delegate-to-delegate messaging over WebSocket.
@@ -307,12 +356,8 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
                     // is reachable in the RAW bytes returned to this client. If
                     // this assertion ever fails, the observer below is blind and
                     // step 3's silence proves nothing.
-                    let leaked = values.iter().any(|m| match m {
-                        OutboundDelegateMsg::ApplicationMessage(msg) => {
-                            contains_subsequence(&msg.payload, b"inter-delegate-e2e")
-                        }
-                        _ => false,
-                    });
+                    let leaked =
+                        leaks_any_window(&client_visible_bytes(&values), b"inter-delegate-e2e");
                     assert!(
                         leaked,
                         "NEGATIVE CONTROL FAILED: an echoing receiver's payload did not reach \
@@ -334,7 +379,12 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
         // secrets to its successor, the successor stores them via `set_secret`
         // and reports a count only. Nothing carrying the payload may reach the
         // client driving the sender.
-        let secret = b"succession-secret-must-not-leak".to_vec();
+        // High-entropy on purpose: `leaks_any_window` matches on 8-byte runs, so a
+        // low-entropy or ASCII secret could collide with unrelated response bytes
+        // and fail the test for the wrong reason.
+        let secret: Vec<u8> = (0u8..32)
+            .map(|i| i.wrapping_mul(97).wrapping_add(29))
+            .collect();
         {
             let mut deposit = b"SECRET:".to_vec();
             deposit.extend_from_slice(&secret);
@@ -359,16 +409,16 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
             let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
             match resp {
                 HostResponse::DelegateResponse { values, .. } => {
-                    // THE SECURITY ASSERTION. Scan raw bytes, not decoded
-                    // messages, so a leak is caught however it was framed.
-                    for m in values.iter() {
-                        if let OutboundDelegateMsg::ApplicationMessage(msg) = m {
-                            assert!(
-                                !contains_subsequence(&msg.payload, &secret),
-                                "LEAK: deposited secret bytes reached the driving client"
-                            );
-                        }
-                    }
+                    // THE SECURITY ASSERTION. Scans the CONCATENATION of every
+                    // client-visible payload, for any 8-byte run of the secret —
+                    // so a leak that is partial, or split across two messages, or
+                    // routed through `ContextUpdated` instead, is still caught.
+                    // A transformed leak (hex, XOR, reversed) is NOT caught; see
+                    // `leaks_any_window`.
+                    assert!(
+                        !leaks_any_window(&client_visible_bytes(&values), &secret),
+                        "LEAK: deposited secret bytes reached the driving client"
+                    );
 
                     let stored = values
                         .iter()

--- a/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
@@ -29,6 +29,11 @@ enum InboundAppMessage {
     Ping {
         data: Vec<u8>,
     },
+    /// Appended in lockstep with the fixture. Variants MUST stay in the same
+    /// order in both copies: bincode encodes the discriminant positionally.
+    VerifySecret {
+        expected: Vec<u8>,
+    },
 }
 
 /// Message types matching test-delegate-messaging's OutboundAppMessage
@@ -42,6 +47,27 @@ enum OutboundAppMessage {
     PingResponse {
         data: Vec<u8>,
     },
+    /// Appended in lockstep with the fixture — see the note above.
+    SecretStored {
+        byte_count: u64,
+        sender_key_bytes: Vec<u8>,
+        origin_delegate_key_bytes: Option<Vec<u8>>,
+    },
+    SecretVerified {
+        present: bool,
+        matches: bool,
+    },
+}
+
+/// Does `haystack` contain `needle` as a contiguous subsequence?
+///
+/// Used to scan RAW returned bytes rather than decoded messages, so a leak is
+/// caught regardless of how the leaking delegate happened to frame it.
+fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
 }
 
 /// E2E test for delegate-to-delegate messaging over WebSocket.
@@ -275,10 +301,163 @@ async fn test_delegate_to_delegate_messaging_e2e() -> anyhow::Result<()> {
                         sent_msg.is_some(),
                         "Expected MessageSent from delegate A in output"
                     );
+
+                    // NEGATIVE CONTROL for step 3, and the reason step 3 means
+                    // anything. B echoed its received payload, and that payload
+                    // is reachable in the RAW bytes returned to this client. If
+                    // this assertion ever fails, the observer below is blind and
+                    // step 3's silence proves nothing.
+                    let leaked = values.iter().any(|m| match m {
+                        OutboundDelegateMsg::ApplicationMessage(msg) => {
+                            contains_subsequence(&msg.payload, b"inter-delegate-e2e")
+                        }
+                        _ => false,
+                    });
+                    assert!(
+                        leaked,
+                        "NEGATIVE CONTROL FAILED: an echoing receiver's payload did not reach \
+                         the driving client, so this harness cannot observe a leak and the \
+                         no-leak assertion in step 3 would pass vacuously"
+                    );
                 }
                 other => {
                     return Err(anyhow!(
                         "Expected DelegateResponse for send-to-delegate, got: {other:?}"
+                    ));
+                }
+            }
+        }
+
+        // Step 3: the same hop, but the receiver DEPOSITS instead of echoing.
+        //
+        // This is the shape delegate succession relies on: the predecessor pushes
+        // secrets to its successor, the successor stores them via `set_secret`
+        // and reports a count only. Nothing carrying the payload may reach the
+        // client driving the sender.
+        let secret = b"succession-secret-must-not-leak".to_vec();
+        {
+            let mut deposit = b"SECRET:".to_vec();
+            deposit.extend_from_slice(&secret);
+
+            let payload = bincode::serialize(&InboundAppMessage::SendToDelegate {
+                target_key_bytes: key_b.bytes().to_vec(),
+                target_code_hash: key_b.code_hash().as_ref().to_vec(),
+                payload: deposit,
+            })?;
+            let app_msg = ApplicationMessage::new(payload);
+
+            client
+                .send(ClientRequest::DelegateOp(
+                    freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                        key: key_a.clone(),
+                        params: params_a.clone(),
+                        inbound: vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
+                    },
+                ))
+                .await?;
+
+            let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
+            match resp {
+                HostResponse::DelegateResponse { values, .. } => {
+                    // THE SECURITY ASSERTION. Scan raw bytes, not decoded
+                    // messages, so a leak is caught however it was framed.
+                    for m in values.iter() {
+                        if let OutboundDelegateMsg::ApplicationMessage(msg) = m {
+                            assert!(
+                                !contains_subsequence(&msg.payload, &secret),
+                                "LEAK: deposited secret bytes reached the driving client"
+                            );
+                        }
+                    }
+
+                    let stored = values
+                        .iter()
+                        .filter_map(|m| match m {
+                            OutboundDelegateMsg::ApplicationMessage(msg) => {
+                                bincode::deserialize::<OutboundAppMessage>(&msg.payload).ok()
+                            }
+                            _ => None,
+                        })
+                        .find(|m| matches!(m, OutboundAppMessage::SecretStored { .. }));
+
+                    match stored {
+                        Some(OutboundAppMessage::SecretStored {
+                            byte_count,
+                            sender_key_bytes,
+                            origin_delegate_key_bytes,
+                        }) => {
+                            assert_eq!(
+                                byte_count as usize,
+                                secret.len(),
+                                "Receiver reported the wrong deposited length"
+                            );
+                            assert_eq!(
+                                sender_key_bytes,
+                                key_a.bytes(),
+                                "Deposit should be attributed to delegate A"
+                            );
+                            assert_eq!(
+                                origin_delegate_key_bytes.as_deref(),
+                                Some(key_a.bytes()),
+                                "Runtime-attested origin should be delegate A"
+                            );
+                        }
+                        _ => return Err(anyhow!("Expected SecretStored from delegate B")),
+                    }
+                }
+                other => {
+                    return Err(anyhow!(
+                        "Expected DelegateResponse for deposit, got: {other:?}"
+                    ));
+                }
+            }
+        }
+
+        // Step 4: prove the deposit actually landed.
+        //
+        // Without this, step 3 would pass for a receiver that silently discarded
+        // the payload. B compares internally and returns booleans only, so this
+        // check cannot itself become the leak it is guarding.
+        {
+            let payload = bincode::serialize(&InboundAppMessage::VerifySecret {
+                expected: secret.clone(),
+            })?;
+            let app_msg = ApplicationMessage::new(payload);
+
+            client
+                .send(ClientRequest::DelegateOp(
+                    freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                        key: key_b.clone(),
+                        params: params_b.clone(),
+                        inbound: vec![InboundDelegateMsg::ApplicationMessage(app_msg)],
+                    },
+                ))
+                .await?;
+
+            let resp = tokio::time::timeout(Duration::from_secs(30), client.recv()).await??;
+            match resp {
+                HostResponse::DelegateResponse { values, .. } => {
+                    let verified = values
+                        .iter()
+                        .filter_map(|m| match m {
+                            OutboundDelegateMsg::ApplicationMessage(msg) => {
+                                bincode::deserialize::<OutboundAppMessage>(&msg.payload).ok()
+                            }
+                            _ => None,
+                        })
+                        .find(|m| matches!(m, OutboundAppMessage::SecretVerified { .. }));
+
+                    match verified {
+                        Some(OutboundAppMessage::SecretVerified { present, matches }) => {
+                            assert!(present, "Delegate B holds no deposited secret");
+                            assert!(matches, "Delegate B's deposited secret does not match");
+                        }
+                        _ => return Err(anyhow!("Expected SecretVerified from delegate B")),
+                    }
+                }
+                other => {
+                    return Err(anyhow!(
+                        "Expected DelegateResponse for verify, got: {other:?}"
                     ));
                 }
             }

--- a/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_messaging_e2e.rs
@@ -67,33 +67,27 @@ fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.windows(needle.len()).any(|w| w == needle)
 }
 
-/// Every raw byte the runtime hands back to the driving client, concatenated.
+/// Every byte the runtime hands back to the driving client, as one buffer.
 ///
-/// Two variants reach the client from a delegate hop. `contract.rs` filters only
-/// `SendDelegateMessage` from the target's output; both `ApplicationMessage` and
-/// `ContextUpdated` pass through into the client's `values`. Scanning only the
-/// first would leave the second as an unchecked channel.
+/// Serialises the WHOLE response rather than picking out variants. That is
+/// deliberate: `contract.rs:1036-1039` filters only `SendDelegateMessage` from the
+/// target's output and forwards **everything else** — `ApplicationMessage`,
+/// `ContextUpdated`, `RequestUserInput` and all four contract-request variants,
+/// each of which carries a `context` field that could hold the payload. An
+/// earlier revision enumerated two of those seven and silently missed the rest.
+///
+/// Serialising also means a variant added to `OutboundDelegateMsg` in future is
+/// covered automatically, where a match with a `_ => {}` arm would quietly not be.
 ///
 /// `ContextUpdated` is ORDER-DEPENDENT, which is easy to get wrong when writing a
-/// test for it. Emitted BEFORE a terminal message it is consumed by
+/// mutation for it. Emitted BEFORE a terminal message it is consumed by
 /// `process_outbound` to update the delegate's own stored context
 /// (`wasm_runtime/delegate/execution.rs:393`) and never reaches the client.
 /// Emitted AFTER one it goes out through the drain path (`execution.rs:69-74`)
 /// and does reach the client. Only the second ordering is a leak, and a mutation
 /// written the first way passes while proving nothing.
-///
-/// Concatenating matters too: scanning each message separately misses a payload
-/// split across two messages, since no single one then holds the whole run.
 fn client_visible_bytes(values: &[OutboundDelegateMsg]) -> Vec<u8> {
-    let mut out = Vec::new();
-    for m in values {
-        match m {
-            OutboundDelegateMsg::ApplicationMessage(msg) => out.extend_from_slice(&msg.payload),
-            OutboundDelegateMsg::ContextUpdated(ctx) => out.extend_from_slice(ctx.as_ref()),
-            _ => {}
-        }
-    }
-    out
+    bincode::serialize(values).expect("OutboundDelegateMsg is serializable")
 }
 
 /// Smallest run of secret bytes whose appearance counts as a leak.

--- a/tests/test-delegate-messaging/src/lib.rs
+++ b/tests/test-delegate-messaging/src/lib.rs
@@ -11,6 +11,14 @@ pub enum InboundAppMessage {
     Ping {
         data: Vec<u8>,
     },
+    /// Ask this delegate whether it holds the secret deposited by a previous
+    /// `SECRET_PREFIX` delegate message, and whether it matches `expected`.
+    ///
+    /// The comparison happens INSIDE the delegate and only a boolean leaves it,
+    /// so this query cannot itself become the leak it exists to rule out.
+    VerifySecret {
+        expected: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -27,14 +35,40 @@ pub enum OutboundAppMessage {
     PingResponse {
         data: Vec<u8>,
     },
+    /// Emitted after a `SECRET_PREFIX` delegate message is stored.
+    ///
+    /// Deliberately carries NO payload bytes — only a length and the attested
+    /// sender. This is the "output discipline" a receiving delegate must
+    /// maintain: its output goes to whoever drove the SENDER, so anything it
+    /// puts here is client-visible.
+    SecretStored {
+        byte_count: u64,
+        sender_key_bytes: Vec<u8>,
+        origin_delegate_key_bytes: Option<Vec<u8>>,
+    },
+    /// Answer to `VerifySecret`. Booleans only, never the stored bytes.
+    SecretVerified {
+        present: bool,
+        matches: bool,
+    },
 }
+
+/// A delegate message whose payload begins with this prefix is treated as a
+/// secret DEPOSIT: the receiver stores the remainder via `set_secret` and
+/// reports only a byte count. Any other payload keeps the pre-existing
+/// echo-it-back behaviour, which the `..._e2e` test asserts and which is the
+/// negative control proving this harness can observe a leak at all.
+pub const SECRET_PREFIX: &[u8] = b"SECRET:";
+
+/// Where a deposited secret lands.
+pub const DEPOSITED_SECRET_KEY: &[u8] = b"deposited-secret";
 
 struct Delegate;
 
 #[delegate]
 impl DelegateInterface for Delegate {
     fn process(
-        _ctx: &mut DelegateCtx,
+        ctx: &mut DelegateCtx,
         _params: Parameters<'static>,
         origin: Option<MessageOrigin>,
         messages: InboundDelegateMsg,
@@ -80,19 +114,58 @@ impl DelegateInterface for Delegate {
                         let response = ApplicationMessage::new(response_payload).processed(true);
                         Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)])
                     }
+                    InboundAppMessage::VerifySecret { expected } => {
+                        // Compare INSIDE the delegate and emit only booleans, so
+                        // this query cannot become the leak it exists to rule out.
+                        let stored = ctx.get_secret(DEPOSITED_SECRET_KEY);
+                        let present = stored.is_some();
+                        let matches = stored.as_deref() == Some(expected.as_slice());
+                        let response_payload =
+                            bincode::serialize(&OutboundAppMessage::SecretVerified {
+                                present,
+                                matches,
+                            })
+                            .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                        let response = ApplicationMessage::new(response_payload).processed(true);
+                        Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)])
+                    }
                 }
             }
             InboundDelegateMsg::DelegateMessage(msg) => {
                 let sender_key_bytes = msg.sender.bytes().to_vec();
-                // Echo the runtime-attested origin so the test can assert that
-                // `MessageOrigin::Delegate(caller_key)` reaches the receiver
-                // (issue #3860). Match exhaustively so a future MessageOrigin
-                // variant isn't silently dropped.
-                let origin_delegate_key_bytes = match &origin {
+                // Runtime-attested caller key. Computed before either branch so
+                // the deposit path reports it too.
+                let attested_origin = match &origin {
                     Some(MessageOrigin::Delegate(k)) => Some(k.bytes().to_vec()),
                     Some(MessageOrigin::WebApp(_)) | None => None,
                     Some(_) => None,
                 };
+
+                // SECRET DEPOSIT PATH. Store the payload and report a COUNT ONLY.
+                //
+                // This is the shape a real succession receiver must use. The
+                // sibling branch below echoes the payload instead, and
+                // `run_delegate_messaging_e2e` asserts that echo reaches the
+                // driving CLIENT — so the two branches together demonstrate that
+                // privacy across a delegate hop is the receiver's own output
+                // discipline and nothing the runtime enforces.
+                if let Some(secret) = msg.payload.strip_prefix(SECRET_PREFIX) {
+                    let byte_count = secret.len() as u64;
+                    ctx.set_secret(DEPOSITED_SECRET_KEY, secret);
+                    let response_payload = bincode::serialize(&OutboundAppMessage::SecretStored {
+                        byte_count,
+                        sender_key_bytes,
+                        origin_delegate_key_bytes: attested_origin,
+                    })
+                    .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                    let response = ApplicationMessage::new(response_payload).processed(true);
+                    return Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)]);
+                }
+                // Echo the runtime-attested origin so the test can assert that
+                // `MessageOrigin::Delegate(caller_key)` reaches the receiver
+                // (issue #3860). Match exhaustively so a future MessageOrigin
+                // variant isn't silently dropped.
+                let origin_delegate_key_bytes = attested_origin;
                 let response_payload =
                     bincode::serialize(&OutboundAppMessage::DelegateMessageReceived {
                         sender_key_bytes,


### PR DESCRIPTION
## Problem

A delegate hop is not a privacy boundary, and nothing says so.

When delegate A sends a message to delegate B, the runtime runs B and then
accumulates B's output into the response returned to **whoever drove A** — a client
connection.

Note the two paths differ, and conflating them is easy. Delegate A's OWN output goes
through an exhaustive classification match (`contract.rs:671-682`) which routes
contract requests into their own handling. Delegate B's output does not: the
inter-delegate hop (`contract.rs:1036-1039`) filters ONLY `SendDelegateMessage` and
pushes **everything else through raw**, unclassified, straight into the response the
client receives. So seven of the eight variants reach the client from B, not two.

This is already asserted behaviour rather than an accident: the existing e2e checks
that a payload B received comes back to the driving client verbatim. But the natural
assumption when reading the code is the opposite — that a delegate-to-delegate hop
keeps data between the two delegates — and nothing in the tests or comments corrects
it.

That matters because carrying a user's private data across a delegate re-key depends
on a predecessor handing secrets to its successor without them transiting a client
connection. That is achievable, but **only because `set_secret` is a host function
that emits no message** — not because the hop is private. It is an obligation on the
receiving delegate, not a property of the runtime, and an implementation that gets it
wrong leaks silently.

## Approach

Add the depositing shape alongside the existing echoing one, in the **same test**, so
both are observed by the same harness in one run.

- **Step 2 (existing, plus one assertion).** B echoes its received payload. Now
  explicitly asserts a raw byte scan of the client's response **does** find it. This
  is the negative control: if it ever fails, the observer is blind.
- **Step 3 (new).** Same hop, but B stores via `set_secret` and reports a byte count
  only. Asserts no 8-byte run of the secret appears in the CONCATENATION of every
  client-visible payload, across both forwarded variants, and that the deposit
  carries A's runtime-attested key.
- **Step 4 (new).** Asks B whether it holds the secret. B compares internally and
  returns booleans only, so the check cannot become the leak it guards.

Extending the existing test rather than adding a parallel one is deliberate. A quiet
assertion in its own test proves nothing about whether the observer works; putting a
known leak and an expected non-leak in front of the same observer, in one run, is
what makes the negative result evidence.

Scanning **raw** returned bytes rather than decoded messages means a leak is caught
however the leaking delegate framed it.

**Scope of the detector, stated rather than implied.** An earlier revision matched
the whole secret, contiguously, in a single `ApplicationMessage`. Adversarial review
found three real leaks that passed it: a partial leak, a leak split across two
messages, and one routed through `ContextUpdated`, which the scan did not inspect.
It now concatenates every client-visible payload across both forwarded variants and
matches any 8-byte run. A **transformed** leak (hex, base64, XOR, reversed) is still
undetectable — no byte scan can catch that, and ruling it out is the receiving
delegate's own responsibility.

## Testing

`cargo test --test run_delegate_messaging_e2e` — 1 passed, 0 filtered, ~21s.

Both new assertions were verified to fail under mutation rather than assumed to work:

| Mutation | Expected | Result |
|---|---|---|
| Receiver echoes the whole secret into its output | step 3 fails | CONFIRMED |
| Receiver reports success but never calls `set_secret` | step 4 fails | CONFIRMED — `Delegate B holds no deposited secret` |
| Receiver leaks only 8 bytes of the secret | step 3 fails | CONFIRMED |
| Receiver splits the secret across two messages | step 3 fails | CONFIRMED |
| Receiver leaks via `ContextUpdated` after a terminal message | step 3 fails | CONFIRMED |

A sixth was run and correctly did NOT fail: `ContextUpdated` emitted *before* a
terminal message is consumed by `process_outbound` to update the delegate's own
context (`execution.rs:393`) and never reaches the client, so it is not a leak.
`ContextUpdated` only escapes via the drain path when emitted *after* a terminal
message (`execution.rs:69-74`). That ordering dependency is now documented in the
test, because a mutation written the wrong way round passes while proving nothing.

Note the two enum copies (fixture and test) were already slightly out of sync — the
fixture's `DelegateMessageReceived` carries a third field the test's does not, and it
works only because bincode tolerates trailing bytes. New variants are appended at the
**end** of both, in the same order, so existing discriminants are untouched. Not
fixing the pre-existing drift here; flagging it.

## What this does not do

No behaviour change. This pins existing runtime behaviour and documents the obligation
it places on delegate authors. It does not make the hop private, and it does not
implement secret succession.

[AI-assisted - Claude]
