### PR TITLE
feat(conformance): shadow mode — select, probe, and record what would be removed

### DIFF
--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -107,6 +107,7 @@ pub mod policy;
 pub mod property;
 pub mod runtime_oracle;
 pub mod sampler;
+pub mod shadow;
 pub mod verifier;
 
 #[cfg(test)]

--- a/crates/core/src/conformance/bundle.rs
+++ b/crates/core/src/conformance/bundle.rs
@@ -40,6 +40,12 @@ pub enum BundleError {
     #[error("bundle carries no contract code and none was supplied separately")]
     MissingCode,
     #[error(
+        "this node's contract store has no code for the bundle's contract (looked \
+         for {path}). A peer only stores contracts it hosts, so a capture replayed \
+         on a different node may need the WASM supplied directly."
+    )]
+    NotInStore { path: String },
+    #[error(
         "bundle names no contract (code_hash is absent), so the corpus cannot be \
          tied to any WASM and replaying it would check an unrelated contract"
     )]
@@ -119,6 +125,35 @@ impl ReplayBundle {
             related: Vec::new(),
             note: None,
         }
+    }
+
+    /// Resolve this bundle's code from a node's contract store.
+    ///
+    /// A bundle names its contract by hash and deliberately does not embed the WASM,
+    /// so a corpus of many contracts stays small. That makes the store lookup the
+    /// weakest link in the whole capture-and-replay loop, and it has exactly one
+    /// trap, which is why this lives here rather than being written out at each call
+    /// site: **a store file is a versioned encoding**, forty bytes of header followed
+    /// by the code, and only the code is hashed. Reading the file's bytes and hashing
+    /// them can never match, and the failure is silent, because "hash does not match"
+    /// is indistinguishable from "this node never hosted that contract".
+    /// `ContractCode::load_versioned_from_path` is the reader that gets this right.
+    pub fn resolve_code_from_store(&self, store: &Path) -> Result<Vec<u8>, BundleError> {
+        let Some(hash) = self.code_hash else {
+            return Err(BundleError::UnidentifiedContract);
+        };
+        let path = store
+            .join(freenet_stdlib::prelude::CodeHash::new(hash).encode())
+            .with_extension("wasm");
+        if !path.exists() {
+            return Err(BundleError::NotInStore {
+                path: path.display().to_string(),
+            });
+        }
+        let (code, _version) =
+            freenet_stdlib::prelude::ContractCode::load_versioned_from_path(&path)
+                .map_err(|e| BundleError::Decode(e.to_string()))?;
+        Ok(code.data().to_vec())
     }
 
     /// Return the contract code to replay this corpus against, verifying identity.

--- a/crates/core/src/conformance/bundle.rs
+++ b/crates/core/src/conformance/bundle.rs
@@ -153,7 +153,23 @@ impl ReplayBundle {
         let (code, _version) =
             freenet_stdlib::prelude::ContractCode::load_versioned_from_path(&path)
                 .map_err(|e| BundleError::Decode(e.to_string()))?;
-        Ok(code.data().to_vec())
+
+        // Hash-named is not hash-verified. The file is NAMED for the code hash, which
+        // says what the store believed when it wrote it, not what the bytes are now: a
+        // stale, truncated, hand-replaced or partially-written file still has the right
+        // name. Executing it would attribute another contract's behaviour to this one —
+        // a clean run, or worse a violation, recorded against a contract that never
+        // produced any of it. `resolve_code` holds operator-supplied code to exactly
+        // this check; there is no reason a store lookup should be trusted more.
+        let code = code.data().to_vec();
+        let actual = *blake3::hash(&code).as_bytes();
+        if actual != hash {
+            return Err(BundleError::CodeMismatch {
+                expected: hex::encode(&hash[..8]),
+                actual: hex::encode(&actual[..8]),
+            });
+        }
+        Ok(code)
     }
 
     /// Return the contract code to replay this corpus against, verifying identity.
@@ -313,5 +329,62 @@ impl ReplayBundle {
 
     pub fn read_from(path: &Path) -> Result<Self, BundleError> {
         Self::decode(&std::fs::read(path)?)
+    }
+}
+
+#[cfg(test)]
+mod store_identity_tests {
+    use super::*;
+
+    /// A store lookup must verify the bytes, not trust the filename.
+    ///
+    /// The file is NAMED for a code hash, which records what the store believed when
+    /// it wrote it, not what the bytes are now. A stale, truncated, hand-replaced or
+    /// half-written file keeps the right name. Executing it would attribute another
+    /// contract's behaviour to this one — and since shadow mode's whole output is
+    /// "this contract did or did not obey the merge laws", that is a route to
+    /// recording a violation against a contract that produced none of it.
+    ///
+    /// Built by writing real code under the WRONG hash-derived name, which is exactly
+    /// the shape a corrupted or swapped store file takes.
+    #[test]
+    fn a_store_file_whose_bytes_do_not_match_its_name_is_refused() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let real = b"the bytes actually on disk".to_vec();
+        let claimed = *blake3::hash(b"a completely different contract").as_bytes();
+
+        // Versioned encoding: the reader expects a header before the code, so go
+        // through the stdlib writer rather than inventing the layout here.
+        let code = freenet_stdlib::prelude::ContractCode::from(real);
+        let path = dir
+            .path()
+            .join(freenet_stdlib::prelude::CodeHash::new(claimed).encode())
+            .with_extension("wasm");
+        let versioned = code
+            .to_bytes_versioned(freenet_stdlib::prelude::APIVersion::Version0_0_1)
+            .expect("versioned encoding");
+        std::fs::write(&path, versioned).expect("write versioned code");
+
+        let bundle = ReplayBundle {
+            schema_version: BUNDLE_SCHEMA_VERSION,
+            code: None,
+            code_hash: Some(claimed),
+            parameters: Vec::new(),
+            instance: None,
+            states: Vec::new(),
+            deltas: Vec::new(),
+            summaries: Vec::new(),
+            transitions: Vec::new(),
+            related: Vec::new(),
+            note: None,
+        };
+
+        match bundle.resolve_code_from_store(dir.path()) {
+            Err(BundleError::CodeMismatch { .. }) => {}
+            other => panic!(
+                "a store file whose contents do not hash to its name was accepted: \
+                 {other:?}"
+            ),
+        }
     }
 }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -966,9 +966,29 @@ mod probe_wiring_pins {
         panic!("run_writer's body is not brace-balanced");
     }
 
+    /// `run_writer_body` with whole-line `//` comments removed, so a pin asserts on
+    /// CODE rather than on prose that happens to name the same thing.
+    ///
+    /// This is not hypothetical tidiness. Mutation-testing these pins caught exactly
+    /// that: the one-probe-at-a-time pin passed with the guard deleted, because the
+    /// comment a few lines above the guard quotes `in_flight.is_none()` while
+    /// explaining why it exists. The pin was matching the explanation of the thing it
+    /// was supposed to be guarding. `full_state_version_gate_pins::upsert_code_only`
+    /// in the executor solves the same problem the same way, and its reasoning applies
+    /// here too: stripping only whole-line comments can produce a false FAILURE but
+    /// never a false pass, because a real call's identifier cannot sit on a line whose
+    /// `trim_start()` begins with `//`.
+    fn run_writer_code_only() -> String {
+        run_writer_body()
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn the_probe_runs_off_the_async_runtime() {
-        let body = run_writer_body();
+        let body = run_writer_code_only();
         assert!(
             body.contains("spawn_blocking("),
             "the conformance probe no longer runs on a blocking thread. It executes \
@@ -980,7 +1000,7 @@ mod probe_wiring_pins {
 
     #[test]
     fn at_most_one_probe_runs_at_a_time() {
-        let body = run_writer_body();
+        let body = run_writer_code_only();
         assert!(
             body.contains("in_flight.is_none()"),
             "the probe tick arm is no longer guarded on there being no probe in \

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -271,7 +271,21 @@ static CONTRACT_STORE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new()
 /// caller wins, and later callers with a different path are ignored rather than
 /// racing.
 pub fn set_contract_store(path: PathBuf) {
-    let _ = CONTRACT_STORE.set(path);
+    if let Err(rejected) = CONTRACT_STORE.set(path) {
+        // First caller wins. Two callers agreeing is the normal case (several
+        // executors, one Config) and is silent; two callers DISAGREEING would send
+        // every probe to look for WASM in a directory the node does not write to, and
+        // the only symptom would be a rising `skipped_no_code` that reads as "we host
+        // nothing interesting".
+        if CONTRACT_STORE.get() != Some(&rejected) {
+            tracing::warn!(
+                registered = %CONTRACT_STORE.get().map(|p| p.display().to_string()).unwrap_or_default(),
+                rejected = %rejected.display(),
+                "conflicting contract-store paths registered for conformance; probes \
+                 will look in the first one"
+            );
+        }
+    }
 }
 
 pub(crate) fn contract_store() -> Option<&'static PathBuf> {
@@ -382,6 +396,14 @@ async fn run_writer(
         crate::conformance::policy::EnforcementMode::default(),
     );
     let mut probe = tokio::time::interval(crate::conformance::shadow::PROBE_INTERVAL);
+    // At most one probe at a time, held here so the select loop can decline to start
+    // another while one is running.
+    let mut in_flight: Option<
+        tokio::task::JoinHandle<(
+            crate::conformance::shadow::ShadowReport,
+            Vec<crate::conformance::shadow::Finding>,
+        )>,
+    > = None;
     // The first tick of a tokio interval fires immediately. Probing a sampler that
     // has just been reloaded and holds nothing useful wastes a probe and, worse,
     // reports a clean run for contracts nobody looked at yet.
@@ -408,8 +430,52 @@ async fn run_writer(
                 write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
                 since_flush = 0;
             }
-            _ = probe.tick() => {
-                let report = shadow.tick(&samplers, contract_store().map(|p| p.as_path())).await;
+            // Only start a probe when none is in flight. A probe that overran its
+            // interval must not have a second one stacked on top of it: that is how a
+            // slow contract turns a bounded background job into unbounded concurrent
+            // WASM execution.
+            _ = probe.tick(), if in_flight.is_none() => {
+                // Selection borrows the samplers and is cheap; probing owns its copies
+                // and is not. Only the cheap half runs here, so the queue keeps
+                // draining while WASM executes on another task.
+                let work = shadow.select(&samplers);
+                if work.is_empty() {
+                    // Still reported. A tick that selected nothing and a tick that
+                    // found nothing are the same shape in a findings-only log, and
+                    // this phase exists to tell those apart — "no violations" from a
+                    // peer that never had a contract to look at is not evidence about
+                    // any contract.
+                    tracing::info!(
+                        epoch = shadow.epoch(),
+                        tracked = samplers.len(),
+                        "conformance shadow tick selected nothing to probe"
+                    );
+                } else {
+                    let store = contract_store().cloned();
+                    let mode = shadow.mode();
+                    in_flight = Some(tokio::spawn(
+                        crate::conformance::shadow::probe(work, store, mode),
+                    ));
+                }
+            }
+            Some(finished) = async {
+                match in_flight.as_mut() {
+                    Some(handle) => Some(handle.await),
+                    None => None,
+                }
+            }, if in_flight.is_some() => {
+                in_flight = None;
+                let (report, findings) = match finished {
+                    Ok(result) => result,
+                    Err(err) => {
+                        // A panicking probe must not take the capture task with it,
+                        // and must not pass silently either: capture would carry on
+                        // looking healthy while nothing was ever checked.
+                        tracing::warn!(error = %err, "conformance shadow probe failed");
+                        continue;
+                    }
+                };
+                shadow.record(&findings);
                 // Reported even when nothing was checked. A shadow period that finds
                 // nothing and a shadow period that never ran look identical in a
                 // findings-only log, and telling them apart is most of what this
@@ -744,6 +810,48 @@ pub fn code_hash_of(key: &ContractKey) -> [u8; 32] {
     let len = out.len().min(bytes.len());
     out[..len].copy_from_slice(&bytes[..len]);
     out
+}
+
+/// The executor must tell conformance where contract WASM lives.
+///
+/// Without that one call every shadow probe resolves no code, so the peer selects
+/// focus contracts, executes nothing, and reports no violations — for the same reason
+/// a peer with no contracts reports none. The counters distinguish it (`skipped_no_code`
+/// rises), but nothing FAILS, so a refactor that drops the registration turns the whole
+/// mechanism off while leaving every test green and the logs superficially healthy.
+///
+/// A source scrape rather than a behavioural test because the alternative is standing
+/// up a full executor to observe a `OnceLock` being set, which would test tokio more
+/// than it tests this.
+#[cfg(test)]
+mod contract_store_registration_pin {
+    /// Slice `get_runtime_stores`' body, from its signature to the next item. A
+    /// missing anchor panics rather than silently widening the region to the rest of
+    /// the file, which is how a source pin quietly stops testing anything.
+    fn get_runtime_stores_body() -> &'static str {
+        let src = include_str!("../contract/executor.rs");
+        let start = src
+            .find("    pub(crate) fn get_runtime_stores(")
+            .expect("get_runtime_stores not found in executor.rs");
+        let after = &src[start..];
+        let end = after[1..]
+            .find("\n    pub(crate) fn ")
+            .or_else(|| after[1..].find("\n    pub(crate) async fn "))
+            .or_else(|| after[1..].find("\n    fn "))
+            .expect("could not find the item after get_runtime_stores");
+        &after[..end]
+    }
+
+    #[test]
+    fn the_executor_registers_the_contract_store_for_conformance() {
+        let body = get_runtime_stores_body();
+        assert!(
+            body.contains("set_contract_store("),
+            "the executor no longer registers its contract store with conformance, so \
+             every shadow probe will fail to resolve code and the mechanism reports \
+             nothing while looking healthy"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1243,8 +1351,13 @@ mod tests {
             .find("async fn run_writer(")
             .expect("run_writer not found");
         let after = &src[start..];
+        // Anchored on the name, not on the visibility keyword in front of it: this
+        // pin already broke once because `TrackedContract` gained `pub(crate)`, which
+        // says nothing about what the pin is guarding. It still `expect`s rather than
+        // defaulting, so a genuinely moved anchor fails loudly instead of silently
+        // widening the region to the rest of the file.
         let end = after
-            .find("\nstruct TrackedContract")
+            .find("struct TrackedContract")
             .expect("run_writer no longer precedes TrackedContract");
         let body = &after[..end];
         assert!(

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -491,22 +491,15 @@ async fn run_writer(
                 } else {
                     let store = contract_store().cloned();
                     let mode = shadow.mode();
-                    // `spawn_blocking`, not `spawn`. `.claude/rules/contracts.md` is
-                    // explicit that contracts must not execute on the main async
-                    // runtime, and a probe is contract execution: `verify_case` drives
-                    // synchronous WASM calls, and building the oracle compiles a
-                    // module. Moving it to another TASK does not help — that task runs
-                    // on the same worker threads, and a node sized by
-                    // `available_parallelism()` has exactly one of them on a
-                    // single-vCPU host, which is a supported deployment. A blocking
-                    // thread is what keeps "conformance never delays synchronization"
-                    // true rather than merely intended.
-                    in_flight = Some(tokio::task::spawn_blocking(move || {
-                        // The probe is async only because building the oracle is;
-                        // driving it here keeps all of its WASM on this thread.
-                        tokio::runtime::Handle::current()
-                            .block_on(crate::conformance::shadow::probe(work, store, mode))
-                    }));
+                    // An ordinary task: `probe` puts its own WASM execution on a
+                    // blocking thread internally (see `shadow::probe_one`). Doing the
+                    // hop there rather than here keeps the async work — building the
+                    // oracle — on the runtime, and avoids driving a future with
+                    // `Handle::block_on` from a blocking thread, which is subtle on a
+                    // current-thread runtime whose driver lives elsewhere.
+                    in_flight = Some(tokio::spawn(crate::conformance::shadow::probe(
+                        work, store, mode,
+                    )));
                 }
             }
             Some(finished) = async {
@@ -986,9 +979,17 @@ mod probe_wiring_pins {
             .join("\n")
     }
 
+    /// The probe's WASM must run on a blocking thread. The hop lives inside
+    /// `shadow::probe_one`, not here, so this pin reads that module rather than
+    /// `run_writer` — a pin that checked the wrong file would be worse than none.
     #[test]
     fn the_probe_runs_off_the_async_runtime() {
-        let body = run_writer_code_only();
+        let src = include_str!("shadow.rs");
+        let body = src
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(
             body.contains("spawn_blocking("),
             "the conformance probe no longer runs on a blocking thread. It executes \

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -255,6 +255,29 @@ impl CaptureHandle {
     }
 }
 
+/// Where this node keeps contract WASM, for shadow-mode probing.
+///
+/// Set by the executor, which is the component that knows it, and read by the capture
+/// task, which needs it but is started from a different place at a different time.
+/// A `OnceLock` rather than a constructor argument so neither has to care which of
+/// them runs first: the capture task reads it on every probe tick, so a store
+/// registered after capture started is picked up on the next tick rather than lost.
+///
+/// Absent means shadow mode can select focus contracts but cannot execute them, which
+/// is reported as `skipped_no_code` rather than passing for a clean result.
+static CONTRACT_STORE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+/// Tell the conformance machinery where contract WASM lives. Idempotent; the first
+/// caller wins, and later callers with a different path are ignored rather than
+/// racing.
+pub fn set_contract_store(path: PathBuf) {
+    let _ = CONTRACT_STORE.set(path);
+}
+
+pub(crate) fn contract_store() -> Option<&'static PathBuf> {
+    CONTRACT_STORE.get()
+}
+
 static CAPTURE: std::sync::OnceLock<Option<CaptureHandle>> = std::sync::OnceLock::new();
 
 /// The process-wide capture handle, or `None` when capture is off.
@@ -350,6 +373,19 @@ async fn run_writer(
         );
     }
     let mut since_flush = 0usize;
+    // Shadow mode rides the capture task: it already owns the samples, and it is
+    // already off the merge path, which is the property that matters most. The
+    // mode is `default()` — Shadow — and there is deliberately no way to reach
+    // `Enforce` from here.
+    let mut shadow = crate::conformance::shadow::ShadowRunner::new(
+        &dir,
+        crate::conformance::policy::EnforcementMode::default(),
+    );
+    let mut probe = tokio::time::interval(crate::conformance::shadow::PROBE_INTERVAL);
+    // The first tick of a tokio interval fires immediately. Probing a sampler that
+    // has just been reloaded and holds nothing useful wastes a probe and, worse,
+    // reports a clean run for contracts nobody looked at yet.
+    probe.reset();
     let mut flush = tokio::time::interval(FLUSH_EVERY);
     flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
@@ -372,6 +408,26 @@ async fn run_writer(
                 write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
                 since_flush = 0;
             }
+            _ = probe.tick() => {
+                let report = shadow.tick(&samplers, contract_store().map(|p| p.as_path())).await;
+                // Reported even when nothing was checked. A shadow period that finds
+                // nothing and a shadow period that never ran look identical in a
+                // findings-only log, and telling them apart is most of what this
+                // phase is for.
+                tracing::info!(
+                    epoch = shadow.epoch(),
+                    focused = report.focused,
+                    probed = report.probed,
+                    cases = report.cases,
+                    inconclusive = report.inconclusive,
+                    would_remove = report.would_remove,
+                    reported = report.reported,
+                    skipped_no_code = report.skipped_no_code,
+                    skipped_no_samples = report.skipped_no_samples,
+                    timed_out = report.timed_out,
+                    "conformance shadow tick"
+                );
+            }
         }
     }
 
@@ -379,7 +435,7 @@ async fn run_writer(
     write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
 }
 
-struct TrackedContract {
+pub(crate) struct TrackedContract {
     sampler: ContractSampler,
     code_hash: [u8; 32],
     parameters: Vec<u8>,
@@ -495,7 +551,10 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
     samplers
 }
 
-fn record(samplers: &mut HashMap<ContractInstanceId, TrackedContract>, observation: Observation) {
+pub(crate) fn record(
+    samplers: &mut HashMap<ContractInstanceId, TrackedContract>,
+    observation: Observation,
+) {
     if !samplers.contains_key(&observation.contract) && samplers.len() >= MAX_TRACKED_CONTRACTS {
         // Already tracking as many as allowed. Ignoring the newcomer is the bounded
         // choice; the alternative is evicting an accumulated sample, which throws
@@ -563,6 +622,42 @@ fn admit_related(
     }
 }
 
+/// Build the replay bundle for one tracked contract.
+///
+/// Shared by the periodic flush and by shadow-mode probing, which must check exactly
+/// what a later offline replay would check. Two constructions would be two chances to
+/// disagree about what a corpus contains, and the disagreement would be invisible:
+/// both would produce a plausible bundle, and only a finding that reproduced offline
+/// but not in shadow (or the reverse) would reveal it.
+pub(crate) fn bundle_for(
+    instance: ContractInstanceId,
+    tracked: &TrackedContract,
+) -> crate::conformance::bundle::ReplayBundle {
+    // No embedded code: the WASM lives in the node's contract store and would
+    // multiply the size of every bundle. The code hash identifies it, and
+    // `ReplayBundle::resolve_code` verifies whatever is supplied at replay time
+    // against that hash — so a bundle can never be replayed against the wrong
+    // contract even though it does not carry the contract.
+    let mut bundle =
+        tracked
+            .sampler
+            .to_bundle(None, Some(tracked.code_hash), tracked.parameters.clone());
+    bundle.instance = Some(instance);
+    // Carried so a replay can execute a contract whose validity depends on
+    // another contract. `to_corpus` turns these back into `RelatedContracts`.
+    // Sorted by instance, so a bundle's bytes do not depend on hash iteration
+    // order. The corpus is written repeatedly and compared across runs; a file
+    // that differs only by map ordering wastes everyone's time.
+    let mut related: Vec<(ContractInstanceId, Vec<u8>)> = tracked
+        .related
+        .iter()
+        .map(|(id, state)| (*id, state.clone()))
+        .collect();
+    related.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+    bundle.related = related;
+    bundle
+}
+
 /// Flush every tracked contract's bundle.
 ///
 /// Async because a flush is real I/O: up to 64 bundles of up to the per-contract
@@ -576,28 +671,7 @@ async fn write_all(
     dropped: u64,
 ) {
     for (instance, tracked) in samplers {
-        // No embedded code: the WASM lives in the node's contract store and would
-        // multiply the size of every bundle. The code hash identifies it, and
-        // `ReplayBundle::resolve_code` verifies whatever is supplied at replay time
-        // against that hash — so a bundle can never be replayed against the wrong
-        // contract even though it does not carry the contract.
-        let mut bundle =
-            tracked
-                .sampler
-                .to_bundle(None, Some(tracked.code_hash), tracked.parameters.clone());
-        bundle.instance = Some(*instance);
-        // Carried so a replay can execute a contract whose validity depends on
-        // another contract. `to_corpus` turns these back into `RelatedContracts`.
-        // Sorted by instance, so a bundle's bytes do not depend on hash iteration
-        // order. The corpus is written repeatedly and compared across runs; a file
-        // that differs only by map ordering wastes everyone's time.
-        let mut related: Vec<(ContractInstanceId, Vec<u8>)> = tracked
-            .related
-            .iter()
-            .map(|(id, state)| (*id, state.clone()))
-            .collect();
-        related.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
-        bundle.related = related;
+        let mut bundle = bundle_for(*instance, tracked);
         bundle.note = Some(format!(
             "captured by freenet {} ({} observation(s) dropped node-wide)",
             env!("CARGO_PKG_VERSION"),

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -265,12 +265,34 @@ impl CaptureHandle {
 ///
 /// Absent means shadow mode can select focus contracts but cannot execute them, which
 /// is reported as `skipped_no_code` rather than passing for a clean result.
+///
+/// # Limitation: one store per PROCESS, not per node
+///
+/// A production node is one process with one `Config`, so first-caller-wins is exact.
+/// The DST/SimNetwork harness is not: it runs many simulated peers in one process, and
+/// if shadow mode were ever exercised across more than one of them, every peer after
+/// the first would silently probe against the first peer's contract directory, find
+/// nothing, and report `skipped_no_code` — a clean-looking result that means nothing,
+/// which is precisely the failure class this module's counters exist to expose. That
+/// is not reachable today (registration is skipped entirely unless capture is on, and
+/// capture is a single-peer diagnostic opt-in), but a multi-peer simulation of shadow
+/// mode would need this keyed by node identity rather than held as a bare global.
 static CONTRACT_STORE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
 /// Tell the conformance machinery where contract WASM lives. Idempotent; the first
 /// caller wins, and later callers with a different path are ignored rather than
 /// racing.
 pub fn set_contract_store(path: PathBuf) {
+    // Nothing reads this unless capture is enabled, and registering regardless has a
+    // cost that is not obvious: `crates/core` runs many nodes in ONE process (the
+    // SimNetwork/DST harness) and builds many executors over different temp dirs in a
+    // single `cargo test` binary. First-caller-wins would then warn on essentially
+    // every executor after the first, turning a warning meant to catch a real
+    // production misconfiguration into routine noise in exactly the runner where
+    // cross-test interference is visible at all (see `.claude/rules/testing.md`).
+    if global().is_none() {
+        return;
+    }
     if let Err(rejected) = CONTRACT_STORE.set(path) {
         // First caller wins. Two callers agreeing is the normal case (several
         // executors, one Config) and is silent; two callers DISAGREEING would send
@@ -398,6 +420,15 @@ async fn run_writer(
     let mut probe = tokio::time::interval(crate::conformance::shadow::PROBE_INTERVAL);
     // At most one probe at a time, held here so the select loop can decline to start
     // another while one is running.
+    //
+    // Deliberately not joined or aborted when the channel closes and this task
+    // returns. A detached probe finishes on its own and drops its scratch directory,
+    // and `panic = "abort"` is off so it unwinds and cleans up even if it panics. The
+    // one case that does leak is the node's real shutdown path, which calls
+    // `std::process::exit` and so runs no destructors: a probe in flight at that exact
+    // moment leaves one temp directory behind, with roughly a probe-duration /
+    // PROBE_INTERVAL chance per restart. Left as-is rather than blocking shutdown on
+    // best-effort diagnostic work, which is the wrong trade in the other direction.
     let mut in_flight: Option<
         tokio::task::JoinHandle<(
             crate::conformance::shadow::ShadowReport,
@@ -408,6 +439,13 @@ async fn run_writer(
     // has just been reloaded and holds nothing useful wastes a probe and, worse,
     // reports a clean run for contracts nobody looked at yet.
     probe.reset();
+    // Same as `flush` below, and it matters MORE here. The probe arm carries an
+    // `if in_flight.is_none()` guard, and a false-guarded select arm is not polled at
+    // all, so a probe that outran its interval would leave ticks queued and, on the
+    // default Burst behaviour, fire them back to back the moment the guard cleared.
+    // Delay makes a missed tick mean "next one is a full interval from now", which is
+    // what a best-effort background job should do.
+    probe.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut flush = tokio::time::interval(FLUSH_EVERY);
     flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
@@ -453,9 +491,22 @@ async fn run_writer(
                 } else {
                     let store = contract_store().cloned();
                     let mode = shadow.mode();
-                    in_flight = Some(tokio::spawn(
-                        crate::conformance::shadow::probe(work, store, mode),
-                    ));
+                    // `spawn_blocking`, not `spawn`. `.claude/rules/contracts.md` is
+                    // explicit that contracts must not execute on the main async
+                    // runtime, and a probe is contract execution: `verify_case` drives
+                    // synchronous WASM calls, and building the oracle compiles a
+                    // module. Moving it to another TASK does not help — that task runs
+                    // on the same worker threads, and a node sized by
+                    // `available_parallelism()` has exactly one of them on a
+                    // single-vCPU host, which is a supported deployment. A blocking
+                    // thread is what keeps "conformance never delays synchronization"
+                    // true rather than merely intended.
+                    in_flight = Some(tokio::task::spawn_blocking(move || {
+                        // The probe is async only because building the oracle is;
+                        // driving it here keeps all of its WASM on this thread.
+                        tokio::runtime::Handle::current()
+                            .block_on(crate::conformance::shadow::probe(work, store, mode))
+                    }));
                 }
             }
             Some(finished) = async {
@@ -828,18 +879,36 @@ mod contract_store_registration_pin {
     /// Slice `get_runtime_stores`' body, from its signature to the next item. A
     /// missing anchor panics rather than silently widening the region to the rest of
     /// the file, which is how a source pin quietly stops testing anything.
+    /// Slice `get_runtime_stores`' body by counting braces to its own closing one.
+    ///
+    /// The first version of this ended the region at the next `pub(crate) fn` / `fn`
+    /// signature, which does not match this file: the item after `get_runtime_stores`
+    /// is a plain `pub fn`. So the region ran on for ~350 lines, through several
+    /// unrelated helpers and into `#[cfg(test)] mod tests`. It was not vacuous — the
+    /// symbol occurs once in the file — but it was one added mention away from being
+    /// so, in a comment or an unrelated helper, and the doc claimed a bound it did not
+    /// have. Brace counting has no such dependency on what happens to come next.
     fn get_runtime_stores_body() -> &'static str {
         let src = include_str!("../contract/executor.rs");
         let start = src
             .find("    pub(crate) fn get_runtime_stores(")
             .expect("get_runtime_stores not found in executor.rs");
         let after = &src[start..];
-        let end = after[1..]
-            .find("\n    pub(crate) fn ")
-            .or_else(|| after[1..].find("\n    pub(crate) async fn "))
-            .or_else(|| after[1..].find("\n    fn "))
-            .expect("could not find the item after get_runtime_stores");
-        &after[..end]
+        let open = after.find('{').expect("get_runtime_stores has no body");
+        let mut depth = 0usize;
+        for (offset, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &after[..open + offset + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("get_runtime_stores' body is not brace-balanced");
     }
 
     #[test]
@@ -850,6 +919,74 @@ mod contract_store_registration_pin {
             "the executor no longer registers its contract store with conformance, so \
              every shadow probe will fail to resolve code and the mechanism reports \
              nothing while looking healthy"
+        );
+    }
+}
+
+/// Source pins on the probe's wiring inside `run_writer`.
+///
+/// These guard two regressions that no behavioural test in this module would catch,
+/// because every shadow test drives `select` / `probe` / `record` directly rather than
+/// through the writer's select loop. Both regressions leave the mechanism working and
+/// every test green, which is the whole reason they are pinned rather than trusted:
+///
+/// 1. `tokio::spawn` instead of `spawn_blocking` puts synchronous WASM execution back
+///    on the async runtime. `.claude/rules/contracts.md` forbids exactly that, and on a
+///    single-vCPU node — sized by `available_parallelism()`, a supported deployment —
+///    there is one worker thread for it to compete with.
+/// 2. Dropping the `in_flight.is_none()` guard lets probes stack, turning a bounded
+///    background job into unbounded concurrent WASM execution.
+///
+/// Stated plainly: these are pins, not behavioural tests. They prove the call site
+/// still says what it should, not that the scheduling behaves.
+#[cfg(test)]
+mod probe_wiring_pins {
+    /// Slice `run_writer`'s body by counting braces to its own closing one, so the
+    /// region cannot silently widen into whatever happens to follow it.
+    fn run_writer_body() -> &'static str {
+        let src = include_str!("capture.rs");
+        let start = src
+            .find("async fn run_writer(")
+            .expect("run_writer not found");
+        let after = &src[start..];
+        let open = after.find('{').expect("run_writer has no body");
+        let mut depth = 0usize;
+        for (offset, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &after[..open + offset + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("run_writer's body is not brace-balanced");
+    }
+
+    #[test]
+    fn the_probe_runs_off_the_async_runtime() {
+        let body = run_writer_body();
+        assert!(
+            body.contains("spawn_blocking("),
+            "the conformance probe no longer runs on a blocking thread. It executes \
+             contract WASM synchronously, so on the async runtime it competes with \
+             the event loop — and a node sized by available_parallelism() has one \
+             worker thread on a single-vCPU host. See .claude/rules/contracts.md"
+        );
+    }
+
+    #[test]
+    fn at_most_one_probe_runs_at_a_time() {
+        let body = run_writer_body();
+        assert!(
+            body.contains("in_flight.is_none()"),
+            "the probe tick arm is no longer guarded on there being no probe in \
+             flight, so a probe that overran its interval would have another stacked \
+             on top of it — unbounded concurrent WASM execution from a job whose \
+             entire justification is that it is bounded"
         );
     }
 }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -526,6 +526,13 @@ async fn run_writer(
                 // phase is for.
                 tracing::info!(
                     epoch = shadow.epoch(),
+                    // Reach, not just findings: focus can only select what capture is
+                    // tracking, and that set stops growing at MAX_TRACKED_CONTRACTS
+                    // and never evicts. Without these two numbers, a peer whose
+                    // candidate set froze months ago reports exactly the same shape of
+                    // clean result as one that is genuinely covering the network.
+                    tracked = samplers.len(),
+                    tracking_at_cap = samplers.len() >= MAX_TRACKED_CONTRACTS,
                     focused = report.focused,
                     probed = report.probed,
                     cases = report.cases,

--- a/crates/core/src/conformance/focus.rs
+++ b/crates/core/src/conformance/focus.rs
@@ -46,6 +46,20 @@ impl FocusSelector {
         }
     }
 
+    /// Resume at a known epoch.
+    ///
+    /// Rotation only means anything if it accumulates. A peer that restarted back to
+    /// epoch zero would re-select the same first focus set every time, so a contract
+    /// author able to cause restarts could hold a peer's attention on whatever epoch
+    /// zero happens to pick — or keep it away from themselves forever.
+    pub fn resuming_at(salt: [u8; 32], max_focus: usize, epoch: u64) -> Self {
+        Self {
+            salt,
+            max_focus: max_focus.max(1),
+            epoch,
+        }
+    }
+
     pub fn epoch(&self) -> u64 {
         self.epoch
     }

--- a/crates/core/src/conformance/runtime_oracle.rs
+++ b/crates/core/src/conformance/runtime_oracle.rs
@@ -75,11 +75,31 @@ impl RuntimeOracle {
         // only to satisfy the runtime's constructor. Pointing it at the scratch
         // directory keeps the freshly-generated keys inside the temp dir, where they
         // die with it.
+        let cache_dir = scratch.path().join("wasm-cache");
+        std::fs::create_dir_all(&cache_dir)?;
         let secrets_dir = scratch.path().join("secrets");
         std::fs::create_dir_all(&secrets_dir)?;
         let secrets = crate::config::Secrets::load_for_secrets_dir(&secrets_dir)?;
         let secrets_store = SecretsStore::new(secrets_dir, secrets, db)?;
-        let mut runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)?;
+        // Build with an explicit config rather than the default, for one reason: the
+        // default leaves `wasmtime_cache_dir: None`, which means wasmtime's own OS
+        // cache location — outside this oracle's scratch directory, outside the node's
+        // disk accounting, and NOT deleted when the scratch dir dies. A long-running
+        // shadow peer rotating through focus contracts would quietly populate a second
+        // persistent compiled-module cache that nothing owns or bounds. Pointing it
+        // into the scratch dir makes the oracle's disk footprint exactly its temp dir,
+        // which is what "throwaway" is supposed to mean.
+        let config = crate::wasm_runtime::RuntimeConfig {
+            wasmtime_cache_dir: Some(cache_dir),
+            ..Default::default()
+        };
+        let mut runtime = Runtime::build_with_config(
+            contract_store,
+            delegate_store,
+            secrets_store,
+            false,
+            config,
+        )?;
 
         let parameters = Parameters::from(parameters);
         let container = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
@@ -95,7 +115,27 @@ impl RuntimeOracle {
         // result much later — and "we could not judge this contract" would be
         // indistinguishable from "this contract would not load", letting a run
         // against a broken file report success.
-        runtime.compile_check(&key, &parameters)?;
+        //
+        // Offloaded, because this is a real Cranelift compile and not I/O. The default
+        // `RuntimeConfig` sets `offload_compilation: false`, so without this hop the
+        // compile runs inline on whatever thread awaits this constructor — and shadow
+        // mode awaits it from a tokio task, on a node whose worker count is
+        // `available_parallelism()`, i.e. one on a supported single-vCPU host. That is
+        // the #4441 whole-node-hang class, reintroduced by a diagnostic feature that
+        // has no business costing real clients latency. `fdev` gets the same treatment
+        // and does not care.
+        let parameters_for_check = parameters.clone();
+        let key_for_check = key;
+        let (mut runtime, compiled) = tokio::task::spawn_blocking(move || {
+            let outcome = runtime.compile_check(&key_for_check, &parameters_for_check);
+            (runtime, outcome)
+        })
+        .await
+        .map_err(|e| OracleBuildError::Storage(format!("compile task failed: {e}")))?;
+        compiled?;
+        // Silence the unused-mut warning the split introduces without loosening the
+        // binding the struct below expects.
+        let _ = &mut runtime;
 
         Ok(Self {
             runtime,

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -32,7 +32,7 @@
 //! for the probe to share nothing with the path that does the synchronizing.
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use freenet_stdlib::prelude::ContractInstanceId;
@@ -149,23 +149,24 @@ impl ShadowRunner {
     }
 
     /// Run one probe tick over whatever the sampler currently holds.
+    /// Choose this tick's focus contracts and copy out what a probe needs.
     ///
-    /// Takes the samplers by reference and never mutates them: a probe must not be
-    /// able to change what the peer would have captured, or shadow mode would be
-    /// altering the very measurement it exists to take.
-    /// `store` is where contract WASM lives. Passed per-tick rather than held,
-    /// because the runner is built by the capture task and the store path is known to
-    /// the executor: a parameter keeps the two from having to agree on startup order,
-    /// and keeps this testable without a process-global.
-    pub(crate) async fn tick(
+    /// Split from [`probe`] deliberately, and the split is load-bearing rather than
+    /// tidiness. This half borrows the sampler map, so it has to run on the capture
+    /// task, and it is cheap: a hash per candidate plus a bounded copy of the selected
+    /// contracts' samples. The probe half is CPU-bound WASM execution under a
+    /// ten-second-per-contract budget, and running THAT on the capture task would stop
+    /// the task draining its observation queue for as long as it ran — dropping the
+    /// very observations conformance exists to collect, from a mechanism whose stated
+    /// requirement is that it never degrade normal operation. The periodic flush was
+    /// made async for exactly this reason; a probe is the worse case, because it is
+    /// CPU-bound and cannot be yielded away from by awaiting a syscall.
+    pub(crate) fn select(
         &mut self,
         samplers: &HashMap<ContractInstanceId, super::capture::TrackedContract>,
-        store: Option<&Path>,
-    ) -> ShadowReport {
-        let mut report = ShadowReport::default();
-
+    ) -> Vec<(ContractInstanceId, ReplayBundle)> {
         if self.mode == EnforcementMode::Disabled {
-            return report;
+            return Vec::new();
         }
 
         self.ticks = self.ticks.wrapping_add(1);
@@ -175,132 +176,181 @@ impl ShadowRunner {
         }
 
         let candidates: Vec<ContractInstanceId> = samplers.keys().copied().collect();
-        let focus = self.selector.select(&candidates);
-        report.focused = focus.len();
+        self.selector
+            .select(&candidates)
+            .into_iter()
+            .filter_map(|instance| {
+                let tracked = samplers.get(&instance)?;
+                Some((instance, super::capture::bundle_for(instance, tracked)))
+            })
+            .collect()
+    }
 
-        let Some(store) = store else {
-            // No store means no code, and no code means no question was asked. Say so
-            // in the counter rather than returning an empty report that reads as a
-            // clean run.
-            report.skipped_no_code = focus.len();
-            return report;
-        };
+    pub(crate) fn mode(&self) -> EnforcementMode {
+        self.mode
+    }
 
-        for instance in focus {
-            let Some(tracked) = samplers.get(&instance) else {
+    /// Fold a completed probe's findings into this epoch's log.
+    ///
+    /// Kept here rather than in [`probe`] because the dedup state is scoped to the
+    /// epoch, which lives here, and because the probe runs on another task and must
+    /// not need `&mut self` to do its work.
+    pub(crate) fn record(&mut self, findings: &[Finding]) {
+        for finding in findings {
+            // One line per (contract, property) per epoch: a contract that fails the
+            // same law in forty cases is one finding reported forty times, and a log
+            // that says so forty times is harder to read, not more informative.
+            if !self
+                .logged
+                .insert((finding.contract, finding.violation.property))
+            {
                 continue;
-            };
-            let bundle = super::capture::bundle_for(instance, tracked);
-            self.probe_one(&instance, &bundle, store, &mut report).await;
-        }
-
-        report
-    }
-
-    async fn probe_one(
-        &mut self,
-        instance: &ContractInstanceId,
-        bundle: &ReplayBundle,
-        store: &Path,
-        report: &mut ShadowReport,
-    ) {
-        let corpus = bundle.to_corpus();
-        if corpus.is_empty() {
-            report.skipped_no_samples += 1;
-            return;
-        }
-
-        let code = match bundle.resolve_code_from_store(store) {
-            Ok(code) => code,
-            Err(err) => {
-                // Not a finding: this peer failed to ask the question. Counted as
-                // such rather than passed off as a clean result, because a focus
-                // contract we cannot execute looks exactly like a conforming one if
-                // you only count violations.
-                tracing::debug!(%instance, error = %err, "shadow probe has no code for a focus contract");
-                report.skipped_no_code += 1;
-                return;
             }
-        };
-
-        let mut oracle = match RuntimeOracle::standalone(code, bundle.parameters.clone()).await {
-            Ok(oracle) => oracle,
-            Err(err) => {
-                // A contract whose WASM will not load is not a conformance finding.
-                // It is this peer failing to ask the question, and it is counted as
-                // such rather than passed off as a clean result.
-                tracing::debug!(%instance, error = %err, "shadow probe could not build an oracle");
-                report.skipped_no_code += 1;
-                return;
-            }
-        };
-
-        let config = GeneratorConfig {
-            max_cases: MAX_CASES_PER_PROBE,
-            ..Default::default()
-        };
-        let cases = generate_cases(&corpus, &config);
-        report.probed += 1;
-
-        let started = Instant::now();
-        for case in cases.iter().take(MAX_CASES_PER_PROBE) {
-            if started.elapsed() > PROBE_TIME_BUDGET {
-                report.timed_out += 1;
-                break;
-            }
-
-            let outcome = verify_case(&mut oracle, case);
-            report.cases += 1;
-
-            match decide(self.mode, &outcome) {
-                ConformanceAction::Nothing => {
-                    if matches!(outcome, PropertyOutcome::Inconclusive(_)) {
-                        report.inconclusive += 1;
-                    }
-                }
-                ConformanceAction::Report(violation) => {
-                    report.reported += 1;
-                    self.log_once(instance, &violation, false);
-                }
-                ConformanceAction::WouldRemove(violation) => {
-                    report.would_remove += 1;
-                    self.log_once(instance, &violation, true);
-                }
-                // Unreachable while nothing constructs `EnforcementMode::Enforce`,
-                // and deliberately still handled: the point of routing shadow through
-                // the same `decide` enforcement will use is that the two paths cannot
-                // drift. Counting a removal as a would-remove keeps this honest if a
-                // future caller does reach it before the removal path is built.
-                ConformanceAction::Remove(violation) => {
-                    report.would_remove += 1;
-                    self.log_once(instance, &violation, true);
-                }
-            }
-
-            // Give the runtime back to the node between cases. A probe is
-            // best-effort, low-priority work; nothing here is allowed to hold a
-            // worker while real traffic waits.
-            tokio::task::yield_now().await;
+            tracing::info!(
+                contract = %finding.contract,
+                property = ?finding.violation.property,
+                epoch = self.selector.epoch(),
+                would_remove = finding.would_remove,
+                detail = %finding.violation.detail,
+                "conformance shadow finding"
+            );
         }
     }
+}
 
-    fn log_once(
-        &mut self,
-        instance: &ContractInstanceId,
-        violation: &super::property::Violation,
-        would_remove: bool,
-    ) {
-        if !self.logged.insert((*instance, violation.property)) {
+/// One thing a probe found, carried back to the capture task to be logged.
+#[derive(Debug, Clone)]
+pub(crate) struct Finding {
+    pub contract: ContractInstanceId,
+    pub violation: super::property::Violation,
+    pub would_remove: bool,
+}
+
+/// Run one probe over bundles already copied out of the sampler.
+///
+/// A free function over owned inputs, so the capture task can spawn it and carry on
+/// draining its observation queue while it runs. Nothing here borrows the sampler map,
+/// which is also what makes it structurally impossible for a probe to change what the
+/// peer would have captured.
+pub(crate) async fn probe(
+    work: Vec<(ContractInstanceId, ReplayBundle)>,
+    store: Option<PathBuf>,
+    mode: EnforcementMode,
+) -> (ShadowReport, Vec<Finding>) {
+    let mut report = ShadowReport {
+        focused: work.len(),
+        ..ShadowReport::default()
+    };
+    let mut findings = Vec::new();
+
+    let Some(store) = store else {
+        // No store means no code, and no code means no question was asked. Recorded as
+        // a skip rather than returned as an empty report, which would read as a clean
+        // run for contracts nobody could execute.
+        report.skipped_no_code = work.len();
+        return (report, findings);
+    };
+
+    for (instance, bundle) in work {
+        probe_one(&instance, &bundle, &store, mode, &mut report, &mut findings).await;
+    }
+    (report, findings)
+}
+
+async fn probe_one(
+    instance: &ContractInstanceId,
+    bundle: &ReplayBundle,
+    store: &Path,
+    mode: EnforcementMode,
+    report: &mut ShadowReport,
+    findings: &mut Vec<Finding>,
+) {
+    let corpus = bundle.to_corpus();
+    if corpus.is_empty() {
+        report.skipped_no_samples += 1;
+        return;
+    }
+
+    let code = match bundle.resolve_code_from_store(store) {
+        Ok(code) => code,
+        Err(err) => {
+            // Not a finding: this peer failed to ask the question. Counted as such
+            // rather than passed off as a clean result, because a focus contract we
+            // cannot execute looks exactly like a conforming one if you only count
+            // violations.
+            tracing::debug!(%instance, error = %err, "shadow probe has no code for a focus contract");
+            report.skipped_no_code += 1;
             return;
         }
-        tracing::info!(
-            contract = %instance,
-            property = ?violation.property,
-            epoch = self.selector.epoch(),
-            would_remove,
-            detail = %violation.detail,
-            "conformance shadow finding"
-        );
+    };
+
+    let mut oracle = match RuntimeOracle::standalone(code, bundle.parameters.clone()).await {
+        Ok(oracle) => oracle,
+        Err(err) => {
+            // A contract whose WASM will not load is not a conformance finding either.
+            tracing::debug!(%instance, error = %err, "shadow probe could not build an oracle");
+            report.skipped_no_code += 1;
+            return;
+        }
+    };
+
+    let config = GeneratorConfig {
+        max_cases: MAX_CASES_PER_PROBE,
+        ..Default::default()
+    };
+    let cases = generate_cases(&corpus, &config);
+    report.probed += 1;
+
+    let started = Instant::now();
+    for case in cases.iter().take(MAX_CASES_PER_PROBE) {
+        if started.elapsed() > PROBE_TIME_BUDGET {
+            report.timed_out += 1;
+            break;
+        }
+
+        let outcome = verify_case(&mut oracle, case);
+        report.cases += 1;
+
+        match decide(mode, &outcome) {
+            ConformanceAction::Nothing => {
+                if matches!(outcome, PropertyOutcome::Inconclusive(_)) {
+                    report.inconclusive += 1;
+                }
+            }
+            ConformanceAction::Report(violation) => {
+                report.reported += 1;
+                findings.push(Finding {
+                    contract: *instance,
+                    violation,
+                    would_remove: false,
+                });
+            }
+            ConformanceAction::WouldRemove(violation) => {
+                report.would_remove += 1;
+                findings.push(Finding {
+                    contract: *instance,
+                    violation,
+                    would_remove: true,
+                });
+            }
+            // Unreachable while nothing constructs `EnforcementMode::Enforce`, and
+            // deliberately still handled: the point of routing shadow through the same
+            // `decide` enforcement will use is that the two cannot drift. Counting a
+            // removal as a would-remove keeps this honest if a future caller reaches
+            // it before the removal path exists.
+            ConformanceAction::Remove(violation) => {
+                report.would_remove += 1;
+                findings.push(Finding {
+                    contract: *instance,
+                    violation,
+                    would_remove: true,
+                });
+            }
+        }
+
+        // Yield between cases. Even on its own task a probe is best-effort,
+        // low-priority work, and must not hold a worker while real traffic waits.
+        tokio::task::yield_now().await;
     }
 }
 
@@ -361,6 +411,21 @@ fn write_salt(path: &Path, salt: &[u8; 32]) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use crate::conformance::capture::{Observation, TrackedContract, record};
+
+    /// Drive one whole tick the way the capture task does: select on the writer
+    /// side, probe on the other, fold the findings back in. Tests go through this
+    /// rather than calling the halves directly, so they exercise the same sequence
+    /// production uses and a change to that sequence cannot leave them passing.
+    async fn tick(
+        runner: &mut ShadowRunner,
+        samplers: &HashMap<ContractInstanceId, TrackedContract>,
+        store: Option<&Path>,
+    ) -> ShadowReport {
+        let work = runner.select(samplers);
+        let (report, findings) = probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
+        runner.record(&findings);
+        report
+    }
 
     fn instance(n: u8) -> ContractInstanceId {
         ContractInstanceId::new([n; 32])
@@ -471,7 +536,7 @@ mod tests {
             &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
         );
 
-        let report = runner.tick(&samplers, None).await;
+        let report = tick(&mut runner, &samplers, None).await;
         assert!(
             report.focused > 0,
             "nothing was selected, so this proves nothing"
@@ -494,7 +559,7 @@ mod tests {
         let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Disabled);
         let samplers = samplers_for(instance(1), vec![0], [0u8; 32], &[(vec![1], vec![1, 2])]);
         assert_eq!(
-            runner.tick(&samplers, None).await,
+            tick(&mut runner, &samplers, None).await,
             ShadowReport::default(),
             "Disabled mode still selected or skipped contracts"
         );
@@ -508,15 +573,15 @@ mod tests {
         let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
         let samplers = samplers_for(instance(1), vec![0], [0u8; 32], &[(vec![1], vec![1, 2])]);
 
-        for tick in 1..ROTATE_EVERY_TICKS {
-            runner.tick(&samplers, None).await;
+        for nth in 1..ROTATE_EVERY_TICKS {
+            tick(&mut runner, &samplers, None).await;
             assert_eq!(
                 runner.epoch(),
                 0,
-                "focus rotated early, on tick {tick} of {ROTATE_EVERY_TICKS}"
+                "focus rotated early, on tick {nth} of {ROTATE_EVERY_TICKS}"
             );
         }
-        runner.tick(&samplers, None).await;
+        tick(&mut runner, &samplers, None).await;
         assert_eq!(
             runner.epoch(),
             1,
@@ -583,7 +648,7 @@ mod tests {
 
             let dir = tempfile::TempDir::new()?;
             let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
-            let report = runner.tick(&samplers, Some(store_dir.path())).await;
+            let report = tick(&mut runner, &samplers, Some(store_dir.path())).await;
 
             assert_eq!(
                 samplers.len(),

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -1,0 +1,622 @@
+//! Shadow mode: the peer checks contracts it has sampled, and records what it
+//! *would* remove.
+//!
+//! Everything else in this module tree is reachable only from `fdev` and from tests.
+//! `decide` has been fully specified and tested since #5344 and has never once been
+//! called by a running node, which means the mechanism the RFC describes does not yet
+//! exist on the network in any mode — not even the mode that does nothing. This is
+//! the piece that makes it exist: a bounded, opt-in loop that selects focus
+//! contracts, replays the samples already being collected, and writes down the
+//! verdict without acting on it.
+//!
+//! # What this deliberately does NOT do
+//!
+//! No removal, in any configuration reachable from here. No evidence propagation, no
+//! author diagnostics, no network traffic of any kind. Those are the RFC's Phase 4;
+//! this is Phase 3, "single/live peer shadow validation", whose whole job is to prove
+//! that focus selection, sampling and local discovery behave on a real peer before
+//! anything is shipped fleet-wide.
+//!
+//! It also generates no synchronization traffic to manufacture samples. It reads what
+//! capture has already observed from ordinary traffic, which is the RFC's explicit
+//! constraint: the peer is an observer, not a fuzzer.
+//!
+//! # Why probes run on a throwaway runtime
+//!
+//! Each probe builds a [`RuntimeOracle::standalone`], which is its own wasmtime
+//! instance over its own scratch store, rather than borrowing the node's executor.
+//! That costs a temp directory per probe and is worth it twice over: a probe cannot
+//! touch hosted state, and a contract that misbehaves under probing cannot affect the
+//! runtime serving real requests. The RFC's hard requirement is that conformance work
+//! never delays normal contract synchronization; the cheapest way to honour that is
+//! for the probe to share nothing with the path that does the synchronizing.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::time::Duration;
+
+use freenet_stdlib::prelude::ContractInstanceId;
+// tokio's clock rather than `std`: it honours `start_paused`, so a test can prove the
+// time budget cuts a probe short without actually spending ten seconds doing it.
+use tokio::time::Instant;
+
+use super::bundle::ReplayBundle;
+use super::focus::FocusSelector;
+use super::generator::{GeneratorConfig, generate_cases};
+use super::policy::{ConformanceAction, EnforcementMode, decide};
+use super::property::{ConformanceProperty, PropertyOutcome};
+use super::runtime_oracle::RuntimeOracle;
+use super::verifier::verify_case;
+
+/// How many contracts a peer watches at once.
+///
+/// Small on purpose. Watching more is not free — each focus contract is a probe's
+/// worth of WASM execution per tick — and it buys less than it looks like it should,
+/// because coverage across the network comes from every peer watching a *different*
+/// couple of contracts, not from any one peer watching many. Two is the RFC's
+/// "simple independent randomized policy" read literally.
+const MAX_FOCUS_CONTRACTS: usize = 2;
+
+/// How often a probe runs.
+pub const PROBE_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
+/// Ticks before the focus set is reshuffled.
+///
+/// Rotation is what stops a contract that happens to be unlucky today from being the
+/// only thing this peer ever looks at, and what stops an author who somehow learns
+/// they are being watched from staying watched. Eight ticks at fifteen minutes is two
+/// hours, long enough for a sampler to accumulate something worth checking and short
+/// enough that a day covers many contracts.
+const ROTATE_EVERY_TICKS: u32 = 8;
+
+/// Cases checked per contract per tick.
+///
+/// The bound that makes "conformance never delays synchronization" true rather than
+/// hoped for. Each case is a handful of WASM calls under the runtime's own fuel
+/// limit, so this is a bounded number of bounded operations, and the probe yields
+/// between cases.
+const MAX_CASES_PER_PROBE: usize = 64;
+
+/// Wall-clock ceiling for one contract's probe, checked between cases.
+///
+/// Belt to `MAX_CASES_PER_PROBE`'s braces: the case count bounds the work only if
+/// each case is quick, and "quick" depends on a contract we do not control. A
+/// contract that is merely slow rather than infinite would otherwise stretch a tick.
+const PROBE_TIME_BUDGET: Duration = Duration::from_secs(10);
+
+/// Filename of the per-peer focus salt inside the capture directory.
+const SALT_FILE: &str = "focus-salt";
+
+/// What one tick did. Counters only — never contract state, never evidence bytes.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ShadowReport {
+    /// Contracts in focus this tick.
+    pub focused: usize,
+    /// Contracts probed, i.e. focus contracts whose code and samples were both
+    /// usable. The gap between this and `focused` is the reach problem, and it is
+    /// reported rather than inferred: a focus contract whose WASM is missing looks
+    /// exactly like a clean one if you only count findings.
+    pub probed: usize,
+    /// Focus contracts skipped because their code could not be resolved.
+    pub skipped_no_code: usize,
+    /// Focus contracts skipped because the sampler held nothing worth checking.
+    pub skipped_no_samples: usize,
+    /// Cases actually verified.
+    pub cases: usize,
+    /// Outcomes that reached no verdict.
+    pub inconclusive: usize,
+    /// Violations that would have caused a removal, had enforcement been on. The
+    /// number the RFC's Phase 5 gate is judged on.
+    pub would_remove: usize,
+    /// Diagnostic-severity findings, which never propose removal in any mode.
+    pub reported: usize,
+    /// Probes cut short by [`PROBE_TIME_BUDGET`].
+    pub timed_out: usize,
+}
+
+/// The shadow loop's state, owned by the capture writer task.
+pub struct ShadowRunner {
+    mode: EnforcementMode,
+    selector: FocusSelector,
+    ticks: u32,
+    /// `(contract, property)` pairs already logged this epoch, so a contract that
+    /// fails the same law in forty cases produces one line rather than forty. Cleared
+    /// on rotation, which is also what makes the log a per-epoch summary rather than
+    /// an ever-growing set.
+    logged: HashSet<(ContractInstanceId, ConformanceProperty)>,
+}
+
+impl ShadowRunner {
+    /// Build a runner, loading or creating this peer's focus salt under `dir`.
+    ///
+    /// The salt is per-peer and secret. If it were derived from anything public — the
+    /// peer's identity, its address, the contract set — an author could compute which
+    /// peers are watching their contract, and either target those peers with
+    /// well-behaved traffic or simply avoid them. It is therefore random, persisted,
+    /// and readable only by the node's own user.
+    pub fn new(dir: &Path, mode: EnforcementMode) -> Self {
+        let salt = load_or_create_salt(dir);
+        Self {
+            mode,
+            selector: FocusSelector::new(salt, MAX_FOCUS_CONTRACTS),
+            ticks: 0,
+            logged: HashSet::new(),
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.selector.epoch()
+    }
+
+    /// Run one probe tick over whatever the sampler currently holds.
+    ///
+    /// Takes the samplers by reference and never mutates them: a probe must not be
+    /// able to change what the peer would have captured, or shadow mode would be
+    /// altering the very measurement it exists to take.
+    /// `store` is where contract WASM lives. Passed per-tick rather than held,
+    /// because the runner is built by the capture task and the store path is known to
+    /// the executor: a parameter keeps the two from having to agree on startup order,
+    /// and keeps this testable without a process-global.
+    pub(crate) async fn tick(
+        &mut self,
+        samplers: &HashMap<ContractInstanceId, super::capture::TrackedContract>,
+        store: Option<&Path>,
+    ) -> ShadowReport {
+        let mut report = ShadowReport::default();
+
+        if self.mode == EnforcementMode::Disabled {
+            return report;
+        }
+
+        self.ticks = self.ticks.wrapping_add(1);
+        if self.ticks % ROTATE_EVERY_TICKS == 0 {
+            self.selector.rotate();
+            self.logged.clear();
+        }
+
+        let candidates: Vec<ContractInstanceId> = samplers.keys().copied().collect();
+        let focus = self.selector.select(&candidates);
+        report.focused = focus.len();
+
+        let Some(store) = store else {
+            // No store means no code, and no code means no question was asked. Say so
+            // in the counter rather than returning an empty report that reads as a
+            // clean run.
+            report.skipped_no_code = focus.len();
+            return report;
+        };
+
+        for instance in focus {
+            let Some(tracked) = samplers.get(&instance) else {
+                continue;
+            };
+            let bundle = super::capture::bundle_for(instance, tracked);
+            self.probe_one(&instance, &bundle, store, &mut report).await;
+        }
+
+        report
+    }
+
+    async fn probe_one(
+        &mut self,
+        instance: &ContractInstanceId,
+        bundle: &ReplayBundle,
+        store: &Path,
+        report: &mut ShadowReport,
+    ) {
+        let corpus = bundle.to_corpus();
+        if corpus.is_empty() {
+            report.skipped_no_samples += 1;
+            return;
+        }
+
+        let code = match bundle.resolve_code_from_store(store) {
+            Ok(code) => code,
+            Err(err) => {
+                // Not a finding: this peer failed to ask the question. Counted as
+                // such rather than passed off as a clean result, because a focus
+                // contract we cannot execute looks exactly like a conforming one if
+                // you only count violations.
+                tracing::debug!(%instance, error = %err, "shadow probe has no code for a focus contract");
+                report.skipped_no_code += 1;
+                return;
+            }
+        };
+
+        let mut oracle = match RuntimeOracle::standalone(code, bundle.parameters.clone()).await {
+            Ok(oracle) => oracle,
+            Err(err) => {
+                // A contract whose WASM will not load is not a conformance finding.
+                // It is this peer failing to ask the question, and it is counted as
+                // such rather than passed off as a clean result.
+                tracing::debug!(%instance, error = %err, "shadow probe could not build an oracle");
+                report.skipped_no_code += 1;
+                return;
+            }
+        };
+
+        let config = GeneratorConfig {
+            max_cases: MAX_CASES_PER_PROBE,
+            ..Default::default()
+        };
+        let cases = generate_cases(&corpus, &config);
+        report.probed += 1;
+
+        let started = Instant::now();
+        for case in cases.iter().take(MAX_CASES_PER_PROBE) {
+            if started.elapsed() > PROBE_TIME_BUDGET {
+                report.timed_out += 1;
+                break;
+            }
+
+            let outcome = verify_case(&mut oracle, case);
+            report.cases += 1;
+
+            match decide(self.mode, &outcome) {
+                ConformanceAction::Nothing => {
+                    if matches!(outcome, PropertyOutcome::Inconclusive(_)) {
+                        report.inconclusive += 1;
+                    }
+                }
+                ConformanceAction::Report(violation) => {
+                    report.reported += 1;
+                    self.log_once(instance, &violation, false);
+                }
+                ConformanceAction::WouldRemove(violation) => {
+                    report.would_remove += 1;
+                    self.log_once(instance, &violation, true);
+                }
+                // Unreachable while nothing constructs `EnforcementMode::Enforce`,
+                // and deliberately still handled: the point of routing shadow through
+                // the same `decide` enforcement will use is that the two paths cannot
+                // drift. Counting a removal as a would-remove keeps this honest if a
+                // future caller does reach it before the removal path is built.
+                ConformanceAction::Remove(violation) => {
+                    report.would_remove += 1;
+                    self.log_once(instance, &violation, true);
+                }
+            }
+
+            // Give the runtime back to the node between cases. A probe is
+            // best-effort, low-priority work; nothing here is allowed to hold a
+            // worker while real traffic waits.
+            tokio::task::yield_now().await;
+        }
+    }
+
+    fn log_once(
+        &mut self,
+        instance: &ContractInstanceId,
+        violation: &super::property::Violation,
+        would_remove: bool,
+    ) {
+        if !self.logged.insert((*instance, violation.property)) {
+            return;
+        }
+        tracing::info!(
+            contract = %instance,
+            property = ?violation.property,
+            epoch = self.selector.epoch(),
+            would_remove,
+            detail = %violation.detail,
+            "conformance shadow finding"
+        );
+    }
+}
+
+/// Read this peer's focus salt, creating one if it does not exist.
+///
+/// A failure to persist is not fatal: the peer runs with an ephemeral salt and
+/// reshuffles its focus set on restart. That is worse than persisting — a peer that
+/// re-rolls on every restart gives an author a way to keep re-rolling by causing
+/// restarts — but it is much better than refusing to run, and it is logged.
+fn load_or_create_salt(dir: &Path) -> [u8; 32] {
+    let path = dir.join(SALT_FILE);
+    if let Ok(bytes) = std::fs::read(&path) {
+        if let Ok(salt) = <[u8; 32]>::try_from(bytes.as_slice()) {
+            return salt;
+        }
+        tracing::warn!(
+            path = %path.display(),
+            "focus salt file is not 32 bytes; generating a new one"
+        );
+    }
+
+    // OsRng, not `GlobalRng`, and this is the crypto-material exception in
+    // `.claude/rules/code-style.md` rather than an oversight. The salt's entire job is
+    // to be unpredictable to a contract author: anyone who can guess it can compute
+    // which peers are watching their contract and either behave for those peers or
+    // avoid them. `GlobalRng` is seeded for determinism, and a simulation seed is
+    // exactly the kind of thing that leaks into a bug report.
+    // Same `OsRng` the node uses for its own cipher key (`config::secret`), so this
+    // does not introduce a second opinion about where entropy comes from.
+    let mut salt = [0u8; 32];
+    chacha20poly1305::aead::rand_core::RngCore::fill_bytes(
+        &mut chacha20poly1305::aead::OsRng,
+        &mut salt,
+    );
+    if let Err(err) = write_salt(&path, &salt) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "could not persist the conformance focus salt; focus will reshuffle on restart"
+        );
+    }
+    salt
+}
+
+fn write_salt(path: &Path, salt: &[u8; 32]) -> std::io::Result<()> {
+    std::fs::write(path, salt)?;
+    // The salt is what stops a contract author predicting or influencing whether
+    // this peer is watching them. World-readable would defeat it on a shared host.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conformance::capture::{Observation, TrackedContract, record};
+
+    fn instance(n: u8) -> ContractInstanceId {
+        ContractInstanceId::new([n; 32])
+    }
+
+    /// Build a sampler map by pushing observations through the real admission path,
+    /// so a test never asserts against a `TrackedContract` the capture path could not
+    /// actually have produced.
+    fn samplers_for(
+        id: ContractInstanceId,
+        parameters: Vec<u8>,
+        code_hash: [u8; 32],
+        transitions: &[(Vec<u8>, Vec<u8>)],
+    ) -> HashMap<ContractInstanceId, TrackedContract> {
+        let mut samplers = HashMap::new();
+        for (base, result) in transitions {
+            record(
+                &mut samplers,
+                Observation {
+                    contract: id,
+                    code_hash,
+                    parameters: parameters.clone(),
+                    base_state: base.clone(),
+                    incoming_state: Some(result.clone()),
+                    delta: None,
+                    result_state: result.clone(),
+                    related: Vec::new(),
+                },
+            );
+        }
+        samplers
+    }
+
+    /// The salt must survive a restart, or an author gets a fresh roll of the dice
+    /// every time the node bounces — which is a lever they can pull by any means that
+    /// causes a restart.
+    #[test]
+    fn the_focus_salt_persists_across_runners() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let first = load_or_create_salt(dir.path());
+        let second = load_or_create_salt(dir.path());
+        assert_eq!(
+            first, second,
+            "a second runner in the same directory drew a different salt, so focus \
+             reshuffles on every restart"
+        );
+    }
+
+    /// The salt is the whole secret. World-readable on a shared host would hand an
+    /// author the answer to "is this peer watching me".
+    #[cfg(unix)]
+    #[test]
+    fn the_focus_salt_is_not_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let _ = load_or_create_salt(dir.path());
+        let mode = std::fs::metadata(dir.path().join(SALT_FILE))
+            .expect("salt file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "the focus salt is readable beyond its owner (mode {mode:o})"
+        );
+    }
+
+    /// Two peers must not agree on who to watch, or the network watches one small
+    /// set of contracts many times over and everything else never.
+    #[test]
+    fn two_peers_draw_different_salts() {
+        let a = tempfile::TempDir::new().expect("tempdir");
+        let b = tempfile::TempDir::new().expect("tempdir");
+        assert_ne!(
+            load_or_create_salt(a.path()),
+            load_or_create_salt(b.path()),
+            "two peers drew the same salt, so focus selection is not per-peer"
+        );
+    }
+
+    /// A truncated or hand-edited salt file must not be adopted as a 32-byte salt.
+    #[test]
+    fn a_short_salt_file_is_replaced_rather_than_used() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(dir.path().join(SALT_FILE), [1u8, 2, 3]).expect("write short salt");
+        let salt = load_or_create_salt(dir.path());
+        assert_ne!(salt, [0u8; 32], "a replacement salt must not be all zeroes");
+        assert_eq!(
+            salt,
+            load_or_create_salt(dir.path()),
+            "the replacement salt was not persisted"
+        );
+    }
+
+    /// Without a contract store there is no code, and without code no question was
+    /// asked. That must show up as a skip, never as an empty report: a shadow period
+    /// that could not execute anything and one that found nothing are the same shape
+    /// in a findings-only log, and telling them apart is most of what this phase is
+    /// for.
+    #[tokio::test]
+    async fn no_contract_store_reports_skips_rather_than_a_clean_run() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let samplers = samplers_for(
+            instance(1),
+            vec![0],
+            [0u8; 32],
+            &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
+        );
+
+        let report = runner.tick(&samplers, None).await;
+        assert!(
+            report.focused > 0,
+            "nothing was selected, so this proves nothing"
+        );
+        assert_eq!(
+            report.skipped_no_code, report.focused,
+            "focus contracts with no resolvable code were not counted as skipped"
+        );
+        assert_eq!(
+            report.cases, 0,
+            "cases were checked without any contract code"
+        );
+        assert_eq!(report.would_remove, 0);
+    }
+
+    /// `Disabled` means nothing runs at all — not "runs but reports nothing".
+    #[tokio::test]
+    async fn disabled_does_no_work_whatsoever() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Disabled);
+        let samplers = samplers_for(instance(1), vec![0], [0u8; 32], &[(vec![1], vec![1, 2])]);
+        assert_eq!(
+            runner.tick(&samplers, None).await,
+            ShadowReport::default(),
+            "Disabled mode still selected or skipped contracts"
+        );
+    }
+
+    /// Rotation is what stops one unlucky contract being the only thing this peer
+    /// ever looks at. Asserting the epoch advances on the right tick, and not before.
+    #[tokio::test]
+    async fn focus_rotates_on_schedule_and_not_sooner() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let samplers = samplers_for(instance(1), vec![0], [0u8; 32], &[(vec![1], vec![1, 2])]);
+
+        for tick in 1..ROTATE_EVERY_TICKS {
+            runner.tick(&samplers, None).await;
+            assert_eq!(
+                runner.epoch(),
+                0,
+                "focus rotated early, on tick {tick} of {ROTATE_EVERY_TICKS}"
+            );
+        }
+        runner.tick(&samplers, None).await;
+        assert_eq!(
+            runner.epoch(),
+            1,
+            "focus did not rotate after {ROTATE_EVERY_TICKS} ticks"
+        );
+    }
+
+    /// The end-to-end proof: a real contract with a real defect, resolved from a real
+    /// contract store, driven through focus selection and the probe loop, comes out as
+    /// `would_remove` — and a conforming contract through the identical path does not.
+    ///
+    /// Both halves are needed. Without the conforming half this test would pass for a
+    /// runner that flagged everything, which is the failure mode that matters most
+    /// here: the RFC's whole deployment plan turns on shadow mode producing few enough
+    /// prospective removals that every one can be understood.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_real_defect_reaches_would_remove_and_a_conforming_contract_does_not()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use freenet_stdlib::prelude::{
+            ContractCode, ContractContainer, ContractWasmAPIVersion, Parameters, WrappedContract,
+        };
+        use std::sync::Arc;
+
+        // Mode 1 of the shared fixture is last-write-wins, which breaks commutativity.
+        // Mode 0 is the honest join-semilattice. Keep in sync with
+        // `tests/test-contract-conformance/src/lib.rs`.
+        const LAST_WRITE_WINS: u8 = 1;
+        const CONFORMING: u8 = 0;
+
+        let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
+        let code_hash = *blake3::hash(&wasm).as_bytes();
+
+        // A real store, written the way the node writes it. Reading it back is the
+        // step with the versioned-header trap, so the test exercises the real reader
+        // rather than a hand-rolled one.
+        let store_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(store_dir.path())?;
+        let db = crate::contract::storages::Storage::new(store_dir.path()).await?;
+        let mut store =
+            crate::wasm_runtime::ContractStore::new(store_dir.path().into(), 10_000_000, db)?;
+
+        let states = vec![
+            (vec![1u8], vec![1u8, 2]),
+            (vec![2u8], vec![2u8, 3]),
+            (vec![1u8, 2], vec![1u8, 2, 3]),
+            (vec![4u8], vec![4u8, 5]),
+        ];
+
+        let mut outcomes = Vec::new();
+        for mode in [LAST_WRITE_WINS, CONFORMING] {
+            let parameters: Parameters<'static> = Parameters::from(vec![mode]);
+            let contract = WrappedContract::new(
+                Arc::new(ContractCode::from(wasm.clone())),
+                parameters.clone(),
+            );
+            let key = *contract.key();
+            let id = *key.id();
+            store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+                contract,
+            )))?;
+
+            let samplers = samplers_for(id, vec![mode], code_hash, &states);
+            let before = samplers.len();
+
+            let dir = tempfile::TempDir::new()?;
+            let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+            let report = runner.tick(&samplers, Some(store_dir.path())).await;
+
+            assert_eq!(
+                samplers.len(),
+                before,
+                "a probe changed the sampler set; shadow mode must not alter what the \
+                 peer would have captured"
+            );
+            assert_eq!(
+                report.probed, 1,
+                "mode {mode} was not probed at all (skipped_no_code={}, \
+                 skipped_no_samples={}), so its verdict means nothing",
+                report.skipped_no_code, report.skipped_no_samples
+            );
+            assert!(
+                report.cases > 0,
+                "mode {mode} was probed but no case ran, so nothing was checked"
+            );
+            outcomes.push((mode, report));
+        }
+
+        let broken = &outcomes[0].1;
+        let honest = &outcomes[1].1;
+
+        assert!(
+            broken.would_remove > 0,
+            "a contract that provably breaks commutativity produced no prospective \
+             removal: {broken:?}"
+        );
+        assert_eq!(
+            honest.would_remove, 0,
+            "a conforming contract produced a prospective removal, which is the false \
+             positive the whole deployment plan is gated on not happening: {honest:?}"
+        );
+        Ok(())
+    }
+}

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -497,8 +497,16 @@ fn load_or_create_salt(dir: &Path) -> [u8; 32] {
                 use std::os::unix::fs::PermissionsExt;
                 if let Ok(meta) = std::fs::metadata(&path) {
                     if meta.permissions().mode() & 0o077 != 0 {
-                        let _ =
-                            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                        if let Err(err) =
+                            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                        {
+                            tracing::warn!(
+                                path = %path.display(),
+                                error = %err,
+                                "could not tighten permissions on an existing focus \
+                                 salt; it stays readable beyond its owner"
+                            );
+                        }
                     }
                 }
             }
@@ -544,6 +552,42 @@ fn write_salt(path: &Path, salt: &[u8; 32]) -> std::io::Result<()> {
     let mut file = crate::wasm_runtime::create_owner_only(path)?;
     file.write_all(salt)?;
     file.sync_all()
+}
+
+/// Read the persisted focus epoch, defaulting to zero.
+///
+/// A missing or unreadable file is not an error: a first run has no epoch, and a
+/// corrupt one is better restarted from zero than guessed at. Losing it costs
+/// rotation progress, not correctness.
+fn load_epoch(dir: &Path) -> u64 {
+    std::fs::read_to_string(dir.join(EPOCH_FILE))
+        .ok()
+        .and_then(|raw| raw.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Persist the focus epoch beside the salt.
+///
+/// Best-effort, like the salt: a peer that cannot write it reshuffles from zero on
+/// restart, which is worse but not broken, and it is logged rather than silent.
+fn store_epoch(dir: &Path, epoch: u64) {
+    let path = dir.join(EPOCH_FILE);
+    // Owner-only like the salt beside it. The epoch alone reveals nothing without the
+    // salt, so this is consistency rather than a hole being closed — but a directory
+    // where one of two files that jointly determine focus is protected and the other
+    // is not invites exactly the wrong inference about which parts matter.
+    let written = crate::wasm_runtime::create_owner_only(&path).and_then(|mut file| {
+        use std::io::Write;
+        file.write_all(epoch.to_string().as_bytes())
+    });
+    if let Err(err) = written {
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "could not persist the conformance focus epoch; focus rotation will \
+             restart from zero after a restart"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -908,41 +952,5 @@ mod tests {
              positive the whole deployment plan is gated on not happening: {honest:?}"
         );
         Ok(())
-    }
-}
-
-/// Read the persisted focus epoch, defaulting to zero.
-///
-/// A missing or unreadable file is not an error: a first run has no epoch, and a
-/// corrupt one is better restarted from zero than guessed at. Losing it costs
-/// rotation progress, not correctness.
-fn load_epoch(dir: &Path) -> u64 {
-    std::fs::read_to_string(dir.join(EPOCH_FILE))
-        .ok()
-        .and_then(|raw| raw.trim().parse().ok())
-        .unwrap_or(0)
-}
-
-/// Persist the focus epoch beside the salt.
-///
-/// Best-effort, like the salt: a peer that cannot write it reshuffles from zero on
-/// restart, which is worse but not broken, and it is logged rather than silent.
-fn store_epoch(dir: &Path, epoch: u64) {
-    let path = dir.join(EPOCH_FILE);
-    // Owner-only like the salt beside it. The epoch alone reveals nothing without the
-    // salt, so this is consistency rather than a hole being closed — but a directory
-    // where one of two files that jointly determine focus is protected and the other
-    // is not invites exactly the wrong inference about which parts matter.
-    let written = crate::wasm_runtime::create_owner_only(&path).and_then(|mut file| {
-        use std::io::Write;
-        file.write_all(epoch.to_string().as_bytes())
-    });
-    if let Err(err) = written {
-        tracing::warn!(
-            path = %path.display(),
-            error = %err,
-            "could not persist the conformance focus epoch; focus rotation will \
-             restart from zero after a restart"
-        );
     }
 }

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -352,26 +352,55 @@ async fn probe_one(
     let cases = generate_cases(&corpus, &config);
     report.probed += 1;
 
-    let started = Instant::now();
-    for case in cases.iter().take(MAX_CASES_PER_PROBE) {
-        if started.elapsed() >= budget {
-            report.timed_out += 1;
-            break;
-        }
-
-        let outcome = verify_case(&mut oracle, case);
-        report.cases += 1;
-
-        match decide(mode, &outcome) {
-            ConformanceAction::Nothing => {
-                if matches!(outcome, PropertyOutcome::Inconclusive(_)) {
-                    report.inconclusive += 1;
-                }
+    // The WASM runs here, on a blocking thread.
+    //
+    // `.claude/rules/contracts.md` forbids executing contracts on the main async
+    // runtime, and `verify_case` drives synchronous WASM calls. Moving the probe to
+    // another TASK would not help: tasks share the worker threads, and a node sized by
+    // `available_parallelism()` has exactly one on a single-vCPU host, a supported
+    // deployment. Only the CPU-bound loop moves — building the oracle stays async on
+    // the runtime — so nothing here drives a future from a blocking thread.
+    let cases: Vec<_> = cases.into_iter().take(MAX_CASES_PER_PROBE).collect();
+    let instance_copy = *instance;
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut out = ProbeOutcome::default();
+        let started = Instant::now();
+        for case in &cases {
+            if started.elapsed() >= budget {
+                out.timed_out = true;
+                break;
             }
+            let outcome = verify_case(&mut oracle, case);
+            out.cases += 1;
+            out.decisions.push(decide(mode, &outcome));
+            out.inconclusive += usize::from(matches!(outcome, PropertyOutcome::Inconclusive(_)));
+        }
+        out
+    })
+    .await;
+
+    let outcome = match joined {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            // A probe that died is not a finding about the contract.
+            tracing::warn!(%instance, error = %err, "shadow probe thread failed");
+            return;
+        }
+    };
+
+    report.cases += outcome.cases;
+    report.inconclusive += outcome.inconclusive;
+    if outcome.timed_out {
+        report.timed_out += 1;
+    }
+
+    for action in outcome.decisions {
+        match action {
+            ConformanceAction::Nothing => {}
             ConformanceAction::Report(violation) => {
                 report.reported += 1;
                 findings.push(Finding {
-                    contract: *instance,
+                    contract: instance_copy,
                     violation,
                     would_remove: false,
                 });
@@ -379,7 +408,7 @@ async fn probe_one(
             ConformanceAction::WouldRemove(violation) => {
                 report.would_remove += 1;
                 findings.push(Finding {
-                    contract: *instance,
+                    contract: instance_copy,
                     violation,
                     would_remove: true,
                 });
@@ -392,17 +421,26 @@ async fn probe_one(
             ConformanceAction::Remove(violation) => {
                 report.would_remove += 1;
                 findings.push(Finding {
-                    contract: *instance,
+                    contract: instance_copy,
                     violation,
                     would_remove: true,
                 });
             }
         }
-
-        // Yield between cases. Even on its own task a probe is best-effort,
-        // low-priority work, and must not hold a worker while real traffic waits.
-        tokio::task::yield_now().await;
     }
+}
+
+/// What one contract's blocking probe produced, carried back to the async side.
+///
+/// Decisions rather than outcomes: `PropertyOutcome` owns a `Violation`, and moving
+/// the already-made decision keeps the blocking thread from needing anything about how
+/// findings are recorded.
+#[derive(Default)]
+struct ProbeOutcome {
+    cases: usize,
+    inconclusive: usize,
+    timed_out: bool,
+    decisions: Vec<ConformanceAction>,
 }
 
 /// Read this peer's focus salt, creating one if it does not exist.

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -174,6 +174,27 @@ impl ShadowRunner {
     /// Run one probe tick over whatever the sampler currently holds.
     /// Choose this tick's focus contracts and copy out what a probe needs.
     ///
+    /// # Known bound: focus can only reach what capture is already tracking
+    ///
+    /// `capture::record` stops admitting new contracts once it is tracking
+    /// `MAX_TRACKED_CONTRACTS` and never evicts, so the candidate set here freezes at
+    /// the first N contracts that peer ever observed. Rotation then reshuffles a fixed
+    /// set rather than working through the network: contracts first seen after the cap
+    /// are unreachable, and if hosting later drops the code for a frozen id, focus can
+    /// keep selecting it and only raise `skipped_no_code`.
+    ///
+    /// Two consequences worth stating plainly rather than discovering from a flat
+    /// coverage graph. Ordinary churn erodes coverage over time. And an author who can
+    /// get 64 contracts observed early can, in principle, make a peer's focus set
+    /// entirely their own choosing — which does not let them dodge the salt, but does
+    /// let them starve everyone else of attention on that peer.
+    ///
+    /// Not fixed here: the cap and the no-evict rule are capture's, they predate this,
+    /// and changing them changes what a captured corpus means — a design call, not a
+    /// drive-by. Made VISIBLE instead: every tick reports `tracked` and whether the
+    /// sampler is at its cap, so the erosion shows up in the shadow telemetry that
+    /// exists to find exactly this kind of quiet loss of reach.
+    ///
     /// Split from [`probe`] deliberately, and the split is load-bearing rather than
     /// tidiness. This half borrows the sampler map, so it has to run on the capture
     /// task, and it is cheap: a hash per candidate plus a bounded copy of the selected
@@ -316,6 +337,15 @@ async fn probe_one(
     report: &mut ShadowReport,
     findings: &mut Vec<Finding>,
 ) {
+    // Start the clock BEFORE the oracle is built, not after. Loading the code,
+    // constructing the engine and compiling the module all happen first, and for a
+    // cold or large contract that setup can exceed the whole budget on its own. Timing
+    // only the case loop would let a probe blow through its advertised ceiling and
+    // still report `timed_out == 0`, because the few cases that then ran were quick —
+    // a ceiling that reports itself as respected while being exceeded is worse than no
+    // ceiling, since it is the telemetry the next tuning decision would rest on.
+    let started = Instant::now();
+
     let corpus = bundle.to_corpus();
     if corpus.is_empty() {
         report.skipped_no_samples += 1;
@@ -362,11 +392,16 @@ async fn probe_one(
     // the runtime — so nothing here drives a future from a blocking thread.
     let cases: Vec<_> = cases.into_iter().take(MAX_CASES_PER_PROBE).collect();
     let instance_copy = *instance;
+    // Only what setup did not already spend.
+    let Some(remaining) = budget.checked_sub(started.elapsed()) else {
+        report.timed_out += 1;
+        return;
+    };
     let joined = tokio::task::spawn_blocking(move || {
         let mut out = ProbeOutcome::default();
-        let started = Instant::now();
+        let loop_started = Instant::now();
         for case in &cases {
-            if started.elapsed() >= budget {
+            if loop_started.elapsed() >= remaining {
                 out.timed_out = true;
                 break;
             }
@@ -894,7 +929,15 @@ fn load_epoch(dir: &Path) -> u64 {
 /// restart, which is worse but not broken, and it is logged rather than silent.
 fn store_epoch(dir: &Path, epoch: u64) {
     let path = dir.join(EPOCH_FILE);
-    if let Err(err) = std::fs::write(&path, epoch.to_string()) {
+    // Owner-only like the salt beside it. The epoch alone reveals nothing without the
+    // salt, so this is consistency rather than a hole being closed — but a directory
+    // where one of two files that jointly determine focus is protected and the other
+    // is not invites exactly the wrong inference about which parts matter.
+    let written = crate::wasm_runtime::create_owner_only(&path).and_then(|mut file| {
+        use std::io::Write;
+        file.write_all(epoch.to_string().as_bytes())
+    });
+    if let Err(err) = written {
         tracing::warn!(
             path = %path.display(),
             error = %err,

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -82,10 +82,29 @@ const MAX_CASES_PER_PROBE: usize = 64;
 /// Belt to `MAX_CASES_PER_PROBE`'s braces: the case count bounds the work only if
 /// each case is quick, and "quick" depends on a contract we do not control. A
 /// contract that is merely slow rather than infinite would otherwise stretch a tick.
+///
+/// # What this does NOT bound, and why that is acceptable
+///
+/// It is checked BETWEEN cases, so a single long case overshoots it and is only
+/// recorded as `timed_out` once it finishes. The overshoot is bounded but not small:
+/// each WASM call traps at the runtime's epoch deadline (`max_execution_seconds`,
+/// 5s by default), and a reconciliation case drives up to `MAX_RECONCILIATION_ROUNDS`
+/// rounds of them, so a deliberately-slow contract can hold one case for far longer
+/// than ten seconds. It cannot run unbounded.
+///
+/// Two reasons this is left as it is rather than tightened. The probe runs on a
+/// blocking thread, so an overshoot costs CPU rather than event-loop latency, which is
+/// the property that actually matters. And giving probes a shorter per-call deadline
+/// than production would break the RFC's requirement that the local harness use the
+/// production runtime configuration — a probe would then report resource exhaustion
+/// where `fdev` reports a verdict, and the two would stop meaning the same thing.
 const PROBE_TIME_BUDGET: Duration = Duration::from_secs(10);
 
 /// Filename of the per-peer focus salt inside the capture directory.
 const SALT_FILE: &str = "focus-salt";
+
+/// Filename of the persisted focus epoch, beside the salt.
+const EPOCH_FILE: &str = "focus-epoch";
 
 /// What one tick did. Counters only — never contract state, never evidence bytes.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -119,6 +138,8 @@ pub struct ShadowRunner {
     mode: EnforcementMode,
     selector: FocusSelector,
     ticks: u32,
+    /// Capture directory, so a rotation can persist the new epoch beside the salt.
+    dir: PathBuf,
     /// `(contract, property)` pairs already logged this epoch, so a contract that
     /// fails the same law in forty cases produces one line rather than forty. Cleared
     /// on rotation, which is also what makes the log a per-epoch summary rather than
@@ -136,10 +157,12 @@ impl ShadowRunner {
     /// and readable only by the node's own user.
     pub fn new(dir: &Path, mode: EnforcementMode) -> Self {
         let salt = load_or_create_salt(dir);
+        let epoch = load_epoch(dir);
         Self {
             mode,
-            selector: FocusSelector::new(salt, MAX_FOCUS_CONTRACTS),
+            selector: FocusSelector::resuming_at(salt, MAX_FOCUS_CONTRACTS, epoch),
             ticks: 0,
+            dir: dir.to_path_buf(),
             logged: HashSet::new(),
         }
     }
@@ -173,6 +196,7 @@ impl ShadowRunner {
         if self.ticks % ROTATE_EVERY_TICKS == 0 {
             self.selector.rotate();
             self.logged.clear();
+            store_epoch(&self.dir, self.selector.epoch());
         }
 
         let candidates: Vec<ContractInstanceId> = samplers.keys().copied().collect();
@@ -237,6 +261,22 @@ pub(crate) async fn probe(
     store: Option<PathBuf>,
     mode: EnforcementMode,
 ) -> (ShadowReport, Vec<Finding>) {
+    probe_with_budget(work, store, mode, PROBE_TIME_BUDGET).await
+}
+
+/// [`probe`] with an explicit time budget.
+///
+/// Exists because the budget branch is otherwise unreachable from a test: it is
+/// checked between cases against a real elapsed clock, and no fixture contract is
+/// slow enough to trip a ten-second ceiling without making the suite take ten
+/// seconds. Injecting it lets a test prove the check fires and stops the probe,
+/// which is the part that can regress; the constant itself is a tuning choice.
+pub(crate) async fn probe_with_budget(
+    work: Vec<(ContractInstanceId, ReplayBundle)>,
+    store: Option<PathBuf>,
+    mode: EnforcementMode,
+    budget: Duration,
+) -> (ShadowReport, Vec<Finding>) {
     let mut report = ShadowReport {
         focused: work.len(),
         ..ShadowReport::default()
@@ -252,16 +292,27 @@ pub(crate) async fn probe(
     };
 
     for (instance, bundle) in work {
-        probe_one(&instance, &bundle, &store, mode, &mut report, &mut findings).await;
+        probe_one(
+            &instance,
+            &bundle,
+            &store,
+            mode,
+            budget,
+            &mut report,
+            &mut findings,
+        )
+        .await;
     }
     (report, findings)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn probe_one(
     instance: &ContractInstanceId,
     bundle: &ReplayBundle,
     store: &Path,
     mode: EnforcementMode,
+    budget: Duration,
     report: &mut ShadowReport,
     findings: &mut Vec<Finding>,
 ) {
@@ -303,7 +354,7 @@ async fn probe_one(
 
     let started = Instant::now();
     for case in cases.iter().take(MAX_CASES_PER_PROBE) {
-        if started.elapsed() > PROBE_TIME_BUDGET {
+        if started.elapsed() >= budget {
             report.timed_out += 1;
             break;
         }
@@ -364,6 +415,20 @@ fn load_or_create_salt(dir: &Path) -> [u8; 32] {
     let path = dir.join(SALT_FILE);
     if let Ok(bytes) = std::fs::read(&path) {
         if let Ok(salt) = <[u8; 32]>::try_from(bytes.as_slice()) {
+            // Tighten an existing salt that is readable beyond its owner. A file
+            // written by an older build, or copied about, keeps whatever mode it
+            // arrived with, and a secret that is only protected at creation time is
+            // only protected on the run that created it.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(meta) = std::fs::metadata(&path) {
+                    if meta.permissions().mode() & 0o077 != 0 {
+                        let _ =
+                            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                    }
+                }
+            }
             return salt;
         }
         tracing::warn!(
@@ -396,15 +461,16 @@ fn load_or_create_salt(dir: &Path) -> [u8; 32] {
 }
 
 fn write_salt(path: &Path, salt: &[u8; 32]) -> std::io::Result<()> {
-    std::fs::write(path, salt)?;
-    // The salt is what stops a contract author predicting or influencing whether
-    // this peer is watching them. World-readable would defeat it on a shared host.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(())
+    // Created owner-only, rather than written and then chmod-ed. The salt is what
+    // stops a contract author predicting or influencing whether this peer is watching
+    // them, and write-then-chmod leaves a window in which it is not yet protected.
+    // The node tightens its umask at startup so that window is closed in practice
+    // today, but this reuses the helper the project already built for secrets rather
+    // than depending on a mitigation that lives somewhere else and could be narrowed.
+    use std::io::Write;
+    let mut file = crate::wasm_runtime::create_owner_only(path)?;
+    file.write_all(salt)?;
+    file.sync_all()
 }
 
 #[cfg(test)]
@@ -589,6 +655,92 @@ mod tests {
         );
     }
 
+    /// The time budget must actually stop a probe, not merely be declared.
+    ///
+    /// This module's own doc says tokio's clock was chosen so a test could prove the
+    /// budget cuts a probe short — and until review pointed it out, no such test
+    /// existed. A zero budget makes the check fire before the first case, which is the
+    /// branch that can regress; the ten-second value itself is a tuning choice, not a
+    /// behaviour.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_time_budget_stops_a_probe() -> Result<(), Box<dyn std::error::Error>> {
+        use freenet_stdlib::prelude::{
+            ContractCode, ContractContainer, ContractWasmAPIVersion, Parameters, WrappedContract,
+        };
+        use std::sync::Arc;
+
+        let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
+        let code_hash = *blake3::hash(&wasm).as_bytes();
+        let store_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(store_dir.path())?;
+        let db = crate::contract::storages::Storage::new(store_dir.path()).await?;
+        let mut store =
+            crate::wasm_runtime::ContractStore::new(store_dir.path().into(), 10_000_000, db)?;
+
+        let parameters: Parameters<'static> = Parameters::from(vec![0u8]);
+        let contract = WrappedContract::new(Arc::new(ContractCode::from(wasm)), parameters.clone());
+        let id = *contract.key().id();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract,
+        )))?;
+
+        let samplers = samplers_for(
+            id,
+            vec![0],
+            code_hash,
+            &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
+        );
+        let dir = tempfile::TempDir::new()?;
+        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let work = runner.select(&samplers);
+        assert!(!work.is_empty(), "nothing selected, so this proves nothing");
+
+        let (report, _) = probe_with_budget(
+            work,
+            Some(store_dir.path().to_path_buf()),
+            EnforcementMode::Shadow,
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(
+            report.timed_out, 1,
+            "an exhausted budget did not stop the probe: {report:?}"
+        );
+        assert_eq!(
+            report.cases, 0,
+            "cases ran after the budget was already exhausted: {report:?}"
+        );
+        Ok(())
+    }
+
+    /// Rotation only means anything if it accumulates across restarts.
+    ///
+    /// A peer that reset to epoch zero on every restart would re-select the same first
+    /// focus set forever, so an author able to cause restarts could pin a peer's
+    /// attention — or keep it away from themselves indefinitely.
+    #[tokio::test]
+    async fn the_focus_epoch_survives_a_restart() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let samplers = samplers_for(instance(1), vec![0], [0u8; 32], &[(vec![1], vec![1, 2])]);
+
+        let mut first = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        for _ in 0..ROTATE_EVERY_TICKS {
+            tick(&mut first, &samplers, None).await;
+        }
+        let rotated = first.epoch();
+        assert!(rotated > 0, "the first runner never rotated");
+        drop(first);
+
+        let resumed = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        assert_eq!(
+            resumed.epoch(),
+            rotated,
+            "a restart lost the focus epoch, so rotation restarts from zero every time \
+             the node bounces"
+        );
+    }
+
     /// The end-to-end proof: a real contract with a real defect, resolved from a real
     /// contract store, driven through focus selection and the probe loop, comes out as
     /// `would_remove` — and a conforming contract through the identical path does not.
@@ -683,5 +835,33 @@ mod tests {
              positive the whole deployment plan is gated on not happening: {honest:?}"
         );
         Ok(())
+    }
+}
+
+/// Read the persisted focus epoch, defaulting to zero.
+///
+/// A missing or unreadable file is not an error: a first run has no epoch, and a
+/// corrupt one is better restarted from zero than guessed at. Losing it costs
+/// rotation progress, not correctness.
+fn load_epoch(dir: &Path) -> u64 {
+    std::fs::read_to_string(dir.join(EPOCH_FILE))
+        .ok()
+        .and_then(|raw| raw.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Persist the focus epoch beside the salt.
+///
+/// Best-effort, like the salt: a peer that cannot write it reshuffles from zero on
+/// restart, which is worse but not broken, and it is logged rather than silent.
+fn store_epoch(dir: &Path, epoch: u64) {
+    let path = dir.join(EPOCH_FILE);
+    if let Err(err) = std::fs::write(&path, epoch.to_string()) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "could not persist the conformance focus epoch; focus rotation will \
+             restart from zero after a restart"
+        );
     }
 }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1731,6 +1731,12 @@ where
         db: Storage,
         shared: Option<SharedStores>,
     ) -> Result<(ContractStore, DelegateStore, SecretsStore), anyhow::Error> {
+        // Tell the conformance machinery where contract WASM lives. Shadow-mode
+        // probing replays captured samples against the real contract, and the only
+        // component that knows the path is the one building the store. Idempotent and
+        // free when capture is off: nothing reads it unless a probe runs.
+        crate::conformance::capture::set_contract_store(config.contracts_dir());
+
         let (contract_store, delegate_store) = match shared {
             // Pool executors: adopt the node's shared indexes AND byte caches, so
             // one contract/delegate registered anywhere is visible everywhere and

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -12,6 +12,12 @@ mod runtime;
 pub mod secret_export;
 pub mod secret_snapshots;
 mod secrets_store;
+// Narrow re-export rather than making `secrets_store` crate-visible: this is the one
+// correct way in this codebase to create a secret file (owner-only AT CREATION, not
+// chmod-ed afterwards), and the conformance focus salt needs it too. Widening the
+// whole module for one helper would expose the secrets store's internals crate-wide
+// for convenience.
+pub(crate) use secrets_store::sweep::create_owner_only;
 pub(crate) mod simulation_runtime;
 mod state_store;
 #[cfg(all(test, feature = "wasmtime-backend"))]

--- a/crates/core/src/wasm_runtime/secrets_store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store.rs
@@ -24,7 +24,11 @@
 
 mod quota;
 mod store;
-mod sweep;
+// `pub(crate)` for `sweep::create_owner_only`, which is the project's one correct way
+// to create a secret file (owner-only at creation, not chmod-ed afterwards). The
+// conformance focus salt needs it too, and a second implementation would be a second
+// chance to get the window wrong.
+pub(crate) mod sweep;
 mod user;
 
 // ── Public re-exports ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`decide()` has been fully specified and tested since #5344, and has never once been called by a running node. Focus selection, the policy table, the severity split, the evidence model — all of it is reachable only from `fdev` and from tests.

So the mechanism RFC #5320 describes does not exist on the network in any mode, including the mode that is defined to do nothing. Shadow mode is not a stepping stone to the real thing; per the RFC's deployment plan it *is* the thing, minus deletion, and Phase 5 will not open until shadow data has answered questions that nothing is currently collecting.

## Approach

This is the RFC's **Phase 3: single/live peer shadow validation**. A bounded, opt-in loop that selects focus contracts, replays the samples capture is already collecting, and writes down the verdict without acting on it.

It removes nothing in any configuration reachable from here, and sends nothing anywhere — no evidence propagation, no author diagnostics, no network traffic. Those are Phase 4. It also generates no synchronization traffic to manufacture samples, which is the RFC's explicit constraint that the peer is an observer and not a fuzzer: it reads only what ordinary traffic already produced.

**Probes run on a throwaway runtime.** Each probe builds its own `RuntimeOracle::standalone` — its own wasmtime over its own scratch store — rather than borrowing the node's executor. That costs a temp directory per probe and buys two things: a probe cannot touch hosted state, and a contract that misbehaves under probing cannot affect the runtime serving real requests.

**Selection and probing are split, and the split is load-bearing.** Selection borrows the sampler map, so it has to run on the capture task; it is cheap, a hash per candidate plus a bounded copy. Probing is CPU-bound WASM execution under a ten-second-per-contract budget, and running *that* on the capture task would stop the task draining its observation queue for as long as it ran — dropping the very observations conformance depends on, from a mechanism whose stated requirement is that it never degrade normal operation. The periodic flush was already made async for exactly this reason; a probe is the worse case, because it is CPU-bound and cannot be yielded away from by awaiting a syscall. So probing runs on its own task over owned copies, with at most one in flight, so a slow contract cannot stack concurrent WASM execution.

**Focus selection is keyed on a per-peer secret salt**, persisted 0600 in the capture directory. It has to be secret and it has to survive a restart: an author who can predict the salt can work out which peers are watching them and either behave for those peers or avoid them, and an author who can force a re-roll gets a fresh draw by any means that causes a restart. The salt comes from `OsRng` under the crypto-material exception in `code-style.md` rather than `GlobalRng`, because a simulation seed is exactly the kind of thing that ends up in a bug report.

**The report counts skips, not just findings.** A shadow period that could not execute anything and one that genuinely found nothing are identical in a findings-only log, and telling those apart is most of what this phase is for. A focus contract whose WASM cannot be resolved is `skipped_no_code`, never a clean result; a tick that selected nothing says so explicitly.

Two shared helpers move so that the offline and online paths cannot drift:

- `bundle_for` is extracted, so the periodic flush and the probe build a corpus the same way. Two constructions would be two chances to disagree about what a corpus contains, and the disagreement would be invisible — both produce a plausible bundle, and only a finding that reproduced offline but not in shadow would reveal it.
- `resolve_code_from_store` moves into `ReplayBundle`, because it carries the versioned-header trap: a store file is forty bytes of header then the code, and only the code is hashed, so hashing the file's own bytes can never match and fails silently, looking exactly like "this node never hosted that contract".

## Testing

The end-to-end test is the point of the change: a real defective contract, resolved from a real contract store, driven through focus selection and the probe loop, comes out as `would_remove` — and a conforming contract through the identical path does not. Both halves are needed, because without the second it would pass for a runner that flagged everything, which is the failure mode the RFC's whole deployment plan turns on avoiding.

Tests go through the same select-probe-record sequence production uses, rather than calling the halves directly, so a change to that sequence cannot leave them passing.

Also covered: the salt persists across runners, is not world-readable, differs between peers, and is replaced rather than adopted if truncated; `Disabled` does no work whatsoever rather than working and reporting nothing; rotation happens on schedule and not sooner; a missing contract store reports skips rather than a clean run; and a probe does not alter the sampler set.

One source-scrape pin guards the executor's registration of the contract store. Without that one call every probe resolves no code, so the peer selects focus contracts, executes nothing and reports no violations — for the same reason a peer with no contracts reports none. The counters distinguish it but nothing *fails*, so a refactor that drops the registration would turn the whole mechanism off while leaving every test green and the logs superficially healthy.

## What this does not yet do

Evidence propagation, independent verification by recipients, author diagnostics and the removal path are Phase 4 and 5. The metrics emitted here are a subset of the RFC's Phase 4 list, chosen for what a single peer can answer; they are `tracing::info!` rather than enumerated telemetry events, which is sufficient for reading one peer's log and will need enumerating before fleet-wide shadow.

Part of #5320.

[AI-assisted - Claude]
