### PR TITLE
fix(conformance): select focus over hosted contracts, and sample what focus picked

### DIFF
--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1394,9 +1394,16 @@ mod tests {
 
     /// Wide mode keeps the old bounded-refusal behaviour: a developer corpus whose
     /// contents depended on eviction order would stop meaning "what this peer saw".
+    ///
+    /// Asserting only that the map stopped at its cap does NOT test this - a map that
+    /// evicts one entry per admission also sits exactly at the cap forever. The first
+    /// version of this test did exactly that and passed under the rollover it was
+    /// written to forbid. What separates the two is WHICH contracts survive: refusal
+    /// keeps the earliest, rollover keeps the latest.
     #[test]
     fn wide_sampling_stops_at_the_cap_rather_than_rolling_over() {
         let mut samplers = HashMap::new();
+        let first = ContractInstanceId::new([0; 32]);
         for i in 0..(MAX_TRACKED_CONTRACTS + 20) {
             let id = ContractInstanceId::new([(i % 251) as u8; 32]);
             record(&mut samplers, &SamplingScope::Wide, observation_for(id));
@@ -1405,6 +1412,16 @@ mod tests {
             samplers.len(),
             MAX_TRACKED_CONTRACTS,
             "wide capture did not stop at its cap"
+        );
+        assert!(
+            samplers.contains_key(&first),
+            "wide capture dropped the earliest contract it saw, so the corpus now \
+             depends on eviction order rather than on what the peer observed"
+        );
+        let last = ContractInstanceId::new([(MAX_TRACKED_CONTRACTS + 19) as u8; 32]);
+        assert!(
+            !samplers.contains_key(&last),
+            "wide capture admitted a contract past its cap"
         );
     }
 

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -314,6 +314,49 @@ pub(crate) fn contract_store() -> Option<&'static PathBuf> {
     CONTRACT_STORE.get()
 }
 
+/// How the peer enumerates the contracts it currently hosts.
+///
+/// The RFC selects focus contracts from *what the peer hosts*, not from what the
+/// sampler happens to have collected. Those are different sets, and the difference is
+/// not cosmetic: a sampler-sourced candidate pool can only ever offer contracts that
+/// already arrived through it, so once it reached its tracking cap the peer became
+/// permanently unable to focus on anything new (#5366 - observed live as
+/// `tracking_at_cap=true` on every tick for hours). Sourcing candidates from the
+/// hosting cache makes the horizon the peer's actual hosted set, and makes sampling a
+/// consequence of focus rather than its precondition.
+///
+/// Registered by the ring, which owns the hosting cache; read by the capture task,
+/// which is started elsewhere. The closure holds a `Weak`, so registering it never
+/// keeps a ring alive past node teardown; a dead ring reads as "no candidates", which
+/// surfaces as `focused=0` rather than as a stale set.
+///
+/// Absent means no source was registered, which is reported per tick rather than
+/// silently falling back - see [`super::shadow::CandidateSource`].
+type HostedContractsFn = Box<dyn Fn() -> Vec<ContractInstanceId> + Send + Sync>;
+static HOSTED_CONTRACTS: std::sync::OnceLock<HostedContractsFn> = std::sync::OnceLock::new();
+
+/// Tell the conformance machinery how to list hosted contracts. First caller wins.
+pub fn set_hosted_contracts_source(source: HostedContractsFn) {
+    // Same reasoning as `set_contract_store`: skip entirely unless capture is on, so
+    // the many-nodes-in-one-process test harness does not produce conflict warnings
+    // for a path nothing reads.
+    if global().is_none() {
+        return;
+    }
+    if HOSTED_CONTRACTS.set(source).is_err() {
+        // Unlike the contract store there is nothing useful to compare - two closures
+        // are not comparable - so this cannot distinguish "same ring twice" from "two
+        // different rings". It is logged at debug because in the one process where it
+        // can happen (the simulation harness) it is expected, and in production a
+        // second ring in one process would have larger problems than this.
+        tracing::debug!("hosted-contract source already registered for conformance");
+    }
+}
+
+pub(crate) fn hosted_contracts() -> Option<Vec<ContractInstanceId>> {
+    HOSTED_CONTRACTS.get().map(|source| source())
+}
+
 static CAPTURE: std::sync::OnceLock<Option<CaptureHandle>> = std::sync::OnceLock::new();
 
 /// The process-wide capture handle, or `None` when capture is off.
@@ -449,6 +492,24 @@ async fn run_writer(
     let mut flush = tokio::time::interval(FLUSH_EVERY);
     flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // Focus is computed once up front, not left empty until the first probe tick.
+    // Under focus-scoped sampling an empty focus set records NOTHING, so deferring
+    // this would throw away every observation in the first probe interval - and the
+    // interval is fifteen minutes, which on a restarting peer is a real hole in the
+    // corpus rather than a rounding error.
+    let mut last_focus = crate::conformance::shadow::FocusTick::default();
+    let mut scope = if wide_capture_requested() {
+        SamplingScope::Wide
+    } else {
+        SamplingScope::Focused(
+            shadow
+                .focus(&samplers.keys().copied().collect::<Vec<_>>())
+                .selected
+                .into_iter()
+                .collect(),
+        )
+    };
+
     loop {
         tokio::select! {
             received = rx.recv() => {
@@ -457,7 +518,7 @@ async fn run_writer(
                 // the budget measures what is actually in flight rather than
                 // everything ever admitted.
                 queued_bytes.fetch_sub(observation.queued_bytes(), Ordering::Relaxed);
-                record(&mut samplers, observation);
+                record(&mut samplers, &scope, observation);
                 since_flush += 1;
                 if since_flush >= FLUSH_EVERY_OBSERVATIONS {
                     write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
@@ -476,7 +537,16 @@ async fn run_writer(
                 // Selection borrows the samplers and is cheap; probing owns its copies
                 // and is not. Only the cheap half runs here, so the queue keeps
                 // draining while WASM executes on another task.
-                let work = shadow.select(&samplers);
+                shadow.advance();
+                let focus = shadow.focus(&samplers.keys().copied().collect::<Vec<_>>());
+                // Recomputed every tick so a rotation, or a change in what the peer
+                // hosts, takes effect on sampling immediately rather than at the next
+                // restart. Wide mode ignores focus by definition.
+                if !matches!(scope, SamplingScope::Wide) {
+                    scope = SamplingScope::Focused(focus.selected.iter().copied().collect());
+                }
+                last_focus = focus.clone();
+                let work = shadow.select(&focus, &samplers);
                 if work.is_empty() {
                     // Still reported. A tick that selected nothing and a tick that
                     // found nothing are the same shape in a findings-only log, and
@@ -486,6 +556,10 @@ async fn run_writer(
                     tracing::info!(
                         epoch = shadow.epoch(),
                         tracked = samplers.len(),
+                        candidates = focus.candidates,
+                        candidate_source = focus.source.as_str(),
+                        focused = focus.selected.len(),
+                        scope = scope.as_str(),
                         "conformance shadow tick selected nothing to probe"
                     );
                 } else {
@@ -533,6 +607,15 @@ async fn run_writer(
                     // clean result as one that is genuinely covering the network.
                     tracked = samplers.len(),
                     tracking_at_cap = samplers.len() >= MAX_TRACKED_CONTRACTS,
+                    // Where focus could reach this tick. `candidates` is the size of
+                    // the pool focus chose from; when `candidate_source` is `hosted`
+                    // that is the peer's hosted set, which is the whole point of the
+                    // #5366 fix. A tick reading `candidate_source=sampler` means no
+                    // hosted source was registered and reach has silently narrowed
+                    // back to whatever the sampler already held.
+                    candidates = last_focus.candidates,
+                    candidate_source = last_focus.source.as_str(),
+                    scope = scope.as_str(),
                     focused = report.focused,
                     probed = report.probed,
                     cases = report.cases,
@@ -668,15 +751,103 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
     samplers
 }
 
+/// Which contracts the sampler will keep samples for.
+///
+/// The RFC samples the *focus* contracts: "while a contract is in the focus set, the
+/// peer records a bounded, diverse sample of the states and update context it
+/// naturally observes". Sampling everything and then choosing focus from what was
+/// collected is the inversion that produced #5366, and it also makes an ordinary
+/// peer's corpus grow with its traffic rather than with its focus.
+#[derive(Debug, Clone)]
+pub(crate) enum SamplingScope {
+    /// Record only for the contracts currently in focus. The production shape: the
+    /// corpus stays proportional to the focus set, not to what the peer happens to
+    /// route.
+    Focused(std::collections::HashSet<ContractInstanceId>),
+    /// Record for everything observed, up to the tracking cap.
+    ///
+    /// Developer corpus-building only, behind [`CAPTURE_WIDE_ENV`]. This is how the
+    /// corpora that found every violation so far were gathered - offline replay needs
+    /// many contracts from one peer, which is precisely what a production peer should
+    /// not be doing.
+    Wide,
+}
+
+impl SamplingScope {
+    /// Whether this scope admits `contract` as a newly tracked contract.
+    fn admits(&self, contract: &ContractInstanceId) -> bool {
+        match self {
+            SamplingScope::Focused(focus) => focus.contains(contract),
+            SamplingScope::Wide => true,
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            SamplingScope::Focused(_) => "focused",
+            SamplingScope::Wide => "wide",
+        }
+    }
+}
+
+/// Set to `1`/`true` to sample every contract observed rather than only the focus set.
+///
+/// Developer-only. It exists because offline replay - which is what actually found
+/// the deployed violations - needs a broad corpus from a single peer, and a peer
+/// obeying the RFC's focus-scoped sampling will never build one.
+pub const CAPTURE_WIDE_ENV: &str = "FREENET_CONFORMANCE_CAPTURE_WIDE";
+
+fn wide_capture_requested() -> bool {
+    matches!(
+        std::env::var(CAPTURE_WIDE_ENV).ok().as_deref(),
+        Some("1") | Some("true")
+    )
+}
+
 pub(crate) fn record(
     samplers: &mut HashMap<ContractInstanceId, TrackedContract>,
+    scope: &SamplingScope,
     observation: Observation,
 ) {
-    if !samplers.contains_key(&observation.contract) && samplers.len() >= MAX_TRACKED_CONTRACTS {
-        // Already tracking as many as allowed. Ignoring the newcomer is the bounded
-        // choice; the alternative is evicting an accumulated sample, which throws
-        // away the diversity this is collecting.
+    let known = samplers.contains_key(&observation.contract);
+    if !known && !scope.admits(&observation.contract) {
+        // Not in focus, so not sampled. Note this drops observations for a contract
+        // that WAS in focus and has rotated out only for NEW contracts - an existing
+        // entry keeps accumulating until it is evicted, which is the RFC's "may
+        // outlive a focus period for a bounded time so returning to a contract does
+        // not always start from zero".
         return;
+    }
+    if !known && samplers.len() >= MAX_TRACKED_CONTRACTS {
+        // At the tracking cap with a contract that focus has actually selected.
+        //
+        // Refusing here is what caused #5366: the map fills, admission stops, and no
+        // amount of rotation can ever get the current focus contract sampled - the
+        // peer keeps probing whatever it captured first, forever, while reporting
+        // healthy ticks. Under focus-scoped sampling that failure returns in a worse
+        // form, because rotation guarantees the map fills with contracts that are no
+        // longer in focus.
+        //
+        // So evict a contract that is NOT in focus to make room. Deterministic (lowest
+        // id) rather than random so behaviour is reproducible in tests; the sample
+        // being discarded belongs to a contract nothing is looking at.
+        let evictable = match scope {
+            SamplingScope::Focused(focus) => samplers
+                .keys()
+                .filter(|id| !focus.contains(id))
+                .min_by(|a, b| a.as_bytes().cmp(b.as_bytes()))
+                .copied(),
+            // Wide mode has no focus to protect and is a developer path where the cap
+            // is the intended stopping point: a corpus that silently rolled over would
+            // make "what this peer saw" depend on eviction order.
+            SamplingScope::Wide => None,
+        };
+        match evictable {
+            Some(victim) => {
+                samplers.remove(&victim);
+            }
+            None => return,
+        }
     }
 
     let tracked = samplers
@@ -911,6 +1082,71 @@ mod contract_store_registration_pin {
         panic!("get_runtime_stores' body is not brace-balanced");
     }
 
+    /// Slice `Ring::new`'s body by counting braces to its own closing one.
+    ///
+    /// Same discipline as `get_runtime_stores_body` above and for the same reason: a
+    /// region ended at "the next `fn`" silently widens when the following item is not
+    /// the shape the pin assumed, and a widened region can match the pin's own
+    /// assertion text and pass vacuously.
+    fn ring_new_body() -> &'static str {
+        let src = include_str!("../ring.rs");
+        let start = src
+            .find("    pub fn new<ER: NetEventRegister>(")
+            .expect("Ring::new not found in ring.rs");
+        let after = &src[start..];
+        let open = after.find('{').expect("Ring::new has no body");
+        let mut depth = 0usize;
+        for (offset, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &after[..open + offset + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("Ring::new's body is not brace-balanced");
+    }
+
+    /// The ring must register how to enumerate hosted contracts.
+    ///
+    /// Without it, focus falls back to the sampler keys and silently reinstates the
+    /// #5366 horizon: the peer keeps probing, keeps logging clean ticks, and can never
+    /// reach a contract it did not happen to observe early. The fallback is reported
+    /// per tick (`candidate_source=sampler`), but nothing in a unit test would notice
+    /// the registration going away, because no unit test builds a `Ring`.
+    #[test]
+    fn the_ring_registers_its_hosted_contracts_for_conformance() {
+        let body = ring_new_body();
+        assert!(
+            body.contains("set_hosted_contracts_source("),
+            "the ring no longer tells conformance how to list hosted contracts, so \
+             focus selection falls back to whatever the sampler already held (#5366)"
+        );
+    }
+
+    /// The registration must not hold the ring alive.
+    ///
+    /// The closure lives in a process-global that outlives the node. A strong `Arc`
+    /// there would leak an entire ring, its caches and its background-task handles
+    /// past teardown - and in the simulation harness, one per simulated peer.
+    #[test]
+    fn the_hosted_contracts_source_holds_only_a_weak_reference() {
+        let body = ring_new_body();
+        let start = body
+            .find("set_hosted_contracts_source(")
+            .expect("registration missing; the sibling pin covers that");
+        let before = &body[..start];
+        assert!(
+            before.contains("Arc::downgrade(&ring)"),
+            "the hosted-contract source does not downgrade the ring first, so the \
+             process-global closure may be keeping the ring alive after teardown"
+        );
+    }
+
     #[test]
     fn the_executor_registers_the_contract_store_for_conformance() {
         let body = get_runtime_stores_body();
@@ -1022,6 +1258,155 @@ mod probe_wiring_pins {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn instance(n: u8) -> ContractInstanceId {
+        ContractInstanceId::new([n; 32])
+    }
+
+    fn observation_for(contract: ContractInstanceId) -> Observation {
+        Observation {
+            contract,
+            code_hash: [2; 32],
+            parameters: vec![3],
+            base_state: vec![1, 2],
+            incoming_state: Some(vec![2, 3]),
+            delta: None,
+            result_state: vec![1, 2, 3],
+            related: Vec::new(),
+        }
+    }
+
+    fn focused_on(ids: &[u8]) -> SamplingScope {
+        SamplingScope::Focused(ids.iter().copied().map(instance).collect())
+    }
+
+    /// Sampling follows focus: a contract nobody is watching is not recorded.
+    ///
+    /// This is the RFC's shape ("while a contract is in the focus set, the peer
+    /// records a bounded, diverse sample") and it is what keeps an ordinary peer's
+    /// corpus proportional to its focus set rather than to its traffic.
+    #[test]
+    fn focused_sampling_records_only_the_focus_set() {
+        let mut samplers = HashMap::new();
+        let scope = focused_on(&[1]);
+
+        record(&mut samplers, &scope, observation_for(instance(1)));
+        record(&mut samplers, &scope, observation_for(instance(2)));
+
+        assert!(
+            samplers.contains_key(&instance(1)),
+            "the focused contract was not sampled"
+        );
+        assert!(
+            !samplers.contains_key(&instance(2)),
+            "an unfocused contract was sampled: sampling is not following focus"
+        );
+    }
+
+    /// Wide mode is the developer corpus path and deliberately ignores focus.
+    #[test]
+    fn wide_sampling_records_contracts_outside_the_focus_set() {
+        let mut samplers = HashMap::new();
+        record(
+            &mut samplers,
+            &SamplingScope::Wide,
+            observation_for(instance(2)),
+        );
+        assert!(
+            samplers.contains_key(&instance(2)),
+            "wide capture refused a contract, so no corpus can be built"
+        );
+    }
+
+    /// The #5366 regression, in the form focus-scoped sampling would take.
+    ///
+    /// A full tracking map must not be able to lock the CURRENT focus contract out of
+    /// being sampled. Rotation guarantees the map fills with contracts that are no
+    /// longer in focus, so a refuse-the-newcomer rule means that after enough
+    /// rotations a peer probes only what it captured first - forever, while its tick
+    /// lines still read healthy. Room is made by evicting something nothing is
+    /// watching.
+    #[test]
+    fn a_full_map_still_admits_the_contract_focus_selected() {
+        let mut samplers = HashMap::new();
+        // Fill to the cap with contracts that are not in focus.
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            let id = ContractInstanceId::new([(i % 251) as u8; 32]);
+            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+        }
+        // Distinct ids only, otherwise this fills nothing and proves nothing.
+        assert_eq!(
+            samplers.len(),
+            MAX_TRACKED_CONTRACTS,
+            "fixture did not reach the cap, so the admission path under test never ran"
+        );
+
+        let newcomer = ContractInstanceId::new([255; 32]);
+        assert!(
+            !samplers.contains_key(&newcomer),
+            "fixture already tracked the newcomer"
+        );
+        let scope = SamplingScope::Focused([newcomer].into_iter().collect());
+        record(&mut samplers, &scope, observation_for(newcomer));
+
+        assert!(
+            samplers.contains_key(&newcomer),
+            "a full map locked out the contract focus actually selected (#5366)"
+        );
+        assert!(
+            samplers.len() <= MAX_TRACKED_CONTRACTS,
+            "admission grew the map past its cap: {}",
+            samplers.len()
+        );
+    }
+
+    /// Eviction to make room must never take a contract that IS in focus - that would
+    /// trade one starvation for another, discarding the sample being actively built.
+    #[test]
+    fn making_room_never_evicts_a_focused_contract() {
+        let mut samplers = HashMap::new();
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            let id = ContractInstanceId::new([(i % 251) as u8; 32]);
+            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+        }
+        assert_eq!(samplers.len(), MAX_TRACKED_CONTRACTS);
+
+        // Focus on one contract already tracked, plus one that is not.
+        let held = *samplers
+            .keys()
+            .min_by(|a, b| a.as_bytes().cmp(b.as_bytes()))
+            .expect("fixture is empty");
+        let newcomer = ContractInstanceId::new([255; 32]);
+        let scope = SamplingScope::Focused([held, newcomer].into_iter().collect());
+
+        record(&mut samplers, &scope, observation_for(newcomer));
+
+        assert!(
+            samplers.contains_key(&held),
+            "eviction took a focused contract - the lowest id is exactly what the \
+             deterministic victim rule would pick if it did not skip focus"
+        );
+        assert!(
+            samplers.contains_key(&newcomer),
+            "newcomer was not admitted"
+        );
+    }
+
+    /// Wide mode keeps the old bounded-refusal behaviour: a developer corpus whose
+    /// contents depended on eviction order would stop meaning "what this peer saw".
+    #[test]
+    fn wide_sampling_stops_at_the_cap_rather_than_rolling_over() {
+        let mut samplers = HashMap::new();
+        for i in 0..(MAX_TRACKED_CONTRACTS + 20) {
+            let id = ContractInstanceId::new([(i % 251) as u8; 32]);
+            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+        }
+        assert_eq!(
+            samplers.len(),
+            MAX_TRACKED_CONTRACTS,
+            "wide capture did not stop at its cap"
+        );
+    }
 
     fn observation() -> Observation {
         Observation {
@@ -1181,7 +1566,7 @@ mod tests {
         observed.related = vec![(related_id, vec![42, 43])];
 
         let mut samplers = HashMap::new();
-        record(&mut samplers, observed);
+        record(&mut samplers, &SamplingScope::Wide, observed);
 
         let dir = tempfile::TempDir::new().expect("tempdir");
         write_all(dir.path(), &samplers, 0).await;
@@ -1229,7 +1614,7 @@ mod tests {
         for i in 0..4u8 {
             let mut observed = observation();
             observed.related = vec![(ContractInstanceId::new([i; 32]), vec![i; chunk])];
-            record(&mut samplers, observed);
+            record(&mut samplers, &SamplingScope::Wide, observed);
         }
 
         let tracked = samplers.values().next().expect("one contract tracked");
@@ -1249,7 +1634,7 @@ mod tests {
         let before = tracked.related.len();
         let mut again = observation();
         again.related = vec![(ContractInstanceId::new([0; 32]), vec![0; chunk])];
-        record(&mut samplers, again);
+        record(&mut samplers, &SamplingScope::Wide, again);
         let tracked = samplers.values().next().expect("one contract tracked");
         assert_eq!(
             tracked.related.len(),
@@ -1314,7 +1699,7 @@ mod tests {
         for i in 0..(MAX_RELATED_CONTRACTS + 4) {
             let mut observed = observation();
             observed.related = vec![(ContractInstanceId::new([i as u8; 32]), vec![i as u8; 16])];
-            record(&mut samplers, observed);
+            record(&mut samplers, &SamplingScope::Wide, observed);
         }
         let tracked = samplers.values().next().expect("one contract tracked");
         assert!(
@@ -1331,7 +1716,7 @@ mod tests {
             ContractInstanceId::new([200; 32]),
             vec![0u8; MAX_RELATED_BYTES + 1],
         )];
-        record(&mut samplers, huge);
+        record(&mut samplers, &SamplingScope::Wide, huge);
         let tracked = samplers.values().next().expect("one contract tracked");
         assert_eq!(
             tracked.related.len(),
@@ -1391,7 +1776,7 @@ mod tests {
     #[tokio::test]
     async fn a_written_bundle_identifies_its_contract() {
         let mut samplers = HashMap::new();
-        record(&mut samplers, observation());
+        record(&mut samplers, &SamplingScope::Wide, observation());
 
         let dir = tempfile::TempDir::new().expect("tempdir");
         write_all(dir.path(), &samplers, 0).await;
@@ -1427,7 +1812,7 @@ mod tests {
         oversized.base_state = vec![7; ceiling + 1];
         oversized.incoming_state = Some(vec![8; ceiling + 1]);
         oversized.result_state = vec![9; ceiling + 1];
-        record(&mut samplers, oversized);
+        record(&mut samplers, &SamplingScope::Wide, oversized);
 
         assert_eq!(
             samplers
@@ -1469,7 +1854,7 @@ mod tests {
             let mut obs = observation();
             obs.base_state = vec![i; 16];
             obs.result_state = vec![i; 17];
-            record(&mut samplers, obs);
+            record(&mut samplers, &SamplingScope::Wide, obs);
         }
         write_all(dir.path(), &samplers, 0).await;
         let before = samplers
@@ -1549,7 +1934,7 @@ mod tests {
         for i in 0..(MAX_TRACKED_CONTRACTS + 50) {
             let mut obs = observation();
             obs.contract = ContractInstanceId::new([(i % 251) as u8; 32]);
-            record(&mut samplers, obs);
+            record(&mut samplers, &SamplingScope::Wide, obs);
         }
         assert!(samplers.len() <= MAX_TRACKED_CONTRACTS);
     }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -120,6 +120,13 @@ const MAX_RELATED_CONTRACTS: usize = 8;
 /// Upper bound on contracts sampled concurrently.
 const MAX_TRACKED_CONTRACTS: usize = 64;
 
+/// How often to retry drawing focus from the hosted set before it is registered.
+///
+/// Short, because until it succeeds a focus-scoped peer is sampling against an empty
+/// focus set and therefore recording nothing. Bounded work: the arm switches off for
+/// good as soon as one draw reports [`CandidateSource::Hosted`].
+const HOSTED_SOURCE_WARMUP: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// How many observations may accumulate before a flush, regardless of the clock.
 ///
 /// The timer alone leaves the whole interval exposed, and worse for a short run:
@@ -497,7 +504,26 @@ async fn run_writer(
     // this would throw away every observation in the first probe interval - and the
     // interval is fifteen minutes, which on a restarting peer is a real hole in the
     // corpus rather than a rounding error.
+    //
+    // Computing it here is necessary but NOT sufficient, and the reason is worth
+    // stating because it is the opposite of what it looks like: this task is spawned
+    // BY `global()`, which `set_hosted_contracts_source` calls on its own first line
+    // to decide whether to register at all. So the writer starts one line before the
+    // hosted source is installed, and `set_contract_store` triggers the same thing
+    // earlier still. The startup computation therefore usually runs with no hosted
+    // source, falls back to an empty sampler, and installs an empty focus - exactly
+    // the hole it was added to close. The warm-up ticker below re-runs it until the
+    // source appears, then stops.
+    // Re-runs focus until the hosted source shows up, then never fires again. Cheap
+    // (one `OnceLock` read per tick, and the arm is disabled once satisfied) and
+    // self-terminating, rather than re-deriving focus on every observation - which
+    // would take the ring's hosting-cache read lock on the merge path's queue drain.
+    let mut warmup = tokio::time::interval(HOSTED_SOURCE_WARMUP);
+    warmup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last_focus = crate::conformance::shadow::FocusTick::default();
+    // Focused contracts with no samples yet, carried across the probe so the finished
+    // tick can report them rather than silently omitting them from `focused`.
+    let mut awaiting_samples = 0usize;
     let mut scope = if wide_capture_requested() {
         SamplingScope::Wide
     } else {
@@ -518,12 +544,43 @@ async fn run_writer(
                 // the budget measures what is actually in flight rather than
                 // everything ever admitted.
                 queued_bytes.fetch_sub(observation.queued_bytes(), Ordering::Relaxed);
-                record(&mut samplers, &scope, observation);
+                if let Some(evicted) = record(&mut samplers, &scope, observation) {
+                    // Dropping the entry alone orphans the file: eviction fires on
+                    // every rotation once the map is full, so the directory would
+                    // grow without bound and `reload` could resurrect a long-evicted
+                    // contract ahead of the current focus set. Best-effort - a failed
+                    // unlink must never disturb capture, let alone the merge path.
+                    let path = bundle_path(&dir, &evicted);
+                    if let Err(err) = tokio::fs::remove_file(&path).await {
+                        if err.kind() != std::io::ErrorKind::NotFound {
+                            tracing::debug!(
+                                path = %path.display(),
+                                error = %err,
+                                "could not remove an evicted conformance bundle"
+                            );
+                        }
+                    }
+                }
                 since_flush += 1;
                 if since_flush >= FLUSH_EVERY_OBSERVATIONS {
                     write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
                     since_flush = 0;
                 }
+            }
+            // Disabled the moment focus has actually been drawn from the hosted set.
+            // `Wide` never consults focus, so it never needs this either.
+            _ = warmup.tick(), if !matches!(scope, SamplingScope::Wide)
+                && last_focus.source != crate::conformance::shadow::CandidateSource::Hosted => {
+                let focus = shadow.focus(&samplers.keys().copied().collect::<Vec<_>>());
+                if focus.source == crate::conformance::shadow::CandidateSource::Hosted {
+                    tracing::debug!(
+                        candidates = focus.candidates,
+                        focused = focus.selected.len(),
+                        "conformance capture picked up the hosted-contract source"
+                    );
+                }
+                scope = SamplingScope::Focused(focus.selected.iter().copied().collect());
+                last_focus = focus;
             }
             _ = flush.tick() => {
                 write_all(&dir, &samplers, dropped.load(Ordering::Relaxed)).await;
@@ -546,7 +603,8 @@ async fn run_writer(
                     scope = SamplingScope::Focused(focus.selected.iter().copied().collect());
                 }
                 last_focus = focus.clone();
-                let work = shadow.select(&focus, &samplers);
+                let (work, awaiting) = shadow.select(&focus, &samplers);
+                awaiting_samples = awaiting;
                 if work.is_empty() {
                     // Still reported. A tick that selected nothing and a tick that
                     // found nothing are the same shape in a findings-only log, and
@@ -583,7 +641,7 @@ async fn run_writer(
                 }
             }, if in_flight.is_some() => {
                 in_flight = None;
-                let (report, findings) = match finished {
+                let (mut report, findings) = match finished {
                     Ok(result) => result,
                     Err(err) => {
                         // A panicking probe must not take the capture task with it,
@@ -593,6 +651,11 @@ async fn run_writer(
                         continue;
                     }
                 };
+                // Focus picked these; they simply had nothing to check yet. Counted
+                // in both, so `focused` is the size of the focus set rather than the
+                // size of the subset that happened to have samples.
+                report.focused += awaiting_samples;
+                report.skipped_no_samples += awaiting_samples;
                 shadow.record(&findings);
                 // Reported even when nothing was checked. A shadow period that finds
                 // nothing and a shadow period that never ran look identical in a
@@ -600,11 +663,11 @@ async fn run_writer(
                 // phase is for.
                 tracing::info!(
                     epoch = shadow.epoch(),
-                    // Reach, not just findings: focus can only select what capture is
-                    // tracking, and that set stops growing at MAX_TRACKED_CONTRACTS
-                    // and never evicts. Without these two numbers, a peer whose
-                    // candidate set froze months ago reports exactly the same shape of
-                    // clean result as one that is genuinely covering the network.
+                    // How much sample storage is in use. This used to describe focus
+                    // REACH, because focus selected out of this very map; it no longer
+                    // does (see `candidates` below), and the map now evicts. Kept as a
+                    // storage metric: at the cap, every new focus pick costs an older
+                    // contract's accumulated sample.
                     tracked = samplers.len(),
                     tracking_at_cap = samplers.len() >= MAX_TRACKED_CONTRACTS,
                     // Where focus could reach this tick. `candidates` is the size of
@@ -697,7 +760,16 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
         return samplers;
     };
 
-    for entry in entries.flatten() {
+    // Sorted, because this loop stops at MAX_TRACKED_CONTRACTS and `read_dir` order is
+    // undefined. Unsorted, WHICH contracts survive a restart is decided by whatever the
+    // filesystem happens to enumerate first - and with eviction now deleting bundles,
+    // a directory can legitimately hold entries in any order. Sorting does not make the
+    // choice smart (nothing here knows the current focus set), but it makes it
+    // reproducible, so a peer that restarts twice reloads the same corpus twice.
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("bundle") {
             continue;
@@ -804,20 +876,44 @@ fn wide_capture_requested() -> bool {
     )
 }
 
+/// Where a contract's persisted bundle lives. One definition, so an eviction cannot
+/// delete a path the writer never wrote.
+pub(crate) fn bundle_path(dir: &Path, instance: &ContractInstanceId) -> PathBuf {
+    dir.join(format!("{instance}.bundle"))
+}
+
+/// Fold one observation into the sampler map.
+///
+/// Returns the contract evicted to make room, if any. The caller must delete that
+/// contract's persisted bundle: dropping it from this map alone leaves the `.bundle`
+/// file behind forever, and since eviction happens on every rotation once the map is
+/// full, those orphans accumulate without bound - which also lets `reload` resurrect a
+/// long-evicted contract ahead of the current focus set on the next restart.
+#[must_use = "the evicted contract's bundle must be deleted, or it is orphaned on disk"]
 pub(crate) fn record(
     samplers: &mut HashMap<ContractInstanceId, TrackedContract>,
     scope: &SamplingScope,
     observation: Observation,
-) {
+) -> Option<ContractInstanceId> {
     let known = samplers.contains_key(&observation.contract);
-    if !known && !scope.admits(&observation.contract) {
-        // Not in focus, so not sampled. Note this drops observations for a contract
-        // that WAS in focus and has rotated out only for NEW contracts - an existing
-        // entry keeps accumulating until it is evicted, which is the RFC's "may
-        // outlive a focus period for a bounded time so returning to a contract does
-        // not always start from zero".
-        return;
+    if !scope.admits(&observation.contract) {
+        // Not in focus, so not COLLECTED - whether or not it is already tracked.
+        //
+        // The first version of this gated only new admissions (`!known && !admits`),
+        // which let any contract that had ever been focused keep absorbing every
+        // observation it saw, forever. With focus rotating every couple of hours and a
+        // 64-entry map, steady state was 64 contracts collecting rather than the two
+        // in focus - so "sampling follows focus" held for a few days after a clean
+        // deploy and then quietly stopped being true. The RFC's allowance is that a
+        // sample "may outlive a focus period for a BOUNDED time so returning to a
+        // contract does not always start from zero"; that is about RETAINING what was
+        // collected, not about continuing to collect, and there was no bound at all.
+        //
+        // Retention is preserved: an out-of-focus entry stays in the map, and stays on
+        // disk, until eviction needs its slot. It simply stops growing.
+        return None;
     }
+    let mut evicted = None;
     if !known && samplers.len() >= MAX_TRACKED_CONTRACTS {
         // At the tracking cap with a contract that focus has actually selected.
         //
@@ -845,8 +941,24 @@ pub(crate) fn record(
         match evictable {
             Some(victim) => {
                 samplers.remove(&victim);
+                evicted = Some(victim);
             }
-            None => return,
+            None => {
+                // Every tracked contract is in focus and the map is full, so there is
+                // nothing to give up. Unreachable while MAX_FOCUS_CONTRACTS (2) is far
+                // below MAX_TRACKED_CONTRACTS (64), but MAX_FOCUS_CONTRACTS is a
+                // documented operational tunable: raise it without revisiting the cap
+                // and this starts silently discarding exactly the focus-selected
+                // observations the eviction rule exists to protect. Counted rather
+                // than dropped in silence.
+                tracing::warn!(
+                    contract = %observation.contract,
+                    tracked = samplers.len(),
+                    "conformance capture could not make room for a focused contract: \
+                     every tracked contract is in focus"
+                );
+                return None;
+            }
         }
     }
 
@@ -872,6 +984,8 @@ pub(crate) fn record(
     if matches!(admission, Admission::TooLarge) {
         tracked.refused_too_large += 1;
     }
+
+    evicted
 }
 
 /// Admit related-contract states into a tracked contract, within the allowance.
@@ -980,7 +1094,7 @@ async fn write_all(
             continue;
         }
 
-        let path = dir.join(format!("{instance}.bundle"));
+        let path = bundle_path(dir, instance);
         // Encode on this task (pure CPU, no syscall) and hand only the bytes to the
         // async write, so the syscalls yield rather than parking the worker.
         match bundle.encode() {
@@ -1242,6 +1356,46 @@ mod probe_wiring_pins {
         );
     }
 
+    /// The writer must delete an evicted contract's persisted bundle.
+    ///
+    /// `record` returns the victim and is `#[must_use]`, so ignoring it is a compile
+    /// error - but `let _ = ...` silences that, and a refactor reaching for it would
+    /// reintroduce unbounded orphan files with no test failing.
+    #[test]
+    fn an_evicted_contract_has_its_bundle_removed() {
+        let body = run_writer_code_only();
+        assert!(
+            body.contains("remove_file"),
+            "the writer no longer deletes evicted bundles, so every rotation past the \
+             tracking cap orphans a file that nothing will ever clean up"
+        );
+    }
+
+    /// Focus must be drawn before the select loop, and retried until the hosted source
+    /// exists.
+    ///
+    /// Both halves are load-bearing and neither is reachable from a test, because
+    /// nothing calls `run_writer`. Under focus-scoped sampling an empty focus set
+    /// records NOTHING, and this task is spawned BY `global()` from inside
+    /// `set_hosted_contracts_source` - one line before the source is registered - so
+    /// the startup draw alone reliably misses it and the peer records nothing until the
+    /// first probe tick fifteen minutes later.
+    #[test]
+    fn focus_is_drawn_at_startup_and_retried_until_the_hosted_source_arrives() {
+        let body = run_writer_code_only();
+        let loop_start = body.find("loop {").expect("run_writer has no select loop");
+        assert!(
+            body[..loop_start].contains(".focus("),
+            "focus is no longer computed before the select loop, so a focus-scoped \
+             peer records nothing for the first probe interval after every restart"
+        );
+        assert!(
+            body.contains("HOSTED_SOURCE_WARMUP"),
+            "the hosted-source warm-up retry is gone; the startup draw alone runs \
+             before the ring registers its hosted contracts and therefore misses it"
+        );
+    }
+
     #[test]
     fn at_most_one_probe_runs_at_a_time() {
         let body = run_writer_code_only();
@@ -1290,8 +1444,8 @@ mod tests {
         let mut samplers = HashMap::new();
         let scope = focused_on(&[1]);
 
-        record(&mut samplers, &scope, observation_for(instance(1)));
-        record(&mut samplers, &scope, observation_for(instance(2)));
+        let _evicted = record(&mut samplers, &scope, observation_for(instance(1)));
+        let _evicted = record(&mut samplers, &scope, observation_for(instance(2)));
 
         assert!(
             samplers.contains_key(&instance(1)),
@@ -1303,11 +1457,139 @@ mod tests {
         );
     }
 
+    /// Sampling follows focus for contracts ALREADY tracked, not just new ones.
+    ///
+    /// The first version gated only new admissions, so any contract that had ever been
+    /// focused kept absorbing observations forever. With focus rotating every couple of
+    /// hours into a 64-entry map, steady state was 64 contracts collecting rather than
+    /// the two in focus - the narrow behaviour held for a few days after a clean deploy
+    /// and then quietly stopped being true.
+    ///
+    /// Counts `total_seen` rather than distinct states, so the assertion cannot be
+    /// satisfied by deduplication happening to hide a sampler that is still collecting.
+    #[test]
+    fn a_contract_that_leaves_focus_stops_collecting() {
+        let mut samplers = HashMap::new();
+        let watched = instance(1);
+
+        let _evicted = record(&mut samplers, &focused_on(&[1]), observation_for(watched));
+        let before = samplers
+            .get(&watched)
+            .expect("focused contract was not sampled")
+            .sampler
+            .total_seen();
+        assert!(
+            before > 0,
+            "fixture recorded nothing, so this proves nothing"
+        );
+
+        // Rotate it out of focus, then keep sending it traffic with distinct states.
+        let elsewhere = focused_on(&[2]);
+        for n in 0..8u8 {
+            let mut obs = observation_for(watched);
+            obs.result_state = vec![n, 9, 9];
+            let _evicted = record(&mut samplers, &elsewhere, obs);
+        }
+
+        let after = samplers
+            .get(&watched)
+            .expect("an out-of-focus contract must be RETAINED, only not collected")
+            .sampler
+            .total_seen();
+        assert_eq!(
+            before, after,
+            "a contract kept collecting after it left the focus set"
+        );
+    }
+
+    /// Retention survives defocus even though collection stops - the RFC's "may outlive
+    /// a focus period ... so returning to a contract does not always start from zero".
+    #[test]
+    fn a_contract_that_leaves_focus_keeps_what_it_already_collected() {
+        let mut samplers = HashMap::new();
+        let watched = instance(1);
+        let _evicted = record(&mut samplers, &focused_on(&[1]), observation_for(watched));
+        let _evicted = record(
+            &mut samplers,
+            &focused_on(&[2]),
+            observation_for(instance(2)),
+        );
+        assert!(
+            samplers.contains_key(&watched),
+            "defocusing a contract discarded its accumulated sample"
+        );
+    }
+
+    /// Eviction names its victim so the caller can delete the persisted bundle.
+    ///
+    /// Removing the entry alone orphans the file. Eviction fires on every rotation once
+    /// the map is full, so those orphans accumulate without bound - and `reload` can
+    /// then resurrect a long-evicted contract ahead of the current focus set.
+    #[test]
+    fn eviction_reports_the_victim_so_its_bundle_can_be_deleted() {
+        let mut samplers = HashMap::new();
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            let id = ContractInstanceId::new([(i % 251) as u8; 32]);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+        }
+        assert_eq!(samplers.len(), MAX_TRACKED_CONTRACTS);
+
+        let newcomer = ContractInstanceId::new([255; 32]);
+        let scope = SamplingScope::Focused([newcomer].into_iter().collect());
+        let evicted = record(&mut samplers, &scope, observation_for(newcomer));
+
+        let victim = evicted.expect("eviction happened but reported no victim to clean up");
+        assert!(
+            !samplers.contains_key(&victim),
+            "the reported victim is still tracked"
+        );
+        assert_ne!(
+            victim, newcomer,
+            "eviction reported the newcomer as its own victim"
+        );
+    }
+
+    /// The victim is specifically the LOWEST-id non-focused contract.
+    ///
+    /// Asserting only "a non-focused contract was evicted" does not pin this: the
+    /// earlier tests protected a contract that already sat at the minimum id, so
+    /// swapping `min_by` for `max_by` passed them both.
+    #[test]
+    fn eviction_takes_the_lowest_id_contract_not_in_focus() {
+        let mut samplers = HashMap::new();
+        for i in 0..MAX_TRACKED_CONTRACTS {
+            let id = ContractInstanceId::new([(i % 251) as u8; 32]);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+        }
+        assert_eq!(samplers.len(), MAX_TRACKED_CONTRACTS);
+
+        // Protect the lowest id, so the expected victim is the SECOND lowest. Under a
+        // max_by rule the victim would be the highest instead.
+        let mut ids: Vec<_> = samplers.keys().copied().collect();
+        ids.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        let protected = ids[0];
+        let expected_victim = ids[1];
+        let newcomer = ContractInstanceId::new([255; 32]);
+
+        let scope = SamplingScope::Focused([protected, newcomer].into_iter().collect());
+        let evicted = record(&mut samplers, &scope, observation_for(newcomer));
+
+        assert_eq!(
+            evicted,
+            Some(expected_victim),
+            "eviction did not take the lowest-id non-focused contract"
+        );
+        assert!(
+            samplers.contains_key(&protected),
+            "a focused contract was evicted"
+        );
+    }
+
     /// Wide mode is the developer corpus path and deliberately ignores focus.
     #[test]
     fn wide_sampling_records_contracts_outside_the_focus_set() {
         let mut samplers = HashMap::new();
-        record(
+        let _evicted = record(
             &mut samplers,
             &SamplingScope::Wide,
             observation_for(instance(2)),
@@ -1332,7 +1614,7 @@ mod tests {
         // Fill to the cap with contracts that are not in focus.
         for i in 0..MAX_TRACKED_CONTRACTS {
             let id = ContractInstanceId::new([(i % 251) as u8; 32]);
-            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observation_for(id));
         }
         // Distinct ids only, otherwise this fills nothing and proves nothing.
         assert_eq!(
@@ -1347,7 +1629,7 @@ mod tests {
             "fixture already tracked the newcomer"
         );
         let scope = SamplingScope::Focused([newcomer].into_iter().collect());
-        record(&mut samplers, &scope, observation_for(newcomer));
+        let _evicted = record(&mut samplers, &scope, observation_for(newcomer));
 
         assert!(
             samplers.contains_key(&newcomer),
@@ -1367,7 +1649,7 @@ mod tests {
         let mut samplers = HashMap::new();
         for i in 0..MAX_TRACKED_CONTRACTS {
             let id = ContractInstanceId::new([(i % 251) as u8; 32]);
-            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observation_for(id));
         }
         assert_eq!(samplers.len(), MAX_TRACKED_CONTRACTS);
 
@@ -1379,7 +1661,7 @@ mod tests {
         let newcomer = ContractInstanceId::new([255; 32]);
         let scope = SamplingScope::Focused([held, newcomer].into_iter().collect());
 
-        record(&mut samplers, &scope, observation_for(newcomer));
+        let _evicted = record(&mut samplers, &scope, observation_for(newcomer));
 
         assert!(
             samplers.contains_key(&held),
@@ -1406,7 +1688,7 @@ mod tests {
         let first = ContractInstanceId::new([0; 32]);
         for i in 0..(MAX_TRACKED_CONTRACTS + 20) {
             let id = ContractInstanceId::new([(i % 251) as u8; 32]);
-            record(&mut samplers, &SamplingScope::Wide, observation_for(id));
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observation_for(id));
         }
         assert_eq!(
             samplers.len(),
@@ -1583,7 +1865,7 @@ mod tests {
         observed.related = vec![(related_id, vec![42, 43])];
 
         let mut samplers = HashMap::new();
-        record(&mut samplers, &SamplingScope::Wide, observed);
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, observed);
 
         let dir = tempfile::TempDir::new().expect("tempdir");
         write_all(dir.path(), &samplers, 0).await;
@@ -1631,7 +1913,7 @@ mod tests {
         for i in 0..4u8 {
             let mut observed = observation();
             observed.related = vec![(ContractInstanceId::new([i; 32]), vec![i; chunk])];
-            record(&mut samplers, &SamplingScope::Wide, observed);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observed);
         }
 
         let tracked = samplers.values().next().expect("one contract tracked");
@@ -1651,7 +1933,7 @@ mod tests {
         let before = tracked.related.len();
         let mut again = observation();
         again.related = vec![(ContractInstanceId::new([0; 32]), vec![0; chunk])];
-        record(&mut samplers, &SamplingScope::Wide, again);
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, again);
         let tracked = samplers.values().next().expect("one contract tracked");
         assert_eq!(
             tracked.related.len(),
@@ -1716,7 +1998,7 @@ mod tests {
         for i in 0..(MAX_RELATED_CONTRACTS + 4) {
             let mut observed = observation();
             observed.related = vec![(ContractInstanceId::new([i as u8; 32]), vec![i as u8; 16])];
-            record(&mut samplers, &SamplingScope::Wide, observed);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, observed);
         }
         let tracked = samplers.values().next().expect("one contract tracked");
         assert!(
@@ -1733,7 +2015,7 @@ mod tests {
             ContractInstanceId::new([200; 32]),
             vec![0u8; MAX_RELATED_BYTES + 1],
         )];
-        record(&mut samplers, &SamplingScope::Wide, huge);
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, huge);
         let tracked = samplers.values().next().expect("one contract tracked");
         assert_eq!(
             tracked.related.len(),
@@ -1793,7 +2075,7 @@ mod tests {
     #[tokio::test]
     async fn a_written_bundle_identifies_its_contract() {
         let mut samplers = HashMap::new();
-        record(&mut samplers, &SamplingScope::Wide, observation());
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, observation());
 
         let dir = tempfile::TempDir::new().expect("tempdir");
         write_all(dir.path(), &samplers, 0).await;
@@ -1829,7 +2111,7 @@ mod tests {
         oversized.base_state = vec![7; ceiling + 1];
         oversized.incoming_state = Some(vec![8; ceiling + 1]);
         oversized.result_state = vec![9; ceiling + 1];
-        record(&mut samplers, &SamplingScope::Wide, oversized);
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, oversized);
 
         assert_eq!(
             samplers
@@ -1871,7 +2153,7 @@ mod tests {
             let mut obs = observation();
             obs.base_state = vec![i; 16];
             obs.result_state = vec![i; 17];
-            record(&mut samplers, &SamplingScope::Wide, obs);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, obs);
         }
         write_all(dir.path(), &samplers, 0).await;
         let before = samplers
@@ -1951,7 +2233,7 @@ mod tests {
         for i in 0..(MAX_TRACKED_CONTRACTS + 50) {
             let mut obs = observation();
             obs.contract = ContractInstanceId::new([(i % 251) as u8; 32]);
-            record(&mut samplers, &SamplingScope::Wide, obs);
+            let _evicted = record(&mut samplers, &SamplingScope::Wide, obs);
         }
         assert!(samplers.len() <= MAX_TRACKED_CONTRACTS);
     }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -123,9 +123,19 @@ const MAX_TRACKED_CONTRACTS: usize = 64;
 /// How often to retry drawing focus from the hosted set before it is registered.
 ///
 /// Short, because until it succeeds a focus-scoped peer is sampling against an empty
-/// focus set and therefore recording nothing. Bounded work: the arm switches off for
-/// good as soon as one draw reports [`CandidateSource::Hosted`].
+/// focus set and therefore recording nothing.
 const HOSTED_SOURCE_WARMUP: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// How many warm-up draws to make before giving up.
+///
+/// The arm normally switches off on its first successful draw, so this only matters
+/// when no hosted source is EVER registered - which is reachable, not hypothetical:
+/// `freenet` calls `capture::global()` (spawning this task) before it checks whether
+/// the daemon is disabled, and a disabled daemon idles forever without ever building a
+/// `Ring`. Without a cap the ticker would fire every five seconds for days, while the
+/// constant above claimed to be self-terminating. A minute of retries is far longer
+/// than node startup needs.
+const HOSTED_SOURCE_WARMUP_ATTEMPTS: u32 = 12;
 
 /// How many observations may accumulate before a flush, regardless of the clock.
 ///
@@ -344,12 +354,13 @@ static HOSTED_CONTRACTS: std::sync::OnceLock<HostedContractsFn> = std::sync::Onc
 
 /// Tell the conformance machinery how to list hosted contracts. First caller wins.
 pub fn set_hosted_contracts_source(source: HostedContractsFn) {
-    // Same reasoning as `set_contract_store`: skip entirely unless capture is on, so
-    // the many-nodes-in-one-process test harness does not produce conflict warnings
-    // for a path nothing reads.
-    if global().is_none() {
-        return;
-    }
+    // Deliberately NOT gated on `global()`, unlike `set_contract_store`. That gate
+    // exists there to keep a conflict WARNING quiet in the many-nodes-in-one-process
+    // test harness; this function logs conflicts at debug, so it buys nothing - and it
+    // costs correctness, because `capture::start` is public: an embedder starting
+    // capture explicitly rather than from the environment would have registration
+    // refused, leaving focus permanently empty and every observation discarded.
+    // Registering when nothing reads it is free.
     if HOSTED_CONTRACTS.set(source).is_err() {
         // Unlike the contract store there is nothing useful to compare - two closures
         // are not comparable - so this cannot distinguish "same ring twice" from "two
@@ -520,21 +531,28 @@ async fn run_writer(
     // would take the ring's hosting-cache read lock on the merge path's queue drain.
     let mut warmup = tokio::time::interval(HOSTED_SOURCE_WARMUP);
     warmup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    let mut last_focus = crate::conformance::shadow::FocusTick::default();
+    // Seeded from the real draw below, never left at `Default`. The first version left
+    // it defaulted, and because `CandidateSource` then defaulted to `Hosted` the
+    // warm-up guard read "already on the hosted set" before any draw had happened - so
+    // the retry arm was never polled once and the startup gap it exists to close stayed
+    // wide open. The default is now the pessimistic variant too, but seeding this
+    // correctly is the fix; the default is only the backstop.
+    let mut last_focus;
+    let mut warmup_attempts = 0u32;
     // Focused contracts with no samples yet, carried across the probe so the finished
     // tick can report them rather than silently omitting them from `focused`.
     let mut awaiting_samples = 0usize;
-    let mut scope = if wide_capture_requested() {
+    let wide = wide_capture_requested();
+    let startup_focus = shadow.focus(
+        hosted_contracts(),
+        &samplers.keys().copied().collect::<Vec<_>>(),
+    );
+    let mut scope = if wide {
         SamplingScope::Wide
     } else {
-        SamplingScope::Focused(
-            shadow
-                .focus(&samplers.keys().copied().collect::<Vec<_>>())
-                .selected
-                .into_iter()
-                .collect(),
-        )
+        SamplingScope::Focused(startup_focus.selected.iter().copied().collect())
     };
+    last_focus = startup_focus;
 
     loop {
         tokio::select! {
@@ -569,9 +587,14 @@ async fn run_writer(
             }
             // Disabled the moment focus has actually been drawn from the hosted set.
             // `Wide` never consults focus, so it never needs this either.
-            _ = warmup.tick(), if !matches!(scope, SamplingScope::Wide)
-                && last_focus.source != crate::conformance::shadow::CandidateSource::Hosted => {
-                let focus = shadow.focus(&samplers.keys().copied().collect::<Vec<_>>());
+            _ = warmup.tick(),
+                if crate::conformance::shadow::needs_hosted_warmup(
+                    wide, &last_focus, warmup_attempts, HOSTED_SOURCE_WARMUP_ATTEMPTS) => {
+                warmup_attempts += 1;
+                let focus = shadow.focus(
+                    hosted_contracts(),
+                    &samplers.keys().copied().collect::<Vec<_>>(),
+                );
                 if focus.source == crate::conformance::shadow::CandidateSource::Hosted {
                     tracing::debug!(
                         candidates = focus.candidates,
@@ -595,7 +618,10 @@ async fn run_writer(
                 // and is not. Only the cheap half runs here, so the queue keeps
                 // draining while WASM executes on another task.
                 shadow.advance();
-                let focus = shadow.focus(&samplers.keys().copied().collect::<Vec<_>>());
+                let focus = shadow.focus(
+                    hosted_contracts(),
+                    &samplers.keys().copied().collect::<Vec<_>>(),
+                );
                 // Recomputed every tick so a rotation, or a change in what the peer
                 // hosts, takes effect on sampling immediately rather than at the next
                 // restart. Wide mode ignores focus by definition.
@@ -944,19 +970,28 @@ pub(crate) fn record(
                 evicted = Some(victim);
             }
             None => {
-                // Every tracked contract is in focus and the map is full, so there is
-                // nothing to give up. Unreachable while MAX_FOCUS_CONTRACTS (2) is far
-                // below MAX_TRACKED_CONTRACTS (64), but MAX_FOCUS_CONTRACTS is a
-                // documented operational tunable: raise it without revisiting the cap
-                // and this starts silently discarding exactly the focus-selected
-                // observations the eviction rule exists to protect. Counted rather
-                // than dropped in silence.
-                tracing::warn!(
-                    contract = %observation.contract,
-                    tracked = samplers.len(),
-                    "conformance capture could not make room for a focused contract: \
-                     every tracked contract is in focus"
-                );
+                // Two very different situations reach here, and warning for both says
+                // something false about one of them.
+                //
+                // Wide mode maps to `None` unconditionally: refuse-at-the-cap IS its
+                // design, the steady state of any long developer capture run, and it
+                // has no focus set to speak of. Warning there fires continuously and
+                // calls the newcomer "focused", which it is not.
+                //
+                // Focused mode reaching `None` means every tracked contract is in
+                // focus with the map full. Unreachable while MAX_FOCUS_CONTRACTS (2)
+                // sits far below MAX_TRACKED_CONTRACTS (64) - but that is a documented
+                // operational tunable, and raising it without revisiting the cap would
+                // start discarding exactly the focus-selected observations this
+                // eviction rule exists to protect. That one is worth a warning.
+                if matches!(scope, SamplingScope::Focused(_)) {
+                    tracing::warn!(
+                        contract = %observation.contract,
+                        tracked = samplers.len(),
+                        "conformance capture could not make room for a focused \
+                         contract: every tracked contract is in focus"
+                    );
+                }
                 return None;
             }
         }
@@ -1364,8 +1399,17 @@ mod probe_wiring_pins {
     #[test]
     fn an_evicted_contract_has_its_bundle_removed() {
         let body = run_writer_code_only();
+        // Bound to the EVICTED binding, not merely to `remove_file` appearing
+        // somewhere: the writer already unlinks its own `.tmp` staging file on a failed
+        // write, so a bare substring check passes even if the deletion is aimed at the
+        // wrong contract entirely.
         assert!(
-            body.contains("remove_file"),
+            body.contains("bundle_path(&dir, &evicted)"),
+            "the writer no longer derives the deleted path from the evicted contract, \
+             so eviction either orphans a bundle or deletes the wrong one"
+        );
+        assert!(
+            body.contains("remove_file(&path)"),
             "the writer no longer deletes evicted bundles, so every rotation past the \
              tracking cap orphans a file that nothing will ever clean up"
         );
@@ -1396,6 +1440,27 @@ mod probe_wiring_pins {
             body.contains("warmup.tick()"),
             "the hosted-source warm-up retry arm is gone; the startup draw alone runs \
              before the ring registers its hosted contracts and therefore misses it"
+        );
+    }
+
+    /// A focus contract still warming up must be counted, not dropped from the tick.
+    ///
+    /// `focused` is derived from the probe's work length, so a focus contract with no
+    /// samples yet vanished entirely: two selected with samples for one reported
+    /// `focused=1, skipped_no_samples=0`, which reads as "one contract, fully checked".
+    /// Warm-up is the normal state now that focus draws from the hosted set rather than
+    /// from what was already sampled, so this hid the common case.
+    #[test]
+    fn contracts_awaiting_samples_are_counted_in_the_tick() {
+        let body = run_writer_code_only();
+        assert!(
+            body.contains("report.focused += awaiting_samples"),
+            "focus contracts still awaiting samples no longer count toward `focused`, \
+             so a warming-up focus set reports as a smaller, fully-checked one"
+        );
+        assert!(
+            body.contains("report.skipped_no_samples += awaiting_samples"),
+            "focus contracts still awaiting samples are no longer reported as skipped"
         );
     }
 
@@ -1457,6 +1522,52 @@ mod tests {
         assert!(
             !samplers.contains_key(&instance(2)),
             "an unfocused contract was sampled: sampling is not following focus"
+        );
+    }
+
+    /// A restart reloads the SAME contracts every time.
+    ///
+    /// `reload` stops at `MAX_TRACKED_CONTRACTS`, and `read_dir` order is undefined, so
+    /// without a sort which contracts survive a restart is decided by whatever the
+    /// filesystem happens to enumerate first. Every other reload test writes a single
+    /// bundle, so the truncation path they exercise is the one where truncation never
+    /// happens - deleting the sort left all of them green.
+    #[test]
+    fn a_restart_reloads_a_deterministic_set_when_there_are_more_bundles_than_slots() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+
+        // More bundles than slots, so truncation actually runs.
+        let extra = 12usize;
+        for i in 0..(MAX_TRACKED_CONTRACTS + extra) {
+            let instance = ContractInstanceId::new([(i % 251) as u8; 32]);
+            let mut bundle = super::super::bundle::ReplayBundle::new(vec![9, 9], vec![3]);
+            bundle.instance = Some(instance);
+            bundle.states = vec![vec![1, 2], vec![2, 3]];
+            bundle
+                .write_to(&bundle_path(dir.path(), &instance))
+                .expect("write bundle");
+        }
+
+        let loaded = |dir: &Path| {
+            let mut ids: Vec<Vec<u8>> = reload(dir)
+                .into_keys()
+                .map(|id| id.as_bytes().to_vec())
+                .collect();
+            ids.sort_unstable();
+            ids
+        };
+        let first = loaded(dir.path());
+        let second = loaded(dir.path());
+
+        assert_eq!(
+            first.len(),
+            MAX_TRACKED_CONTRACTS,
+            "fixture did not exceed the cap, so truncation never ran"
+        );
+        assert_eq!(
+            first, second,
+            "two reloads of the same directory kept different contracts, so which \
+             samples survive a restart depends on filesystem enumeration order"
         );
     }
 

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1389,9 +1389,12 @@ mod probe_wiring_pins {
             "focus is no longer computed before the select loop, so a focus-scoped \
              peer records nothing for the first probe interval after every restart"
         );
+        // The ARM, not merely the constant: deleting the select arm leaves
+        // `let mut warmup = interval(HOSTED_SOURCE_WARMUP)` behind, so a pin on the
+        // constant's name passes with the retry gone - confirmed by mutation.
         assert!(
-            body.contains("HOSTED_SOURCE_WARMUP"),
-            "the hosted-source warm-up retry is gone; the startup draw alone runs \
+            body.contains("warmup.tick()"),
+            "the hosted-source warm-up retry arm is gone; the startup draw alone runs \
              before the ring registers its hosted contracts and therefore misses it"
         );
     }
@@ -1509,11 +1512,17 @@ mod tests {
         let mut samplers = HashMap::new();
         let watched = instance(1);
         let _evicted = record(&mut samplers, &focused_on(&[1]), observation_for(watched));
-        let _evicted = record(
-            &mut samplers,
-            &focused_on(&[2]),
-            observation_for(instance(2)),
-        );
+
+        // Traffic MUST keep arriving for the defocused contract. Without it the
+        // not-admitted branch never executes, and a version of `record` that discarded
+        // the entry on defocus would pass this test unchanged - confirmed by mutation.
+        let elsewhere = focused_on(&[2]);
+        for n in 0..4u8 {
+            let mut obs = observation_for(watched);
+            obs.result_state = vec![n, 4, 4];
+            let _evicted = record(&mut samplers, &elsewhere, obs);
+        }
+
         assert!(
             samplers.contains_key(&watched),
             "defocusing a contract discarded its accumulated sample"

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1525,21 +1525,29 @@ mod tests {
         );
     }
 
-    /// A restart reloads the SAME contracts every time.
+    /// A restart keeps a NAMED set of contracts, not whatever the filesystem lists first.
     ///
     /// `reload` stops at `MAX_TRACKED_CONTRACTS`, and `read_dir` order is undefined, so
-    /// without a sort which contracts survive a restart is decided by whatever the
-    /// filesystem happens to enumerate first. Every other reload test writes a single
-    /// bundle, so the truncation path they exercise is the one where truncation never
-    /// happens - deleting the sort left all of them green.
+    /// without a sort which contracts survive a restart is decided by enumeration
+    /// order. Every other reload test writes a single bundle, so the truncation path
+    /// they cover is the one where truncation never happens - deleting the sort left
+    /// all of them green.
+    ///
+    /// Asserting "two reloads agree" does NOT test this either, and that version of
+    /// this test was vacuous: `read_dir` is stable across calls within one process even
+    /// though its order is unspecified, so both reloads agreed with the sort deleted.
+    /// What the sort actually guarantees is WHICH set survives - the lexicographically
+    /// smallest filenames - and that holds only by luck under ext4's hash order.
     #[test]
     fn a_restart_reloads_a_deterministic_set_when_there_are_more_bundles_than_slots() {
         let dir = tempfile::TempDir::new().expect("tempdir");
 
         // More bundles than slots, so truncation actually runs.
         let extra = 12usize;
+        let mut written = Vec::new();
         for i in 0..(MAX_TRACKED_CONTRACTS + extra) {
             let instance = ContractInstanceId::new([(i % 251) as u8; 32]);
+            written.push(instance);
             let mut bundle = super::super::bundle::ReplayBundle::new(vec![9, 9], vec![3]);
             bundle.instance = Some(instance);
             bundle.states = vec![vec![1, 2], vec![2, 3]];
@@ -1548,26 +1556,26 @@ mod tests {
                 .expect("write bundle");
         }
 
-        let loaded = |dir: &Path| {
-            let mut ids: Vec<Vec<u8>> = reload(dir)
-                .into_keys()
-                .map(|id| id.as_bytes().to_vec())
-                .collect();
-            ids.sort_unstable();
-            ids
-        };
-        let first = loaded(dir.path());
-        let second = loaded(dir.path());
+        // What the sort promises: the lexicographically smallest bundle filenames.
+        let mut expected: Vec<String> = written.iter().map(|id| format!("{id}.bundle")).collect();
+        expected.sort();
+        expected.truncate(MAX_TRACKED_CONTRACTS);
+
+        let mut kept: Vec<String> = reload(dir.path())
+            .into_keys()
+            .map(|id| format!("{id}.bundle"))
+            .collect();
+        kept.sort();
 
         assert_eq!(
-            first.len(),
+            kept.len(),
             MAX_TRACKED_CONTRACTS,
             "fixture did not exceed the cap, so truncation never ran"
         );
         assert_eq!(
-            first, second,
-            "two reloads of the same directory kept different contracts, so which \
-             samples survive a restart depends on filesystem enumeration order"
+            kept, expected,
+            "reload kept a different set than the ordering promises, so which samples \
+             survive a restart depends on filesystem enumeration order"
         );
     }
 

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -160,6 +160,24 @@ impl CandidateSource {
     }
 }
 
+/// Choose the pool focus selects from, and say where it came from.
+///
+/// Pulled out of [`ShadowRunner::focus`] purely so it can be tested. The hosted branch
+/// is the entire point of #5366's fix, and in-process it is unreachable from a test:
+/// `set_hosted_contracts_source` no-ops unless capture is enabled, and capture reads
+/// its switch from the environment on first touch. Reading the global inside `focus`
+/// therefore made the branch that matters the one branch no test could take - swapping
+/// the two arms passed the whole suite.
+pub(crate) fn candidate_pool(
+    hosted: Option<Vec<ContractInstanceId>>,
+    fallback: &[ContractInstanceId],
+) -> (Vec<ContractInstanceId>, CandidateSource) {
+    match hosted {
+        Some(hosted) => (hosted, CandidateSource::Hosted),
+        None => (fallback.to_vec(), CandidateSource::SamplerFallback),
+    }
+}
+
 /// One tick's focus decision, before any samples are gathered for it.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FocusTick {
@@ -249,10 +267,7 @@ impl ShadowRunner {
         if self.mode == EnforcementMode::Disabled {
             return FocusTick::default();
         }
-        let (candidates, source) = match super::capture::hosted_contracts() {
-            Some(hosted) => (hosted, CandidateSource::Hosted),
-            None => (fallback.to_vec(), CandidateSource::SamplerFallback),
-        };
+        let (candidates, source) = candidate_pool(super::capture::hosted_contracts(), fallback);
         FocusTick {
             selected: self.selector.select(&candidates),
             candidates: candidates.len(),
@@ -272,22 +287,33 @@ impl ShadowRunner {
     /// that it never degrade normal operation. The periodic flush was made async for
     /// exactly this reason; a probe is the worse case, because it is CPU-bound and
     /// cannot be yielded away from by awaiting a syscall.
+    /// Returns the work plus the number of focused contracts that have no samples yet.
+    ///
+    /// That count is not incidental. `ShadowReport::focused` is derived from the work
+    /// length, so a focus contract still warming up simply vanished: a tick that
+    /// selected two contracts and found samples for one reported `focused=1,
+    /// skipped_no_samples=0`, which reads as "one contract, fully checked" rather than
+    /// "half the focus set had nothing to check". Warm-up is the NORMAL state now that
+    /// focus picks from the hosted set rather than from what was already sampled, so
+    /// hiding it would hide the common case.
     pub(crate) fn select(
         &self,
         focus: &FocusTick,
         samplers: &HashMap<ContractInstanceId, super::capture::TrackedContract>,
-    ) -> Vec<(ContractInstanceId, ReplayBundle)> {
+    ) -> (Vec<(ContractInstanceId, ReplayBundle)>, usize) {
         if self.mode == EnforcementMode::Disabled {
-            return Vec::new();
+            return (Vec::new(), 0);
         }
-        focus
+        let work: Vec<_> = focus
             .selected
             .iter()
             .filter_map(|instance| {
                 let tracked = samplers.get(instance)?;
                 Some((*instance, super::capture::bundle_for(*instance, tracked)))
             })
-            .collect()
+            .collect();
+        let awaiting_samples = focus.selected.len().saturating_sub(work.len());
+        (work, awaiting_samples)
     }
 
     pub(crate) fn mode(&self) -> EnforcementMode {
@@ -668,10 +694,56 @@ mod tests {
         // to the sampler keys - which is exactly the fallback path production reports
         // as `candidate_source=sampler`.
         let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
-        let work = runner.select(&focus, samplers);
+        let (work, _awaiting) = runner.select(&focus, samplers);
         let (report, findings) = probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
         runner.record(&findings);
         report
+    }
+
+    /// The hosted set is preferred, and is reported as such.
+    ///
+    /// This branch is the entire point of #5366's fix and was, until `candidate_pool`
+    /// was extracted, the one branch no test could reach: `focus` read a process-global
+    /// that only registers when capture is enabled from the environment, so every test
+    /// took the fallback and swapping the two arms passed the whole suite.
+    #[test]
+    fn candidates_come_from_the_hosted_set_when_one_is_available() {
+        let hosted = vec![instance(7), instance(8), instance(9)];
+        let sampler_keys = vec![instance(1), instance(2)];
+
+        let (pool, source) = candidate_pool(Some(hosted.clone()), &sampler_keys);
+
+        assert_eq!(pool, hosted, "focus did not draw from the hosted set");
+        assert_eq!(source, CandidateSource::Hosted);
+    }
+
+    /// With no hosted source, focus keeps working off the sampler - and says so.
+    ///
+    /// The fallback reinstates exactly the #5366 horizon, so the distinction has to
+    /// reach the logs; a peer degraded to it otherwise looks like one hosting little.
+    #[test]
+    fn candidates_fall_back_to_the_sampler_and_report_it() {
+        let sampler_keys = vec![instance(1), instance(2)];
+
+        let (pool, source) = candidate_pool(None, &sampler_keys);
+
+        assert_eq!(pool, sampler_keys);
+        assert_eq!(source, CandidateSource::SamplerFallback);
+        assert_eq!(source.as_str(), "sampler");
+    }
+
+    /// An empty hosted set is NOT the same as an absent source.
+    ///
+    /// A peer that genuinely hosts nothing must report `hosted` with zero candidates,
+    /// not silently borrow the sampler's contents and claim the fix is working.
+    #[test]
+    fn an_empty_hosted_set_does_not_fall_back_to_the_sampler() {
+        let sampler_keys = vec![instance(1), instance(2)];
+
+        let (pool, source) = candidate_pool(Some(Vec::new()), &sampler_keys);
+
+        assert!(pool.is_empty(), "an empty hosted set borrowed sampler keys");
+        assert_eq!(source, CandidateSource::Hosted);
     }
 
     fn instance(n: u8) -> ContractInstanceId {
@@ -689,7 +761,7 @@ mod tests {
     ) -> HashMap<ContractInstanceId, TrackedContract> {
         let mut samplers = HashMap::new();
         for (base, result) in transitions {
-            record(
+            let _evicted = record(
                 &mut samplers,
                 &crate::conformance::capture::SamplingScope::Wide,
                 Observation {
@@ -875,7 +947,7 @@ mod tests {
         let dir = tempfile::TempDir::new()?;
         let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
         let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
-        let work = runner.select(&focus, &samplers);
+        let (work, _awaiting) = runner.select(&focus, &samplers);
         assert!(!work.is_empty(), "nothing selected, so this proves nothing");
 
         let (report, _) = probe_with_budget(

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -134,6 +134,43 @@ pub struct ShadowReport {
 }
 
 /// The shadow loop's state, owned by the capture writer task.
+/// Where this tick's focus candidates came from.
+///
+/// Reported on every tick rather than assumed. The two sources have very different
+/// reach - the hosted set is the whole point of #5366's fix, the sampler set is the
+/// horizon that bug created - and a peer degraded to the second one produces tick
+/// lines that are otherwise indistinguishable from a healthy peer hosting few
+/// contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum CandidateSource {
+    /// The contracts the peer hosts. The intended source.
+    #[default]
+    Hosted,
+    /// The contracts the sampler already holds, used when no hosted source was
+    /// registered. Keeps probing alive; does not cover the hosted set.
+    SamplerFallback,
+}
+
+impl CandidateSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            CandidateSource::Hosted => "hosted",
+            CandidateSource::SamplerFallback => "sampler",
+        }
+    }
+}
+
+/// One tick's focus decision, before any samples are gathered for it.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FocusTick {
+    /// The contracts to watch this tick.
+    pub selected: Vec<ContractInstanceId>,
+    /// How many contracts were eligible. Distinguishes "this peer hosts almost
+    /// nothing" from "selection is broken".
+    pub candidates: usize,
+    pub source: CandidateSource,
+}
+
 pub struct ShadowRunner {
     mode: EnforcementMode,
     selector: FocusSelector,
@@ -171,62 +208,84 @@ impl ShadowRunner {
         self.selector.epoch()
     }
 
-    /// Run one probe tick over whatever the sampler currently holds.
-    /// Choose this tick's focus contracts and copy out what a probe needs.
+    /// Advance to the next probe tick, rotating the focus set when one is due.
     ///
-    /// # Known bound: focus can only reach what capture is already tracking
-    ///
-    /// `capture::record` stops admitting new contracts once it is tracking
-    /// `MAX_TRACKED_CONTRACTS` and never evicts, so the candidate set here freezes at
-    /// the first N contracts that peer ever observed. Rotation then reshuffles a fixed
-    /// set rather than working through the network: contracts first seen after the cap
-    /// are unreachable, and if hosting later drops the code for a frozen id, focus can
-    /// keep selecting it and only raise `skipped_no_code`.
-    ///
-    /// Two consequences worth stating plainly rather than discovering from a flat
-    /// coverage graph. Ordinary churn erodes coverage over time. And an author who can
-    /// get 64 contracts observed early can, in principle, make a peer's focus set
-    /// entirely their own choosing — which does not let them dodge the salt, but does
-    /// let them starve everyone else of attention on that peer.
-    ///
-    /// Not fixed here: the cap and the no-evict rule are capture's, they predate this,
-    /// and changing them changes what a captured corpus means — a design call, not a
-    /// drive-by. Made VISIBLE instead: every tick reports `tracked` and whether the
-    /// sampler is at its cap, so the erosion shows up in the shadow telemetry that
-    /// exists to find exactly this kind of quiet loss of reach.
-    ///
-    /// Split from [`probe`] deliberately, and the split is load-bearing rather than
-    /// tidiness. This half borrows the sampler map, so it has to run on the capture
-    /// task, and it is cheap: a hash per candidate plus a bounded copy of the selected
-    /// contracts' samples. The probe half is CPU-bound WASM execution under a
-    /// ten-second-per-contract budget, and running THAT on the capture task would stop
-    /// the task draining its observation queue for as long as it ran — dropping the
-    /// very observations conformance exists to collect, from a mechanism whose stated
-    /// requirement is that it never degrade normal operation. The periodic flush was
-    /// made async for exactly this reason; a probe is the worse case, because it is
-    /// CPU-bound and cannot be yielded away from by awaiting a syscall.
-    pub(crate) fn select(
-        &mut self,
-        samplers: &HashMap<ContractInstanceId, super::capture::TrackedContract>,
-    ) -> Vec<(ContractInstanceId, ReplayBundle)> {
-        if self.mode == EnforcementMode::Disabled {
-            return Vec::new();
-        }
-
+    /// Separate from [`focus`](Self::focus) so focus can be computed at startup
+    /// without consuming a tick. Rotation counts probe ticks rather than wall time so
+    /// a peer that was down does not skip epochs it never sampled in.
+    pub(crate) fn advance(&mut self) {
         self.ticks = self.ticks.wrapping_add(1);
         if self.ticks % ROTATE_EVERY_TICKS == 0 {
             self.selector.rotate();
             self.logged.clear();
             store_epoch(&self.dir, self.selector.epoch());
         }
+    }
 
-        let candidates: Vec<ContractInstanceId> = samplers.keys().copied().collect();
-        self.selector
-            .select(&candidates)
-            .into_iter()
+    /// The contracts this peer should be watching right now.
+    ///
+    /// Candidates are the contracts the peer HOSTS, per the RFC: "each peer
+    /// independently selects one or a small bounded number of hosted contracts as
+    /// focus contracts". They are deliberately not the contracts the sampler has
+    /// collected. Sourcing them from the sampler is what caused #5366 - the sampler
+    /// stops admitting new contracts at its tracking cap and never evicts, so the
+    /// candidate pool froze at the first N contracts the peer ever observed and
+    /// rotation reshuffled a fixed set forever. On the live capture peer that showed
+    /// up as `tracking_at_cap=true` on every tick for hours, with focus unable to
+    /// reach anything new no matter how long it ran.
+    ///
+    /// Hosted-sourced focus inverts the dependency: focus decides what to sample,
+    /// rather than sampling deciding what can be focused. A freshly focused contract
+    /// therefore starts with no samples and accumulates them from ordinary traffic,
+    /// which is the intended behaviour and is reported as `skipped_no_samples`, not
+    /// as a failure.
+    ///
+    /// `fallback` is used only when no hosted-contract source has been registered.
+    /// Callers pass the sampler keys, which keeps a peer probing rather than going
+    /// silent, but reinstates exactly the #5366 horizon - so the tick reports which
+    /// source it used. `candidates=sampler` means focus has stopped covering the
+    /// hosted set, a state that otherwise looks identical to a peer hosting little.
+    pub(crate) fn focus(&self, fallback: &[ContractInstanceId]) -> FocusTick {
+        if self.mode == EnforcementMode::Disabled {
+            return FocusTick::default();
+        }
+        let (candidates, source) = match super::capture::hosted_contracts() {
+            Some(hosted) => (hosted, CandidateSource::Hosted),
+            None => (fallback.to_vec(), CandidateSource::SamplerFallback),
+        };
+        FocusTick {
+            selected: self.selector.select(&candidates),
+            candidates: candidates.len(),
+            source,
+        }
+    }
+
+    /// Copy out what a probe needs for the focused contracts.
+    ///
+    /// Split from [`probe`] deliberately, and the split is load-bearing rather than
+    /// tidiness. This half borrows the sampler map, so it has to run on the capture
+    /// task, and it is cheap: a bounded copy of the selected contracts' samples. The
+    /// probe half is CPU-bound WASM execution under a ten-second-per-contract budget,
+    /// and running THAT on the capture task would stop the task draining its
+    /// observation queue for as long as it ran - dropping the very observations
+    /// conformance exists to collect, from a mechanism whose stated requirement is
+    /// that it never degrade normal operation. The periodic flush was made async for
+    /// exactly this reason; a probe is the worse case, because it is CPU-bound and
+    /// cannot be yielded away from by awaiting a syscall.
+    pub(crate) fn select(
+        &self,
+        focus: &FocusTick,
+        samplers: &HashMap<ContractInstanceId, super::capture::TrackedContract>,
+    ) -> Vec<(ContractInstanceId, ReplayBundle)> {
+        if self.mode == EnforcementMode::Disabled {
+            return Vec::new();
+        }
+        focus
+            .selected
+            .iter()
             .filter_map(|instance| {
-                let tracked = samplers.get(&instance)?;
-                Some((instance, super::capture::bundle_for(instance, tracked)))
+                let tracked = samplers.get(instance)?;
+                Some((*instance, super::capture::bundle_for(*instance, tracked)))
             })
             .collect()
     }
@@ -604,7 +663,12 @@ mod tests {
         samplers: &HashMap<ContractInstanceId, TrackedContract>,
         store: Option<&Path>,
     ) -> ShadowReport {
-        let work = runner.select(samplers);
+        runner.advance();
+        // No hosted-contract source is registered in unit tests, so focus falls back
+        // to the sampler keys - which is exactly the fallback path production reports
+        // as `candidate_source=sampler`.
+        let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
+        let work = runner.select(&focus, samplers);
         let (report, findings) = probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
         runner.record(&findings);
         report
@@ -627,6 +691,7 @@ mod tests {
         for (base, result) in transitions {
             record(
                 &mut samplers,
+                &crate::conformance::capture::SamplingScope::Wide,
                 Observation {
                     contract: id,
                     code_hash,
@@ -808,8 +873,9 @@ mod tests {
             &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
         );
         let dir = tempfile::TempDir::new()?;
-        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
-        let work = runner.select(&samplers);
+        let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
+        let work = runner.select(&focus, &samplers);
         assert!(!work.is_empty(), "nothing selected, so this proves nothing");
 
         let (report, _) = probe_with_budget(

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -144,10 +144,18 @@ pub struct ShadowReport {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum CandidateSource {
     /// The contracts the peer hosts. The intended source.
-    #[default]
     Hosted,
     /// The contracts the sampler already holds, used when no hosted source was
     /// registered. Keeps probing alive; does not cover the hosted set.
+    ///
+    /// The DEFAULT, deliberately, and this is load-bearing rather than arbitrary.
+    /// `Hosted` was the default first, which made `FocusTick::default()` assert the
+    /// hosted source was already in use before any draw had happened - and the writer's
+    /// warm-up retry is guarded on `source != Hosted`, so the guard was false from the
+    /// first tick and the retry arm was never once polled. A default must be the claim
+    /// that is safe to be wrong about; "we are on the fallback" costs a retry, while
+    /// "we are on the hosted set" silently cancels the recovery path.
+    #[default]
     SamplerFallback,
 }
 
@@ -176,6 +184,23 @@ pub(crate) fn candidate_pool(
         Some(hosted) => (hosted, CandidateSource::Hosted),
         None => (fallback.to_vec(), CandidateSource::SamplerFallback),
     }
+}
+
+/// Whether the writer should keep retrying its focus draw.
+///
+/// Extracted so the condition can be TESTED. As a bare `tokio::select!` arm guard it
+/// could not be: nothing calls `run_writer`, and a source pin can only see that the arm
+/// is written, never that its guard is permanently false. That is exactly how the first
+/// version shipped - `CandidateSource` defaulted to `Hosted`, so the guard was false
+/// from the first tick and the retry never ran once.
+pub(crate) fn needs_hosted_warmup(
+    wide: bool,
+    last: &FocusTick,
+    attempts: u32,
+    budget: u32,
+) -> bool {
+    // Wide capture ignores focus entirely, so it has nothing to warm up.
+    !wide && last.source != CandidateSource::Hosted && attempts < budget
 }
 
 /// One tick's focus decision, before any samples are gathered for it.
@@ -263,11 +288,15 @@ impl ShadowRunner {
     /// silent, but reinstates exactly the #5366 horizon - so the tick reports which
     /// source it used. `candidates=sampler` means focus has stopped covering the
     /// hosted set, a state that otherwise looks identical to a peer hosting little.
-    pub(crate) fn focus(&self, fallback: &[ContractInstanceId]) -> FocusTick {
+    pub(crate) fn focus(
+        &self,
+        hosted: Option<Vec<ContractInstanceId>>,
+        fallback: &[ContractInstanceId],
+    ) -> FocusTick {
         if self.mode == EnforcementMode::Disabled {
             return FocusTick::default();
         }
-        let (candidates, source) = candidate_pool(super::capture::hosted_contracts(), fallback);
+        let (candidates, source) = candidate_pool(hosted, fallback);
         FocusTick {
             selected: self.selector.select(&candidates),
             candidates: candidates.len(),
@@ -693,11 +722,102 @@ mod tests {
         // No hosted-contract source is registered in unit tests, so focus falls back
         // to the sampler keys - which is exactly the fallback path production reports
         // as `candidate_source=sampler`.
-        let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
+        let focus = runner.focus(None, &samplers.keys().copied().collect::<Vec<_>>());
         let (work, _awaiting) = runner.select(&focus, samplers);
         let (report, findings) = probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
         runner.record(&findings);
         report
+    }
+
+    /// A fresh `FocusTick` must NOT claim the hosted source is already in use.
+    ///
+    /// This is the bug that shipped: `CandidateSource` derived `Default` with `Hosted`
+    /// marked `#[default]`, so `FocusTick::default()` asserted the hosted set was in
+    /// use before any draw had happened. The writer's warm-up retry is guarded on
+    /// `source != Hosted`, so the guard was false from the first tick and the retry arm
+    /// was never polled once - leaving exactly the startup gap it was added to close.
+    #[test]
+    fn a_default_focus_tick_does_not_claim_the_hosted_source() {
+        assert_eq!(
+            FocusTick::default().source,
+            CandidateSource::SamplerFallback,
+            "a focus decision that has not happened yet must not claim the hosted set"
+        );
+    }
+
+    /// The warm-up keeps retrying while focus is still on the fallback.
+    #[test]
+    fn warmup_retries_while_focus_is_still_on_the_fallback() {
+        let fallback = FocusTick {
+            source: CandidateSource::SamplerFallback,
+            ..FocusTick::default()
+        };
+        assert!(
+            needs_hosted_warmup(false, &fallback, 0, 12),
+            "warm-up gave up while focus was still on the sampler fallback"
+        );
+        // And specifically for a DEFAULT tick, which is the state at task start.
+        assert!(
+            needs_hosted_warmup(false, &FocusTick::default(), 0, 12),
+            "warm-up was disabled before the first draw had even happened"
+        );
+    }
+
+    /// It stops for good once a draw reaches the hosted set.
+    #[test]
+    fn warmup_stops_once_focus_reaches_the_hosted_set() {
+        let hosted = FocusTick {
+            source: CandidateSource::Hosted,
+            ..FocusTick::default()
+        };
+        assert!(!needs_hosted_warmup(false, &hosted, 0, 12));
+    }
+
+    /// Wide capture never warms up: it ignores focus entirely.
+    #[test]
+    fn warmup_does_not_run_for_wide_capture() {
+        assert!(!needs_hosted_warmup(true, &FocusTick::default(), 0, 12));
+    }
+
+    /// It gives up rather than ticking forever when no source ever appears.
+    ///
+    /// Reachable, not hypothetical: the node calls `capture::global()` - which spawns
+    /// the writer - before it checks whether the daemon is disabled, and a disabled
+    /// daemon idles indefinitely without ever constructing a `Ring` to register one.
+    #[test]
+    fn warmup_gives_up_after_its_attempt_budget() {
+        assert!(
+            !needs_hosted_warmup(false, &FocusTick::default(), 12, 12),
+            "warm-up would retry forever on a node that never builds a ring"
+        );
+    }
+
+    /// `focus` actually consults the hosted set it is handed.
+    ///
+    /// The wiring, not just `candidate_pool`: hardcoding `None` at the call site would
+    /// silently reinstate #5366 in production, and until `focus` took the lookup as a
+    /// parameter no test could tell the difference.
+    #[tokio::test]
+    async fn focus_selects_from_the_hosted_set_it_is_given() -> anyhow::Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let hosted: Vec<_> = (10..40u8).map(instance).collect();
+
+        let tick = runner.focus(Some(hosted.clone()), &[instance(1), instance(2)]);
+
+        assert_eq!(tick.source, CandidateSource::Hosted);
+        assert_eq!(tick.candidates, hosted.len());
+        assert!(
+            !tick.selected.is_empty(),
+            "hosted candidates selected nothing"
+        );
+        for picked in &tick.selected {
+            assert!(
+                hosted.contains(picked),
+                "focus selected {picked} which the peer does not host"
+            );
+        }
+        Ok(())
     }
 
     /// The hosted set is preferred, and is reported as such.
@@ -946,7 +1066,7 @@ mod tests {
         );
         let dir = tempfile::TempDir::new()?;
         let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
-        let focus = runner.focus(&samplers.keys().copied().collect::<Vec<_>>());
+        let focus = runner.focus(None, &samplers.keys().copied().collect::<Vec<_>>());
         let (work, _awaiting) = runner.select(&focus, &samplers);
         assert!(!work.is_empty(), "nothing selected, so this proves nothing");
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -721,6 +721,29 @@ impl Ring {
         }
 
         let ring = Arc::new(ring);
+
+        // Conformance focus selects over the contracts this peer HOSTS (RFC #5320),
+        // so the ring - which owns the hosting cache - is what can answer that. A
+        // `Weak` deliberately: this closure is stored in a process-global that
+        // outlives the node, and holding a strong `Arc` there would keep an entire
+        // ring, its background tasks' handles and its caches alive past teardown. A
+        // dead ring reads as "no candidates", which surfaces as `focused=0` rather
+        // than as a stale set. Registration is a no-op unless capture is enabled.
+        {
+            let weak = Arc::downgrade(&ring);
+            crate::conformance::capture::set_hosted_contracts_source(Box::new(move || {
+                weak.upgrade()
+                    .map(|ring| {
+                        ring.hosting_manager
+                            .hosting_contract_keys()
+                            .into_iter()
+                            .map(|key| *key.id())
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            }));
+        }
+
         let current_span = tracing::Span::current();
         let span = if current_span.is_none() {
             tracing::info_span!("connection_maintenance")


### PR DESCRIPTION
## Problem

Conformance focus selection drew its candidates from the capture sampler's tracked
map. That map stops admitting new contracts at `MAX_TRACKED_CONTRACTS` (64) and never
evicts, so a peer's candidate pool froze at the first 64 contracts it ever observed.
Rotation then reshuffled a fixed set forever: anything first seen after the cap was
unreachable, and no amount of running time widened the peer's reach.

The live shadow peer showed this plainly — `tracking_at_cap=true` on every tick for
eight hours, probing a frozen set while every tick line read healthy. A peer whose
coverage stopped growing months ago produces exactly the same shape of clean result as
one genuinely covering the network, which is the failure class the shadow counters
exist to expose. Reported as #5366.

It is also a deviation from the RFC (#5320), which selects over what the peer **hosts**:

> each peer independently selects one or a small bounded number of hosted contracts as
> focus contracts

and then samples those:

> while a contract is in the focus set, the peer records a bounded, diverse sample of
> the states and update context it naturally observes

The dependency was inverted — sampling decided what could be focused, rather than focus
deciding what was sampled.

## Approach

Invert it back.

- **The ring registers how to enumerate hosted contracts.** It owns the hosting cache,
  so it is what can answer. The closure holds a `Weak`, because it lives in a
  process-global that outlives the node and a strong `Arc` there would keep a whole
  ring, its caches and its background-task handles alive past teardown — one per
  simulated peer in the test harness. A dead ring reads as "no candidates", surfacing
  as `focused=0` rather than as a stale set.
- **`ShadowRunner` splits into `advance` / `focus` / `select`.** Splitting `focus` out
  of the tick lets the writer compute it at startup without consuming a tick. That
  matters: under focus-scoped sampling an empty focus set records *nothing*, and the
  probe interval is fifteen minutes, so deferring it would punch a real hole in the
  corpus on every restart.
- **`record` takes a `SamplingScope`.** `Focused` records only the focus set. `Wide`
  records everything up to the cap and is developer-only, behind
  `FREENET_CONFORMANCE_CAPTURE_WIDE` — offline replay of a broad single-peer corpus is
  what actually found every deployed violation so far, and a peer obeying the RFC's
  focus-scoped sampling will never build one.

### The cap needed rethinking, not just rewiring

Refusing newcomers is what caused #5366, and under focus-scoped sampling it returns in
a worse form: rotation *guarantees* the map fills with contracts no longer in focus, so
the contract focus just selected could never be sampled at all. `Focused` therefore
evicts a non-focused contract to make room — deterministic (lowest id) so it is
reproducible, and never a focused one. `Wide` keeps the old refusal, because a
developer corpus whose contents depend on eviction order stops meaning "what this peer
saw".

### Failing loudly instead of quietly

If no hosted source is registered, focus falls back to the sampler keys rather than
going silent — but that fallback reinstates exactly the horizon this fixes, and looks
identical to a peer that simply hosts little. So every tick now reports
`candidate_source` (`hosted` / `sampler`) alongside `candidates` and `scope`.

## Testing

Five behavioural tests and two source pins. **Every one was mutation-checked** against
the exact regression it names — the mutation applied, the test run, and confirmed to
fail:

| Mutation | Test |
|---|---|
| sampling ignores focus | `focused_sampling_records_only_the_focus_set` |
| full map refuses the focused newcomer (the original #5366 rule) | `a_full_map_still_admits_the_contract_focus_selected` |
| victim rule stops skipping focused contracts | `making_room_never_evicts_a_focused_contract` |
| wide mode evicts to make room | `wide_sampling_stops_at_the_cap_rather_than_rolling_over` |
| ring stops registering hosted contracts | `the_ring_registers_its_hosted_contracts_for_conformance` |
| closure captures a strong `Arc` | `the_hosted_contracts_source_holds_only_a_weak_reference` |

That exercise earned its keep twice. The rollover test originally asserted only that
the map stopped at its cap — but a map evicting one entry per admission also sits at
exactly the cap forever, so it **passed under the rollover it was written to forbid**.
It now asserts which contracts survive, since refusal keeps the earliest and rollover
keeps the latest (commit `4d33a96`). Separately, the mutation harness itself
misclassified five real detections as build failures, because `cargo test` prints
`error: test failed, to rerun pass ...` when a *test* fails and the classifier keyed on
`^error`.

The pins slice `Ring::new`'s body by brace counting rather than ending at "the next
`fn`", following the discipline the sibling contract-store pin documents: a region
ended on a guessed anchor silently widens and can match the pin's own assertion text,
passing vacuously.

## Deployment note

This changes what a captured corpus means. Existing bundles were gathered wide; a
production-shaped peer now samples a couple of contracts deeply instead of 64 broadly.
The capture peer needs `FREENET_CONFORMANCE_CAPTURE_WIDE=1` when redeployed, or it
switches to narrow sampling and stops building the offline corpus. The 66 bundles
already on disk are unaffected.

Refs #5366, #5320

[AI-assisted - Claude]
