### PR TITLE
fix(conformance): scale the related-state budget and count refusals

### DIFF
--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -128,6 +128,20 @@ const MAX_QUEUED_BYTES: usize = 8 * 1024 * 1024;
 ///
 /// So: the same per-state ceiling and the same per-contract total the sampler uses,
 /// both of which the operator can already raise for a diagnostic run.
+///
+/// # This raises the DEFAULT footprint, not just the override's reach
+///
+/// Worth stating plainly rather than leaving to be discovered. At
+/// `SamplerConfig::default()` the related-state total per tracked contract goes from a
+/// flat 512 KiB to `max_bytes` (4 MiB), and the per-state ceiling from 512 KiB to
+/// `max_state_bytes` (1 MiB) - so a node that sets no environment variable at all still
+/// carries more. Node-wide worst case at `MAX_TRACKED_CONTRACTS` is bounded by
+/// `64 * (max_bytes + max_bytes)`, related state plus samples.
+///
+/// Accepted because capture does not run unless an operator sets
+/// `FREENET_CONFORMANCE_CAPTURE_DIR`, `MAX_RELATED_CONTRACTS` still bounds the count,
+/// and the alternative is what this comment exists to describe: a budget too small to
+/// judge the contracts it was collected for.
 fn related_budgets(config: &SamplerConfig) -> (usize, usize) {
     (config.max_state_bytes, config.max_bytes)
 }
@@ -855,6 +869,7 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
         }
         // Read before the struct takes ownership of `sampler`.
         let (max_related_state, max_related_total) = related_budgets(sampler.config());
+        let mut reload_refusals = RelatedRefusals::default();
         samplers.insert(
             instance,
             TrackedContract {
@@ -866,21 +881,29 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
                     // wrote the bundle: an operator who raised the budget to make a
                     // contract checkable must not have a corpus written under the old
                     // one silently re-truncated to it.
-                    let mut ignored = RelatedRefusals::default();
                     admit_related(
                         &mut restored,
                         &bundle.related,
-                        &mut ignored,
+                        &mut reload_refusals,
                         max_related_state,
                         max_related_total,
                     );
                     restored
                 },
                 parameters: bundle.parameters,
-                // Not persisted in the bundle: these count what THIS process
-                // refused, and a reloaded corpus has no refusals of its own yet.
+                // Not persisted in the bundle: this counts what THIS process refused,
+                // and a reloaded corpus has none of its own yet.
                 refused_too_large: 0,
-                refused_related: RelatedRefusals::default(),
+                // Related refusals ARE carried, because reload genuinely makes them.
+                //
+                // An earlier version discarded them into a throwaway local, with a
+                // comment claiming "a reloaded corpus has no refusals of its own yet".
+                // That was false on its own terms: reload re-admits under THIS
+                // process's budgets, so a run that captured under a raised budget and
+                // then restarted under the default has its related state trimmed right
+                // here - silently, with the next flush writing "0 refused" over the
+                // evidence. That is the exact invariant this type exists to hold.
+                refused_related: reload_refusals,
             },
         );
     }
@@ -1200,10 +1223,27 @@ async fn write_all(
             if refused.total() == 0 {
                 String::new()
             } else {
-                format!(
-                    " (related state refused: {} too large, {} over budget, {} no slot                      - this corpus may be unable to reach a verdict for this contract;                      raise {})",
-                    refused.too_large, refused.over_budget, refused.no_slot, CAPTURE_MAX_BYTES_ENV,
-                )
+                // Built by concatenation, not a `\`-continued literal: a wrapped
+                // literal bakes its own source indentation into every bundle note a
+                // reader ever sees, and rustfmt does not touch string contents.
+                let mut extra = format!(
+                    " (related state refused: {} too large, {} over budget, {} no slot.",
+                    refused.too_large, refused.over_budget, refused.no_slot,
+                );
+                extra.push_str(" This corpus may be unable to reach a verdict for this contract.");
+                if refused.too_large > 0 || refused.over_budget > 0 {
+                    extra.push_str(&format!(" Raise {CAPTURE_MAX_BYTES_ENV} to capture it."));
+                }
+                if refused.no_slot > 0 {
+                    // Raising the byte budget cannot help here: the slot limit is a
+                    // compile-time constant, so do not send a reader after that knob.
+                    extra.push_str(&format!(
+                        " {} related contract(s) exceeded the {}-contract limit, which no configuration changes.",
+                        refused.no_slot, MAX_RELATED_CONTRACTS,
+                    ));
+                }
+                extra.push(')');
+                extra
             },
         ));
 
@@ -1219,9 +1259,17 @@ async fn write_all(
                 over_budget = refused.over_budget,
                 no_slot = refused.no_slot,
                 related_held = tracked.related.len(),
+                // Only suggest the byte budget when the byte budget is what bound.
+                // `no_slot` is the MAX_RELATED_CONTRACTS limit, a compile-time
+                // constant, and sending an operator to re-run with a bigger budget
+                // that cannot possibly help is worse than saying nothing.
+                remedy = if refused.too_large > 0 || refused.over_budget > 0 {
+                    CAPTURE_MAX_BYTES_ENV
+                } else {
+                    "none: the related-contract COUNT limit bound, which is not configurable"
+                },
                 "conformance capture refused related-contract state; replays of this \
-                 contract may reach no verdict. Raise {} to capture it.",
-                CAPTURE_MAX_BYTES_ENV,
+                 contract may reach no verdict"
             );
         }
 
@@ -1696,6 +1744,53 @@ mod tests {
             kept, expected,
             "reload kept a different set than the ordering promises, so which samples \
              survive a restart depends on filesystem enumeration order"
+        );
+    }
+
+    /// Reload counts the related state IT refuses.
+    ///
+    /// Reload re-admits under the CURRENT process's budgets, so a run that captured
+    /// under a raised budget and then restarted under a smaller one has its related
+    /// state trimmed at reload. An earlier version threw that count away into a
+    /// throwaway local, so the next flush wrote "0 refused" over the evidence - the
+    /// exact silent truncation this counter exists to prevent, in the one path that
+    /// most needs it.
+    #[test]
+    fn reload_reports_related_state_it_had_to_refuse() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let instance = ContractInstanceId::new([3; 32]);
+        let (max_state, _) = related_budgets(&sampler_config());
+
+        // A bundle carrying more related contracts than the slot limit allows, which
+        // binds regardless of how the byte budgets are configured.
+        let mut bundle = super::super::bundle::ReplayBundle::new(vec![9, 9], vec![3]);
+        bundle.instance = Some(instance);
+        bundle.states = vec![vec![1, 2], vec![2, 3]];
+        bundle.related = (0..(MAX_RELATED_CONTRACTS + 4))
+            .map(|i| (ContractInstanceId::new([i as u8; 32]), vec![i as u8; 16]))
+            .collect();
+        assert!(
+            max_state > 16,
+            "fixture states must be individually admissible"
+        );
+        bundle
+            .write_to(&bundle_path(dir.path(), &instance))
+            .expect("write bundle");
+
+        let samplers = reload(dir.path());
+        let tracked = samplers
+            .get(&instance)
+            .expect("bundle should have reloaded");
+
+        assert_eq!(
+            tracked.related.len(),
+            MAX_RELATED_CONTRACTS,
+            "reload did not trim to the slot limit, so nothing was refused"
+        );
+        assert_eq!(
+            tracked.refused_related.no_slot, 4,
+            "reload trimmed related state without counting it, so the next flush will \
+             record a corpus as complete when it is not"
         );
     }
 
@@ -2283,16 +2378,42 @@ mod tests {
     #[tokio::test]
     async fn the_total_related_byte_allowance_holds() {
         let mut samplers = HashMap::new();
-        let chunk = test_related_budgets().1 / 3;
+        let (max_state, max_total) = test_related_budgets();
 
-        // Three entries of a third of the allowance each: the third is the one that
-        // must be refused on the TOTAL, since each is individually well within the
-        // per-entry bound.
-        for i in 0..4u8 {
+        // Each entry sits exactly AT the per-state ceiling, so every one is
+        // individually admissible and only the running total can refuse them.
+        //
+        // This used to divide the TOTAL budget into thirds, which was correct while
+        // one constant served as both caps. Once they became distinct
+        // (`max_state_bytes` is a quarter of `max_bytes`), a third of the total
+        // exceeded the per-state cap, so every entry was refused as `TooLarge`, the
+        // map stayed empty, and the assertions below passed without the total-budget
+        // path ever running.
+        let chunk = max_state;
+        let entries = (max_total / chunk) + 1;
+        assert!(
+            entries >= 2,
+            "fixture needs at least two entries to test a TOTAL bound"
+        );
+        for i in 0..entries {
             let mut observed = observation();
-            observed.related = vec![(ContractInstanceId::new([i; 32]), vec![i; chunk])];
+            observed.related = vec![(ContractInstanceId::new([i as u8; 32]), vec![7u8; chunk])];
             let _evicted = record(&mut samplers, &SamplingScope::Wide, observed);
         }
+
+        let refused = samplers
+            .values()
+            .next()
+            .expect("one contract tracked")
+            .refused_related;
+        assert_eq!(
+            refused.too_large, 0,
+            "entries were refused on the PER-STATE cap, so the total was never tested"
+        );
+        assert!(
+            refused.over_budget > 0,
+            "nothing was refused on the total, so the allowance never bound"
+        );
 
         let tracked = samplers.values().next().expect("one contract tracked");
         let held: usize = tracked.related.values().map(Vec::len).sum();
@@ -2302,8 +2423,8 @@ mod tests {
             test_related_budgets().1
         );
         assert!(
-            tracked.related.len() < 4,
-            "all four entries were admitted, so the total allowance is not binding"
+            tracked.related.len() < entries,
+            "all {entries} entries were admitted, so the total allowance is not binding"
         );
 
         // Replacing an existing entry must discount what it already held: offering

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1649,7 +1649,6 @@ mod probe_wiring_pins {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     /// The related-state budgets the sampler config in force for tests implies.

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1095,19 +1095,6 @@ pub(crate) fn record(
     evicted
 }
 
-/// Admit related-contract states into a tracked contract, within the allowance.
-///
-/// Shared by `record` and `reload` on purpose. Everything else a reload restores goes
-/// back through the sampler's own admission checks, so it is self-correcting: a
-/// bundle written under looser limits is trimmed to what the current build allows.
-/// Related state was the one field that skipped that and was collected raw, so a
-/// bundle from a looser build — or an edited one, since nothing bounds the vector on
-/// disk — loaded straight past today's limits. One function, called from both paths,
-/// is what stops the two rules drifting again.
-///
-/// Both bounds refuse rather than evict: a contract referencing a hundred others must
-/// not be able to churn this map, and states already retained are more useful than an
-/// arbitrary newcomer.
 /// Related state a contract offered and capture would not keep.
 ///
 /// Counted, never silently dropped. Three `continue`s used to discard related state
@@ -1132,6 +1119,19 @@ impl RelatedRefusals {
     }
 }
 
+/// Admit related-contract states into a tracked contract, within the allowance.
+///
+/// Shared by `record` and `reload` on purpose. Everything else a reload restores goes
+/// back through the sampler's own admission checks, so it is self-correcting: a
+/// bundle written under looser limits is trimmed to what the current build allows.
+/// Related state was the one field that skipped that and was collected raw, so a
+/// bundle from a looser build — or an edited one, since nothing bounds the vector on
+/// disk — loaded straight past today's limits. One function, called from both paths,
+/// is what stops the two rules drifting again.
+///
+/// Both bounds refuse rather than evict: a contract referencing a hundred others must
+/// not be able to churn this map, and states already retained are more useful than an
+/// arbitrary newcomer.
 fn admit_related(
     held: &mut HashMap<ContractInstanceId, Vec<u8>>,
     offered: &[(ContractInstanceId, Vec<u8>)],
@@ -1238,7 +1238,7 @@ async fn write_all(
                     // Raising the byte budget cannot help here: the slot limit is a
                     // compile-time constant, so do not send a reader after that knob.
                     extra.push_str(&format!(
-                        " {} related contract(s) exceeded the {}-contract limit, which no configuration changes.",
+                        " {} related contract(s) exceeded the {}-contract limit, which no configuration can raise.",
                         refused.no_slot, MAX_RELATED_CONTRACTS,
                     ));
                 }
@@ -1263,11 +1263,23 @@ async fn write_all(
                 // `no_slot` is the MAX_RELATED_CONTRACTS limit, a compile-time
                 // constant, and sending an operator to re-run with a bigger budget
                 // that cannot possibly help is worse than saying nothing.
-                remedy = if refused.too_large > 0 || refused.over_budget > 0 {
-                    CAPTURE_MAX_BYTES_ENV
-                } else {
-                    "none: the related-contract COUNT limit bound, which is not configurable"
+                // Must describe BOTH causes when both fired. Collapsing to the byte
+                // budget alone sends an operator to raise it, re-run, and get an
+                // incomplete corpus again with no explanation - and a large, popular
+                // related contract is exactly the case that trips both at once.
+                remedy = match (
+                    refused.too_large > 0 || refused.over_budget > 0,
+                    refused.no_slot > 0,
+                ) {
+                    (true, true) => "raise the byte budget; some refusals are also \
+                                     capped by the related-contract COUNT limit, which \
+                                     is not configurable",
+                    (true, false) => "raise the byte budget",
+                    (false, true) => "none: the related-contract COUNT limit bound, \
+                                      which is not configurable",
+                    (false, false) => "none",
                 },
+                byte_budget_env = CAPTURE_MAX_BYTES_ENV,
                 "conformance capture refused related-contract state; replays of this \
                  contract may reach no verdict"
             );
@@ -1792,6 +1804,52 @@ mod tests {
             "reload trimmed related state without counting it, so the next flush will \
              record a corpus as complete when it is not"
         );
+    }
+
+    /// Each reloaded bundle gets ITS OWN refusal count, not a running total.
+    ///
+    /// The direct regression for the worse bug the first fix could have introduced.
+    /// `reload_refusals` has to be declared inside the per-bundle loop; hoisted above
+    /// it, every contract after the first inherits the earlier contracts' refusals and
+    /// the counter starts lying in the opposite direction - overstating rather than
+    /// hiding, which is worse, because an overstated count sends someone hunting a
+    /// truncation that never happened.
+    ///
+    /// The existing multi-bundle reload test cannot catch this: its bundles carry no
+    /// related state at all, so no bundle refuses anything.
+    #[test]
+    fn each_reloaded_bundle_counts_only_its_own_refusals() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+
+        // Two bundles, each over the slot limit by a DIFFERENT amount, so a shared
+        // counter cannot coincidentally produce the right answer for both.
+        let over_by = [3usize, 5usize];
+        let instances = [
+            ContractInstanceId::new([200; 32]),
+            ContractInstanceId::new([201; 32]),
+        ];
+        for (instance, extra) in instances.iter().zip(over_by) {
+            let mut bundle = super::super::bundle::ReplayBundle::new(vec![9, 9], vec![3]);
+            bundle.instance = Some(*instance);
+            bundle.states = vec![vec![1, 2], vec![2, 3]];
+            bundle.related = (0..(MAX_RELATED_CONTRACTS + extra))
+                .map(|i| (ContractInstanceId::new([i as u8; 32]), vec![i as u8; 16]))
+                .collect();
+            bundle
+                .write_to(&bundle_path(dir.path(), instance))
+                .expect("write bundle");
+        }
+
+        let samplers = reload(dir.path());
+
+        for (instance, extra) in instances.iter().zip(over_by) {
+            let tracked = samplers.get(instance).expect("bundle should have reloaded");
+            assert_eq!(
+                tracked.refused_related.no_slot, extra as u64,
+                "{instance} reported a refusal count that is not its own; a shared \
+                 counter across bundles makes every contract after the first overstate"
+            );
+        }
     }
 
     /// The related budget SCALES with the sampler budget an operator sets.

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1649,6 +1649,9 @@ mod probe_wiring_pins {
 
 #[cfg(test)]
 mod tests {
+
+    use super::*;
+
     /// The related-state budgets the sampler config in force for tests implies.
     ///
     /// Was a bare `MAX_RELATED_BYTES` constant. It is now derived from the sampler
@@ -1658,8 +1661,6 @@ mod tests {
     fn test_related_budgets() -> (usize, usize) {
         related_budgets(&sampler_config())
     }
-
-    use super::*;
 
     fn instance(n: u8) -> ContractInstanceId {
         ContractInstanceId::new([n; 32])

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -105,14 +105,32 @@ const OBSERVATION_QUEUE: usize = 256;
 /// exhaust memory" is no by construction rather than by argument.
 const MAX_QUEUED_BYTES: usize = 8 * 1024 * 1024;
 
-/// Upper bound on related-contract state retained per tracked contract.
+/// Budgets for related-contract state, derived from the sampler's own budgets.
 ///
-/// Related state gets its OWN allowance rather than sharing the per-contract
-/// sample budget. Sharing would let a contract with large related state crowd out
-/// the very samples the related state exists to make checkable, which is a silly
-/// way to lose. Small, because one recent state per related contract is enough to
-/// execute against — this is context, not a corpus.
-const MAX_RELATED_BYTES: usize = 512 * 1024;
+/// Related state gets its OWN allowance rather than sharing the per-contract sample
+/// budget: sharing would let large related state crowd out the very samples the
+/// related state exists to make checkable. But the allowance must SCALE with the
+/// sampler's, and until #5320's follow-up it did not - it was a hardcoded 512 KiB,
+/// used as both the per-state cap and the total.
+///
+/// That number was quietly deciding what could be checked at all. States on the live
+/// network run to ~356 KiB, so TWO related contracts already exceeded the total and
+/// the second was silently discarded; `FREENET_CONFORMANCE_CAPTURE_MAX_BYTES` raised
+/// the sampler's budget but never reached this one. Measured consequence: 1,567 of
+/// 5,856 replayed cases reached no verdict for want of related state, and five
+/// contracts produced no verdict on ANY case.
+///
+/// Why that is a correctness problem and not a resource trade-off: a contract that
+/// depends on a large related contract becomes permanently unjudgeable, and an
+/// unjudgeable contract reads as a clean one. Depending on related state must not be
+/// a way to escape conformance checking. The RFC's adversarial corpus names this
+/// class directly - "attempts to make violations hard to trigger".
+///
+/// So: the same per-state ceiling and the same per-contract total the sampler uses,
+/// both of which the operator can already raise for a diagnostic run.
+fn related_budgets(config: &SamplerConfig) -> (usize, usize) {
+    (config.max_state_bytes, config.max_bytes)
+}
 
 /// Upper bound on distinct related contracts retained per tracked contract.
 const MAX_RELATED_CONTRACTS: usize = 8;
@@ -728,6 +746,12 @@ pub(crate) struct TrackedContract {
     sampler: ContractSampler,
     code_hash: [u8; 32],
     parameters: Vec<u8>,
+    /// Related-contract state this contract offered that capture would not keep.
+    ///
+    /// Load-bearing for reading a corpus honestly: a bundle whose related map is
+    /// empty because nothing was ever needed and one whose related state was refused
+    /// look identical, and only the second explains why a replay can reach no verdict.
+    pub(crate) refused_related: RelatedRefusals,
     /// Observations the sampler refused because a state exceeded its per-state
     /// ceiling.
     ///
@@ -829,6 +853,8 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
                 &transition.result_state,
             );
         }
+        // Read before the struct takes ownership of `sampler`.
+        let (max_related_state, max_related_total) = related_budgets(sampler.config());
         samplers.insert(
             instance,
             TrackedContract {
@@ -836,13 +862,25 @@ fn reload(dir: &Path) -> HashMap<ContractInstanceId, TrackedContract> {
                 code_hash,
                 related: {
                     let mut restored = HashMap::new();
-                    admit_related(&mut restored, &bundle.related);
+                    // Re-admitted under THIS process's budgets, not the ones that
+                    // wrote the bundle: an operator who raised the budget to make a
+                    // contract checkable must not have a corpus written under the old
+                    // one silently re-truncated to it.
+                    let mut ignored = RelatedRefusals::default();
+                    admit_related(
+                        &mut restored,
+                        &bundle.related,
+                        &mut ignored,
+                        max_related_state,
+                        max_related_total,
+                    );
                     restored
                 },
                 parameters: bundle.parameters,
-                // Not persisted in the bundle: this counts what THIS process
+                // Not persisted in the bundle: these count what THIS process
                 // refused, and a reloaded corpus has no refusals of its own yet.
                 refused_too_large: 0,
+                refused_related: RelatedRefusals::default(),
             },
         );
     }
@@ -1004,10 +1042,21 @@ pub(crate) fn record(
             code_hash: observation.code_hash,
             parameters: observation.parameters.clone(),
             refused_too_large: 0,
+            refused_related: RelatedRefusals::default(),
             related: HashMap::new(),
         });
 
-    admit_related(&mut tracked.related, &observation.related);
+    // The sampler's own budgets, so raising FREENET_CONFORMANCE_CAPTURE_MAX_BYTES for
+    // a diagnostic run reaches the related state too. Read into locals first: the
+    // config lives behind `tracked.sampler` and `related` is a sibling field.
+    let (max_related_state, max_related_total) = related_budgets(tracked.sampler.config());
+    admit_related(
+        &mut tracked.related,
+        &observation.related,
+        &mut tracked.refused_related,
+        max_related_state,
+        max_related_total,
+    );
 
     let admission = tracked.sampler.observe_transition(
         &observation.base_state,
@@ -1036,15 +1085,44 @@ pub(crate) fn record(
 /// Both bounds refuse rather than evict: a contract referencing a hundred others must
 /// not be able to churn this map, and states already retained are more useful than an
 /// arbitrary newcomer.
+/// Related state a contract offered and capture would not keep.
+///
+/// Counted, never silently dropped. Three `continue`s used to discard related state
+/// with no record at all, which made an EMPTY related map indistinguishable from
+/// "this contract never needed any" - and the difference decides whether a later
+/// replay can reach a verdict. The main sampler already counts its refusals
+/// (`refused_too_large`); this is the same discipline applied to the context those
+/// samples need in order to mean anything.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RelatedRefusals {
+    /// A single related state exceeded the per-state ceiling.
+    pub too_large: u64,
+    /// Keeping it would have exceeded the per-contract related total.
+    pub over_budget: u64,
+    /// Already holding [`MAX_RELATED_CONTRACTS`] distinct related contracts.
+    pub no_slot: u64,
+}
+
+impl RelatedRefusals {
+    pub(crate) fn total(&self) -> u64 {
+        self.too_large + self.over_budget + self.no_slot
+    }
+}
+
 fn admit_related(
     held: &mut HashMap<ContractInstanceId, Vec<u8>>,
     offered: &[(ContractInstanceId, Vec<u8>)],
+    refused: &mut RelatedRefusals,
+    max_state_bytes: usize,
+    max_total_bytes: usize,
 ) {
     for (instance, state) in offered {
-        if state.len() > MAX_RELATED_BYTES {
+        if state.len() > max_state_bytes {
+            refused.too_large += 1;
             continue;
         }
         if !held.contains_key(instance) && held.len() >= MAX_RELATED_CONTRACTS {
+            refused.no_slot += 1;
             continue;
         }
         let total: usize = held.values().map(Vec::len).sum();
@@ -1052,7 +1130,8 @@ fn admit_related(
         // non-zero only when the instance is already a key, in which case its length
         // is part of `total`.
         let replacing = held.get(instance).map_or(0, Vec::len);
-        if total - replacing + state.len() > MAX_RELATED_BYTES {
+        if total - replacing + state.len() > max_total_bytes {
+            refused.over_budget += 1;
             continue;
         }
         held.insert(*instance, state.clone());
@@ -1109,11 +1188,42 @@ async fn write_all(
 ) {
     for (instance, tracked) in samplers {
         let mut bundle = bundle_for(*instance, tracked);
+        let refused = tracked.refused_related;
         bundle.note = Some(format!(
-            "captured by freenet {} ({} observation(s) dropped node-wide)",
+            "captured by freenet {} ({} observation(s) dropped node-wide){}",
             env!("CARGO_PKG_VERSION"),
             dropped,
+            // Carried INTO the corpus, not just logged. A replay reads the bundle
+            // long after the node's logs have rotated, and "no related state" versus
+            // "related state was refused" is the difference between a contract that
+            // needs none and one this corpus cannot judge.
+            if refused.total() == 0 {
+                String::new()
+            } else {
+                format!(
+                    " (related state refused: {} too large, {} over budget, {} no slot                      - this corpus may be unable to reach a verdict for this contract;                      raise {})",
+                    refused.too_large, refused.over_budget, refused.no_slot, CAPTURE_MAX_BYTES_ENV,
+                )
+            },
         ));
+
+        // Warned as well as recorded. A contract whose related state was refused is
+        // not merely under-sampled: it becomes UNJUDGEABLE, and an unjudgeable
+        // contract reads exactly like a clean one. Depending on related state must
+        // not be a way to escape conformance checking, so the one signal that says it
+        // happened cannot be silent.
+        if refused.total() > 0 {
+            tracing::warn!(
+                contract = %instance,
+                too_large = refused.too_large,
+                over_budget = refused.over_budget,
+                no_slot = refused.no_slot,
+                related_held = tracked.related.len(),
+                "conformance capture refused related-contract state; replays of this \
+                 contract may reach no verdict. Raise {} to capture it.",
+                CAPTURE_MAX_BYTES_ENV,
+            );
+        }
 
         // A bundle with no states is worse than no bundle: it looks like evidence
         // and replays as "the corpus is empty", which invites the reader to
@@ -1479,6 +1589,16 @@ mod probe_wiring_pins {
 
 #[cfg(test)]
 mod tests {
+    /// The related-state budgets the sampler config in force for tests implies.
+    ///
+    /// Was a bare `MAX_RELATED_BYTES` constant. It is now derived from the sampler
+    /// config so a raised capture budget reaches related state too, and these tests
+    /// have to ask the same question the code does rather than a fixed number that
+    /// could drift away from it.
+    fn test_related_budgets() -> (usize, usize) {
+        related_budgets(&sampler_config())
+    }
+
     use super::*;
 
     fn instance(n: u8) -> ContractInstanceId {
@@ -1576,6 +1696,136 @@ mod tests {
             kept, expected,
             "reload kept a different set than the ordering promises, so which samples \
              survive a restart depends on filesystem enumeration order"
+        );
+    }
+
+    /// The related budget SCALES with the sampler budget an operator sets.
+    ///
+    /// It used to be a hardcoded 512 KiB, used as both the per-state and the total
+    /// cap, and `FREENET_CONFORMANCE_CAPTURE_MAX_BYTES` never reached it. Live states
+    /// run to ~356 KiB, so two related contracts already blew the total and the second
+    /// was discarded - which is why 1,567 of 5,856 replayed cases reached no verdict.
+    #[test]
+    fn the_related_budget_follows_the_sampler_budget() {
+        let small = sampler_config_from(Some("1048576"));
+        let large = sampler_config_from(Some("16777216"));
+
+        let (_, small_total) = related_budgets(&small);
+        let (_, large_total) = related_budgets(&large);
+
+        assert!(
+            large_total > small_total,
+            "raising the capture budget did not raise the related-state budget, so a \
+             contract that needs large related state stays unjudgeable however the \
+             operator configures the run ({small_total} vs {large_total})"
+        );
+        assert_eq!(large_total, large.max_bytes);
+    }
+
+    /// Related state offered but not kept is COUNTED, never silently dropped.
+    ///
+    /// The whole point: an empty related map and a refused one look identical in a
+    /// corpus, and only the second explains why a replay reaches no verdict. A
+    /// contract that depends on related state must not be able to become quietly
+    /// unjudgeable - that would make "depends on a big related contract" a way to
+    /// escape conformance checking entirely.
+    #[test]
+    fn refused_related_state_is_counted_rather_than_dropped_silently() {
+        let config = sampler_config();
+        let (max_state, _) = related_budgets(&config);
+        let mut held = HashMap::new();
+        let mut refused = RelatedRefusals::default();
+
+        // One oversized state.
+        admit_related(
+            &mut held,
+            &[(instance(9), vec![0u8; max_state + 1])],
+            &mut refused,
+            max_state,
+            config.max_bytes,
+        );
+
+        assert!(held.is_empty(), "an oversized related state was admitted");
+        assert_eq!(
+            refused.too_large, 1,
+            "an oversized related state was dropped without being counted"
+        );
+        assert_eq!(refused.total(), 1);
+    }
+
+    /// Exceeding the TOTAL budget is counted under its own reason.
+    #[test]
+    fn related_state_over_the_total_budget_is_counted_separately() {
+        let mut held = HashMap::new();
+        let mut refused = RelatedRefusals::default();
+        // Per-state cap generous, total cap tight: the second offer must not fit.
+        let (max_state, max_total) = (1024, 1024);
+
+        admit_related(
+            &mut held,
+            &[(instance(1), vec![0u8; 800]), (instance(2), vec![0u8; 800])],
+            &mut refused,
+            max_state,
+            max_total,
+        );
+
+        assert_eq!(held.len(), 1, "both states fit, so the budget never bound");
+        assert_eq!(
+            refused.over_budget, 1,
+            "a related state refused for budget was not counted"
+        );
+        assert_eq!(refused.too_large, 0, "counted under the wrong reason");
+    }
+
+    /// Running out of slots is counted under its own reason too.
+    #[test]
+    fn related_state_beyond_the_slot_limit_is_counted_separately() {
+        let mut held = HashMap::new();
+        let mut refused = RelatedRefusals::default();
+        let offered: Vec<_> = (0..(MAX_RELATED_CONTRACTS + 3))
+            .map(|i| (instance(i as u8), vec![0u8; 8]))
+            .collect();
+
+        admit_related(&mut held, &offered, &mut refused, 4096, 1 << 20);
+
+        assert_eq!(held.len(), MAX_RELATED_CONTRACTS);
+        assert_eq!(
+            refused.no_slot, 3,
+            "related contracts beyond the slot limit were dropped uncounted"
+        );
+    }
+
+    /// A bundle whose related state was refused SAYS SO, in the bundle itself.
+    ///
+    /// The logs rotate; the corpus is replayed later and elsewhere. If the refusal
+    /// only ever reached a log line, a reader of the bundle would see an empty
+    /// related map and conclude the contract needed none.
+    #[tokio::test]
+    async fn a_bundle_records_that_related_state_was_refused() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mut samplers = HashMap::new();
+        let watched = instance(1);
+
+        let mut obs = observation_for(watched);
+        let (max_state, _) = related_budgets(&sampler_config());
+        obs.related = vec![(instance(2), vec![0u8; max_state + 1])];
+        let _evicted = record(&mut samplers, &SamplingScope::Wide, obs);
+
+        assert_eq!(
+            samplers[&watched].refused_related.too_large, 1,
+            "fixture did not trigger a refusal, so this proves nothing"
+        );
+
+        write_all(dir.path(), &samplers, 0).await;
+
+        let bundle =
+            super::super::bundle::ReplayBundle::read_from(&bundle_path(dir.path(), &watched))
+                .expect("bundle should have been written");
+        let note = bundle.note.unwrap_or_default();
+        assert!(
+            note.contains("related state refused"),
+            "the bundle does not record that related state was refused, so a replay \
+             cannot tell 'needed none' from 'could not keep it': {note}"
         );
     }
 
@@ -2033,7 +2283,7 @@ mod tests {
     #[tokio::test]
     async fn the_total_related_byte_allowance_holds() {
         let mut samplers = HashMap::new();
-        let chunk = MAX_RELATED_BYTES / 3;
+        let chunk = test_related_budgets().1 / 3;
 
         // Three entries of a third of the allowance each: the third is the one that
         // must be refused on the TOTAL, since each is individually well within the
@@ -2047,9 +2297,9 @@ mod tests {
         let tracked = samplers.values().next().expect("one contract tracked");
         let held: usize = tracked.related.values().map(Vec::len).sum();
         assert!(
-            held <= MAX_RELATED_BYTES,
+            held <= test_related_budgets().1,
             "related state totalled {held} bytes against an allowance of {}",
-            MAX_RELATED_BYTES
+            test_related_budgets().1
         );
         assert!(
             tracked.related.len() < 4,
@@ -2108,7 +2358,7 @@ mod tests {
             MAX_RELATED_CONTRACTS
         );
         assert!(
-            tracked.related.values().map(Vec::len).sum::<usize>() <= MAX_RELATED_BYTES,
+            tracked.related.values().map(Vec::len).sum::<usize>() <= test_related_budgets().1,
             "reload admitted more related bytes than the allowance"
         );
     }
@@ -2141,7 +2391,7 @@ mod tests {
         let mut huge = observation();
         huge.related = vec![(
             ContractInstanceId::new([200; 32]),
-            vec![0u8; MAX_RELATED_BYTES + 1],
+            vec![0u8; test_related_budgets().0 + 1],
         )];
         let _evicted = record(&mut samplers, &SamplingScope::Wide, huge);
         let tracked = samplers.values().next().expect("one contract tracked");
@@ -2151,7 +2401,7 @@ mod tests {
             "an oversized related state must be refused, not admitted or swapped in"
         );
         assert!(
-            tracked.related.values().map(Vec::len).sum::<usize>() <= MAX_RELATED_BYTES,
+            tracked.related.values().map(Vec::len).sum::<usize>() <= test_related_budgets().1,
             "the related-state allowance must hold"
         );
     }

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -867,6 +867,95 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
     }
 }
 
+/// Source pin on `load_inputs`' output stream.
+///
+/// `--json` promises a machine-readable report, which means stdout must carry ONE JSON
+/// document and nothing else. `load_inputs` runs before the report is emitted, so
+/// anything it prints to stdout lands ahead of that document and breaks every consumer
+/// that parses it — `fdev conformance --bundle x --json | jq` simply fails.
+///
+/// That shipped once: the bundle note was printed with `println!`, and because every
+/// bundle this codebase writes always sets a note, it fired on essentially every
+/// `--bundle` replay. It was caught in review rather than by CI, because verifying it
+/// by hand (running the binary and piping to `jq`, which is how the fix was confirmed)
+/// leaves nothing behind that a later refactor has to keep true.
+///
+/// A pin rather than an integration test: spawning `fdev` against a real bundle needs a
+/// contract store and a WASM runtime, which is a large amount of fixture to guard a
+/// one-token property. This asserts the property at the only place it can regress.
+#[cfg(test)]
+mod stdout_purity_pin {
+    /// Slice `load_inputs`' body by counting braces to its own closing one.
+    ///
+    /// Brace-counting rather than "up to the next `fn`": a region ended on a guessed
+    /// anchor silently widens when the following item is not the shape assumed, and a
+    /// widened region here would swallow the human-report code — which prints to stdout
+    /// legitimately — and pass vacuously.
+    fn load_inputs_body() -> &'static str {
+        let src = include_str!("conformance.rs");
+        let start = src
+            .find("fn load_inputs(")
+            .expect("load_inputs not found in conformance.rs");
+        let after = &src[start..];
+        let open = after.find('{').expect("load_inputs has no body");
+        let mut depth = 0usize;
+        for (offset, ch) in after[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &after[..open + offset + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("load_inputs' body is not brace-balanced");
+    }
+
+    /// Strip whole-line comments, so a comment mentioning `println!` cannot satisfy or
+    /// defeat the assertion. The comment above the `eprintln!` call names both.
+    fn code_only() -> String {
+        load_inputs_body()
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// `code_only` with the stderr macros removed.
+    ///
+    /// Needed because `eprintln!` CONTAINS `println!` as a substring - the first
+    /// version of this pin asserted `!body.contains("println!")` and could therefore
+    /// never pass while the correct `eprintln!` call was present. It failed on correct
+    /// code, which is the harmless direction; the same trap the other way is how a pin
+    /// passes vacuously forever.
+    fn stdout_macros_only() -> String {
+        code_only().replace("eprintln!", "").replace("eprint!", "")
+    }
+
+    #[test]
+    fn load_inputs_never_writes_to_stdout() {
+        let body = stdout_macros_only();
+        assert!(
+            !body.contains("println!") && !body.contains("print!("),
+            "load_inputs writes to stdout, which lands ahead of the --json document \
+             and corrupts it for every consumer that parses stdout"
+        );
+    }
+
+    #[test]
+    fn the_bundle_note_still_reaches_the_reader() {
+        let body = code_only();
+        assert!(
+            body.contains("eprintln!"),
+            "the bundle note is no longer surfaced at all; a corpus whose related \
+             state was refused would replay as a clean bill of health"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -500,7 +500,15 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
         // exactly this reason, with nothing in the replay output saying so. The note is
         // the only durable record - node logs rotate long before a corpus is replayed.
         if let Some(note) = bundle.note.as_deref() {
-            println!("bundle note: {note}");
+            // STDERR deliberately. `--json` writes one JSON document to stdout, and a
+            // plain line ahead of it corrupts the stream for anything parsing it -
+            // `fdev conformance --bundle x --json | jq` would simply fail. `write_bundle`
+            // in this same file already uses `eprintln!` for its status line for
+            // exactly this reason; the first version of this did not follow it.
+            //
+            // Still visible in ordinary terminal use, which is the case that matters:
+            // a reader replaying a corpus needs to see that it may be incomplete.
+            eprintln!("bundle note: {note}");
         }
 
         let corpus = bundle.to_corpus();

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -489,6 +489,20 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
             )
         })?;
         let parameters = bundle.parameters.clone();
+
+        // Print the bundle's own provenance note before replaying it.
+        //
+        // Not decoration. Capture records in this note when it REFUSED related-contract
+        // state, and a corpus missing that state cannot reach a verdict: every case
+        // comes back Inconclusive, the command exits 0, and the run reads as a clean
+        // bill of health for a contract nothing actually judged. Measured on a live
+        // corpus: 9 of 54 contracts produced no verdict on any of 2,474 cases for
+        // exactly this reason, with nothing in the replay output saying so. The note is
+        // the only durable record - node logs rotate long before a corpus is replayed.
+        if let Some(note) = bundle.note.as_deref() {
+            println!("bundle note: {note}");
+        }
+
         let corpus = bundle.to_corpus();
         Ok((wasm, parameters, corpus))
     } else {


### PR DESCRIPTION
## Problem

A contract that depends on a large related contract was **permanently unjudgeable**, and
an unjudgeable contract reads exactly like a clean one. Depending on related state must
not be a way to escape conformance checking — the RFC's adversarial-corpus section names
this class directly ("attempts to make violations hard to trigger").

`MAX_RELATED_BYTES` was a hardcoded 512 KiB used as **both** the per-state ceiling and
the per-contract total, and `FREENET_CONFORMANCE_CAPTURE_MAX_BYTES` never reached it —
the capture peer's 16 MiB override raised the sampler budget while the binding
constraint stayed at 512 KiB. States on the live network run to ~356 KiB, so **two**
related contracts already exceeded the total and the second was discarded.

All three refusal paths in `admit_related` were bare `continue`s. Nothing counted,
nothing logged, nothing recorded in the bundle — so an empty related map was
indistinguishable from "this contract never needed any."

### Measured, by replaying the live capture corpus

54 contracts, 11,951 cases:

| | |
|---|---|
| Inconclusive | 2,967 (24.8%) |
| Violations found | 549 (341 enforceable) |
| **Contracts with no verdict on ANY case** | **9 of 54 (17%)** |

| Cases | Contracts | Reason |
|---|---|---|
| 2,474 | 9 | requires related contract state |
| 400 | 7 | contract error |
| 93 | 1 | reconciliation round budget exhausted |

Every one of those 2,474 cases belongs to the nine wholly-unjudgeable contracts — 512,
512, 512, 432, 279, 110, 95, 16 and 6 cases deep. This is not a scattering of hard cases
across a healthy corpus; it is 17% of the peer's hosted contracts exempt from checking by
construction, with nothing in the corpus saying so.

### The obvious diagnosis is wrong, and worth stating

The verifier resolves related state correctly: `generator.rs` fills `case.related` from
the bundle and the verifier passes it into every `validate_state`. Capture reads it from
the right place too — on the update path the executor already resolves `RequestRelated`
by looking each contract up in the **local state store** and re-entering the update with
`UpdateData::RelatedState` (`contract_ops.rs`), which is exactly what capture records.

So nothing needs fetching and nothing is added to the merge path. **The related state
was present and capture threw it away.**

## Approach

- **`related_budgets()`** derives the per-state and total caps from the sampler's own
  `max_state_bytes` / `max_bytes`, so raising the capture budget for a diagnostic run
  reaches related state too. Related state keeps its own allowance rather than sharing
  the sample budget — that original reasoning was sound, only the number was not.
- **`RelatedRefusals`** counts each refusal under its own reason: too large, over
  budget, no slot.
- The counts go into **`bundle.note`**, so a replay reading the corpus months later can
  tell "needed none" from "could not keep it" without the node's logs, and into a
  `warn!` naming the env var to raise.
- **`reload` re-admits under the current process's budgets**, so an operator who raises
  the budget to make a contract checkable does not have an old corpus silently
  re-truncated to the budget that wrote it.

## Testing

Five tests, each mutation-verified (mutation applied, test confirmed to fail):

| Mutation | Test |
|---|---|
| re-hardcode the 512 KiB cap | `the_related_budget_follows_the_sampler_budget` |
| drop an oversized state uncounted | `refused_related_state_is_counted_rather_than_dropped_silently` |
| drop an over-budget state uncounted | `related_state_over_the_total_budget_is_counted_separately` |
| drop a no-slot state uncounted | `related_state_beyond_the_slot_limit_is_counted_separately` |
| bundle note omits the refusals | `a_bundle_records_that_related_state_was_refused` |

The over-budget and no-slot tests assert the refusal is counted under its **own** reason
and that the others stay zero, so a mutation that miscategorises rather than drops is
caught too.

## Verification still to come

Re-running the replay sweep against a corpus captured **with** this fix is the real
proof: those nine contracts should start producing verdicts. That needs the capture peer
redeployed and a fresh collection window, so it is follow-up evidence rather than
something this PR can demonstrate.

Refs #5320

[AI-assisted - Claude]
