### PR TITLE
fix(dashboard): show the column the eviction table is sorted by

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -48,14 +48,16 @@ pub type RingStatsProvider = Arc<dyn Fn() -> RingStatsSnapshot + Send + Sync + '
 /// `Ring::contract_ban_list` directly — no mirrored counter to rot.
 pub type BanListProvider = Arc<dyn Fn() -> BanListSnapshot + Send + Sync + 'static>;
 
-/// Provider for the demand-driven hosting snapshot (piece A, #4642). Same
-/// pattern as the other providers: registered at node startup, replaceable
-/// for multi-node test harnesses, read by `get_snapshot` on every dashboard
+/// Provider for the demand-driven hosting snapshot (#4642). Same pattern as
+/// the other providers: registered at node startup, replaceable for
+/// multi-node test harnesses, read by `get_snapshot` on every dashboard
 /// request. In production the closure captures `Arc<Ring>` and calls
 /// `Ring::dashboard_hosting_snapshot()`, which reads the canonical hosting
-/// cache (Greedy-Dual keep_score + capability-relative RAM budget) — the
-/// mechanism that actually governs retention now, replacing the dormant MAD
-/// governance detector (#4296).
+/// cache.
+///
+/// Retention is governed by the subscriber-primary sweep (`victim_order`),
+/// NOT by the `keep_score` / `predicted_demand` carried on each row — those
+/// are the demoted telemetry-only estimator.
 pub type HostingProvider = Arc<dyn Fn() -> HostingSnapshot + Send + Sync + 'static>;
 
 /// Snapshot of ring-level statistics exposed to the dashboard.
@@ -1413,9 +1415,9 @@ pub struct NetworkStatusSnapshot {
     /// provider closure — no mirrored counter to rot. Empty when nothing
     /// is banned (the common case).
     pub ban_list: BanListSnapshot,
-    /// Demand-driven hosting state (piece A, #4642): the capability-relative
-    /// RAM budget + per-contract Greedy-Dual keep_score that actually governs
-    /// retention. Drives the "Demand-driven eviction" card. Read from the
+    /// Demand-driven hosting state (#4642): the capability-relative budgets
+    /// plus the per-contract rows the subscriber-primary eviction sweep
+    /// orders. Drives the "Demand-driven eviction" card. Read from the
     /// canonical hosting cache via the provider closure — no mirrored counter.
     pub hosting: HostingSnapshot,
 }
@@ -1645,12 +1647,12 @@ pub struct ContractSnapshot {
     pub in_use: bool,
 }
 
-/// Snapshot of the demand-driven hosting cache (piece A, #4642) for the
-/// local-peer dashboard. This is the mechanism that actually governs
-/// retention today — a capability-relative RAM budget plus a Greedy-Dual
-/// `keep_score` per contract (`ring/hosting/{cache,demand}.rs`) — and it
-/// replaced the dormant MAD `GovernanceManager` (#4296). Default (all zeros,
-/// no contracts) when the node hosts nothing yet or the provider is unset.
+/// Snapshot of the demand-driven hosting cache (#4642) for the local-peer
+/// dashboard: the capability-relative budgets plus the per-contract rows.
+/// Retention is governed by the subscriber-primary sweep
+/// (`ring/hosting/cache.rs::victim_order`) — fewest subscribers first, local
+/// above downstream, `recency_seq` breaking ties. Default (all zeros, no
+/// contracts) when the node hosts nothing yet or the provider is unset.
 #[derive(Default, Clone)]
 pub struct HostingSnapshot {
     /// Configured RAM-scaled byte budget for hosted contract state.
@@ -1714,14 +1716,29 @@ pub struct HostedContractEntry {
     pub key_full: String,
     /// Truncated key for display.
     pub key_short: String,
-    /// Greedy-Dual priority (`eviction_floor + predicted_demand`). Lowest evicts first.
-    pub keep_score: f64,
-    /// Stored per-contract read-demand estimate (reads/second).
-    pub predicted_demand: f64,
+    //
+    // `keep_score` / `predicted_demand` deliberately absent. They are the
+    // demoted telemetry-only Greedy-Dual estimator, which eviction does not
+    // read (see the "Demoted (telemetry-only) demand machinery" section of
+    // `ring/hosting/cache.rs`). The dashboard was their only consumer, and it
+    // presented them as the eviction ranking — describing a mechanism retired
+    // by the subscriber-primary rework, while the rows were really ordered by
+    // `recency_seq` (#4830). They remain on the cache-side
+    // `HostingContractScore`; do NOT re-add them here without a consumer that
+    // labels them as telemetry.
+    //
     /// Per-contract memory cost (state bytes).
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
+    /// Monotonic access sequence at this entry's most recent real GET or PUT.
+    /// This is the field the cache actually sorts these rows by, and the only
+    /// real eviction-ranking input available on the dashboard — the subscriber
+    /// counts that outrank it are computed transiently during the sweep and
+    /// are not carried in the snapshot. Rendered so the table is ordered by a
+    /// column the reader can see; `keep_score` / `predicted_demand` are
+    /// telemetry only and take no part in the ordering.
+    pub recency_seq: u64,
     /// Whether the over-budget sweep would actually consider this contract for
     /// eviction: NOT pinned by demand (`contract_in_use`). There is no longer a
     /// `min_ttl` age gate (dropped 2026-07-08). The renderer badges "next to

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1731,13 +1731,19 @@ pub struct HostedContractEntry {
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
-    /// Monotonic access sequence at this entry's most recent real GET or PUT.
+    /// The entry's eviction recency clock — a per-run monotonic sequence.
+    ///
+    /// Reset by a real GET or PUT, and ALSO by `record_abandonment` when the
+    /// contract loses its last subscriber (a deliberate grace period, so a
+    /// just-unsubscribed contract is not evicted on a stale read accrued while
+    /// it sat in the subscription tier). It is therefore NOT purely a
+    /// last-access time, and must not be labelled as one.
+    ///
     /// This is the field the cache actually sorts these rows by, and the only
     /// real eviction-ranking input available on the dashboard — the subscriber
     /// counts that outrank it are computed transiently during the sweep and
     /// are not carried in the snapshot. Rendered so the table is ordered by a
-    /// column the reader can see; `keep_score` / `predicted_demand` are
-    /// telemetry only and take no part in the ordering.
+    /// column the reader can see.
     pub recency_seq: u64,
     /// Whether the over-budget sweep would actually consider this contract for
     /// eviction: NOT pinned by demand (`contract_in_use`). There is no longer a

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -55,9 +55,9 @@ pub type BanListProvider = Arc<dyn Fn() -> BanListSnapshot + Send + Sync + 'stat
 /// `Ring::dashboard_hosting_snapshot()`, which reads the canonical hosting
 /// cache.
 ///
-/// Retention is governed by the subscriber-primary sweep (`victim_order`),
-/// NOT by the `keep_score` / `predicted_demand` carried on each row — those
-/// are the demoted telemetry-only estimator.
+/// Retention is governed by the subscriber-primary sweep (`victim_order`).
+/// The demoted telemetry-only estimator (`keep_score` / `predicted_demand`)
+/// is deliberately not carried on these rows.
 pub type HostingProvider = Arc<dyn Fn() -> HostingSnapshot + Send + Sync + 'static>;
 
 /// Snapshot of ring-level statistics exposed to the dashboard.

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -515,10 +515,10 @@ impl NodeP2P {
         super::network_status::set_ban_list_provider(std::sync::Arc::new(move || {
             ban_list_ring.dashboard_ban_list_snapshot()
         }));
-        // Same pattern for the demand-driven hosting snapshot (piece A,
-        // #4642) — dashboard reads the canonical hosting cache (RAM budget +
-        // Greedy-Dual keep_score), the mechanism that actually governs
-        // retention now, replacing the dormant MAD governance detector.
+        // Same pattern for the demand-driven hosting snapshot (#4642) — the
+        // dashboard reads the canonical hosting cache. Retention is governed
+        // by the subscriber-primary sweep (`cache::victim_order`), NOT by the
+        // demoted telemetry-only Greedy-Dual `keep_score`.
         let hosting_ring = self.op_manager.ring.clone();
         super::network_status::set_hosting_provider(std::sync::Arc::new(move || {
             hosting_ring.dashboard_hosting_snapshot()

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4515,11 +4515,12 @@ impl Ring {
     /// the `HostingManager`, so the panel can't drift the way a mirrored
     /// counter would.
     ///
-    /// Note that the `keep_score` / `predicted_demand` carried on each row are
-    /// the DEMOTED telemetry-only estimator and do not govern retention; real
-    /// eviction ordering is subscriber-primary (`victim_order`). `recency_seq`
-    /// is the one ranking input available here, and is what the cache actually
-    /// sorts these rows by.
+    /// The demoted telemetry-only estimator (`keep_score` /
+    /// `predicted_demand`) is deliberately NOT carried on these rows: eviction
+    /// does not read it, and rendering it implied a ranking it never governed.
+    /// Real eviction ordering is subscriber-primary (`victim_order`);
+    /// `recency_seq` is the one ranking input available here, and is what the
+    /// cache actually sorts these rows by.
     ///
     /// Per-contract rows are returned in EVICTION order (next victim first).
     /// The renderer bounds how many it displays; the full count is

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4509,12 +4509,17 @@ impl Ring {
     }
 
     /// Snapshot of the demand-driven hosting state for the local-peer
-    /// dashboard (piece A, #4642). Reads the canonical hosting cache — the
-    /// capability-relative RAM budget + per-contract Greedy-Dual keep_score
-    /// that actually governs retention today, replacing the dormant MAD
-    /// governance detector (#4296). No mirror, no cache: the aggregate gauges
-    /// and per-contract rows come straight from the `HostingManager`, so the
-    /// panel can't drift the way a mirrored counter would.
+    /// dashboard (#4642). Reads the canonical hosting cache — the
+    /// capability-relative budget plus the per-contract rows. No mirror, no
+    /// cache: the aggregate gauges and per-contract rows come straight from
+    /// the `HostingManager`, so the panel can't drift the way a mirrored
+    /// counter would.
+    ///
+    /// Note that the `keep_score` / `predicted_demand` carried on each row are
+    /// the DEMOTED telemetry-only estimator and do not govern retention; real
+    /// eviction ordering is subscriber-primary (`victim_order`). `recency_seq`
+    /// is the one ranking input available here, and is what the cache actually
+    /// sorts these rows by.
     ///
     /// Per-contract rows are returned in EVICTION order (next victim first).
     /// The renderer bounds how many it displays; the full count is
@@ -4543,10 +4548,9 @@ impl Ring {
                 ns::HostedContractEntry {
                     key_full,
                     key_short,
-                    keep_score: row.keep_score,
-                    predicted_demand: row.predicted_demand,
                     size_bytes: row.size_bytes,
                     read_count: row.read_count,
+                    recency_seq: row.recency_seq,
                     eviction_eligible,
                 }
             })

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -2534,11 +2534,14 @@ impl HostingManager {
         self.hosting_cache.read().stats()
     }
 
-    /// Per-contract Greedy-Dual eviction rows for the local-peer dashboard,
-    /// in eviction order (next victim first). Reads the canonical hosting
-    /// cache under a single lock — this is piece A's live demand-driven
-    /// retention state (#4642), the mechanism that replaced the dormant MAD
-    /// governance detector. See [`HostingContractScore`].
+    /// Per-contract eviction rows for the local-peer dashboard, in the
+    /// cache-side eviction order (ascending `recency_seq`, then key). Reads
+    /// the canonical hosting cache under a single lock.
+    ///
+    /// That order is only the ordering WITHIN the zero-subscriber tier:
+    /// `cache::victim_order` ranks local-subscription and downstream-subscriber
+    /// counts above recency, and those are computed during the sweep rather
+    /// than carried on the row. See [`HostingContractScore`].
     pub(crate) fn dashboard_hosting_scores(&self) -> Vec<HostingContractScore> {
         self.hosting_cache.read().eviction_ordered_scores()
     }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -657,20 +657,29 @@ pub(crate) struct HostingCacheStats {
 
 /// Per-contract Greedy-Dual priority row for the local-peer dashboard.
 ///
-/// This is what actually governs retention today (piece A of the
-/// demand-driven hosting redesign, #4642): the over-budget walk evicts the
-/// lowest `keep_score` first. Surfaced on the dashboard so an operator can
-/// see the live demand-ordered eviction policy — the mechanism that
-/// replaced the dormant MAD governance detector (#4296). Collected under a
+/// A dashboard/telemetry row for one hosted contract. Collected under a
 /// single cache read lock by [`HostingCache::eviction_ordered_scores`].
+///
+/// **`keep_score` and `predicted_demand` do NOT govern retention.** They are
+/// the demoted, telemetry-only Greedy-Dual estimator (see the "Demoted
+/// (telemetry-only) demand machinery" section in this module's docs); eviction
+/// reads neither. Real eviction ordering is [`victim_order`], ascending
+/// `(local_subscription_count, downstream_subscriber_count, recency_seq,
+/// key_bytes)` — of which only `recency_seq` is carried here, because the
+/// subscriber counts are computed transiently during the sweep and the cache
+/// cannot see them. Present the row accordingly: `recency_seq` is the field
+/// that actually explains this row's position.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct HostingContractScore {
     pub key: ContractKey,
-    /// Greedy-Dual priority = `eviction_floor + predicted_demand` at the last
-    /// refresh. Lowest evicts first.
-    pub keep_score: f64,
-    /// Stored per-contract read-demand estimate (reads/second).
-    pub predicted_demand: f64,
+    //
+    // `keep_score` / `predicted_demand` deliberately absent from this
+    // projection. `HostedContract` still carries them — they drive the
+    // Greedy-Dual `eviction_floor` ratchet — but nothing consumed the copies
+    // on this row once the dashboard stopped rendering them as an eviction
+    // ranking they never governed (#4830). Re-add only alongside a consumer
+    // that presents them as telemetry.
+    //
     /// Per-contract memory cost (state bytes).
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
@@ -2523,8 +2532,6 @@ impl<T: TimeSource> HostingCache<T> {
             .iter()
             .map(|(k, v)| HostingContractScore {
                 key: *k,
-                keep_score: v.keep_score,
-                predicted_demand: v.predicted_demand,
                 size_bytes: v.size_bytes,
                 read_count: v.read_count,
                 recency_seq: v.recency_seq,
@@ -4368,10 +4375,8 @@ mod tests {
         );
         for s in &scores {
             let entry = cache.get(&s.key).expect("scored key is in the cache");
-            assert_eq!(s.keep_score, entry.keep_score);
             assert_eq!(s.size_bytes, entry.size_bytes);
             assert_eq!(s.read_count, entry.read_count);
-            assert_eq!(s.predicted_demand, entry.predicted_demand);
             assert_eq!(s.recency_seq, entry.recency_seq);
         }
     }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -1288,14 +1288,16 @@ pub struct HostingCache<T: TimeSource> {
 /// 1. fewest **local client subscriptions** first — a contract THIS node's own
 ///    client is subscribed to is evicted LAST (Ian's confirmed ordering, #4642);
 /// 2. then fewest **downstream subscribers** (forwarded demand);
-/// 3. then least-recent real **GET** (`recency_seq`, a recency tiebreak — NOT a
-///    primary key; subscription-renewal traffic must not refresh it);
+/// 3. then lowest **eviction recency** (`recency_seq`, a tiebreak — NOT a
+///    primary key). That clock is set by a real GET or PUT, and also by
+///    [`HostingCache::record_abandonment`] at subscription termination;
+///    subscription-renewal traffic must not refresh it;
 /// 4. then contract-key bytes as a final deterministic tiebreak.
 ///
 /// The candidate that sorts FIRST under this order is the one evicted first. A
 /// locally-subscribed contract is ordered LAST but NOT absolutely pinned: in the
 /// extreme where every eligible contract carries a local subscription and the
-/// peer is still over budget, the least-recently-read local one IS the victim
+/// peer is still over budget, the lowest-recency local one IS the victim
 /// (accepted last resort — see [`HostingCache::evict_over_budget`] and
 /// hosting-invariants invariant 3).
 ///

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -46,11 +46,13 @@
 //!
 //! `keep_score`, `eviction_floor`, `predicted_demand` and `record_abandonment`
 //! (the Greedy-Dual + proximity-prior demand estimator, pieces A3/#4650/#4688)
-//! are **retained but no longer drive eviction** — they are kept as the
-//! dashboard/telemetry surface (`predicted_demand` is still trained and
-//! displayed) for telemetry continuity this release, and are scheduled for
-//! deletion in a follow-up once the subscriber-primary policy is field-
-//! validated. Eviction reads NONE of them; it orders by subscriber count and
+//! are **retained but no longer drive eviction**. `predicted_demand` is still
+//! TRAINED, but as of #4830 it is no longer DISPLAYED: the dashboard rendered
+//! it as an eviction ranking it never governed, so it and `keep_score` were
+//! dropped from the dashboard-facing projections. They survive on
+//! `HostedContract` only, driving the `eviction_floor` ratchet, and are
+//! scheduled for deletion in a follow-up once the subscriber-primary policy is
+//! field-validated. Eviction reads NONE of them; it orders by subscriber count and
 //! real GET/PUT recency (see principle 2). `predicted_demand` is still supplied by
 //! the caller (`HostingManager`, which owns the proximity-prior estimator and
 //! the peer's own ring location — see [`super::demand`]) purely so the
@@ -684,10 +686,17 @@ pub(crate) struct HostingContractScore {
     pub size_bytes: u64,
     /// Read accesses (GET/SUBSCRIBE) observed over this entry's residency.
     pub read_count: u32,
-    /// Monotonic access sequence at the entry's most recent real GET or PUT
-    /// (genuine client access) — the eviction recency tiebreak (subscriber-
-    /// primary rework, #4642). The cache orders zero-subscriber eviction
-    /// candidates ascending by this. SUBSCRIBE / renewal traffic does NOT bump it.
+    /// The entry's eviction recency clock — a per-run monotonic sequence, and
+    /// the eviction recency tiebreak (subscriber-primary rework, #4642). The
+    /// cache orders zero-subscriber eviction candidates ascending by this.
+    ///
+    /// Set by a real GET or PUT (genuine client access), and ALSO by
+    /// [`HostingCache::record_abandonment`] when the contract loses its last
+    /// subscriber — a deliberate grace period, so a formerly-subscribed
+    /// contract is not evicted on a stale read accrued while it sat in the
+    /// subscription tier. It is therefore NOT a pure last-access time, and the
+    /// dashboard must not label it as one. SUBSCRIBE / renewal traffic does
+    /// NOT bump it.
     pub recency_seq: u64,
 }
 
@@ -2518,14 +2527,17 @@ impl<T: TimeSource> HostingCache<T> {
     }
 
     /// Per-contract rows for the local dashboard, in the cache-side EVICTION
-    /// order: ascending `(recency_seq, key)` — least-recent real GET/PUT first, the
-    /// same order [`Self::keys_eviction_order`] uses. This reflects the order
+    /// order: ascending `(recency_seq, key)` — least-recent eviction-recency
+    /// first, the same order [`Self::keys_eviction_order`] uses. (That clock is
+    /// set by a real GET/PUT *and* by subscription termination, so it is not a
+    /// pure last-read time — see [`HostingContractScore::recency_seq`].) This reflects the order
     /// among the ZERO-subscriber candidate set the over-budget sweep would evict
     /// under `AtCapacity` (the production pressure); the subscriber-count pin is
     /// applied by the manager via `is_eviction_eligible`, so the front of the
-    /// vec is the next zero-subscriber victim under budget pressure. The rows
-    /// still carry the demoted telemetry score fields (`keep_score`,
-    /// `predicted_demand`) the dashboard renders.
+    /// vec is the next zero-subscriber victim under budget pressure.
+    ///
+    /// Rows carry `size_bytes`, `read_count` and `recency_seq` only — the
+    /// demoted telemetry scores are deliberately not projected here.
     pub(crate) fn eviction_ordered_scores(&self) -> Vec<HostingContractScore> {
         let mut rows: Vec<HostingContractScore> = self
             .contracts

--- a/crates/core/src/ring/hosting/demand.rs
+++ b/crates/core/src/ring/hosting/demand.rs
@@ -194,8 +194,10 @@ impl ProximityPrior {
     ///
     /// `predict()` (and the whole distance-prior estimator) is therefore retained
     /// for **telemetry only** — it backs the demoted `predicted_demand` /
-    /// `keep_score` dashboard signal (see [`super::cache`]) and drives no retention
-    /// decision. The `min_ttl` cold-start floor that once bounded a distance-only
+    /// `keep_score` values on `HostedContract` (see [`super::cache`]) and drives
+    /// no retention decision. Since #4830 those are no longer surfaced on the
+    /// dashboard either, so this estimator currently has no reader outside the
+    /// `eviction_floor` ratchet. The `min_ttl` cold-start floor that once bounded a distance-only
     /// ordering was **dropped entirely** (2026-07-08): a fresh zero-subscriber
     /// PUT/GET is now protected by being the most-recently-accessed, not by an age
     /// floor. Do NOT re-wire this estimate back into the eviction sort — the whole

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2885,10 +2885,20 @@ mod tests {
                 && html.contains("Compile cache: 5.0 MB"),
             "per-component breakdown in tooltip — got:\n{html}"
         );
-        assert!(
-            html.contains("min(RAM budget, disk budget)"),
-            "explanatory paragraph must mention the #4702 min(ram, disk) eviction floor — got:\n{html}"
-        );
+        // The explanatory paragraph must name the pressures that can actually
+        // trigger a sweep. It used to claim the floor was "min(RAM budget,
+        // disk budget)", and this assertion pinned that wording — which is how
+        // the claim outlived the two axes added since: the count-derived
+        // resident-overhead ceiling (#5325, the one that binds first on a
+        // real low-RAM peer) and cost pressure (#4861). Pin the axes, not the
+        // phrasing, so adding a fifth fails here instead of going unnoticed.
+        for axis in ["state bytes", "disk", "resident-overhead", "update work"] {
+            assert!(
+                html.contains(axis),
+                "explanatory paragraph must name the {axis:?} eviction pressure \
+                 — got:\n{html}"
+            );
+        }
     }
 
     /// #5325 PR review Should-Fix #6: the new "Resident overhead" tile

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2686,6 +2686,23 @@ mod tests {
             "footer must state that this is only the zero-subscriber ordering \
              — got:\n{html}"
         );
+        // `recency_seq` is ALSO advanced by `record_abandonment` when a
+        // contract loses its last subscriber, so any copy calling this an
+        // access/read ordering misrepresents a just-abandoned contract. Pin
+        // the invariant (no access-time language), not one phrasing of it.
+        for banned in [
+            "least-recently accessed",
+            "least-recently read",
+            "last accessed",
+            "last read",
+        ] {
+            assert!(
+                !html.contains(banned),
+                "user-visible copy must not describe eviction recency as an \
+                 access time (found {banned:?}) — abandonment advances it too \
+                 — got:\n{html}"
+            );
+        }
     }
 
     fn mk_hosted_entry_seq(

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2588,6 +2588,34 @@ mod tests {
         );
     }
 
+    /// The card must not carry the "piece A" badge, which was internal epic
+    /// jargon rendered in `.g-mode-enforce` — the Governance card's
+    /// *enforcement* red — so a decorative label wore the alarm colour.
+    ///
+    /// Without this pin, restoring the span leaves the suite green.
+    #[test]
+    fn hosting_card_has_no_piece_a_badge() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 1,
+            contracts: vec![mk_hosted_entry_seq("A", 0, true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            !html.contains("piece A"),
+            "the internal epic label must not appear on an operator surface — got:\n{html}"
+        );
+        assert!(
+            !html.contains("g-mode-enforce"),
+            "the eviction card must not borrow the governance enforcement-red \
+             badge style — got:\n{html}"
+        );
+    }
+
     /// A contract pinned by a local client or downstream subscriber sorts to
     /// the top of this table when it has never been read, because the
     /// cache-side sort cannot see subscriber counts — yet the real sweep

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2482,24 +2482,23 @@ mod tests {
             contract_count: 2,
             budget_evictions_total: 3,
             evictions_of_recently_read_total: 1,
-            // Provider emits rows in eviction order (lowest keep_score first).
+            // Provider emits rows in eviction order (least-recently accessed
+            // first — ascending `recency_seq`).
             contracts: vec![
                 HostedContractEntry {
                     key_full: "VICTIM_FULL".to_string(),
                     key_short: "VICTIM...".to_string(),
-                    keep_score: 0.10,
-                    predicted_demand: 0.0,
                     size_bytes: 1024,
                     read_count: 0,
+                    recency_seq: 0,
                     eviction_eligible: true,
                 },
                 HostedContractEntry {
                     key_full: "HOT_FULL".to_string(),
                     key_short: "HOT...".to_string(),
-                    keep_score: 5.0,
-                    predicted_demand: 4.0,
                     size_bytes: 2048,
                     read_count: 42,
+                    recency_seq: 99,
                     eviction_eligible: false,
                 },
             ],
@@ -2519,13 +2518,13 @@ mod tests {
             html.contains("var(--danger"),
             "recently-read eviction count should be highlighted — got:\n{html}"
         );
-        // The next-to-evict badge attaches to the first (lowest keep_score) row.
+        // The next-to-evict badge attaches to the first eligible row.
         let victim_idx = html.find("VICTIM_FULL").expect("victim row present");
         let hot_idx = html.find("HOT_FULL").expect("hot row present");
         let badge_idx = html.find("next to evict").expect("next-to-evict badge");
         assert!(
             victim_idx < hot_idx,
-            "rows must be in eviction order (lowest keep_score first) — got:\n{html}"
+            "rows must be in eviction order (least-recently accessed first) — got:\n{html}"
         );
         assert!(
             badge_idx > victim_idx && badge_idx < hot_idx,
@@ -2533,19 +2532,112 @@ mod tests {
         );
     }
 
+    /// The eviction table must be ordered by a column it actually displays.
+    ///
+    /// Regression for #4830: the card rendered `Keep-score` and `Demand` — the
+    /// demoted telemetry-only estimator that eviction does not read — while the
+    /// rows arrived sorted by `recency_seq`, which was dropped in the dashboard
+    /// mapping and never shown. The table was therefore sorted by an invisible
+    /// column and labelled as sorted by one that had no effect on the order.
+    ///
+    /// Mutation-checked: re-adding a `Keep-score` header or dropping the
+    /// `Recency` column fails this test.
+    #[test]
+    fn hosting_card_shows_the_column_it_is_sorted_by() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 2,
+            contracts: vec![
+                mk_hosted_entry_seq("COLD", 0, true),
+                mk_hosted_entry_seq("WARM", 7, false),
+            ],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+
+        assert!(
+            html.contains(">Recency</th>"),
+            "the ordering column must be a visible header — got:\n{html}"
+        );
+        // The dormant estimator must not be presented as a ranking column.
+        assert!(
+            !html.contains(">Keep-score</th>") && !html.contains(">Demand</th>"),
+            "keep-score/demand are telemetry-only and must not be shown as \
+             eviction ranking columns — got:\n{html}"
+        );
+        // `recency_seq == 0` is "not accessed since startup", not a real
+        // sequence number, so it must not render as a bare 0.
+        assert!(
+            html.contains(">never<"),
+            "recency_seq 0 must render as 'never', not 0 — got:\n{html}"
+        );
+        assert!(
+            html.contains(">7<"),
+            "a non-zero recency_seq must render its value — got:\n{html}"
+        );
+    }
+
+    /// The footer must not claim a ranking the card cannot actually show.
+    ///
+    /// Regression for #4830: it read "the N most-evictable … (lowest keep-score
+    /// first)", which was wrong twice over — keep-score does not order the
+    /// sweep, and the cache-side sort covers only the zero-subscriber tier.
+    #[test]
+    fn hosting_card_footer_does_not_claim_keep_score_ordering() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            // More hosted than rendered, so the footer appears.
+            contract_count: 500,
+            contracts: vec![mk_hosted_entry_seq("A", 0, true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("of 500 hosted contracts"),
+            "footer should report the full hosted count — got:\n{html}"
+        );
+        assert!(
+            !html.to_lowercase().contains("keep-score first"),
+            "footer must not claim keep-score ordering — got:\n{html}"
+        );
+        // The subscriber-tier caveat is the honest part; keep it pinned so a
+        // future copy edit cannot quietly drop it.
+        assert!(
+            html.contains("no subscribers"),
+            "footer must state that this is only the zero-subscriber ordering \
+             — got:\n{html}"
+        );
+    }
+
+    fn mk_hosted_entry_seq(
+        key: &str,
+        recency_seq: u64,
+        eviction_eligible: bool,
+    ) -> crate::node::network_status::HostedContractEntry {
+        let mut e = mk_hosted_entry(key, eviction_eligible);
+        e.recency_seq = recency_seq;
+        e
+    }
+
+    /// Ordering is by `recency_seq`; use `mk_hosted_entry_seq` when a test
+    /// cares about the order. This helper leaves it at 0 ("never accessed").
     fn mk_hosted_entry(
         key: &str,
-        keep_score: f64,
         eviction_eligible: bool,
     ) -> crate::node::network_status::HostedContractEntry {
         use crate::node::network_status::HostedContractEntry;
         HostedContractEntry {
             key_full: format!("{key}_FULL"),
             key_short: format!("{key}..."),
-            keep_score,
-            predicted_demand: 0.0,
             size_bytes: 1024,
             read_count: 0,
+            recency_seq: 0,
             eviction_eligible,
         }
     }
@@ -2566,9 +2658,9 @@ mod tests {
             evictions_of_recently_read_total: 0,
             contracts: vec![
                 // Lowest score, but pinned (in use / within TTL) → not eligible.
-                mk_hosted_entry("PINNED", 0.10, false),
+                mk_hosted_entry("PINNED", false),
                 // Higher score, but actually eligible → this is the real victim.
-                mk_hosted_entry("EVICTABLE", 2.0, true),
+                mk_hosted_entry("EVICTABLE", true),
             ],
             ..Default::default()
         };
@@ -2602,10 +2694,7 @@ mod tests {
             contract_count: 2,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
-            contracts: vec![
-                mk_hosted_entry("A", 0.10, false),
-                mk_hosted_entry("B", 2.0, false),
-            ],
+            contracts: vec![mk_hosted_entry("A", false), mk_hosted_entry("B", false)],
             ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
@@ -2634,7 +2723,7 @@ mod tests {
             contract_count: 1,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
-            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            contracts: vec![mk_hosted_entry("A", false)],
             disk_state_bytes: None,
             disk_wasm_bytes: None,
             disk_compile_cache_bytes: None,
@@ -2676,7 +2765,7 @@ mod tests {
             contract_count: 1,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
-            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            contracts: vec![mk_hosted_entry("A", false)],
             disk_state_bytes: Some(100 * 1024 * 1024),
             disk_wasm_bytes: Some(20 * 1024 * 1024),
             disk_compile_cache_bytes: Some(5 * 1024 * 1024),
@@ -2725,7 +2814,7 @@ mod tests {
             contract_count: 1,
             budget_evictions_total: 0,
             evictions_of_recently_read_total: 0,
-            contracts: vec![mk_hosted_entry("A", 1.0, false)],
+            contracts: vec![mk_hosted_entry("A", false)],
             resident_overhead_budget_bytes: 100 * 1024 * 1024,
             estimated_resident_overhead_bytes: 30 * 1024 * 1024,
             resident_overhead_evictions_total: 7,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2578,6 +2578,51 @@ mod tests {
             html.contains(">7<"),
             "a non-zero recency_seq must render its value — got:\n{html}"
         );
+        // Displayed order must BE the recency order, not merely be labelled as
+        // it. Without this the test would pass on an arbitrary row order.
+        let cold_idx = html.find("COLD_FULL").expect("cold row present");
+        let warm_idx = html.find("WARM_FULL").expect("warm row present");
+        assert!(
+            cold_idx < warm_idx,
+            "rows must render least-recently-accessed first — got:\n{html}"
+        );
+    }
+
+    /// A contract pinned by a local client or downstream subscriber sorts to
+    /// the top of this table when it has never been read, because the
+    /// cache-side sort cannot see subscriber counts — yet the real sweep
+    /// evicts it LAST. Without a marker it is indistinguishable from the most
+    /// evictable row, which is the confusion the "in use" badge exists to
+    /// prevent.
+    #[test]
+    fn hosting_card_marks_pinned_rows_as_in_use() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 256 * 1024 * 1024,
+            used_bytes: 64 * 1024 * 1024,
+            contract_count: 2,
+            contracts: vec![
+                // Never read AND pinned: sorts first, but is not the victim.
+                mk_hosted_entry_seq("PINNED", 0, false),
+                mk_hosted_entry_seq("EVICTABLE", 5, true),
+            ],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        let pinned_idx = html.find("PINNED_FULL").expect("pinned row present");
+        let evictable_idx = html.find("EVICTABLE_FULL").expect("evictable row present");
+        let badge_idx = html.find(">in use<").expect("in-use badge present");
+        assert!(
+            badge_idx > pinned_idx && badge_idx < evictable_idx,
+            "the in-use badge must sit on the pinned row — got:\n{html}"
+        );
+        // Exactly one row is pinned, so exactly one badge.
+        assert_eq!(
+            html.matches(">in use<").count(),
+            1,
+            "only the pinned row may carry the in-use badge — got:\n{html}"
+        );
     }
 
     /// The footer must not claim a ranking the card cannot actually show.

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2688,8 +2688,14 @@ mod tests {
         );
         // `recency_seq` is ALSO advanced by `record_abandonment` when a
         // contract loses its last subscriber, so any copy calling this an
-        // access/read ordering misrepresents a just-abandoned contract. Pin
-        // the invariant (no access-time language), not one phrasing of it.
+        // access/read ordering misrepresents a just-abandoned contract.
+        //
+        // This blocklist is ILLUSTRATIVE, NOT EXHAUSTIVE: it catches the
+        // phrasings that actually shipped, but an equivalent rewording
+        // ("accessed at", "time since last read", "recently accessed") would
+        // pass. A green run here is therefore evidence, not proof — if you are
+        // editing this copy, re-check the claim against `record_abandonment`
+        // rather than trusting the test.
         for banned in [
             "least-recently accessed",
             "least-recently read",

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1315,9 +1315,9 @@ table.sortable thead th.sort-desc::after {
   color: var(--text-muted, #8b949e);
 }
 
-/* "next to evict" badge on the front row of the Demand-driven eviction
- * table (the lowest keep-score contract, i.e. the next budget-pressure
- * victim). */
+/* "next to evict" badge on the first EVICTION-ELIGIBLE row of the
+ * Demand-driven eviction table — the contract the over-budget sweep would
+ * shed first among those no local client or downstream subscriber pins. */
 .hz-badge {
   display: inline-block;
   margin-left: 0.35rem;

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1307,11 +1307,23 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         } else {
             c.recency_seq.to_string()
         };
+        // A contract pinned by a local client or downstream subscriber is
+        // ordered LAST by the real sweep, but the cache-side sort this table
+        // shows cannot see subscriber counts — so a pinned, never-read contract
+        // lands at the top reading "never", looking exactly like the most
+        // evictable row. Mark it, or the ordering caveat in the footer is the
+        // only thing standing between the operator and the wrong conclusion.
+        let pin_badge = if c.eviction_eligible {
+            ""
+        } else {
+            r#" <span class="fresh-pill use-active" title="Pinned by a local client or downstream subscriber. The sweep evicts these last, regardless of this row's position.">in use</span>"#
+        };
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}</td><td class="right" data-sort="{seq}">{recency}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}{pin}</td><td class="right" data-sort="{seq}">{recency}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
             next = next_badge,
+            pin = pin_badge,
             seq = c.recency_seq,
             recency = recency,
             size = c.size_bytes,

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1391,7 +1391,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2></div>
-            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the one with the lowest eviction-recency goes first. Since #4702 the eviction floor is min(RAM budget, disk budget), so either resource running low can trigger a sweep.</p>
+            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the one with the lowest eviction-recency goes first. A sweep can be triggered by any of several independent pressures: contract state bytes, disk usage, the resident-overhead ceiling that scales with hosted-contract count (#5325), or a single zero-demand contract taking a sustained share of the node's update work (#4861).</p>
             <div class="g-verdict-row">
                 <div class="g-norms">
                     <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1273,8 +1273,9 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     // `predicted_demand` are the DEMOTED telemetry-only estimator: eviction
     // reads neither, so rendering them here as though they ranked anything
     // described a mechanism that was retired by the subscriber-primary rework
-    // (#4830). They stay in the snapshot for telemetry consumers; the operator
-    // view shows the real ordering input instead.
+    // (#4830). They are gone from this projection entirely — they survive only
+    // on the cache-side `HostedContract`, where they still drive the
+    // Greedy-Dual `eviction_floor` ratchet.
     //
     // Caveat the footer states rather than hides: the cache-side sort is only
     // the ordering WITHIN the zero-subscriber tier. `victim_order` ranks
@@ -1298,10 +1299,15 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         } else {
             ""
         };
-        // `recency_seq` is a per-run monotonic sequence, not a timestamp: 0
-        // means "not GET/PUT-accessed since this process started" (including
-        // every entry reloaded from disk at startup), which is why so many rows
-        // read "never" on a recently-restarted node.
+        // `recency_seq` is a per-run monotonic sequence, not a timestamp, and
+        // it is the EVICTION recency clock rather than a pure last-read time:
+        // `record_abandonment` also stamps a fresh seq when a contract loses
+        // its last subscriber, deliberately granting a grace period so a
+        // just-unsubscribed contract is not evicted on a stale read accrued
+        // while it sat in the subscription tier. Labelling this column "last
+        // access" would therefore be wrong. 0 means the clock has not been set
+        // since this process started (including every entry reloaded from disk
+        // at startup), which is why so many rows read "never" after a restart.
         let recency = if c.recency_seq == 0 {
             r#"<span style="color: var(--text-muted, #888);">never</span>"#.to_string()
         } else {
@@ -1412,7 +1418,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             </div>
             <div class="table-wrap">
                 <table class="sortable" data-table-id="hosting">
-                    <thead><tr><th data-sort-type="text">Contract</th><th class="right" data-sort-type="num" title="Per-run access sequence at this contract's last real GET or PUT — higher is more recent. &quot;never&quot; means it has not been accessed since this node started, which includes everything reloaded from disk at startup. This is the column the eviction sweep orders by among contracts with no subscribers.">Recency</th><th class="right" data-sort-type="num">Size</th><th class="right" data-sort-type="num">Reads</th></tr></thead>
+                    <thead><tr><th data-sort-type="text">Contract</th><th class="right" data-sort-type="num" title="The eviction recency clock: a per-run sequence, higher is more recent. Reset by a real GET or PUT, and also when a contract loses its last subscriber — the sweep deliberately gives a just-unsubscribed contract a grace period, so this is NOT purely a last-read time. &quot;never&quot; means the clock has not been set since this node started, which includes everything reloaded from disk at startup. This is the column the eviction sweep orders by among contracts with no subscribers.">Recency</th><th class="right" data-sort-type="num">Size</th><th class="right" data-sort-type="num">Reads</th></tr></thead>
                     <tbody>{rows}</tbody>
                 </table>
             </div>

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1340,7 +1340,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     let shown = (h.contracts.len()).min(MAX_ROWS);
     let footer = if (h.contract_count as usize) > shown {
         format!(
-            r#"<p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">Showing {shown} of {total} hosted contracts, least-recently accessed first. Contracts with a local client or downstream subscriber outrank recency and are evicted last, but those counts aren't available here — so this is the eviction order only among contracts with no subscribers.</p>"#,
+            r#"<p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">Showing {shown} of {total} hosted contracts, lowest eviction-recency first. That clock is set by a real GET or PUT and also when a contract loses its last subscriber, so it is not purely a last-read time. Contracts with a local client or downstream subscriber outrank recency and are evicted last, but those counts aren't available here — so this is the eviction order only among contracts with no subscribers.</p>"#,
             shown = shown,
             total = h.contract_count,
         )
@@ -1391,7 +1391,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2></div>
-            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the least-recently read or written goes first. Since #4702 the eviction floor is min(RAM budget, disk budget), so either resource running low can trigger a sweep.</p>
+            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the one with the lowest eviction-recency goes first. Since #4702 the eviction floor is min(RAM budget, disk budget), so either resource running low can trigger a sweep.</p>
             <div class="g-verdict-row">
                 <div class="g-norms">
                     <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1347,7 +1347,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
 
     format!(
         r##"<div class="card">
-            <div class="card-header"><h2>Demand-driven eviction</h2><span class="g-mode g-mode-enforce">piece A</span></div>
+            <div class="card-header"><h2>Demand-driven eviction</h2></div>
             <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven: contracts with the lowest predicted read-demand (keep-score) are evicted first when over budget. Since #4702 the eviction floor is min(RAM budget, disk budget) — either resource running low can trigger eviction.</p>
             <div class="g-verdict-row">
                 <div class="g-norms">

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1227,13 +1227,18 @@ pub fn build_governance_card(snap: &Option<network_status::NetworkStatusSnapshot
     )
 }
 
-/// Build the demand-driven eviction card (piece A, #4642). Surfaces the
-/// capability-relative RAM budget and the per-contract Greedy-Dual
-/// `keep_score` that ACTUALLY governs retention today — the mechanism that
-/// replaced the dormant MAD `GovernanceManager` (#4296), whose dashboard card
-/// is now hidden on default nodes. Every value comes from
+/// Build the demand-driven eviction card (#4642). Surfaces the
+/// capability-relative budgets and the per-contract rows that the
+/// subscriber-primary eviction sweep orders. Every value comes from
 /// `Ring::dashboard_hosting_snapshot` reading the canonical hosting cache;
 /// nothing is invented at render time. See `.claude/rules/hosting-invariants.md`.
+///
+/// The per-contract table shows `recency_seq`, NOT `keep_score` /
+/// `predicted_demand`. The latter two are the demoted telemetry-only
+/// Greedy-Dual estimator, which eviction does not read; presenting them as the
+/// eviction score described a mechanism retired by the subscriber-primary
+/// rework, and left the table sorted by a column it did not display (#4830).
+/// `recency_seq` is the ordering input the cache actually sorts these rows by.
 ///
 /// Hidden when the node hosts nothing (a fresh/idle node) — the budget still
 /// exists but there's nothing to retain, so the panel would just be noise.
@@ -1262,33 +1267,53 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         "0".to_string()
     };
 
-    // Per-contract table, bounded. Rows arrive in EVICTION order (lowest
-    // keep-score first); show at most MAX_ROWS. The tile carries the full count.
+    // Per-contract table, bounded. Rows arrive from the cache already sorted
+    // ascending by `(recency_seq, key)` — so `recency_seq` is the column that
+    // explains each row's position, and it is the one shown. `keep_score` and
+    // `predicted_demand` are the DEMOTED telemetry-only estimator: eviction
+    // reads neither, so rendering them here as though they ranked anything
+    // described a mechanism that was retired by the subscriber-primary rework
+    // (#4830). They stay in the snapshot for telemetry consumers; the operator
+    // view shows the real ordering input instead.
     //
-    // The "next to evict" badge marks the first EVICTION-ELIGIBLE row, not
-    // simply the lowest keep-score row. A contract still in use (a local client /
-    // downstream subscriber) is ordered LAST by the subscriber-primary sweep —
-    // shed only as a last resort when nothing with fewer subscribers is eligible —
-    // so it is not the common-case next victim. `is_eviction_eligible` reflects
-    // that (not in use; there is no longer a `min_ttl` age gate), so the badge
-    // never mislabels a contract the sweep would ordinarily keep. When nothing is
-    // currently eligible (every hosted contract is in use), no row is badged.
+    // Caveat the footer states rather than hides: the cache-side sort is only
+    // the ordering WITHIN the zero-subscriber tier. `victim_order` ranks
+    // local-subscription count and downstream-subscriber count above recency,
+    // and those counts are computed transiently during the sweep — the cache
+    // cannot see them, so they are not available to render.
+    //
+    // The "next to evict" badge marks the first EVICTION-ELIGIBLE row. A
+    // contract still in use (a local client / downstream subscriber) is ordered
+    // LAST by the sweep — shed only as a last resort when nothing with fewer
+    // subscribers is eligible — so it is not the common-case next victim.
+    // `is_eviction_eligible` reflects that (not in use; there is no longer a
+    // `min_ttl` age gate). When nothing is currently eligible (every hosted
+    // contract is in use), no row is badged.
     const MAX_ROWS: usize = 20;
     let next_victim_idx = h.contracts.iter().position(|c| c.eviction_eligible);
     let mut rows = String::new();
     for (i, c) in h.contracts.iter().take(MAX_ROWS).enumerate() {
         let next_badge = if Some(i) == next_victim_idx {
-            r#" <span class="hz-badge hz-next" title="Lowest keep-score among eviction-eligible contracts (not in use) — the over-budget sweep would evict this one first.">next to evict</span>"#
+            r#" <span class="hz-badge hz-next" title="First eviction-eligible contract (not pinned by a local client or downstream subscriber) in the sweep's order — the over-budget sweep would evict this one first.">next to evict</span>"#
         } else {
             ""
         };
+        // `recency_seq` is a per-run monotonic sequence, not a timestamp: 0
+        // means "not GET/PUT-accessed since this process started" (including
+        // every entry reloaded from disk at startup), which is why so many rows
+        // read "never" on a recently-restarted node.
+        let recency = if c.recency_seq == 0 {
+            r#"<span style="color: var(--text-muted, #888);">never</span>"#.to_string()
+        } else {
+            c.recency_seq.to_string()
+        };
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}</td><td class="right" data-sort="{keep:.6}">{keep:.3}</td><td class="right" data-sort="{demand:.6}">{demand:.3}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}</td><td class="right" data-sort="{seq}">{recency}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
             next = next_badge,
-            keep = c.keep_score,
-            demand = c.predicted_demand,
+            seq = c.recency_seq,
+            recency = recency,
             size = c.size_bytes,
             size_fmt = format_bytes(c.size_bytes),
             reads = c.read_count,
@@ -1297,7 +1322,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     let shown = (h.contracts.len()).min(MAX_ROWS);
     let footer = if (h.contract_count as usize) > shown {
         format!(
-            r#"<p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">Showing the {shown} most-evictable of {total} hosted contracts (lowest keep-score first).</p>"#,
+            r#"<p class="empty" style="margin: 0.4rem 0.9rem 0.6rem; font-size: 0.78rem; color: var(--text-muted, #888);">Showing {shown} of {total} hosted contracts, least-recently accessed first. Contracts with a local client or downstream subscriber outrank recency and are evicted last, but those counts aren't available here — so this is the eviction order only among contracts with no subscribers.</p>"#,
             shown = shown,
             total = h.contract_count,
         )
@@ -1348,7 +1373,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2></div>
-            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven: contracts with the lowest predicted read-demand (keep-score) are evicted first when over budget. Since #4702 the eviction floor is min(RAM budget, disk budget) — either resource running low can trigger eviction.</p>
+            <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the least-recently read or written goes first. Since #4702 the eviction floor is min(RAM budget, disk budget), so either resource running low can trigger a sweep.</p>
             <div class="g-verdict-row">
                 <div class="g-norms">
                     <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>
@@ -1375,7 +1400,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             </div>
             <div class="table-wrap">
                 <table class="sortable" data-table-id="hosting">
-                    <thead><tr><th data-sort-type="text">Contract</th><th class="right" data-sort-type="num">Keep-score</th><th class="right" data-sort-type="num">Demand</th><th class="right" data-sort-type="num">Size</th><th class="right" data-sort-type="num">Reads</th></tr></thead>
+                    <thead><tr><th data-sort-type="text">Contract</th><th class="right" data-sort-type="num" title="Per-run access sequence at this contract's last real GET or PUT — higher is more recent. &quot;never&quot; means it has not been accessed since this node started, which includes everything reloaded from disk at startup. This is the column the eviction sweep orders by among contracts with no subscribers.">Recency</th><th class="right" data-sort-type="num">Size</th><th class="right" data-sort-type="num">Reads</th></tr></thead>
                     <tbody>{rows}</tbody>
                 </table>
             </div>


### PR DESCRIPTION
## Problem

The Demand-driven eviction card described a mechanism that was retired by the subscriber-primary rework, and — less obviously — **was sorted by a column it did not display**.

Rows arrive from `HostingCache::eviction_ordered_scores()` sorted ascending on `(recency_seq, key)`. Neither `keep_score` nor `predicted_demand` takes any part in that ordering; both are the demoted telemetry-only Greedy-Dual estimator, and the cache's own module docs say plainly that eviction "reads NONE of them". Yet those two held the prominent numeric columns, the footer read *"the N most-evictable … (lowest keep-score first)"*, and `recency_seq` — the field actually doing the sorting — was dropped in the `ring.rs` dashboard mapping and never rendered.

Observed on four live v0.2.128 peers: every row showed `Keep-score 1.000`, `Demand 1.000`, `Reads 0`. Only `Size` varied. The uniform `1.000` is `NEUTRAL_DEMAND` — on startup the whole persisted hosted set is reloaded with the neutral prior and the real one is applied lazily on first read, so a never-read contract keeps it indefinitely. With `DISTANCE_PRIOR_DECAY = 4.0` a genuine prior would span 1.000 → 0.135 across the keyspace, so three of the table's five columns were carrying no information at all.

Three doc comments still asserted that keep-score is "the mechanism that actually governs retention now", which is plausibly why the card was built this way.

The card also carried a `piece A` badge — internal epic jargon for #4642 — styled with `.g-mode-enforce` (`#ff667a`), the Governance card's *enforcement* red. A purely decorative label rendered in the alarm colour.

## Solution

Show the column the table is ordered by.

- Thread `recency_seq` from `HostingContractScore` through `HostedContractEntry` (it already existed one layer down — this is a one-field mapping change) and render it as a `Recency` column, replacing `Keep-score` and `Demand`.
- Render `recency_seq == 0` as **"never"** rather than a bare `0`. It is a per-run sequence, not a timestamp: zero means "not accessed since this process started", which includes every entry reloaded from disk at startup.
- Correct the footer. It no longer claims keep-score ordering, and it now states the caveat rather than hiding it: `victim_order` ranks local and downstream subscriber counts *above* recency, those counts are computed transiently during the sweep and the cache cannot see them, so this is the eviction order **only among contracts with no subscribers**.
- Rewrite the card description to the real policy (fewest subscribers first, local outranking downstream, recency breaking ties).
- Fix the stale doc comments (`network_status.rs` ×3, `ring.rs`, `cache.rs`).
- Drop the `piece A` badge.

**Remove `keep_score` / `predicted_demand` from `HostedContractEntry` entirely.** Once the card stopped rendering them, `-D warnings` flagged both as never read — and a grep confirmed the card was their only consumer anywhere in the crate. So rather than silence the lint, the dashboard snapshot simply stops carrying a dormant estimator. They remain on the cache-side `HostingContractScore`, and the struct now carries a comment saying not to re-add them without a consumer that labels them as telemetry.

## Testing

Two new regression tests, both mutation-checked rather than assumed:

- `hosting_card_shows_the_column_it_is_sorted_by` — asserts the `Recency` header is present, that `Keep-score`/`Demand` are *not* rendered as ranking columns, and that seq 0 renders as "never" while a non-zero seq renders its value. **Verified by mutation**: restoring the `Keep-score` header makes it fail (`test result: FAILED. 8 passed; 1 failed`), then passes again on revert.
- `hosting_card_footer_does_not_claim_keep_score_ordering` — pins the corrected footer, including the zero-subscriber caveat, so a later copy edit cannot quietly drop it.

Existing hosting-card tests updated for the new field. `cargo test -p freenet --lib home_page`: 128 passed, 0 failed.

## Scope

Dashboard rendering plus doc comments. No change to eviction behaviour — `victim_order` is untouched; this only changes what the operator is shown about it.

Follow-ups from the same review are tracked separately: #5369 (per-contract detail page) and #5370 (split GET NotFound from GET failed).

Addresses item 3 of #4830.

[AI-assisted - Claude]
