### PR TITLE
fix(dashboard): say which budget is closest to binding

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1703,6 +1703,16 @@ pub struct HostingSnapshot {
     /// `resident_overhead_budget_bytes` the same way `used_bytes` is compared
     /// against `budget_bytes`.
     pub estimated_resident_overhead_bytes: u64,
+    /// The resident-overhead budget expressed as the contract COUNT it really
+    /// bounds (`resident_overhead_budget_bytes / 1 MiB-per-contract`).
+    ///
+    /// The dashboard renders this rather than the byte pair, because the byte
+    /// pair is not a memory measurement: the "used" side is
+    /// `contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`, so printing
+    /// it in MB reads to an operator as measured RAM when it is really a
+    /// contract-count ceiling. Derived in `HostingCache::contract_slot_budget`
+    /// so the per-contract constant keeps exactly one reader.
+    pub contract_slot_budget: u64,
     /// Monotonic count of evictions where resident-overhead pressure was
     /// active at decision time (#5325); may overlap with
     /// `budget_evictions_total`.

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -4589,6 +4589,7 @@ impl Ring {
             disk_budget_bytes,
             resident_overhead_budget_bytes: stats.resident_overhead_budget_bytes,
             estimated_resident_overhead_bytes: stats.estimated_resident_overhead_bytes,
+            contract_slot_budget: stats.contract_slot_budget,
             resident_overhead_evictions_total: stats.resident_overhead_evictions_total,
         }
     }

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -237,6 +237,17 @@ pub const ESTIMATED_RESIDENT_BYTES_PER_CONTRACT: u64 = 1024 * 1024;
 /// [`resident_overhead_budget_for`].
 pub const MIN_RESIDENT_OVERHEAD_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 
+/// The floor must leave room for at least one contract, or
+/// [`HostingCache::contract_slot_budget`] truncates to 0 slots — and the
+/// dashboard reads a 0 slot budget as "axis not configured" and hides it,
+/// which is precisely backwards for a node that can host nothing.
+///
+/// That the two constants are currently 128 MiB and 1 MiB makes this hold by
+/// a wide margin, but nothing enforced the relationship, so a future revision
+/// of either (a raised per-contract estimate, an operator-settable floor)
+/// could break it silently. Pinned here rather than left to the reader.
+const _: () = assert!(MIN_RESIDENT_OVERHEAD_BUDGET_BYTES >= ESTIMATED_RESIDENT_BYTES_PER_CONTRACT);
+
 /// Absolute reservation (bytes) for what a node uses REGARDLESS of hosted
 /// contract count or the sizes of the other RAM-scaled caches — the true
 /// OS/tokio-runtime/transport baseline. Deliberately an ABSOLUTE quantity,

--- a/crates/core/src/ring/hosting/cache.rs
+++ b/crates/core/src/ring/hosting/cache.rs
@@ -622,6 +622,12 @@ pub(crate) struct HostingCacheStats {
     /// [`Self::current_bytes`] — unlike that field, this is never persisted
     /// per-contract state, just `contract_count` times a constant.
     pub estimated_resident_overhead_bytes: u64,
+    /// The resident-overhead budget expressed as the contract COUNT it really
+    /// bounds — see [`HostingCache::contract_slot_budget`]. Carried so the
+    /// dashboard can present the ceiling in the unit it actually constrains
+    /// instead of dividing bytes by a constant it would have to reach across
+    /// modules for.
+    pub contract_slot_budget: u64,
     /// Monotonic count of evictions where resident-overhead pressure was
     /// active at decision time (#5325). See
     /// [`HostingCache::resident_overhead_evictions_total`] for the exact
@@ -2415,6 +2421,21 @@ impl<T: TimeSource> HostingCache<T> {
         (self.contracts.len() as u64).saturating_mul(ESTIMATED_RESIDENT_BYTES_PER_CONTRACT)
     }
 
+    /// The resident-overhead budget expressed as what it actually bounds: a
+    /// maximum number of hosted contracts.
+    ///
+    /// Because the estimate is `contract_count *
+    /// ESTIMATED_RESIDENT_BYTES_PER_CONTRACT`, its budget is not really a
+    /// memory measurement — it is a contract-COUNT ceiling wearing memory
+    /// units. Rendering it as bytes reads to an operator as measured RAM,
+    /// which it is not. Derived here rather than in the renderer so the
+    /// per-contract constant has exactly one reader: a metric that describes a
+    /// limit must come from the code that owns the limit, not from arithmetic
+    /// at the call site (see `.claude/rules/bug-prevention-patterns.md`).
+    pub(crate) fn contract_slot_budget(&self) -> u64 {
+        self.resident_overhead_budget_bytes / ESTIMATED_RESIDENT_BYTES_PER_CONTRACT
+    }
+
     /// Raw, instantaneous "is the count-derived estimate over its budget
     /// right now" reading (#5325) — no debounce. Used only to drive the
     /// SUSTAINED gate below and to report point-in-time state (the dashboard
@@ -2505,6 +2526,7 @@ impl<T: TimeSource> HostingCache<T> {
             oom_valve_evictions_total: self.oom_valve_evictions_total,
             resident_overhead_budget_bytes: self.resident_overhead_budget_bytes,
             estimated_resident_overhead_bytes: self.estimated_resident_overhead_bytes(),
+            contract_slot_budget: self.contract_slot_budget(),
             resident_overhead_evictions_total: self.resident_overhead_evictions_total,
         }
     }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2907,46 +2907,147 @@ mod tests {
         }
     }
 
-    /// #5325 PR review Should-Fix #6: the new "Resident overhead" tile
-    /// (count-derived pressure axis, independent of the RAM used/budget
-    /// tile above) must render the actual snapshot values, not just compile.
+    /// The count-derived pressure axis (#5325) must render as contract SLOTS,
+    /// not as bytes.
+    ///
+    /// The underlying pair is `contract_count * 1 MiB` against a RAM-scaled
+    /// ceiling, so printing it as "30.0 MB / 100.0 MB" reads as measured
+    /// memory. It is not measured, and what it constrains is a number of
+    /// contracts — a low-RAM peer showed "520.0 MB / 524.0 MB" when the honest
+    /// statement was "520 of 524 contract slots used".
     #[test]
-    fn hosting_card_renders_resident_overhead_tile() {
+    fn hosting_card_renders_slot_axis_as_counts_not_bytes() {
         use crate::node::network_status::HostingSnapshot;
         let mut snap = base_snapshot();
         snap.hosting = HostingSnapshot {
             budget_bytes: 256 * 1024 * 1024,
             used_bytes: 1024,
-            contract_count: 1,
-            budget_evictions_total: 0,
-            evictions_of_recently_read_total: 0,
+            contract_count: 30,
             contracts: vec![mk_hosted_entry("A", false)],
             resident_overhead_budget_bytes: 100 * 1024 * 1024,
             estimated_resident_overhead_bytes: 30 * 1024 * 1024,
+            contract_slot_budget: 100,
             resident_overhead_evictions_total: 7,
             ..Default::default()
         };
         let html = build_hosting_card(&Some(snap));
         assert!(
-            html.contains("Resident overhead"),
-            "resident-overhead tile label present — got:\n{html}"
+            html.contains("Contract slots used") && html.contains("30 / 100"),
+            "slot axis must render as counts — got:\n{html}"
         );
         assert!(
-            html.contains("30.0 MB"),
-            "resident-overhead used value — got:\n{html}"
-        );
-        assert!(
-            html.contains("100.0 MB"),
-            "resident-overhead budget value — got:\n{html}"
-        );
-        // Headroom = budget(100) - used(30) = 70 MB.
-        assert!(
-            html.contains("70.0 MB"),
-            "resident-overhead headroom value — got:\n{html}"
+            html.contains(">70<"),
+            "slots free = budget(100) - used(30) — got:\n{html}"
         );
         assert!(
             html.contains(">7<"),
-            "resident-overhead eviction counter renders the snapshot value — got:\n{html}"
+            "slot-pressure eviction counter renders the snapshot value — got:\n{html}"
+        );
+        // The byte framing must be gone: it is what made this read as RAM.
+        assert!(
+            !html.contains("Resident overhead (est.)")
+                && !html.contains("Resident overhead budget"),
+            "the byte-denominated resident-overhead tiles must not return — got:\n{html}"
+        );
+    }
+
+    /// The card shows several independent ceilings; it must say which one is
+    /// closest to binding.
+    ///
+    /// Measured on a live low-RAM peer: 34% of the state-byte budget, 1% of
+    /// the disk budget, 99.2% of the contract-slot ceiling. All three rendered
+    /// as identical muted tiles, so the only number that mattered was
+    /// indistinguishable from the two with room to spare.
+    #[test]
+    fn hosting_card_names_the_closest_limit() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            // State bytes: 34% used.
+            budget_bytes: 1000,
+            used_bytes: 340,
+            // Slots: 99% used — this is the binding axis.
+            contract_count: 99,
+            contract_slot_budget: 100,
+            // Disk: 1% used.
+            disk_total_bytes: Some(10),
+            disk_budget_bytes: Some(1000),
+            contracts: vec![mk_hosted_entry("A", true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Closest limit:") && html.contains("contract slots"),
+            "the binding axis must be named — got:\n{html}"
+        );
+        assert!(
+            html.contains("99 of 100"),
+            "the binding axis detail must show its own units — got:\n{html}"
+        );
+        // At 99% it must be flagged, not left in the same muted grey as an
+        // axis with room to spare.
+        assert!(
+            html.contains("var(--danger"),
+            "a near-full binding axis must be coloured — got:\n{html}"
+        );
+    }
+
+    /// The lowest-utilisation axis must NOT be the one reported.
+    #[test]
+    fn hosting_card_picks_the_highest_utilisation_axis() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            // State bytes 90% — the binding axis here.
+            budget_bytes: 1000,
+            used_bytes: 900,
+            // Slots only 10%.
+            contract_count: 10,
+            contract_slot_budget: 100,
+            contracts: vec![mk_hosted_entry("A", true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Closest limit:") && html.contains("contract state"),
+            "state bytes at 90% must outrank slots at 10% — got:\n{html}"
+        );
+        assert!(
+            !html.contains("Closest limit: <strong>contract slots"),
+            "the slack axis must not be reported as closest — got:\n{html}"
+        );
+    }
+
+    /// An unconfigured or not-yet-measured budget is not "100% full".
+    ///
+    /// The disk budget is an `Option` precisely because the tracker is
+    /// unseeded early in a node's life; treating an absent or zero
+    /// denominator as full would report a phantom emergency on every fresh
+    /// start.
+    #[test]
+    fn hosting_card_skips_unconfigured_axes_when_picking_closest_limit() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 1000,
+            used_bytes: 100,
+            contract_count: 5,
+            // A slot budget of 0 means "not configured", NOT "no slots left".
+            contract_slot_budget: 0,
+            // Disk tracker unseeded.
+            disk_total_bytes: None,
+            disk_budget_bytes: None,
+            contracts: vec![mk_hosted_entry("A", true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("Closest limit:") && html.contains("contract state"),
+            "the one configured axis must be reported — got:\n{html}"
+        );
+        assert!(
+            !html.contains("contract slots</strong>"),
+            "an unconfigured axis must not be ranked at all — got:\n{html}"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3018,6 +3018,47 @@ mod tests {
         );
     }
 
+    /// Over budget must render as over budget, not as a clamped 100%.
+    ///
+    /// This state is reachable and important, not an error case: exceeding the
+    /// contract-state budget IS the eviction trigger, and the slot axis sits
+    /// over its ceiling for the whole ~2.5 minute sustained window before
+    /// anything is shed. Clamping the percentage produced "150 of 100 (100%)"
+    /// — a line that contradicts its own detail text and hides how far over
+    /// the node is at exactly the moment that matters.
+    #[test]
+    fn hosting_card_shows_true_percentage_when_over_budget() {
+        use crate::node::network_status::HostingSnapshot;
+        let mut snap = base_snapshot();
+        snap.hosting = HostingSnapshot {
+            budget_bytes: 100,
+            used_bytes: 150,
+            contract_count: 1,
+            contracts: vec![mk_hosted_entry("A", true)],
+            ..Default::default()
+        };
+        let html = build_hosting_card(&Some(snap));
+        assert!(
+            html.contains("150%"),
+            "an over-budget axis must report its true percentage — got:\n{html}"
+        );
+        assert!(
+            !html.contains("(100%)"),
+            "no percentage on the card may be clamped to 100% — the RAM-used \
+             tile had the same clamp and disagreed with the strip — got:\n{html}"
+        );
+        // The RAM-used tile must agree with the strip, not clamp separately.
+        assert!(
+            html.contains("150 B / 100 B (150%)"),
+            "the RAM-used tile must report the true percentage too — got:\n{html}"
+        );
+        // The bar itself is still capped: a fill cannot overflow its track.
+        assert!(
+            html.contains("width: 100.0%"),
+            "the bar width must stay clamped at 100% — got:\n{html}"
+        );
+    }
+
     /// An unconfigured or not-yet-measured budget is not "100% full".
     ///
     /// The disk budget is an `Option` precisely because the tracker is

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1315,6 +1315,36 @@ table.sortable thead th.sort-desc::after {
   color: var(--text-muted, #8b949e);
 }
 
+/* "Closest limit" strip on the Demand-driven eviction card: the card shows
+ * several independent ceilings and this names the one nearest to binding,
+ * because three flat rows of identical tiles gave no clue which mattered. The
+ * fill is coloured only above 75% so the strip is ignorable until it isn't. */
+.hz-binding {
+  margin: 0 0.9rem 0.7rem;
+}
+.hz-binding-head {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #8b949e);
+  margin-bottom: 0.3rem;
+}
+.hz-binding-head strong {
+  color: var(--text-primary, #e6edf3);
+  font-weight: 600;
+}
+.hz-bar {
+  display: block;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(139, 148, 158, 0.18);
+  overflow: hidden;
+}
+.hz-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  min-width: 2px;
+}
+
 /* "next to evict" badge on the first EVICTION-ELIGIBLE row of the
  * Demand-driven eviction table — the contract the over-budget sweep would
  * shed first among those no local client or downstream subscriber pins. */

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1285,7 +1285,22 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     let axis_utilisation = |used: u64, budget: u64| -> Option<f64> {
         (budget > 0).then(|| used as f64 / budget as f64)
     };
-    let mut axes: Vec<(&str, f64, String)> = Vec::new();
+    // Each axis carries a note saying what CROSSING it actually does, because
+    // the three are not the same kind of ceiling and "closest limit" alone
+    // would imply they are:
+    //
+    //   - contract state: the sweep's own condition (`current_bytes >
+    //     budget_bytes`), so crossing fires it directly.
+    //   - contract slots: also a sweep condition, but only once the breach has
+    //     been SUSTAINED (`resident_overhead_over_budget` requires half of
+    //     RESIDENT_OVERHEAD_SUSTAINED_WINDOW, ~2.5 min). A transient spike to
+    //     99% here self-resolves without evicting anything, so the strip must
+    //     not read as though eviction is imminent.
+    //   - disk: not a sweep condition at all. It acts by clamping the
+    //     contract-state budget (`effective = ram.min(disk_budget)` in
+    //     HostingManager), so disk pressure tightens the first axis rather
+    //     than firing on its own.
+    let mut axes: Vec<(&str, f64, String, &str)> = Vec::new();
     if let Some(u) = axis_utilisation(h.used_bytes, h.budget_bytes) {
         axes.push((
             "contract state",
@@ -1295,6 +1310,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                 format_bytes(h.used_bytes),
                 format_bytes(h.budget_bytes)
             ),
+            "Crossing this triggers an eviction sweep.",
         ));
     }
     if let (Some(used), Some(disk_budget)) = (h.disk_total_bytes, h.disk_budget_bytes) {
@@ -1303,6 +1319,8 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                 "disk",
                 u,
                 format!("{} of {}", format_bytes(used), format_bytes(disk_budget)),
+                "Disk does not trigger a sweep by itself: it clamps the contract-state \
+                 budget, so filling it tightens that limit instead.",
             ));
         }
     }
@@ -1311,6 +1329,8 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             "contract slots",
             u,
             format!("{} of {}", h.contract_count, h.contract_slot_budget),
+            "Crossing this triggers a sweep only if it stays over for a few minutes, \
+             so a brief spike here resolves on its own.",
         ));
     }
     // Cost pressure (#4861) is deliberately absent: it is a sustained-rate
@@ -1319,21 +1339,30 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     let binding = axes
         .iter()
         .max_by(|a, b| a.1.total_cmp(&b.1))
-        .map(|(name, util, detail)| {
+        .map(|(name, util, detail, note)| {
             let pct = (util * 100.0).min(100.0);
+            // Threshold on the DISPLAYED figure, not the raw one. Colouring
+            // from `pct` while printing `{pct:.0}` makes the two disagree at
+            // the boundary: 89.6% prints as "90%" but renders amber, and 74.6%
+            // prints as "75%" but renders grey. An operator seeing a red 90%
+            // beside an amber 90% has no way to tell them apart, so round
+            // first and threshold on what they can actually read.
+            let shown_pct = pct.round();
             // Colour only near the ceiling: an operator should be able to
             // ignore this strip until it means something.
-            let tone = if pct >= 90.0 {
+            let tone = if shown_pct >= 90.0 {
                 "var(--danger, #c0392b)"
-            } else if pct >= 75.0 {
+            } else if shown_pct >= 75.0 {
                 "var(--warn, #b8860b)"
             } else {
                 "var(--text-muted, #888)"
             };
             format!(
-                r#"<div class="hz-binding"><div class="hz-binding-head">Closest limit: <strong>{name}</strong> — {detail} ({pct:.0}%)</div><div class="hz-bar" role="img" aria-label="{name} at {pct:.0} percent of its limit"><span class="hz-bar-fill" style="width: {pct:.1}%; background: {tone};"></span></div></div>"#,
+                r#"<div class="hz-binding" title="{note}"><div class="hz-binding-head">Closest limit: <strong>{name}</strong> — {detail} ({shown:.0}%)</div><div class="hz-bar" role="img" aria-label="{name} at {shown:.0} percent of its limit"><span class="hz-bar-fill" style="width: {pct:.1}%; background: {tone};"></span></div></div>"#,
                 name = html_escape(name),
                 detail = html_escape(detail),
+                note = html_escape(note),
+                shown = shown_pct,
                 pct = pct,
                 tone = tone,
             )

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1255,6 +1255,75 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     let used_pct = (h.used_bytes as f64 / budget as f64 * 100.0).min(100.0);
     let headroom = h.budget_bytes.saturating_sub(h.used_bytes);
 
+    // Which limit is actually closest? The card shows three ceilings, and
+    // before this they were three flat rows of identical tiles with nothing
+    // saying which one binds. On a real low-RAM peer that is not academic: a
+    // measured framework node sat at 34% of its state-byte budget, 1% of its
+    // disk budget, and 99.2% of its contract-slot ceiling — the one number
+    // that mattered, rendered in the same muted grey as the two that had room
+    // to spare.
+    //
+    // Utilisation is computed per axis and the highest wins. A budget of 0 is
+    // "not configured / not yet measured", not "completely full", so those
+    // axes are skipped rather than reported as 100%.
+    let axis_utilisation = |used: u64, budget: u64| -> Option<f64> {
+        (budget > 0).then(|| used as f64 / budget as f64)
+    };
+    let mut axes: Vec<(&str, f64, String)> = Vec::new();
+    if let Some(u) = axis_utilisation(h.used_bytes, h.budget_bytes) {
+        axes.push((
+            "contract state",
+            u,
+            format!(
+                "{} of {}",
+                format_bytes(h.used_bytes),
+                format_bytes(h.budget_bytes)
+            ),
+        ));
+    }
+    if let (Some(used), Some(disk_budget)) = (h.disk_total_bytes, h.disk_budget_bytes) {
+        if let Some(u) = axis_utilisation(used, disk_budget) {
+            axes.push((
+                "disk",
+                u,
+                format!("{} of {}", format_bytes(used), format_bytes(disk_budget)),
+            ));
+        }
+    }
+    if let Some(u) = axis_utilisation(h.contract_count, h.contract_slot_budget) {
+        axes.push((
+            "contract slots",
+            u,
+            format!("{} of {}", h.contract_count, h.contract_slot_budget),
+        ));
+    }
+    // Cost pressure (#4861) is deliberately absent: it is a sustained-rate
+    // condition on a single offending contract, not a utilisation ratio, so it
+    // has no comparable denominator to rank against these three.
+    let binding = axes
+        .iter()
+        .max_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(name, util, detail)| {
+            let pct = (util * 100.0).min(100.0);
+            // Colour only near the ceiling: an operator should be able to
+            // ignore this strip until it means something.
+            let tone = if pct >= 90.0 {
+                "var(--danger, #c0392b)"
+            } else if pct >= 75.0 {
+                "var(--warn, #b8860b)"
+            } else {
+                "var(--text-muted, #888)"
+            };
+            format!(
+                r#"<div class="hz-binding"><div class="hz-binding-head">Closest limit: <strong>{name}</strong> — {detail} ({pct:.0}%)</div><div class="hz-bar" role="img" aria-label="{name} at {pct:.0} percent of its limit"><span class="hz-bar-fill" style="width: {pct:.1}%; background: {tone};"></span></div></div>"#,
+                name = html_escape(name),
+                detail = html_escape(detail),
+                pct = pct,
+                tone = tone,
+            )
+        })
+        .unwrap_or_default();
+
     // Recently-read evictions are the miscalibration alarm (#4338): evicting a
     // repeatedly-requested contract means the demand estimate is mis-ordering
     // the working set. Color it when non-zero so an operator notices.
@@ -1378,20 +1447,38 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         _ => MEASURING.to_string(),
     };
 
-    // Resident-overhead tile (#5325): the state-byte budget above bounds
-    // contract STATE bytes only. This tile is the count-derived axis —
-    // `contract_count * ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` — that closes
-    // the gap where many small-state contracts (negligible RAM-used-tile
-    // impact) still exhaust a peer's real resident memory via per-contract
+    // The tile shows slots because that is the unit the ceiling constrains;
+    // the tooltip keeps the RAM derivation available, so an operator who wants
+    // to know WHY the ceiling is where it is can still get there. Estimated,
+    // never measured — say so, since the whole failure this replaces was a
+    // derived count reading as a memory measurement.
+    let slot_tooltip = format!(
+        "A contract-count ceiling, not a memory measurement. Each hosted contract is \
+         charged a flat estimate for per-contract bookkeeping (subscriptions, redb/index \
+         entries) that the contract-state budget does not count, so the RAM-scaled byte \
+         budget behind this (#5325) works out to a maximum number of contracts. \
+         Currently {used} estimated against a {budget} ceiling.",
+        used = format_bytes(h.estimated_resident_overhead_bytes),
+        budget = format_bytes(h.resident_overhead_budget_bytes),
+    );
+
+    // Contract-slot tiles (#5325): the state-byte budget above bounds contract
+    // STATE bytes only. This axis is the count-derived one that closes the gap
+    // where many small-state contracts (negligible impact on the state-byte
+    // tile) still exhaust a peer's real resident memory via per-contract
     // subscription/index bookkeeping.
-    let resident_overhead_headroom = h
-        .resident_overhead_budget_bytes
-        .saturating_sub(h.estimated_resident_overhead_bytes);
+    //
+    // Rendered as SLOTS rather than the underlying bytes. The byte pair was
+    // `contract_count * 1 MiB` against a RAM-scaled ceiling, which prints as
+    // e.g. "520.0 MB / 524.0 MB" and reads as measured memory — it is not
+    // measured, and what it constrains is a number of contracts. The tooltip
+    // keeps the RAM derivation available for anyone who needs it.
 
     format!(
         r##"<div class="card">
             <div class="card-header"><h2>Demand-driven eviction</h2></div>
             <p class="empty" style="margin: 0.2rem 0.9rem 0.4rem; font-size: 0.82rem; color: var(--text-muted, #888);">Retention is demand-driven. When over budget the node sheds contracts with the fewest subscribers first — a local client subscription outranks a downstream one, and among contracts with neither, the one with the lowest eviction-recency goes first. A sweep can be triggered by any of several independent pressures: contract state bytes, disk usage, the resident-overhead ceiling that scales with hosted-contract count (#5325), or a single zero-demand contract taking a sustained share of the node's update work (#4861).</p>
+            {binding}
             <div class="g-verdict-row">
                 <div class="g-norms">
                     <div class="g-norm"><div class="g-norm-label">RAM used</div><div class="g-norm-value">{used} / {budget} ({pct:.0}%)</div></div>
@@ -1410,10 +1497,9 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             </div>
             <div class="g-verdict-row">
                 <div class="g-norms">
-                    <div class="g-norm" title="Estimated, not measured: contract_count × 1 MiB/contract (#5325). Bounds per-contract resident bookkeeping overhead (subscriptions, redb/index entries) that RAM used/budget above does not count."><div class="g-norm-label">Resident overhead (est.)</div><div class="g-norm-value">{resident_overhead_used}</div></div>
-                    <div class="g-norm"><div class="g-norm-label">Resident overhead budget</div><div class="g-norm-value">{resident_overhead_budget}</div></div>
-                    <div class="g-norm"><div class="g-norm-label">Resident overhead headroom</div><div class="g-norm-value">{resident_overhead_headroom}</div></div>
-                    <div class="g-norm"><div class="g-norm-label">Resident overhead evictions</div><div class="g-norm-value">{resident_overhead_evictions}</div></div>
+                    <div class="g-norm" title="{slot_tooltip}"><div class="g-norm-label">Contract slots used</div><div class="g-norm-value">{slots_used} / {slots_budget}</div></div>
+                    <div class="g-norm"><div class="g-norm-label">Slots free</div><div class="g-norm-value">{slots_free}</div></div>
+                    <div class="g-norm" title="Evictions where the contract-slot ceiling was the active pressure (#5325). May overlap with budget evictions."><div class="g-norm-label">Slot-pressure evictions</div><div class="g-norm-value">{resident_overhead_evictions}</div></div>
                 </div>
             </div>
             <div class="table-wrap">
@@ -1424,6 +1510,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             </div>
             {footer}
         </div>"##,
+        binding = binding,
         used = format_bytes(h.used_bytes),
         budget = format_bytes(h.budget_bytes),
         pct = used_pct,
@@ -1435,9 +1522,10 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         disk_used = disk_used_value,
         disk_budget = disk_budget_value,
         disk_headroom = disk_headroom_value,
-        resident_overhead_used = format_bytes(h.estimated_resident_overhead_bytes),
-        resident_overhead_budget = format_bytes(h.resident_overhead_budget_bytes),
-        resident_overhead_headroom = format_bytes(resident_overhead_headroom),
+        slot_tooltip = html_escape(&slot_tooltip),
+        slots_used = h.contract_count,
+        slots_budget = h.contract_slot_budget,
+        slots_free = h.contract_slot_budget.saturating_sub(h.contract_count),
         resident_overhead_evictions = h.resident_overhead_evictions_total,
         rows = rows,
         footer = footer,

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1265,7 +1265,18 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     //
     // Utilisation is computed per axis and the highest wins. A budget of 0 is
     // "not configured / not yet measured", not "completely full", so those
-    // axes are skipped rather than reported as 100%.
+    // axes are skipped rather than reported as 100%. The disk budget is the
+    // real case: it is an `Option` because the tracker is unseeded early in a
+    // node's life, and ranking an absent denominator as full would report a
+    // phantom emergency on every fresh start.
+    //
+    // For the slot axis this is defensive rather than load-bearing: the
+    // resident-overhead budget is floored at MIN_RESIDENT_OVERHEAD_BUDGET_BYTES
+    // (128 MiB, i.e. 128 slots) by `resident_overhead_budget_for`, so a
+    // production node cannot reach 0 slots. Skipping it is therefore not
+    // masking a genuinely-unhostable node — that state is unreachable, and if
+    // it ever becomes reachable the honest fix is to say so explicitly rather
+    // than to let this branch quietly imply "fine".
     let axis_utilisation = |used: u64, budget: u64| -> Option<f64> {
         (budget > 0).then(|| used as f64 / budget as f64)
     };

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1302,10 +1302,15 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     //     RESIDENT_OVERHEAD_SUSTAINED_WINDOW, ~2.5 min). A transient spike to
     //     99% here self-resolves without evicting anything, so the strip must
     //     not read as though eviction is imminent.
-    //   - disk: not a sweep condition at all. It acts by clamping the
-    //     contract-state budget (`effective = ram.min(disk_budget)` in
-    //     HostingManager), so disk pressure tightens the first axis rather
-    //     than firing on its own.
+    //   - disk: not a sweep condition at all. Its direct consequence is
+    //     ADMISSION: `admit_state_write` / `admit_state_update` /
+    //     `admit_wasm_write` (disk_usage.rs) reject new growth once the
+    //     projected total exceeds the budget. It can additionally tighten the
+    //     contract-state limit via `effective = ram.min(disk_budget)`, but
+    //     only when the disk budget is the SMALLER of the two — on a typical
+    //     node it is not (measured: 1.0 GB RAM budget against 32.0 GB disk),
+    //     so saying "filling disk tightens the state limit" would be wrong in
+    //     the ordinary case and wrong precisely when writes start failing.
     let mut axes: Vec<(&str, f64, String, &str)> = Vec::new();
     if let Some(u) = axis_utilisation(h.used_bytes, h.budget_bytes) {
         axes.push((
@@ -1325,8 +1330,12 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                 "disk",
                 u,
                 format!("{} of {}", format_bytes(used), format_bytes(disk_budget)),
-                "Disk does not trigger a sweep by itself: it clamps the contract-state \
-                 budget, so filling it tightens that limit instead.",
+                "Filling this rejects new writes — the disk admission gates refuse \
+                 state and WASM growth once the projected total would exceed the \
+                 budget. It does not by itself trigger an eviction sweep. It can \
+                 also tighten the contract-state limit, but only when the disk \
+                 budget is the smaller of the two, since that limit is \
+                 min(RAM budget, disk budget).",
             ));
         }
     }

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1270,13 +1270,18 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     // node's life, and ranking an absent denominator as full would report a
     // phantom emergency on every fresh start.
     //
-    // For the slot axis this is defensive rather than load-bearing: the
-    // resident-overhead budget is floored at MIN_RESIDENT_OVERHEAD_BUDGET_BYTES
-    // (128 MiB, i.e. 128 slots) by `resident_overhead_budget_for`, so a
-    // production node cannot reach 0 slots. Skipping it is therefore not
-    // masking a genuinely-unhostable node — that state is unreachable, and if
-    // it ever becomes reachable the honest fix is to say so explicitly rather
-    // than to let this branch quietly imply "fine".
+    // For the slot axis this is defensive rather than load-bearing, though the
+    // reason is narrower than "the budget is floored": the SETTER
+    // (`HostingCache::set_resident_overhead_budget_bytes`) does not clamp, but
+    // its only production caller
+    // (`HostingManager::recompute_resident_overhead_budget`) passes the output
+    // of `resident_overhead_budget_for`, which ends in
+    // `.max(MIN_RESIDENT_OVERHEAD_BUDGET_BYTES)` — 128 MiB, i.e. 128 slots.
+    // Every other caller is a test. So 0 slots is unreachable in production
+    // TODAY, by call-site convention rather than by construction; a future
+    // caller that set the budget directly could break that. If a node ever can
+    // reach 0 slots, the honest fix is to say so explicitly rather than let
+    // this branch quietly imply "fine".
     let axis_utilisation = |used: u64, budget: u64| -> Option<f64> {
         (budget > 0).then(|| used as f64 / budget as f64)
     };

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1252,7 +1252,13 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
     }
 
     let budget = h.budget_bytes.max(1);
-    let used_pct = (h.used_bytes as f64 / budget as f64 * 100.0).min(100.0);
+    // NOT clamped to 100%. Over budget is the eviction trigger itself, so it
+    // is a state the operator most needs to see accurately; clamping rendered
+    // "150 B / 100 B (100%)", which contradicts its own numerator and hides
+    // how far over the node is. (Found when the binding strip below started
+    // reporting the true figure and the two disagreed — the clamp here
+    // predates this change.)
+    let used_pct = h.used_bytes as f64 / budget as f64 * 100.0;
     let headroom = h.budget_bytes.saturating_sub(h.used_bytes);
 
     // Which limit is actually closest? The card shows three ceilings, and
@@ -1340,7 +1346,17 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
         .iter()
         .max_by(|a, b| a.1.total_cmp(&b.1))
         .map(|(name, util, detail, note)| {
-            let pct = (util * 100.0).min(100.0);
+            // Over budget is a REAL, reachable state, not an error: exceeding
+            // the contract-state budget is the eviction trigger itself, and
+            // the slot axis sits over its ceiling for the whole ~2.5 min
+            // sustained window before anything is shed. Clamping the
+            // percentage rendered that as "150 of 100 (100%)" — a line that
+            // contradicts itself and hides the breach magnitude at exactly the
+            // moment an operator needs it. So the percentage is unclamped and
+            // only the BAR WIDTH is capped, since a bar cannot overflow its
+            // track.
+            let pct = util * 100.0;
+            let bar_pct = pct.min(100.0);
             // Threshold on the DISPLAYED figure, not the raw one. Colouring
             // from `pct` while printing `{pct:.0}` makes the two disagree at
             // the boundary: 89.6% prints as "90%" but renders amber, and 74.6%
@@ -1358,12 +1374,12 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
                 "var(--text-muted, #888)"
             };
             format!(
-                r#"<div class="hz-binding" title="{note}"><div class="hz-binding-head">Closest limit: <strong>{name}</strong> — {detail} ({shown:.0}%)</div><div class="hz-bar" role="img" aria-label="{name} at {shown:.0} percent of its limit"><span class="hz-bar-fill" style="width: {pct:.1}%; background: {tone};"></span></div></div>"#,
+                r#"<div class="hz-binding" title="{note}"><div class="hz-binding-head">Closest limit: <strong>{name}</strong> — {detail} ({shown:.0}%)</div><div class="hz-bar" role="img" aria-label="{name} at {shown:.0} percent of its limit"><span class="hz-bar-fill" style="width: {bar_pct:.1}%; background: {tone};"></span></div></div>"#,
                 name = html_escape(name),
                 detail = html_escape(detail),
                 note = html_escape(note),
                 shown = shown_pct,
-                pct = pct,
+                bar_pct = bar_pct,
                 tone = tone,
             )
         })


### PR DESCRIPTION
## Problem

The Demand-driven eviction card renders three independent ceilings — contract state bytes, disk, and the count-derived resident-overhead axis (#5325) — as three flat rows of identical tiles. Nothing says which one is closest to binding.

Measured on a live v0.2.128 low-RAM peer, that read:

| Axis | Utilisation |
|---|---|
| Contract state bytes | 34% |
| Disk | ~1% |
| **Resident overhead** | **99.2%** (520.0 MB of 524.0 MB, 4 MB headroom) |

The axis about to trigger the next eviction sat in the third row, in the same muted grey as the two with room to spare.

**Second problem, in the same tiles.** The resident-overhead pair is `contract_count × ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` against a RAM-scaled ceiling. Rendering that as "520.0 MB / 524.0 MB" reads as measured memory. It is neither measured nor really memory — it is a contract-count ceiling wearing memory units, and it is the mechanism behind the large hosted-set drop on the 0.2.126 upgrade.

## Solution

**Name the closest limit.** Compute utilisation per axis, take the highest, and state it above a utilisation bar:

> Closest limit: **contract slots** — 520 of 524 (99%)

Coloured only above 75% (amber) and 90% (danger), so the strip is ignorable until it means something.

An axis whose budget is `0` or `None` is *skipped*, not ranked as 100% full. The disk budget is an `Option` precisely because the tracker is unseeded early in a node's life; treating an absent denominator as full would report a phantom emergency on every fresh start.

Cost pressure (#4861) is deliberately not ranked: it is a sustained-rate condition on a single offending contract, not a utilisation ratio, so it has no comparable denominator. The card's description already names it as a possible trigger.

**Render the count-derived axis as slots.** "Contract slots used — 520 / 524" and "Slots free — 4", with the tooltip carrying the RAM derivation ("currently 520.0 MB estimated against a 524.0 MB ceiling") so the reason the ceiling sits where it does is still one hover away.

The slot budget comes from `HostingCache::contract_slot_budget()`, where `ESTIMATED_RESIDENT_BYTES_PER_CONTRACT` lives, rather than the renderer dividing bytes by a constant it would have to reach across modules for. A metric describing a limit should be produced by the code that owns the limit, not re-derived at the call site — the `bug-prevention-patterns.md` row about re-derived metrics is the same shape.

## Testing

Four new tests:

- `hosting_card_names_the_closest_limit` — the binding axis is named, with its own units, and coloured when near full.
- `hosting_card_picks_the_highest_utilisation_axis` — state bytes at 90% outrank slots at 10%; the slack axis must *not* be reported.
- `hosting_card_skips_unconfigured_axes_when_picking_closest_limit` — a `0`/absent budget is not "full".
- `hosting_card_renders_slot_axis_as_counts_not_bytes` — slots render as counts, and the byte-denominated tiles must not return.

**Mutation-verified**, not assumed: flipping the axis selection from `max_by` to `min_by` (so the card reports the *emptiest* ceiling) fails exactly `hosting_card_names_the_closest_limit` and `hosting_card_picks_the_highest_utilisation_axis` — `12 passed; 2 failed` — and passes again on revert.

`cargo clippy --all-targets` clean, `cargo test -p freenet --lib server::home_page`: 133 passed, 0 failed.

## Scope

Presentation only. No eviction behaviour changes: the axes, their budgets and the sweep are untouched; this changes which of them the operator is pointed at. The one non-rendering change is `contract_slot_budget()`, a division added to the existing `stats()` call that already runs per dashboard request.

Second of six PRs implementing the local-dashboard review. Follows #5371.

[AI-assisted - Claude]
