### PR TITLE
fix(dashboard): filter and collapse the long tables, fix mobile overflow

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3101,6 +3101,55 @@ mod tests {
     // with the feature being completely broken in a browser. The behaviour is
     // covered by driving a real node with Playwright; see the PR.
 
+    /// The Playwright fixture's markup must stay in step with what the server
+    /// actually emits.
+    ///
+    /// `dashboard-table-filter.spec.ts` builds its own filter controls and
+    /// table, because BOTH cards that carry them short-circuit to an empty
+    /// variant when they have no rows — and the Playwright harness node is a
+    /// single isolated peer with neither peers nor subscribed contracts, so on
+    /// CI the real controls are never on the page. That was found the hard
+    /// way: an earlier version of the spec asserted the controls were
+    /// unconditional and failed in CI.
+    ///
+    /// A hand-built fixture is only safe while it matches reality, so this
+    /// test pins every hook the spec selects on. If you change the markup in
+    /// `table_filter_controls`, this fails and tells you to change the spec
+    /// too — which is the whole point, because the spec would otherwise keep
+    /// passing against markup the server no longer produces.
+    #[test]
+    fn filter_fixture_markup_matches_table_filter_controls() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.peers = vec![sample_peer("10.0.0.1:31337", 0.25)];
+        let html = build_peers_card(&Some(snap));
+
+        // Every selector `dashboard-table-filter.spec.ts` depends on. Keep
+        // this list and the spec's `fixtureCardHtml` in lockstep.
+        for hook in [
+            r#"class="table-filter""#,
+            r#"data-filter-for="#,
+            r#"class="tf-input""#,
+            r#"type="search""#,
+            r#"class="tf-status""#,
+            r#"class="tf-toggle""#,
+            r#"aria-expanded="false""#,
+            r#"class="table-wrap""#,
+            r#"class="sortable""#,
+            r#"data-table-id="#,
+            r#"data-sort-type="#,
+        ] {
+            assert!(
+                html.contains(hook),
+                "the Playwright fixture selects on `{hook}`, which the server \
+                 no longer emits. Update `fixtureCardHtml` in \
+                 crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts \
+                 to match, or the spec will pass against markup that does not \
+                 exist — got:\n{html}"
+            );
+        }
+    }
+
     /// Both long tables must carry filter controls wired to their own table.
     ///
     /// The peers table rendered 210 rows on a production gateway — 70% of an

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3092,6 +3092,93 @@ mod tests {
         );
     }
 
+    // ─── Long-table filter controls ────────────────────────────────
+    //
+    // SCOPE WARNING: these tests assert the emitted MARKUP only. They do not
+    // execute `dashboard.js`, have no DOM, and cannot tell you whether the
+    // filter actually filters, whether the collapse collapses, or whether
+    // either survives the 5s `<main>` swap. A green run here is compatible
+    // with the feature being completely broken in a browser. The behaviour is
+    // covered by driving a real node with Playwright; see the PR.
+
+    /// Both long tables must carry filter controls wired to their own table.
+    ///
+    /// The peers table rendered 210 rows on a production gateway — 70% of an
+    /// 11,780px page — with no way to locate a single row.
+    #[test]
+    fn long_tables_render_filter_controls_bound_to_their_table() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.peers = vec![sample_peer("10.0.0.1:31337", 0.25)];
+        let peers_html = build_peers_card(&Some(snap));
+        assert!(
+            peers_html.contains(r#"data-filter-for="peers""#),
+            "peers filter must target the peers table — got:\n{peers_html}"
+        );
+        assert!(
+            peers_html.contains(r#"data-table-id="peers""#),
+            "the targeted table id must exist on the page — got:\n{peers_html}"
+        );
+
+        let mut snap2 = base_snapshot();
+        snap2.open_connections = 2;
+        snap2.contracts = vec![crate::node::network_status::ContractSnapshot {
+            key_short: "AAA1...".to_string(),
+            key_full: "AAA123XYZ".to_string(),
+            instance_id: "AAA123XYZ".to_string(),
+            subscribed_secs: 100,
+            last_updated_secs: Some(5),
+            is_receiving_updates: true,
+            in_use: true,
+        }];
+        let contracts_html = build_contracts_card(&Some(snap2));
+        assert!(
+            contracts_html.contains(r#"data-filter-for="contracts""#),
+            "contracts filter must target the contracts table — got:\n{contracts_html}"
+        );
+    }
+
+    /// The controls must be reachable without a mouse and announce changes.
+    ///
+    /// The status line updates as you type, so it needs a live region or a
+    /// screen-reader user gets no feedback that the table changed under them.
+    #[test]
+    fn filter_controls_are_labelled_and_announced() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 1;
+        snap.peers = vec![sample_peer("10.0.0.1:31337", 0.25)];
+        let html = build_peers_card(&Some(snap));
+        assert!(
+            html.contains(r#"aria-label="Filter peers""#),
+            "the input needs an accessible name — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"aria-live="polite""#),
+            "the row-count status must be announced as it changes — got:\n{html}"
+        );
+        assert!(
+            html.contains(r#"aria-expanded="false""#),
+            "the collapse toggle must expose its state — got:\n{html}"
+        );
+    }
+
+    /// The toggle ships hidden.
+    ///
+    /// It is the JS that decides whether there is anything to collapse; a
+    /// toggle visible before that decision would flash on every refresh, and
+    /// on a small node would offer to expand a table that is already whole.
+    #[test]
+    fn filter_toggle_starts_hidden_for_the_js_to_reveal() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 1;
+        snap.peers = vec![sample_peer("10.0.0.1:31337", 0.25)];
+        let html = build_peers_card(&Some(snap));
+        assert!(
+            html.contains(r#"class="tf-toggle" hidden"#),
+            "the toggle must start hidden — got:\n{html}"
+        );
+    }
+
     // ─── Contract ban-list card (#4302) ────────────────────────────
 
     use crate::node::network_status::{BanListEntry, BanListSnapshot, BanReasonSnapshot};

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -362,8 +362,9 @@ function restoreTableFilters(focusState) {
          deterministically, once the test stopped racing it.
 
          So gate on visibility instead, which needs no engine cooperation: if
-         the box was already in the viewport, focusing it cannot scroll
-         anywhere. If it is off screen the user is reading rows rather than
+         the box was already FULLY in the viewport, focusing it cannot scroll
+         anywhere. Full containment is required — see isInViewport; a
+         half-visible box is still scrolled into view on focus. If it is off screen the user is reading rows rather than
          typing, and silently stealing focus back to an input they cannot see
          is not the behaviour to want anyway. */
       if (focusState && focusState.id === id && focusState.visible) {
@@ -384,14 +385,40 @@ function restoreTableFilters(focusState) {
   });
 }
 
-/* Is the element within the current viewport? Used to decide whether
-   restoring focus is safe — see the comment at the focus() call. */
+/* Is the element FULLY within the viewport? Used to decide whether restoring
+   focus is safe — see the comment at the focus() call.
+ *
+ * Containment, not intersection, and the difference is the whole point. The
+ * browser scrolls a focused element into view unless it is ENTIRELY visible,
+ * so a box with only its top half on screen still gets scrolled — and WebKit
+ * ignores `preventScroll`, so nothing stops it there. An intersection test
+ * (`bottom > 0 && top < h`) would call that box "visible", let the focus
+ * through, and reintroduce the jump for the partial-visibility band. It would
+ * also make the claim at the focus() call ("focusing it cannot scroll
+ * anywhere") false, which is how the bug would survive review: the comment
+ * would still read as correct.
+ *
+ * The cost of being strict is that a box straddling the viewport edge loses
+ * focus on refresh, which is the same outcome as a box fully off screen and
+ * is the safe direction to err. */
 function isInViewport(el) {
   if (!el || typeof el.getBoundingClientRect !== 'function') return false;
   var r = el.getBoundingClientRect();
   var h = window.innerHeight || document.documentElement.clientHeight;
   var w = window.innerWidth || document.documentElement.clientWidth;
-  return r.bottom > 0 && r.right > 0 && r.top < h && r.left < w;
+  /* One pixel of slack. Sub-pixel layout routinely leaves a box that is
+     visually flush with an edge reporting a fractional overflow — measured
+     `bottom: 700.4` against a 700px viewport for a box the browser itself had
+     just scrolled fully into view. An exact comparison calls that "not
+     contained", drops the focus restore, and the caret is lost for a box the
+     user can see perfectly well. The browsers round too. */
+  var slack = 1;
+  return (
+    r.top >= -slack &&
+    r.left >= -slack &&
+    r.bottom <= h + slack &&
+    r.right <= w + slack
+  );
 }
 
 /* Which filter box had focus, and where the caret was, so the refresh can put

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -151,6 +151,119 @@ function restoreSort() {
   });
 }
 
+/* ── Long-table filter + collapse ──────────────────────────────────────
+   The peers and subscribed-contracts tables are unbounded: a production
+   gateway rendered 210 peer rows, 70% of an 11,780px page, with no way to
+   find one row among them. Rather than truncate server-side (which would
+   make a filter lie about what it searched), every row is still rendered
+   and the table is COLLAPSED to a readable default here, with the filter
+   searching the full set and auto-expanding while a query is active.
+
+   State lives in sessionStorage for the same reason sort order does: the
+   5s auto-refresh replaces <main> wholesale, so an un-persisted filter
+   would be wiped mid-keystroke — worse than not having one. */
+var COLLAPSE_ROWS = 25;
+
+function filterKey(id) {
+  return 'filter:' + id;
+}
+function expandKey(id) {
+  return 'expand:' + id;
+}
+
+function applyTableView(wrap) {
+  var id = wrap.getAttribute('data-filter-for');
+  var table = document.querySelector('table[data-table-id="' + id + '"]');
+  if (!table) return;
+  var tbody = table.querySelector('tbody');
+  if (!tbody) return;
+  var input = wrap.querySelector('.tf-input');
+  var status = wrap.querySelector('.tf-status');
+  var toggle = wrap.querySelector('.tf-toggle');
+
+  var q = (input && input.value ? input.value : '').trim().toLowerCase();
+  var expanded = false;
+  try {
+    expanded = sessionStorage.getItem(expandKey(id)) === '1';
+  } catch (e) {}
+  /* A query implies "show me everything that matches", so filtering
+     overrides the collapse rather than fighting it. */
+  var showAll = expanded || q.length > 0;
+
+  var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+  var matched = 0;
+  rows.forEach(function (r) {
+    var hit = q.length === 0 || r.textContent.toLowerCase().indexOf(q) !== -1;
+    if (!hit) {
+      r.style.display = 'none';
+      return;
+    }
+    matched++;
+    r.style.display = showAll || matched <= COLLAPSE_ROWS ? '' : 'none';
+  });
+
+  var total = rows.length;
+  var shown = showAll ? matched : Math.min(matched, COLLAPSE_ROWS);
+  if (status) {
+    if (q.length > 0) {
+      status.textContent =
+        'Showing ' + shown + ' of ' + matched + ' matching (' + total + ' total)';
+    } else if (showAll) {
+      status.textContent = 'Showing all ' + total;
+    } else {
+      status.textContent = 'Showing ' + shown + ' of ' + total;
+    }
+  }
+  if (toggle) {
+    /* While a query is active the collapse is not in force, so offering to
+       toggle it would be a control that does nothing. */
+    toggle.hidden = q.length > 0 || total <= COLLAPSE_ROWS;
+    toggle.textContent = expanded ? 'Show fewer' : 'Show all ' + total;
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  }
+}
+
+function applyAllTableViews() {
+  document.querySelectorAll('.table-filter').forEach(applyTableView);
+}
+
+function restoreTableFilters() {
+  document.querySelectorAll('.table-filter').forEach(function (wrap) {
+    var id = wrap.getAttribute('data-filter-for');
+    var input = wrap.querySelector('.tf-input');
+    if (input) {
+      try {
+        input.value = sessionStorage.getItem(filterKey(id)) || '';
+      } catch (e) {}
+    }
+    applyTableView(wrap);
+  });
+}
+
+function handleFilterInput(input) {
+  var wrap = input.closest('.table-filter');
+  if (!wrap) return;
+  try {
+    sessionStorage.setItem(
+      filterKey(wrap.getAttribute('data-filter-for')),
+      input.value
+    );
+  } catch (e) {}
+  applyTableView(wrap);
+}
+
+function handleFilterToggle(btn) {
+  var wrap = btn.closest('.table-filter');
+  if (!wrap) return;
+  var id = wrap.getAttribute('data-filter-for');
+  var expanded = false;
+  try {
+    expanded = sessionStorage.getItem(expandKey(id)) === '1';
+    sessionStorage.setItem(expandKey(id), expanded ? '0' : '1');
+  } catch (e) {}
+  applyTableView(wrap);
+}
+
 /* ── Update-available check (GitHub releases, cached 12h) ── */
 function compareSemver(a, b) {
   var pa = String(a)
@@ -599,6 +712,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
   restoreTab();
   restoreSort();
+  restoreTableFilters();
   checkForUpdate();
   checkVersionMismatch();
 
@@ -634,6 +748,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
   /* Delegated click handler \u2014 survives <main> innerHTML swaps from auto-refresh,
        so we don't need to re-bind after each refresh. */
+  document.addEventListener('input', function (ev) {
+    var tf = ev.target.closest && ev.target.closest('.tf-input');
+    if (tf) handleFilterInput(tf);
+  });
+
   document.addEventListener('click', function (ev) {
     /* The open button is inside <main>, which auto-refresh re-renders, so it
        must be handled via delegation to survive innerHTML swaps. */
@@ -641,6 +760,15 @@ document.addEventListener('DOMContentLoaded', function () {
     if (importOpen) {
       ev.preventDefault();
       openImportModal();
+      return;
+    }
+    /* Same reason as the import button: the filter controls live inside
+       <main> and are destroyed by every auto-refresh, so they are handled
+       by delegation rather than re-bound. */
+    var tfToggle = ev.target.closest && ev.target.closest('.tf-toggle');
+    if (tfToggle) {
+      ev.preventDefault();
+      handleFilterToggle(tfToggle);
       return;
     }
     var copy = ev.target.closest && ev.target.closest('.copy-key');
@@ -711,9 +839,15 @@ document.addEventListener('DOMContentLoaded', function () {
         var oldIcon = document.querySelector('link[rel="icon"]');
         if (newIcon && oldIcon)
           oldIcon.setAttribute('href', newIcon.getAttribute('href'));
-        /* Restore tab selection and table sort after content swap */
+        /* Restore tab selection, table sort and table filters after the
+           content swap. The filter restore is NOT optional here: the swap
+           destroys the input element, so without this the box empties and the
+           table re-expands roughly every five seconds — which browser
+           validation caught and no Rust test could, since they never execute
+           this file. */
         restoreTab();
         restoreSort();
+        restoreTableFilters();
         /* Re-check the live runtime version so the stale-assets banner
                  appears (or clears) if the serving process changes while the
                  page stays open. The banner's data-asset-version stays anchored

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -227,10 +227,21 @@ function tfSet(key, value) {
  * The text a row is matched against. Extracted by `table_filter.test.mjs`.
  *
  * `textContent` alone is NOT enough and that was a real bug: the contracts
- * table renders a 12-character abbreviated key, while the full key lives in
- * `title` / `data-copy` / `data-sort`. Pasting a real contract key — the
- * obvious thing to do, and what the copy button next to every row puts on the
- * clipboard — matched nothing at all. Fold those attributes in. */
+ * table renders a 12-character abbreviated key, so pasting a real contract key
+ * — the obvious thing to do, and what the copy button beside every row puts on
+ * the clipboard — matched nothing at all.
+ *
+ * The extra text comes from `data-copy` ONLY, and the narrowness is
+ * deliberate. `data-copy` holds the full form of the value the cell
+ * abbreviates, so matching it can only ever surface a row for a reason the
+ * user can see. The two neighbouring attributes both look tempting and are
+ * both wrong: `data-sort` carries raw sort keys that differ from the display
+ * (`data-sort="1048576"` renders as "1.0 MB", `data-sort="{state_rank}"` as a
+ * badge), and `title` carries prose — every contract row has a copy button
+ * titled "Copy contract key", so including it would make the query "key"
+ * match every row in the table. Both would surface rows for reasons invisible
+ * on screen, which is worse than not matching at all: the user cannot tell
+ * why the row is there. */
 function rowSearchText(textContent, attrValues) {
   var parts = [textContent || ''];
   for (var i = 0; i < attrValues.length; i++) {
@@ -279,14 +290,12 @@ function applyTableView(wrap) {
   var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
   var matches = rows.map(function (r) {
     if (q.length === 0) return true;
-    /* Fold in the attributes carrying values the cell text abbreviates —
-       chiefly the full contract key behind a 12-character display form. */
+    /* Fold in the full values the cell text abbreviates. See rowSearchText
+       for why this is data-copy alone and not title or data-sort. */
     var attrs = [];
-    var withAttrs = r.querySelectorAll('[title], [data-copy], [data-sort]');
-    for (var i = 0; i < withAttrs.length; i++) {
-      attrs.push(withAttrs[i].getAttribute('title'));
-      attrs.push(withAttrs[i].getAttribute('data-copy'));
-      attrs.push(withAttrs[i].getAttribute('data-sort'));
+    var withCopy = r.querySelectorAll('[data-copy]');
+    for (var i = 0; i < withCopy.length; i++) {
+      attrs.push(withCopy[i].getAttribute('data-copy'));
     }
     return rowSearchText(r.textContent, attrs).indexOf(q) !== -1;
   });

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -343,13 +343,31 @@ function restoreTableFilters(focusState) {
     var input = wrap.querySelector('.tf-input');
     if (input) {
       input.value = tfGet(filterKey(id)) || '';
-      /* Restoring the VALUE is not enough. The refresh replaces <main>, which
-         destroys the element the caret was in, so without this the next
-         keystroke after a refresh goes nowhere and the user has to click back
-         into the box — every five seconds, while typing. Put the caret back
-         where it was. */
-      if (focusState && focusState.id === id) {
-        input.focus();
+      /* Restoring the VALUE alone is not enough: the refresh replaces <main>,
+         destroying the element the caret was in, so the next keystroke after a
+         refresh goes nowhere and the user has to click back into the box —
+         every five seconds, while typing. Put focus and the caret back too,
+         but ONLY when the box is on screen.
+
+         Restoring it unconditionally is what made the refresh yank the page:
+         focus() scrolls the element into view, the box sits at the TOP of a
+         card whose table can be thousands of pixels tall, so a user who
+         filtered and then scrolled down to read the matches was thrown back
+         every five seconds. Measured: scrollY 3000 -> 231.
+
+         Suppressing that scroll turned out not to be portable. `preventScroll`
+         is honoured by Chromium and Firefox but not WebKit, and neither a
+         synchronous scroll reassignment nor one on the next animation frame
+         beat WebKit's deferred scroll-into-view — it still landed on 1341,
+         deterministically, once the test stopped racing it.
+
+         So gate on visibility instead, which needs no engine cooperation: if
+         the box was already in the viewport, focusing it cannot scroll
+         anywhere. If it is off screen the user is reading rows rather than
+         typing, and silently stealing focus back to an input they cannot see
+         is not the behaviour to want anyway. */
+      if (focusState && focusState.id === id && focusState.visible) {
+        input.focus({ preventScroll: true });
         try {
           /* Unreachable today and kept deliberately: the control is
              `type="search"` (cards.rs), where setSelectionRange is supported
@@ -366,6 +384,16 @@ function restoreTableFilters(focusState) {
   });
 }
 
+/* Is the element within the current viewport? Used to decide whether
+   restoring focus is safe — see the comment at the focus() call. */
+function isInViewport(el) {
+  if (!el || typeof el.getBoundingClientRect !== 'function') return false;
+  var r = el.getBoundingClientRect();
+  var h = window.innerHeight || document.documentElement.clientHeight;
+  var w = window.innerWidth || document.documentElement.clientWidth;
+  return r.bottom > 0 && r.right > 0 && r.top < h && r.left < w;
+}
+
 /* Which filter box had focus, and where the caret was, so the refresh can put
    it back. Read BEFORE the <main> swap; the element does not survive it. */
 function captureFilterFocus() {
@@ -377,6 +405,13 @@ function captureFilterFocus() {
     id: wrap.getAttribute('data-filter-for'),
     start: el.selectionStart,
     end: el.selectionEnd,
+    /* Measured on the OLD element, before the swap. Measuring the fresh one
+       instead races layout: right after the innerHTML write WebKit
+       intermittently reports an off-screen rect, which suppressed the focus
+       restore on ~3 runs in 10. The old element is also the more faithful
+       question to ask — "could the user see the box they were typing in?" —
+       and the replacement occupies the same position. */
+    visible: isInViewport(el),
   };
 }
 

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -351,9 +351,14 @@ function restoreTableFilters(focusState) {
       if (focusState && focusState.id === id) {
         input.focus();
         try {
+          /* Unreachable today and kept deliberately: the control is
+             `type="search"` (cards.rs), where setSelectionRange is supported
+             in every engine. It throws on `email` and `number`, so this catch
+             is here only so that changing the input's type stays a cosmetic
+             change rather than one that breaks the refresh. */
           input.setSelectionRange(focusState.start, focusState.end);
         } catch (e) {
-          /* setSelectionRange is unsupported on some input types */
+          /* leave the caret wherever focus() put it */
         }
       }
     }

--- a/crates/core/src/server/home_page/assets/dashboard.js
+++ b/crates/core/src/server/home_page/assets/dashboard.js
@@ -136,6 +136,26 @@ function handleHeaderClick(th) {
   try {
     sessionStorage.setItem(sortKey(table), idx + ':' + dir);
   } catch (e) {}
+  /* Re-apply the collapse against the NEW order. `applySort` reorders the
+     <tr> elements but never touches `style.display`, and the collapse is a
+     POSITIONAL cut — "the first 25 rows in current order". Without this the
+     display flags stay attached to whichever elements were visible under the
+     PREVIOUS order, so sorting a collapsed table showed an arbitrary
+     leftover subset re-sorted among itself, not the top 25 of the new sort.
+     The count in the status line stayed correct, which is what made it hard
+     to notice: the right number of the wrong rows. */
+  reapplyTableViewFor(table);
+}
+
+/* Find the filter controls governing `table`, if any, and recompute which of
+   its rows are visible. */
+function reapplyTableViewFor(table) {
+  var id = table.getAttribute('data-table-id');
+  if (!id) return;
+  var wrap = document.querySelector(
+    '.table-filter[data-filter-for="' + id + '"]',
+  );
+  if (wrap) applyTableView(wrap);
 }
 
 function restoreSort() {
@@ -150,6 +170,11 @@ function restoreSort() {
     } catch (e) {}
   });
 }
+
+/* Sort restore reorders rows too, so the collapse must be recomputed after it
+   for the same reason as a live header click. `restoreTableFilters` runs
+   after `restoreSort` at both call sites, which covers this — but the
+   ordering between them is load-bearing, so do not reverse it. */
 
 /* ── Long-table filter + collapse ──────────────────────────────────────
    The peers and subscribed-contracts tables are unbounded: a production
@@ -171,6 +196,70 @@ function expandKey(id) {
   return 'expand:' + id;
 }
 
+/* sessionStorage throws in some privacy modes. The existing `sort:` handling
+   swallows that and degrades to "no saved sort", which is harmless. Here it
+   would NOT be: `applyTableView` reads the expand flag back immediately after
+   writing it, so a swallowed write made "Show all" inert — the click appeared
+   to do nothing at all. Mirror every write in memory and read that first, so
+   the controls keep working when persistence does not. */
+var tfMemory = {};
+
+function tfGet(key) {
+  if (Object.prototype.hasOwnProperty.call(tfMemory, key)) return tfMemory[key];
+  try {
+    return sessionStorage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+function tfSet(key, value) {
+  tfMemory[key] = value;
+  try {
+    sessionStorage.setItem(key, value);
+  } catch (e) {
+    /* memory copy above is the fallback */
+  }
+}
+
+/* tf-search:BEGIN
+ *
+ * The text a row is matched against. Extracted by `table_filter.test.mjs`.
+ *
+ * `textContent` alone is NOT enough and that was a real bug: the contracts
+ * table renders a 12-character abbreviated key, while the full key lives in
+ * `title` / `data-copy` / `data-sort`. Pasting a real contract key — the
+ * obvious thing to do, and what the copy button next to every row puts on the
+ * clipboard — matched nothing at all. Fold those attributes in. */
+function rowSearchText(textContent, attrValues) {
+  var parts = [textContent || ''];
+  for (var i = 0; i < attrValues.length; i++) {
+    if (attrValues[i]) parts.push(attrValues[i]);
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+/* Decide which row indices are visible. Pure so it can be tested without a
+ * DOM: `matches` is the per-row predicate result in current table order.
+ *
+ * Separated from the DOM application because the collapse is a POSITIONAL cut
+ * over the CURRENT order, which is what made the post-sort bug possible — the
+ * decision and the elements it was baked into could drift apart. */
+function visibleRowFlags(matches, showAll, cap) {
+  var out = [];
+  var shown = 0;
+  for (var i = 0; i < matches.length; i++) {
+    if (!matches[i]) {
+      out.push(false);
+      continue;
+    }
+    shown++;
+    out.push(showAll || shown <= cap);
+  }
+  return out;
+}
+/* tf-search:END */
+
 function applyTableView(wrap) {
   var id = wrap.getAttribute('data-filter-for');
   var table = document.querySelector('table[data-table-id="' + id + '"]');
@@ -182,24 +271,30 @@ function applyTableView(wrap) {
   var toggle = wrap.querySelector('.tf-toggle');
 
   var q = (input && input.value ? input.value : '').trim().toLowerCase();
-  var expanded = false;
-  try {
-    expanded = sessionStorage.getItem(expandKey(id)) === '1';
-  } catch (e) {}
+  var expanded = tfGet(expandKey(id)) === '1';
   /* A query implies "show me everything that matches", so filtering
      overrides the collapse rather than fighting it. */
   var showAll = expanded || q.length > 0;
 
   var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
-  var matched = 0;
-  rows.forEach(function (r) {
-    var hit = q.length === 0 || r.textContent.toLowerCase().indexOf(q) !== -1;
-    if (!hit) {
-      r.style.display = 'none';
-      return;
+  var matches = rows.map(function (r) {
+    if (q.length === 0) return true;
+    /* Fold in the attributes carrying values the cell text abbreviates —
+       chiefly the full contract key behind a 12-character display form. */
+    var attrs = [];
+    var withAttrs = r.querySelectorAll('[title], [data-copy], [data-sort]');
+    for (var i = 0; i < withAttrs.length; i++) {
+      attrs.push(withAttrs[i].getAttribute('title'));
+      attrs.push(withAttrs[i].getAttribute('data-copy'));
+      attrs.push(withAttrs[i].getAttribute('data-sort'));
     }
-    matched++;
-    r.style.display = showAll || matched <= COLLAPSE_ROWS ? '' : 'none';
+    return rowSearchText(r.textContent, attrs).indexOf(q) !== -1;
+  });
+  var flags = visibleRowFlags(matches, showAll, COLLAPSE_ROWS);
+  var matched = 0;
+  rows.forEach(function (r, i) {
+    if (matches[i]) matched++;
+    r.style.display = flags[i] ? '' : 'none';
   });
 
   var total = rows.length;
@@ -207,7 +302,13 @@ function applyTableView(wrap) {
   if (status) {
     if (q.length > 0) {
       status.textContent =
-        'Showing ' + shown + ' of ' + matched + ' matching (' + total + ' total)';
+        'Showing ' +
+        shown +
+        ' of ' +
+        matched +
+        ' matching (' +
+        total +
+        ' total)';
     } else if (showAll) {
       status.textContent = 'Showing all ' + total;
     } else {
@@ -227,28 +328,48 @@ function applyAllTableViews() {
   document.querySelectorAll('.table-filter').forEach(applyTableView);
 }
 
-function restoreTableFilters() {
+function restoreTableFilters(focusState) {
   document.querySelectorAll('.table-filter').forEach(function (wrap) {
     var id = wrap.getAttribute('data-filter-for');
     var input = wrap.querySelector('.tf-input');
     if (input) {
-      try {
-        input.value = sessionStorage.getItem(filterKey(id)) || '';
-      } catch (e) {}
+      input.value = tfGet(filterKey(id)) || '';
+      /* Restoring the VALUE is not enough. The refresh replaces <main>, which
+         destroys the element the caret was in, so without this the next
+         keystroke after a refresh goes nowhere and the user has to click back
+         into the box — every five seconds, while typing. Put the caret back
+         where it was. */
+      if (focusState && focusState.id === id) {
+        input.focus();
+        try {
+          input.setSelectionRange(focusState.start, focusState.end);
+        } catch (e) {
+          /* setSelectionRange is unsupported on some input types */
+        }
+      }
     }
     applyTableView(wrap);
   });
 }
 
+/* Which filter box had focus, and where the caret was, so the refresh can put
+   it back. Read BEFORE the <main> swap; the element does not survive it. */
+function captureFilterFocus() {
+  var el = document.activeElement;
+  if (!el || !el.classList || !el.classList.contains('tf-input')) return null;
+  var wrap = el.closest('.table-filter');
+  if (!wrap) return null;
+  return {
+    id: wrap.getAttribute('data-filter-for'),
+    start: el.selectionStart,
+    end: el.selectionEnd,
+  };
+}
+
 function handleFilterInput(input) {
   var wrap = input.closest('.table-filter');
   if (!wrap) return;
-  try {
-    sessionStorage.setItem(
-      filterKey(wrap.getAttribute('data-filter-for')),
-      input.value
-    );
-  } catch (e) {}
+  tfSet(filterKey(wrap.getAttribute('data-filter-for')), input.value);
   applyTableView(wrap);
 }
 
@@ -256,11 +377,8 @@ function handleFilterToggle(btn) {
   var wrap = btn.closest('.table-filter');
   if (!wrap) return;
   var id = wrap.getAttribute('data-filter-for');
-  var expanded = false;
-  try {
-    expanded = sessionStorage.getItem(expandKey(id)) === '1';
-    sessionStorage.setItem(expandKey(id), expanded ? '0' : '1');
-  } catch (e) {}
+  var expanded = tfGet(expandKey(id)) === '1';
+  tfSet(expandKey(id), expanded ? '0' : '1');
   applyTableView(wrap);
 }
 
@@ -820,6 +938,9 @@ document.addEventListener('DOMContentLoaded', function () {
         var doc = parser.parseFromString(html, 'text/html');
         var newMain = doc.querySelector('main');
         var oldMain = document.querySelector('main');
+        /* Read the caret position BEFORE the innerHTML write on the next line
+           destroys the element holding it. */
+        var focusBeforeSwap = captureFilterFocus();
         if (newMain && oldMain) oldMain.innerHTML = newMain.innerHTML;
         /* Update the tab title (connection state + count, #3509) so a
            backgrounded tab still surfaces the current status at a glance. */
@@ -847,7 +968,7 @@ document.addEventListener('DOMContentLoaded', function () {
            this file. */
         restoreTab();
         restoreSort();
-        restoreTableFilters();
+        restoreTableFilters(focusBeforeSwap);
         /* Re-check the live runtime version so the stale-assets banner
                  appears (or clears) if the serving process changes while the
                  page stays open. The banner's data-asset-version stays anchored

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -471,7 +471,13 @@ main {
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--text-muted);
-  white-space: nowrap;
+  /* Deliberately NOT `nowrap`. This string embeds three row counts, and the
+     tables it describes are unbounded — a peer hosting tens of thousands of
+     contracts renders a longer string than any fixed layout budgeted for.
+     Measured at 320px it currently fits (291px of 320px with four-digit
+     counts), so this is a latent overflow rather than a live one, but a
+     no-wrap rule on unbounded content is exactly what caused the horizontal
+     scrolling this change set out to fix. Let it wrap instead. */
 }
 .tf-toggle {
   font-family: var(--font-mono);
@@ -1272,6 +1278,16 @@ table.sortable thead th.sort-desc::after {
  * because the tablet and desktop widths are close, which is too dense for
  * labels like "CONTRACT-CAP REJECTS". Keep these AFTER the base rule; moving
  * either one is what broke this the first time. */
+/* `.g-verdict-row` is a two-track grid (`minmax(280px, 0.85fr) 2fr`) built for
+ * a verdict box beside a stat grid. Three of the hosting card's rows contain
+ * ONLY the stat grid, which then sits in track 1 and gets 0.85/2.85 of the
+ * width — measured at 280px of a 726px row, with 446px left empty beside it.
+ * At that width `auto-fit` yields two columns, so five tiles wrapped into
+ * three rows with dead space alongside. Let a sole child span both tracks. */
+.g-verdict-row > .g-norms:only-child {
+  grid-column: 1 / -1;
+}
+
 @media (max-width: 768px) {
   .g-norms {
     grid-template-columns: repeat(3, 1fr);

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -927,23 +927,14 @@ p:last-child {
   }
 
   /* Governance: stack verdict + norms vertically, let table scroll */
-  .g-verdict-row {
-    grid-template-columns: 1fr;
-  }
   .g-verdict {
     min-width: auto;
-  }
-  .g-norms {
-    grid-template-columns: repeat(3, 1fr);
   }
   .app-list li {
     padding: 0.4rem 0;
   }
 }
 @media (max-width: 400px) {
-  .g-norms {
-    grid-template-columns: repeat(2, 1fr);
-  }
   .header-title {
     font-size: 0.9rem;
   }
@@ -1266,6 +1257,30 @@ table.sortable thead th.sort-desc::after {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   gap: 0.5rem;
+}
+
+/* The narrow-viewport column counts. These already existed — at 768px and
+ * 400px, in the media blocks near the top of this file — and had NEVER once
+ * applied: the unconditional base rule above is later in source order at
+ * equal specificity, so it won at every width. That is not a side note, it is
+ * the ROOT CAUSE of the horizontal-overflow bug this change fixes. The
+ * responsive fix was written, shipped, and silently inert, and the page
+ * scrolled sideways on every phone regardless.
+ *
+ * Re-stated here, after the base rule, so they actually take effect. `auto-fit`
+ * alone cannot express the intent: at 768px it yields five ~130px columns
+ * because the tablet and desktop widths are close, which is too dense for
+ * labels like "CONTRACT-CAP REJECTS". Keep these AFTER the base rule; moving
+ * either one is what broke this the first time. */
+@media (max-width: 768px) {
+  .g-norms {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+@media (max-width: 400px) {
+  .g-norms {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 .g-norm {
   background: var(--bg-tertiary);

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -442,6 +442,51 @@ main {
   font-size: 0.8rem;
   margin-top: 0.4rem;
 }
+/* Filter + collapse strip above a long table. Laid out with flex-wrap so it
+ * collapses to two lines on a phone instead of pushing the page sideways —
+ * the failure the `.g-norms` grid above had. */
+.table-filter {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.6rem;
+}
+.tf-input {
+  flex: 1 1 12rem;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  padding: 0.35rem 0.6rem;
+}
+.tf-input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+.tf-status {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.tf-toggle {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--accent-light);
+  background: rgba(94, 234, 212, 0.1);
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  border-radius: 5px;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+.tf-toggle:hover {
+  background: rgba(94, 234, 212, 0.18);
+}
+
 .table-wrap {
   overflow-x: auto;
 }
@@ -1131,6 +1176,21 @@ table.sortable thead th.sort-desc::after {
   gap: 0.75rem;
   margin: 0.5rem 0 0.75rem;
 }
+
+/* The first column's hard 280px minimum cannot share a ~318px phone viewport
+ * with a second column: the second gets laid out past the edge and the whole
+ * PAGE scrolls sideways. Collapse to one column below the breakpoint.
+ *
+ * This override MUST sit after the rule above. An identical block placed in
+ * the earlier `max-width: 768px` section had equal specificity and lost the
+ * cascade to the later definition — it computed to `280px 87.64px` at 390px
+ * and changed nothing. Browser validation caught both the original overflow
+ * and this silently-dead fix for it. */
+@media (max-width: 768px) {
+  .g-verdict-row {
+    grid-template-columns: 1fr;
+  }
+}
 .g-verdict {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
@@ -1193,9 +1253,18 @@ table.sortable thead th.sort-desc::after {
   background: #d33682;
 }
 
+/* Stat-tile grid. Was a hard `repeat(5, 1fr)`, which had two consequences:
+ * at 390px it forced five ~73px tiles past the viewport edge and made the
+ * whole PAGE scroll sideways (the tables are innocent — they sit in
+ * `.table-wrap`, which already scrolls internally), and on wide screens a
+ * row of 3 or 4 tiles left a ragged right edge with dead space beside it.
+ *
+ * `auto-fit` with a 130px floor keeps five columns at the 800px main width
+ * (5x130 + 4 gaps = 682 <= ~745 available) while collapsing to two on a
+ * phone, so both fall out of one rule. */
 .g-norms {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   gap: 0.5rem;
 }
 .g-norm {

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -559,6 +559,7 @@ pub fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) ->
         r#"<div class="card">
             <div class="card-header"><h2>Network Peers</h2>{own_loc}</div>
             {ring_svg}
+            {filter_controls}
             <div class="table-wrap">
                 <table class="sortable" data-table-id="peers">
                     <thead><tr><th data-sort-type="text">Address</th><th data-sort-type="num">Location</th><th data-sort-type="text">Type</th><th data-sort-type="num">Sent</th><th data-sort-type="num">Recv</th><th data-sort-type="num">Connected</th></tr></thead>
@@ -568,7 +569,32 @@ pub fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) ->
         </div>"#,
         own_loc = own_loc,
         ring_svg = ring_svg,
+        filter_controls = table_filter_controls("peers", "peers"),
         rows = rows,
+    )
+}
+
+/// Filter + collapse controls for a long table.
+///
+/// The peers and subscribed-contracts tables are unbounded — a production
+/// gateway rendered 210 peer rows, 70% of an 11,780px page, with no way to
+/// locate one row. The rows are still all rendered (truncating server-side
+/// would make the filter lie about what it searched); `dashboard.js`
+/// collapses the table to a readable default and expands it while a query is
+/// active.
+///
+/// Rendered unconditionally rather than only past a threshold, so the control
+/// does not appear and disappear as a node's peer count crosses a boundary.
+/// The JS hides the toggle itself when there is nothing to collapse.
+fn table_filter_controls(table_id: &str, label: &str) -> String {
+    format!(
+        r#"<div class="table-filter" data-filter-for="{id}">
+            <input type="search" class="tf-input" placeholder="Filter {label}…" aria-label="Filter {label}" autocomplete="off" spellcheck="false">
+            <span class="tf-status" role="status" aria-live="polite"></span>
+            <button type="button" class="tf-toggle" hidden aria-expanded="false"></button>
+        </div>"#,
+        id = html_escape(table_id),
+        label = html_escape(label),
     )
 }
 
@@ -1757,6 +1783,7 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
     format!(
         r#"<div class="card">
             <h2>Subscribed Contracts</h2>
+            {filter_controls}
             <div class="table-wrap">
                 <table class="sortable" data-table-id="contracts">
                     <thead><tr><th data-sort-type="text">Contract</th><th data-sort-type="num">Freshness</th><th data-sort-type="num">Subscribed</th><th data-sort-type="num">Last Update</th></tr></thead>
@@ -1764,6 +1791,7 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
                 </table>
             </div>
         </div>"#,
+        filter_controls = table_filter_controls("contracts", "contracts"),
         rows = rows,
     )
 }

--- a/crates/core/src/server/package.json
+++ b/crates/core/src/server/package.json
@@ -11,7 +11,7 @@
     "lint:prettier": "prettier --check \"**/assets/**/*.{js,css,html}\"",
     "lint:eslint": "eslint \"**/assets/**/*.js\"",
     "format": "prettier --write \"**/assets/**/*.{js,css,html}\"",
-    "test": "node base58_encode.test.mjs && node dashboard_refresh.test.mjs && node shell_bridge_notifications.test.mjs && node shell_bridge_reload.test.mjs && node shell_bridge_permission_ws.test.mjs && node connecting_recovery.test.mjs && node notify_sw.test.mjs && node update_check.test.mjs"
+    "test": "node base58_encode.test.mjs && node dashboard_refresh.test.mjs && node shell_bridge_notifications.test.mjs && node shell_bridge_reload.test.mjs && node shell_bridge_permission_ws.test.mjs && node connecting_recovery.test.mjs && node notify_sw.test.mjs && node update_check.test.mjs && node table_filter.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",

--- a/crates/core/src/server/table_filter.test.mjs
+++ b/crates/core/src/server/table_filter.test.mjs
@@ -109,6 +109,30 @@ check(
   'guards against a false positive from naive concatenation',
 );
 
+// The caller decides WHICH attributes to pass, and the narrowness is the
+// point: only `data-copy` may be folded in, because it holds the full form of
+// what the cell displays. Pin that here so a future "search more attributes"
+// change has to argue with a test rather than slip through.
+//
+// Widening to `data-sort` or `title` surfaces rows for reasons invisible on
+// screen: `data-sort="1048576"` renders as "1.0 MB", and every contract row
+// carries a copy button titled "Copy contract key", so `title` would make the
+// query "key" match the entire table.
+const callerSrc = src.slice(src.indexOf('function applyTableView('));
+const callerBody = callerSrc.slice(0, callerSrc.indexOf('\nfunction '));
+for (const attr of ['data-sort', 'title']) {
+  check(
+    `applyTableView does not fold '${attr}' into the searchable text`,
+    callerBody.indexOf(`getAttribute('${attr}')`) === -1,
+    'it holds a value that differs from what the cell displays',
+  );
+}
+check(
+  "applyTableView does fold 'data-copy' in",
+  callerBody.indexOf("getAttribute('data-copy')") !== -1,
+  'this is what makes a full contract key findable',
+);
+
 // --- visibleRowFlags ------------------------------------------------------
 
 const all = (n) => Array.from({ length: n }, () => true);

--- a/crates/core/src/server/table_filter.test.mjs
+++ b/crates/core/src/server/table_filter.test.mjs
@@ -1,0 +1,153 @@
+// Executable test for the long-table filter/collapse decision logic in
+// `home_page/assets/dashboard.js`.
+//
+// Why this exists: the Rust tests in `home_page.rs` assert the emitted MARKUP
+// — that the controls are present, labelled, and bound to the right table.
+// They never execute a line of `dashboard.js`. Every defect this filter has
+// actually had lived in the JS and was invisible to them:
+//
+//   * the filter matched only `textContent`, so pasting a full contract key
+//     — the thing the copy button next to every row puts on your clipboard —
+//     matched nothing, because the cell renders a 12-character abbreviation
+//     and the full key lives in `title` / `data-copy` / `data-sort`;
+//   * sorting a collapsed table left the visibility flags attached to the
+//     previously-visible elements, so you saw the right NUMBER of the wrong
+//     rows.
+//
+// Both are decisions, not markup, so they are extracted here (between the
+// `tf-search:BEGIN`/`:END` markers) as pure functions and driven under Node.
+// The DOM plumbing around them still needs a browser; that is what the
+// Playwright suite covers.
+//
+// Run via `npm test` in crates/core/src/server (wired into the lint-assets CI
+// job). No dependencies beyond Node's stdlib. Exits non-zero on any mismatch.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const assetPath = join(here, 'home_page/assets/dashboard.js');
+const src = readFileSync(assetPath, 'utf8');
+
+const BEGIN = 'tf-search:BEGIN';
+const END = 'tf-search:END';
+const b = src.indexOf(BEGIN);
+const e = src.indexOf(END);
+if (b < 0 || e < 0 || e < b) {
+  console.error(
+    `FAIL: could not find ${BEGIN}/${END} markers in ${assetPath}. ` +
+      'The filter decision functions must stay bracketed by those markers ' +
+      'so this test can extract and verify them.',
+  );
+  process.exit(1);
+}
+const region = src.slice(b, e);
+for (const name of ['rowSearchText', 'visibleRowFlags']) {
+  if (region.indexOf(`function ${name}(`) < 0) {
+    console.error(`FAIL: no \`function ${name}(\` between the markers.`);
+    process.exit(1);
+  }
+}
+// Trim back to the last closing brace: the region runs up to the END marker,
+// so it would otherwise carry that comment's dangling `/*` opener.
+const body = region.slice(
+  region.indexOf('function rowSearchText('),
+  region.lastIndexOf('}') + 1,
+);
+const { rowSearchText, visibleRowFlags } = new Function(
+  `${body}\nreturn { rowSearchText, visibleRowFlags };`,
+)();
+
+let failures = 0;
+function check(name, pass, detail) {
+  if (!pass) failures++;
+  console.log(
+    `${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? ' — ' + detail : ''}`,
+  );
+}
+const eq = (name, got, want) =>
+  check(
+    name,
+    JSON.stringify(got) === JSON.stringify(want),
+    JSON.stringify(got) === JSON.stringify(want)
+      ? ''
+      : `got ${JSON.stringify(got)} want ${JSON.stringify(want)}`,
+  );
+
+// --- rowSearchText --------------------------------------------------------
+
+// The regression the attribute-folding exists for. The rendered cell shows an
+// abbreviation; the query is the full key.
+const FULL_KEY = '7WSdxLxjPvKgGZBqDpRuPMuoprnQBmXtnkHkDpTPTdcJ';
+const ABBREV = '7WSdxLxjPvKg…';
+check(
+  'a full contract key matches a row that only DISPLAYS its abbreviation',
+  rowSearchText(`${ABBREV} 4.2 kB 2`, [FULL_KEY]).indexOf(
+    FULL_KEY.toLowerCase(),
+  ) !== -1,
+  'this is the primary way an operator searches for a contract',
+);
+check(
+  'and the abbreviation still matches, so typing a prefix keeps working',
+  rowSearchText(`${ABBREV} 4.2 kB 2`, [FULL_KEY]).indexOf('7wsdxlxjpvkg') !==
+    -1,
+);
+eq(
+  'null and empty attributes are dropped rather than stringified',
+  rowSearchText('Row', [null, '', undefined, 'Kept']),
+  'row kept',
+);
+eq('missing text content is tolerated', rowSearchText(null, []), '');
+check(
+  'matching is case-insensitive on both sides',
+  rowSearchText('MiXeD', ['CaSe']).indexOf('mixed case') !== -1,
+);
+check(
+  'attributes are space-joined, so a match cannot straddle two of them',
+  rowSearchText('', ['ab', 'cd']).indexOf('abcd') === -1,
+  'guards against a false positive from naive concatenation',
+);
+
+// --- visibleRowFlags ------------------------------------------------------
+
+const all = (n) => Array.from({ length: n }, () => true);
+
+eq(
+  'a short table is shown in full',
+  visibleRowFlags(all(3), false, 25),
+  [true, true, true],
+);
+eq(
+  'a long table is cut at the cap',
+  visibleRowFlags(all(4), false, 2),
+  [true, true, false, false],
+);
+eq(
+  '"show all" defeats the cap',
+  visibleRowFlags(all(4), true, 2),
+  [true, true, true, true],
+);
+
+// The load-bearing one: the cap counts MATCHING rows, not row positions. If it
+// counted positions, filtering a long table would show a handful of matches
+// and hide the rest under a cap the user has already narrowed past.
+eq(
+  'the cap counts matches, not positions',
+  visibleRowFlags([false, false, true, false, true], false, 2),
+  [false, false, true, false, true],
+);
+eq(
+  'non-matching rows are hidden regardless of "show all"',
+  visibleRowFlags([true, false, true], true, 25),
+  [true, false, true],
+);
+eq('an empty table produces no flags', visibleRowFlags([], false, 25), []);
+eq(
+  'a zero cap hides everything unless expanded',
+  visibleRowFlags(all(2), false, 0),
+  [false, false],
+);
+
+console.log(failures === 0 ? '\nAll checks passed.' : `\n${failures} failed.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/crates/core/tests/playwright/tests/dashboard-layout.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-layout.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test";
+
+// Regression tests for the local dashboard's responsive layout
+// (`home_page/assets/style.css`).
+//
+// Why this lives in Playwright and not in Rust. These are assertions about
+// COMPUTED layout — how many columns a grid resolves to, and whether the page
+// scrolls sideways. Nothing in Rust can see either: the Rust tests assert the
+// emitted markup and never run a layout engine, so a CSS rule that is present
+// in the file but never APPLIES is indistinguishable from one that works.
+//
+// That is not hypothetical, it is the exact bug these guard. Two separate
+// fixes in this area shipped DEAD:
+//
+//   1. `.g-norms` had responsive column counts at 768px and 400px which had
+//      never once applied — the unconditional base rule sits later in the file
+//      at equal specificity, so it won at every width. The page scrolled
+//      sideways on every phone regardless, and the fix looked correct in
+//      review because the rule was right there in the source.
+//   2. the first attempt at fixing `.g-verdict-row` was placed in an earlier
+//      media block and lost the cascade the same way, computing to
+//      `280px 87.64px` at 390px and changing nothing.
+//
+// A reader cannot tell a live rule from a dead one by skimming; only the
+// computed style can. Hence these tests assert computed results, never the
+// presence of a declaration.
+
+const shellUrl = process.env.FREENET_SHELL_URL;
+const dashboardUrl = shellUrl ? new URL("/", shellUrl).toString() : undefined;
+
+test.skip(
+  !shellUrl,
+  "FREENET_SHELL_URL is not set — run via `cargo test --test playwright_shell`",
+);
+
+test.describe("dashboard responsive layout", () => {
+  test("the page does not scroll sideways on a narrow phone", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    // Tables are exempt by design: `.table-wrap` sets `overflow-x: auto`, so
+    // they scroll INSIDE their own box. What must never happen is the whole
+    // document scrolling.
+    expect(
+      scrollWidth,
+      `document scrolls horizontally: scrollWidth ${scrollWidth} > clientWidth ${clientWidth}`,
+    ).toBeLessThanOrEqual(clientWidth);
+  });
+
+  // 768px, not 320px, is where the responsive rules actually bite, and picking
+  // the wrong width would have made this test useless. `auto-fit` with a 130px
+  // minimum independently yields two columns on a 320px phone, so the
+  // breakpoints could be deleted entirely and a 320px assertion would still
+  // pass. Measured with the breakpoints removed: 320px still gives 2 columns,
+  // while 768px jumps to 5. Assert at the width that discriminates.
+  test("stat tiles do not pack five across at tablet width", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 768, height: 900 });
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const columnCounts = await page.evaluate(() =>
+      [...document.querySelectorAll(".g-norms")].map(
+        (n) => getComputedStyle(n).gridTemplateColumns.split(" ").length,
+      ),
+    );
+    expect(
+      columnCounts.length,
+      "no .g-norms grids on the page — this test has stopped covering anything",
+    ).toBeGreaterThan(0);
+    // The 768px breakpoint asks for three. Five ~130px columns is too dense
+    // for labels like "CONTRACT-CAP REJECTS", and five is exactly what the
+    // dead-cascade bug produced here.
+    for (const cols of columnCounts) {
+      expect(
+        cols,
+        `a stat grid resolved to ${cols} columns at 768px wide`,
+      ).toBeLessThanOrEqual(3);
+    }
+  });
+
+  test("a stat grid that is its row's only child spans the full row", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const grids = await page.evaluate(() =>
+      [...document.querySelectorAll(".g-verdict-row > .g-norms")].map((n) => {
+        const parent = n.parentElement!;
+        const tiles = [...n.querySelectorAll(".g-norm")];
+        return {
+          soleChild: parent.children.length === 1,
+          parentWidth: Math.round(parent.getBoundingClientRect().width),
+          width: Math.round(n.getBoundingClientRect().width),
+          tiles: tiles.length,
+          // Distinct top offsets = how many rows the tiles actually wrapped to.
+          renderedRows: new Set(
+            tiles.map((t) => Math.round(t.getBoundingClientRect().top)),
+          ).size,
+        };
+      }),
+    );
+    expect(
+      grids.length,
+      "no .g-verdict-row > .g-norms grids — this test has stopped covering anything",
+    ).toBeGreaterThan(0);
+
+    const sole = grids.filter((g) => g.soleChild);
+    expect(
+      sole.length,
+      "the hosting card renders stat grids as the only child of their row",
+    ).toBeGreaterThan(0);
+
+    for (const g of sole) {
+      // `.g-verdict-row` reserves `minmax(280px, 0.85fr) 2fr` for a verdict box
+      // beside a stat grid. Where the verdict box is absent, the grid was
+      // stranded in track 1 at 280px of a 726px row, wrapping five tiles onto
+      // three lines with 446px empty beside them.
+      expect(
+        g.parentWidth - g.width,
+        `a sole stat grid is ${g.width}px inside a ${g.parentWidth}px row`,
+      ).toBeLessThan(20);
+      expect(
+        g.renderedRows,
+        `${g.tiles} tiles wrapped onto ${g.renderedRows} rows at desktop width`,
+      ).toBe(1);
+    }
+  });
+});

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -1,0 +1,271 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Regression tests for the local dashboard's long-table filter
+// (`home_page/assets/dashboard.js`).
+//
+// Why this lives in Playwright and not in Rust. The Rust tests in
+// `home_page.rs` assert the emitted MARKUP — that the controls are present,
+// labelled, and bound to the right table. They never execute a line of
+// `dashboard.js`: no DOM, no scroll position, no focus, no auto-refresh. Every
+// defect this feature has actually shipped lived in the JS and was invisible
+// to them, and two of the three below were introduced by the FIX for the one
+// before it:
+//
+//   1. the filter box emptied on every 5s auto-refresh, because the
+//      post-refresh path restored the sort but not the filter — a filter you
+//      could not finish typing into;
+//   2. restoring focus to fix (1) reintroduced the caret but scrolled the
+//      viewport: `focus()` scrolls the element into view, and the input sits
+//      at the TOP of a card whose table can be thousands of pixels tall, so a
+//      user who filtered and then scrolled down to READ the matches was yanked
+//      back every five seconds. Measured before the fix: scrollY 3000 -> 231.
+//      Note `preventScroll` does NOT settle this on its own — WebKit's
+//      scroll-into-view is deferred and overrode both it and an explicit
+//      scroll reassignment, landing on 1341 every time. The shipped fix
+//      restores focus only when the box is already visible, so the two tests
+//      below are complementary: off screen means no refocus and no scroll, on
+//      screen means focus and caret both come back;
+//   3. the filter matched only `textContent`, so pasting a full contract key —
+//      what the copy button beside every row puts on the clipboard — matched
+//      nothing, because the cell renders a 12-character abbreviation.
+//
+// `table_filter.test.mjs` covers the pure decision functions under Node. What
+// it cannot cover, and what is asserted here, is everything that only exists
+// in a real engine: scroll position, focus, the caret, and the `<main>` swap.
+//
+// Fixture note. The filter controls are rendered unconditionally by
+// `cards.rs`, so they are present even on a freshly-started node with no
+// peers, and these tests fail loudly rather than skipping if they are missing.
+// Where a test needs rows or page height that the test node does not have, it
+// builds them in-page: the collapse and filter are entirely client-side and
+// operate on whatever is in the DOM, so a cloned row exercises exactly the
+// production path. The one thing that must NOT be built inside `<main>` is
+// page height, because the refresh replaces `<main>` and the resulting shrink
+// clamps the scroll position — see the comment on the spacer below.
+
+const shellUrl = process.env.FREENET_SHELL_URL;
+
+// The dashboard is served from the node's root, on the same origin as the
+// shell URL the harness hands us.
+const dashboardUrl = shellUrl ? new URL("/", shellUrl).toString() : undefined;
+
+// Height of the scroll spacer used by the viewport test. Far larger than the
+// ~50px tolerance below, so a regression that scrolls the filter back into
+// view is unmistakable rather than marginal.
+const SPACER_PX = 6000;
+
+// Where the viewport test parks the scroll position. Far enough down that the
+// filter input is well off-screen (so a scroll-into-view regression must move
+// the page a long way), and far enough from either end that ordinary row
+// churn cannot clamp it.
+const SCROLL_TO_PX = 3000;
+
+// The auto-refresh runs every 5s while the tab is visible. Allow generous
+// slack for a contended CI runner without letting a stalled refresh pass as a
+// success — the tests assert a refresh ACTUALLY happened before drawing any
+// conclusion from it.
+const REFRESH_TIMEOUT_MS = 25_000;
+
+test.skip(
+  !shellUrl,
+  "FREENET_SHELL_URL is not set — run via `cargo test --test playwright_shell`",
+);
+
+/** Wait for one auto-refresh, detected by the uptime text changing. */
+async function waitForRefresh(page: Page): Promise<boolean> {
+  const before = await page.locator(".uptime").textContent();
+  return page
+    .waitForFunction(
+      (prev) => {
+        const el = document.querySelector(".uptime");
+        return !!el && el.textContent !== prev;
+      },
+      before,
+      { timeout: REFRESH_TIMEOUT_MS },
+    )
+    .then(
+      () => true,
+      () => false,
+    );
+}
+
+test.describe("dashboard long-table filter", () => {
+  test("an auto-refresh does not move the viewport while the filter is focused", async ({
+    page,
+  }) => {
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const filter = page.locator('.table-filter[data-filter-for="peers"]');
+    // Fail loudly rather than skipping: the controls are unconditional, so
+    // their absence means the dashboard changed shape and this test has
+    // stopped covering anything.
+    await expect(
+      filter,
+      "the peers filter controls are rendered unconditionally by cards.rs",
+    ).toBeAttached();
+
+    // Make the page tall enough to scroll. The height must come from OUTSIDE
+    // `<main>`: the refresh replaces `<main>`'s innerHTML wholesale, so rows
+    // cloned into a table vanish on the first refresh, the page shrinks, and
+    // the browser CLAMPS scrollY. That clamping looks exactly like the bug
+    // under test — an early version of this test failed with 136px of drift
+    // for that reason alone. A body-level spacer survives the swap, so any
+    // movement observed below is the focus restore and nothing else.
+    await page.evaluate((h) => {
+      const spacer = document.createElement("div");
+      spacer.id = "scroll-spacer";
+      spacer.style.height = `${h}px`;
+      document.body.appendChild(spacer);
+    }, SPACER_PX);
+
+    // Focus the filter, then scroll well away from it — the exact posture of
+    // someone who has filtered and is now reading the matches.
+    const input = filter.locator(".tf-input");
+    /* Order matters, and getting it wrong made this test fail 1 run in 8.
+       WebKit scrolls a newly-focused element into view ASYNCHRONOUSLY, after
+       the focus() call has returned. Focusing and then immediately scrolling
+       means that deferred scroll can land AFTER the baseline is taken, which
+       reads as the refresh having moved the page when it did not.
+
+       Polling for "two consecutive equal reads" does not fix it either — the
+       poll can observe two equal reads in the window before the deferred
+       scroll fires. So: focus FIRST, give the deferred scroll time to happen,
+       and only THEN scroll to the offset under test. Nothing is left pending
+       by the time the baseline is read. */
+    await input.focus();
+    await page.waitForTimeout(400);
+    await page.evaluate((y) => window.scrollTo(0, y), SCROLL_TO_PX);
+    await page.waitForTimeout(150);
+    const scrollBefore = await page.evaluate(() => window.scrollY);
+    expect(
+      scrollBefore,
+      "the page must actually be scrolled, or this test cannot observe a jump",
+    ).toBeGreaterThan(200);
+
+    expect(
+      await waitForRefresh(page),
+      "no auto-refresh fired — the assertion below would pass vacuously",
+    ).toBe(true);
+    // Let the post-swap restore run.
+    await page.waitForTimeout(500);
+
+    const scrollAfter = await page.evaluate(() => window.scrollY);
+    // A few pixels of drift is possible if the refresh changes row heights;
+    // the bug this guards against moved the viewport by thousands.
+    expect(
+      Math.abs(scrollAfter - scrollBefore),
+      `refresh moved the viewport from ${scrollBefore} to ${scrollAfter}`,
+    ).toBeLessThan(50);
+
+    // Focus is deliberately NOT restored here, and that is the mechanism the
+    // scroll assertion above depends on: the box is off screen, so refocusing
+    // it would scroll. The complementary case — box on screen, focus and caret
+    // both restored — is the next test, so "stop restoring focus" cannot pass
+    // this file as a whole.
+    const refocused = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      return !!(el && el.classList && el.classList.contains("tf-input"));
+    });
+    expect(
+      refocused,
+      "an off-screen filter box must not steal focus back on refresh",
+    ).toBe(false);
+  });
+
+  test("the filter value and caret survive the auto-refresh", async ({
+    page,
+  }) => {
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+    const input = page.locator('.table-filter[data-filter-for="peers"] .tf-input');
+    await expect(input).toBeAttached();
+
+    await input.fill("10.9");
+    await input.focus();
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLInputElement;
+      el.setSelectionRange(2, 2);
+    });
+
+    /* Pin the precondition. Focus is restored only when the box is ON SCREEN
+       (see the sibling test), and the card can drift as the page settles —
+       tables gain rows, the ring diagram sizes itself — which pushed the box
+       out of view on ~2 runs in 12 and made this test look flaky when the
+       product was doing exactly what it should. Scroll it into view and assert
+       it is really there, so a failure below means focus was lost rather than
+       correctly declined. */
+    await input.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(150);
+    const visibleBefore = await input.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const h = window.innerHeight || document.documentElement.clientHeight;
+      return r.bottom > 0 && r.top < h;
+    });
+    expect(
+      visibleBefore,
+      "the filter box must be on screen, or declining to refocus is correct",
+    ).toBe(true);
+
+    expect(
+      await waitForRefresh(page),
+      "no auto-refresh fired — the assertions below would pass vacuously",
+    ).toBe(true);
+    await page.waitForTimeout(500);
+
+    const state = await page.evaluate(() => {
+      const el = document.activeElement as HTMLInputElement | null;
+      return {
+        focused: !!(el && el.classList && el.classList.contains("tf-input")),
+        value: el ? el.value : null,
+        caret: el ? el.selectionStart : null,
+      };
+    });
+    expect(state.focused).toBe(true);
+    expect(state.value).toBe("10.9");
+    expect(state.caret).toBe(2);
+  });
+
+  test("a full contract key matches the row that displays its abbreviation", async ({
+    page,
+  }) => {
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const filter = page.locator('.table-filter[data-filter-for="peers"]');
+    await expect(filter).toBeAttached();
+
+    // Reproduce how cards.rs renders a contract key: an abbreviation in the
+    // cell text, the full value only in data-copy on the copy button.
+    const FULL = "ZZTESTKEY1111111111111111111111111111111111";
+    await page.evaluate((full) => {
+      const tbody = document.querySelector(
+        'table[data-table-id="peers"] tbody',
+      ) as HTMLElement;
+      const proto = tbody.querySelector("tr") as HTMLElement;
+      const row = proto.cloneNode(true) as HTMLElement;
+      const cell = row.querySelector("td");
+      if (cell) {
+        cell.textContent = `${full.slice(0, 12)}…`;
+        const btn = document.createElement("button");
+        btn.className = "copy-key";
+        btn.setAttribute("data-copy", full);
+        cell.appendChild(btn);
+      }
+      tbody.appendChild(row);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).applyAllTableViews();
+    }, FULL);
+
+    await filter.locator(".tf-input").fill(FULL);
+
+    const visible = await page.evaluate(() =>
+      [
+        ...document.querySelectorAll('table[data-table-id="peers"] tbody tr'),
+      ].filter((r) => (r as HTMLElement).style.display !== "none").length,
+    );
+    // Exactly one: the planted row. More would mean the query is matching
+    // something invisible; zero is the original bug.
+    expect(
+      visible,
+      "pasting a full key must surface exactly the row that abbreviates it",
+    ).toBe(1);
+  });
+});

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -95,7 +95,20 @@ function fixtureCardHtml(rows: number): string {
     `<div class="table-wrap"><table class="sortable" data-table-id="${FIXTURE_TABLE_ID}">` +
     '<thead><tr><th data-sort-type="text">Address</th>' +
     '<th data-sort-type="num">Connected</th></tr></thead>' +
-    `<tbody>${body}</tbody></table></div></div>`
+    `<tbody>${body}</tbody></table></div>` +
+    /* A spacer with a FIXED height, inside the fixture so it is re-injected on
+       every refresh and its height never changes.
+
+       The row count cannot supply this: the collapse hides all but 25 rows, so
+       150 rows render as ~25 rows tall. On a CI node with no peers and no
+       contracts the rest of <main> is short too, so the page was barely
+       taller than the viewport — the scroll offset clamped, and any height
+       change then moved the anchor row hundreds of pixels. Locally it passed
+       only because that node has 210 peers and supplied the height by
+       accident. This makes the height a property of the fixture rather than of
+       whatever the node happens to be doing. */
+    '<div style="height:4000px" aria-hidden="true"></div>' +
+    "</div>"
   );
 }
 

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -33,14 +33,26 @@ import { test, expect, type Page } from "@playwright/test";
 // it cannot cover, and what is asserted here, is everything that only exists
 // in a real engine: scroll position, focus, the caret, and the `<main>` swap.
 //
-// Fixture note. The filter controls are rendered unconditionally by
-// `cards.rs`, so they are present even on a freshly-started node with no
-// peers, and these tests fail loudly rather than skipping if they are missing.
-// Where a test needs rows or page height that the test node does not have, it
-// builds them in-page: the collapse and filter are entirely client-side and
-// operate on whatever is in the DOM, so a cloned row exercises exactly the
-// production path. The one thing that must NOT be built inside `<main>` is
-// page height, because the refresh replaces `<main>` and the resulting shrink
+// Fixture note, and a correction. An earlier version of these tests asserted
+// that `cards.rs` renders the filter controls unconditionally, and failed
+// loudly in CI when it did not: BOTH the peers and the contracts cards
+// short-circuit to an empty variant (or to no card at all) when they have no
+// rows, and the harness node is a single isolated peer with neither. The
+// controls are therefore absent exactly where CI runs.
+//
+// So these tests build the table and its controls in-page, mirroring
+// `table_filter_controls` in `cards.rs`. That is safe against drift only
+// because the Rust side pins the same markup: see
+// `filter_fixture_markup_matches_table_filter_controls` in `home_page.rs`,
+// which fails if the emitted class names or attributes stop matching the
+// fixture below. If you change one, that test tells you to change the other.
+//
+// What is NOT synthetic is the code under test: `dashboard.js` binds through
+// delegated listeners on `document` and operates on whatever rows are in the
+// DOM, so the fixture drives exactly the production path.
+//
+// One thing must NOT be built inside `<main>`: page height. The refresh
+// replaces `<main>`, so anything added there vanishes and the resulting shrink
 // clamps the scroll position — see the comment on the spacer below.
 
 const shellUrl = process.env.FREENET_SHELL_URL;
@@ -48,17 +60,6 @@ const shellUrl = process.env.FREENET_SHELL_URL;
 // The dashboard is served from the node's root, on the same origin as the
 // shell URL the harness hands us.
 const dashboardUrl = shellUrl ? new URL("/", shellUrl).toString() : undefined;
-
-// Height of the scroll spacer used by the viewport test. Far larger than the
-// ~50px tolerance below, so a regression that scrolls the filter back into
-// view is unmistakable rather than marginal.
-const SPACER_PX = 6000;
-
-// Where the viewport test parks the scroll position. Far enough down that the
-// filter input is well off-screen (so a scroll-into-view regression must move
-// the page a long way), and far enough from either end that ordinary row
-// churn cannot clamp it.
-const SCROLL_TO_PX = 3000;
 
 // The auto-refresh runs every 5s while the tab is visible. Allow generous
 // slack for a contended CI runner without letting a stalled refresh pass as a
@@ -70,6 +71,66 @@ test.skip(
   !shellUrl,
   "FREENET_SHELL_URL is not set — run via `cargo test --test playwright_shell`",
 );
+
+/* Mirrors `table_filter_controls` + a sortable table in `cards.rs`. Pinned by
+   `filter_fixture_markup_matches_table_filter_controls` on the Rust side. */
+const FIXTURE_TABLE_ID = "fixturepeers";
+
+function fixtureCardHtml(rows: number): string {
+  let body = "";
+  for (let i = 0; i < rows; i++) {
+    body +=
+      `<tr><td data-sort="10.9.0.${i}"><code>10.9.0.${i}:31337</code></td>` +
+      `<td data-sort="${1000 - i}">${1000 - i}s</td></tr>`;
+  }
+  return (
+    '<div class="card" id="filter-fixture">' +
+    '<div class="card-header"><h2>Fixture</h2></div>' +
+    `<div class="table-filter" data-filter-for="${FIXTURE_TABLE_ID}">` +
+    '<input type="search" class="tf-input" placeholder="Filter fixture" ' +
+    'aria-label="Filter fixture" autocomplete="off" spellcheck="false">' +
+    '<span class="tf-status" role="status" aria-live="polite"></span>' +
+    '<button type="button" class="tf-toggle" hidden aria-expanded="false"></button>' +
+    "</div>" +
+    `<div class="table-wrap"><table class="sortable" data-table-id="${FIXTURE_TABLE_ID}">` +
+    '<thead><tr><th data-sort-type="text">Address</th>' +
+    '<th data-sort-type="num">Connected</th></tr></thead>' +
+    `<tbody>${body}</tbody></table></div></div>`
+  );
+}
+
+/* Inject the fixture into EVERY response for the dashboard page, so it is
+   present in the refreshed HTML exactly as server-rendered content would be.
+
+   Both simpler approaches are broken, and each hid a different thing:
+     - appending to <main> after load: the refresh replaces <main>'s innerHTML
+       and the fixture disappears on the first refresh, which is the event
+       these tests wait for;
+     - appending to <body>: it survives, but so does the INPUT ELEMENT, so
+       focus is never lost and the restore path under test never runs. That
+       version passed while asserting nothing.
+
+   Rewriting the response is what makes the fixture behave like real markup:
+   destroyed by the swap and rebuilt from the new HTML, exactly as the peers
+   table is on a node that has peers. */
+async function routeFixture(page: Page, rows: number): Promise<void> {
+  const html = fixtureCardHtml(rows);
+  await page.route(dashboardUrl!, async (route) => {
+    const response = await route.fetch();
+    const body = await response.text();
+    const marker = "</main>";
+    const i = body.lastIndexOf(marker);
+    if (i < 0) {
+      throw new Error(
+        "dashboard HTML has no </main> to inject the fixture into",
+      );
+    }
+    await route.fulfill({
+      response,
+      body: body.slice(0, i) + html + body.slice(i),
+    });
+  });
+}
 
 /** Wait for one auto-refresh, detected by the uptime text changing. */
 async function waitForRefresh(page: Page): Promise<boolean> {
@@ -93,73 +154,86 @@ test.describe("dashboard long-table filter", () => {
   test("an auto-refresh does not move the viewport while the filter is focused", async ({
     page,
   }) => {
+    await routeFixture(page, 150);
     await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
 
-    const filter = page.locator('.table-filter[data-filter-for="peers"]');
-    // Fail loudly rather than skipping: the controls are unconditional, so
-    // their absence means the dashboard changed shape and this test has
-    // stopped covering anything.
-    await expect(
-      filter,
-      "the peers filter controls are rendered unconditionally by cards.rs",
-    ).toBeAttached();
+    const filter = page.locator(
+      `.table-filter[data-filter-for="${FIXTURE_TABLE_ID}"]`,
+    );
+    await expect(filter).toBeAttached();
 
-    // Make the page tall enough to scroll. The height must come from OUTSIDE
-    // `<main>`: the refresh replaces `<main>`'s innerHTML wholesale, so rows
-    // cloned into a table vanish on the first refresh, the page shrinks, and
-    // the browser CLAMPS scrollY. That clamping looks exactly like the bug
-    // under test — an early version of this test failed with 136px of drift
-    // for that reason alone. A body-level spacer survives the swap, so any
-    // movement observed below is the focus restore and nothing else.
-    await page.evaluate((h) => {
-      const spacer = document.createElement("div");
-      spacer.id = "scroll-spacer";
-      spacer.style.height = `${h}px`;
-      document.body.appendChild(spacer);
-    }, SPACER_PX);
-
-    // Focus the filter, then scroll well away from it — the exact posture of
-    // someone who has filtered and is now reading the matches.
     const input = filter.locator(".tf-input");
     /* Order matters, and getting it wrong made this test fail 1 run in 8.
        WebKit scrolls a newly-focused element into view ASYNCHRONOUSLY, after
-       the focus() call has returned. Focusing and then immediately scrolling
-       means that deferred scroll can land AFTER the baseline is taken, which
-       reads as the refresh having moved the page when it did not.
-
-       Polling for "two consecutive equal reads" does not fix it either — the
-       poll can observe two equal reads in the window before the deferred
-       scroll fires. So: focus FIRST, give the deferred scroll time to happen,
-       and only THEN scroll to the offset under test. Nothing is left pending
-       by the time the baseline is read. */
+       focus() has returned, so focusing and then immediately scrolling lets
+       that deferred scroll land AFTER the baseline is taken — which reads as
+       the refresh having moved the page when it did not. Focus first, let the
+       deferred scroll happen, and only then scroll to the offset under test. */
     await input.focus();
     await page.waitForTimeout(400);
-    await page.evaluate((y) => window.scrollTo(0, y), SCROLL_TO_PX);
+    /* Scroll relative to the BOX, not to a fixed offset. The fixture is
+       appended after <main>, whose height varies with how much the node has to
+       report, so a hardcoded offset can land right on the filter box and leave
+       it visible — in which case focus IS restored, correctly, and the test
+       fails for the wrong reason. Put the box a full viewport above the top
+       edge so it is unambiguously off screen. */
+    await input.evaluate((el) => {
+      const y = window.scrollY + el.getBoundingClientRect().top;
+      window.scrollTo(0, y + window.innerHeight + 600);
+    });
     await page.waitForTimeout(150);
+
+    const boxOffScreen = await input.evaluate(
+      (el) => el.getBoundingClientRect().bottom < 0,
+    );
+    expect(
+      boxOffScreen,
+      "the filter box must be off screen, or declining to refocus is wrong",
+    ).toBe(true);
+
     const scrollBefore = await page.evaluate(() => window.scrollY);
     expect(
       scrollBefore,
       "the page must actually be scrolled, or this test cannot observe a jump",
     ).toBeGreaterThan(200);
 
+    /* Measure a ROW's position within the viewport, not window.scrollY.
+       Raw scrollY is the wrong instrument here: <main> changes height on every
+       refresh (uptime, counters, row counts), and browsers apply SCROLL
+       ANCHORING to compensate — adjusting scrollY precisely so that what the
+       user is looking at stays put. Asserting on scrollY therefore reports an
+       88px "jump" for a viewport that did not visually move at all. What the
+       user actually cares about, and what this test should pin, is that the
+       row under their eyes stays under their eyes. */
+    const rowTopBefore = await page.evaluate(
+      (id) =>
+        document
+          .querySelector(`table[data-table-id="${id}"] tbody tr:nth-child(100)`)!
+          .getBoundingClientRect().top,
+      FIXTURE_TABLE_ID,
+    );
+
     expect(
       await waitForRefresh(page),
       "no auto-refresh fired — the assertion below would pass vacuously",
     ).toBe(true);
-    // Let the post-swap restore run.
     await page.waitForTimeout(500);
 
-    const scrollAfter = await page.evaluate(() => window.scrollY);
-    // A few pixels of drift is possible if the refresh changes row heights;
-    // the bug this guards against moved the viewport by thousands.
+    const rowTopAfter = await page.evaluate(
+      (id) =>
+        document
+          .querySelector(`table[data-table-id="${id}"] tbody tr:nth-child(100)`)!
+          .getBoundingClientRect().top,
+      FIXTURE_TABLE_ID,
+    );
     expect(
-      Math.abs(scrollAfter - scrollBefore),
-      `refresh moved the viewport from ${scrollBefore} to ${scrollAfter}`,
+      Math.abs(rowTopAfter - rowTopBefore),
+      `the row under the reader moved from ${Math.round(rowTopBefore)} to ${Math.round(rowTopAfter)} in the viewport`,
     ).toBeLessThan(50);
 
     // Focus is deliberately NOT restored here, and that is the mechanism the
-    // scroll assertion above depends on: the box is off screen, so refocusing
-    // it would scroll. The complementary case — box on screen, focus and caret
+    // assertion above depends on: the box is off screen, so refocusing it
+    // would scroll. The complementary case — box on screen, focus and caret
     // both restored — is the next test, so "stop restoring focus" cannot pass
     // this file as a whole.
     const refocused = await page.evaluate(() => {
@@ -175,8 +249,12 @@ test.describe("dashboard long-table filter", () => {
   test("the filter value and caret survive the auto-refresh", async ({
     page,
   }) => {
+    await routeFixture(page, 40);
     await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
-    const input = page.locator('.table-filter[data-filter-for="peers"] .tf-input');
+
+    const input = page.locator(
+      `.table-filter[data-filter-for="${FIXTURE_TABLE_ID}"] .tf-input`,
+    );
     await expect(input).toBeAttached();
 
     await input.fill("10.9");
@@ -187,12 +265,9 @@ test.describe("dashboard long-table filter", () => {
     });
 
     /* Pin the precondition. Focus is restored only when the box is ON SCREEN
-       (see the sibling test), and the card can drift as the page settles —
-       tables gain rows, the ring diagram sizes itself — which pushed the box
-       out of view on ~2 runs in 12 and made this test look flaky when the
-       product was doing exactly what it should. Scroll it into view and assert
-       it is really there, so a failure below means focus was lost rather than
-       correctly declined. */
+       (see the sibling test), and the page can drift as it settles, which
+       pushed the box out of view on ~2 runs in 12 and made this look flaky
+       when the product was doing exactly the right thing. */
     await input.scrollIntoViewIfNeeded();
     await page.waitForTimeout(150);
     const visibleBefore = await input.evaluate((el) => {
@@ -227,39 +302,44 @@ test.describe("dashboard long-table filter", () => {
   test("a full contract key matches the row that displays its abbreviation", async ({
     page,
   }) => {
+    await routeFixture(page, 30);
     await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
 
-    const filter = page.locator('.table-filter[data-filter-for="peers"]');
+    const filter = page.locator(
+      `.table-filter[data-filter-for="${FIXTURE_TABLE_ID}"]`,
+    );
     await expect(filter).toBeAttached();
 
     // Reproduce how cards.rs renders a contract key: an abbreviation in the
     // cell text, the full value only in data-copy on the copy button.
     const FULL = "ZZTESTKEY1111111111111111111111111111111111";
-    await page.evaluate((full) => {
-      const tbody = document.querySelector(
-        'table[data-table-id="peers"] tbody',
-      ) as HTMLElement;
-      const proto = tbody.querySelector("tr") as HTMLElement;
-      const row = proto.cloneNode(true) as HTMLElement;
-      const cell = row.querySelector("td");
-      if (cell) {
-        cell.textContent = `${full.slice(0, 12)}…`;
-        const btn = document.createElement("button");
-        btn.className = "copy-key";
-        btn.setAttribute("data-copy", full);
-        cell.appendChild(btn);
-      }
-      tbody.appendChild(row);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).applyAllTableViews();
-    }, FULL);
+    await page.evaluate(
+      ({ id, full }) => {
+        const tbody = document.querySelector(
+          `table[data-table-id="${id}"] tbody`,
+        ) as HTMLElement;
+        const row = document.createElement("tr");
+        row.innerHTML =
+          "<td>" +
+          full.slice(0, 12) +
+          '…<button type="button" class="copy-key" data-copy="' +
+          full +
+          '"></button></td><td data-sort="1">1s</td>';
+        tbody.appendChild(row);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).applyAllTableViews();
+      },
+      { id: FIXTURE_TABLE_ID, full: FULL },
+    );
 
     await filter.locator(".tf-input").fill(FULL);
 
-    const visible = await page.evaluate(() =>
-      [
-        ...document.querySelectorAll('table[data-table-id="peers"] tbody tr'),
-      ].filter((r) => (r as HTMLElement).style.display !== "none").length,
+    const visible = await page.evaluate(
+      (id) =>
+        [
+          ...document.querySelectorAll(`table[data-table-id="${id}"] tbody tr`),
+        ].filter((r) => (r as HTMLElement).style.display !== "none").length,
+      FIXTURE_TABLE_ID,
     );
     // Exactly one: the planted row. More would mean the query is matching
     // something invisible; zero is the original bug.

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -231,6 +231,23 @@ test.describe("dashboard long-table filter", () => {
       `the row under the reader moved from ${Math.round(rowTopBefore)} to ${Math.round(rowTopAfter)} in the viewport`,
     ).toBeLessThan(50);
 
+    /* The fixture must have SURVIVED the refresh, i.e. the route intercept
+       matched the refresh's own request. `dashboard.js` refreshes with
+       `fetch(window.location.href)`, which is the URL routed above — but if
+       that ever diverges (a cache-buster query string, say), the fixture would
+       be absent from the refreshed HTML and this test would be examining an
+       empty page. Assert it explicitly rather than relying on the row lookup
+       below happening to throw. */
+    const fixtureSurvived = await page.evaluate(
+      (id) => !!document.querySelector(`table[data-table-id="${id}"] tbody tr`),
+      FIXTURE_TABLE_ID,
+    );
+    expect(
+      fixtureSurvived,
+      "the fixture vanished on refresh — the route intercept no longer matches \
+       the refresh request, so this test is examining an empty page",
+    ).toBe(true);
+
     // Focus is deliberately NOT restored here, and that is the mechanism the
     // assertion above depends on: the box is off screen, so refocusing it
     // would scroll. The complementary case — box on screen, focus and caret

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -118,18 +118,58 @@ async function routeFixture(page: Page, rows: number): Promise<void> {
   await page.route(dashboardUrl!, async (route) => {
     const response = await route.fetch();
     const body = await response.text();
-    const marker = "</main>";
-    const i = body.lastIndexOf(marker);
-    if (i < 0) {
-      throw new Error(
-        "dashboard HTML has no </main> to inject the fixture into",
-      );
+    /* Inject at the TOP of <main>, not the bottom. Everything the node
+       reports — uptime, counters, row counts — changes height between
+       refreshes, so a fixture placed after it SHIFTS by that delta and its
+       rows change viewport position without the viewport having moved at all.
+       Measured 68-121px of drift from this alone, which is indistinguishable
+       from a small real jump. Placing the fixture first removes the confound
+       instead of trying to tolerate it. */
+    /* Search AFTER <body>. The inline <script> in <head> is `dashboard.js`,
+       whose comments discuss the `<main>` swap in prose — so a naive
+       indexOf("<main") finds a COMMENT and injects the fixture into the middle
+       of the script, breaking every selector on the page with an error that
+       says only "element not found". */
+    const bodyStart = body.indexOf("<body");
+    const open = bodyStart < 0 ? -1 : body.indexOf("<main", bodyStart);
+    const openEnd = open < 0 ? -1 : body.indexOf(">", open);
+    if (openEnd < 0) {
+      throw new Error("dashboard HTML has no <main> to inject the fixture into");
     }
+    const at = openEnd + 1;
     await route.fulfill({
       response,
-      body: body.slice(0, i) + html + body.slice(i),
+      body: body.slice(0, at) + html + body.slice(at),
     });
   });
+}
+
+/* Viewport-relative top of a row that is actually RENDERED.
+ *
+ * A row hidden by the collapse reports `top: 0, height: 0`, so anchoring on
+ * one makes the movement assertion compare 0 with 0 and pass unconditionally.
+ * This picks the last visible row and asserts it has real geometry, so the
+ * test fails loudly if the collapse ever hides the anchor rather than quietly
+ * measuring nothing. */
+async function anchorRowTop(page: Page): Promise<number> {
+  const r = await page.evaluate((id) => {
+    const rows = [
+      ...document.querySelectorAll(`table[data-table-id="${id}"] tbody tr`),
+    ] as HTMLElement[];
+    const visible = rows.filter((row) => row.style.display !== "none");
+    const target = visible[visible.length - 1];
+    if (!target) return null;
+    const rect = target.getBoundingClientRect();
+    return { top: rect.top, height: rect.height, count: visible.length };
+  }, FIXTURE_TABLE_ID);
+
+  expect(r, "no visible rows to anchor the viewport assertion on").not.toBeNull();
+  expect(
+    r!.height,
+    "the anchor row has zero height — it is hidden, so measuring its position \
+     proves nothing about the viewport",
+  ).toBeGreaterThan(0);
+  return r!.top;
 }
 
 /** Wait for one auto-refresh, detected by the uptime text changing. */
@@ -197,7 +237,15 @@ test.describe("dashboard long-table filter", () => {
       "the page must actually be scrolled, or this test cannot observe a jump",
     ).toBeGreaterThan(200);
 
-    /* Measure a ROW's position within the viewport, not window.scrollY.
+    /* Measure a VISIBLE row. The collapse hides all but the first 25, and a
+       `display: none` row reports `top: 0, height: 0` — so an earlier version
+       of this test anchored on `tr:nth-child(100)` and asserted
+       `|0 - 0| < 50`, which is true no matter what the viewport did. It caught
+       the focus mutation only through the OTHER assertion below, so the
+       coverage looked real and was not. The helper asserts the anchor has
+       non-zero height, which is what stops that recurring.
+
+       Measure a ROW's position within the viewport, not window.scrollY.
        Raw scrollY is the wrong instrument here: <main> changes height on every
        refresh (uptime, counters, row counts), and browsers apply SCROLL
        ANCHORING to compensate — adjusting scrollY precisely so that what the
@@ -205,13 +253,7 @@ test.describe("dashboard long-table filter", () => {
        88px "jump" for a viewport that did not visually move at all. What the
        user actually cares about, and what this test should pin, is that the
        row under their eyes stays under their eyes. */
-    const rowTopBefore = await page.evaluate(
-      (id) =>
-        document
-          .querySelector(`table[data-table-id="${id}"] tbody tr:nth-child(100)`)!
-          .getBoundingClientRect().top,
-      FIXTURE_TABLE_ID,
-    );
+    const rowTopBefore = await anchorRowTop(page);
 
     expect(
       await waitForRefresh(page),
@@ -219,13 +261,7 @@ test.describe("dashboard long-table filter", () => {
     ).toBe(true);
     await page.waitForTimeout(500);
 
-    const rowTopAfter = await page.evaluate(
-      (id) =>
-        document
-          .querySelector(`table[data-table-id="${id}"] tbody tr:nth-child(100)`)!
-          .getBoundingClientRect().top,
-      FIXTURE_TABLE_ID,
-    );
+    const rowTopAfter = await anchorRowTop(page);
     expect(
       Math.abs(rowTopAfter - rowTopBefore),
       `the row under the reader moved from ${Math.round(rowTopBefore)} to ${Math.round(rowTopAfter)} in the viewport`,
@@ -263,6 +299,70 @@ test.describe("dashboard long-table filter", () => {
     ).toBe(false);
   });
 
+  /* The band between "fully visible" and "fully off screen".
+   *
+   * Both reviewers flagged this independently and they were right: an
+   * INTERSECTION test would call a half-visible box visible, let the focus
+   * through, and the browser would scroll it fully into view — WebKit ignores
+   * `preventScroll`, so nothing stops it. The other two tests cannot see this:
+   * one drives the box fully off screen, the other calls
+   * `scrollIntoViewIfNeeded()` and so drives it fully ON screen. Neither ever
+   * lands in the band where the two definitions disagree, which is exactly
+   * where the bug lived. */
+  test("a half-visible filter box does not pull the viewport on refresh", async ({
+    page,
+  }) => {
+    await routeFixture(page, 150);
+    await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    const input = page.locator(
+      `.table-filter[data-filter-for="${FIXTURE_TABLE_ID}"] .tf-input`,
+    );
+    await expect(input).toBeAttached();
+    await input.focus();
+    await page.waitForTimeout(400);
+
+    // Park the box straddling the TOP edge: its lower half on screen, its
+    // upper half above it.
+    await input.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      window.scrollTo(0, window.scrollY + r.top + r.height / 2);
+    });
+    await page.waitForTimeout(200);
+
+    const straddles = await input.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const h = window.innerHeight || document.documentElement.clientHeight;
+      return { top: r.top, bottom: r.bottom, h, partial: r.top < 0 && r.bottom > 0 };
+    });
+    expect(
+      straddles.partial,
+      `the box must straddle the viewport edge for this test to mean anything \
+       (top ${Math.round(straddles.top)}, bottom ${Math.round(straddles.bottom)})`,
+    ).toBe(true);
+
+    const before = await anchorRowTop(page);
+    expect(
+      await waitForRefresh(page),
+      "no auto-refresh fired — the assertion below would pass vacuously",
+    ).toBe(true);
+    await page.waitForTimeout(500);
+    const after = await anchorRowTop(page);
+
+    /* A TIGHT threshold, unlike the sibling test's 50px, and the difference is
+       the point. The movement this test guards is bounded by the hidden sliver
+       of a ~28px-tall input: measured 8px in WebKit and 14px in Chromium under
+       an intersection gate. A 50px tolerance swallows it entirely, so the
+       first version of this test passed happily against the very bug it was
+       written for. The fixture is injected at the top of <main> precisely so
+       nothing above it can drift and force a loose threshold here. */
+    expect(
+      Math.abs(after - before),
+      `a half-visible filter box pulled the viewport: the row under the reader \
+       moved from ${Math.round(before)} to ${Math.round(after)}`,
+    ).toBeLessThan(4);
+  });
+
   test("the filter value and caret survive the auto-refresh", async ({
     page,
   }) => {
@@ -287,14 +387,19 @@ test.describe("dashboard long-table filter", () => {
        when the product was doing exactly the right thing. */
     await input.scrollIntoViewIfNeeded();
     await page.waitForTimeout(150);
+    /* Assert the SAME predicate the product uses — full containment with a
+       pixel of slack, not mere intersection. Checking intersection here while
+       the product checks containment is how this test started failing for a
+       reason that had nothing to do with the behaviour under test. */
     const visibleBefore = await input.evaluate((el) => {
       const r = el.getBoundingClientRect();
       const h = window.innerHeight || document.documentElement.clientHeight;
-      return r.bottom > 0 && r.top < h;
+      const w = window.innerWidth || document.documentElement.clientWidth;
+      return r.top >= -1 && r.left >= -1 && r.bottom <= h + 1 && r.right <= w + 1;
     });
     expect(
       visibleBefore,
-      "the filter box must be on screen, or declining to refocus is correct",
+      "the filter box must be FULLY on screen, or declining to refocus is correct",
     ).toBe(true);
 
     expect(


### PR DESCRIPTION
## Problem

**The row cap was on the wrong table.** Network Peers and Subscribed Contracts are plain unbounded loops (`cards.rs`); the only capped table was the eviction card, at `MAX_ROWS = 20` of up to 2,256 hosted contracts.

Measured on live v0.2.128 peers:

| Card | Cap | Observed | Share of page |
|---|---|---|---|
| Network Peers | none | 210 rows | **70%** (8,040px of 11,780px) |
| Subscribed Contracts | none | 94 rows | 34% |
| Demand-driven eviction | `MAX_ROWS = 20` | 20 of 1,520 | 11% |

So the one table an operator would most want to explore was truncated, while the two that dominate the page had no bound and no way to find a single row among them.

**Mobile.** The page scrolled sideways at 390px — `scrollWidth` 438 vs `clientWidth` 390.

## Solution

**Filter + collapse, client-side.** All rows stay server-rendered and `dashboard.js` collapses each long table to 25, expanding while a query is active. Truncating server-side would have made the filter *lie about what it searched*.

Filter text and expand state persist in `sessionStorage`, for the same reason sort order already does: the 5s auto-refresh replaces `<main>` wholesale.

**Mobile — two grids with hard minimums, not the tables.** `.table-wrap` already sets `overflow-x: auto`, so tables scroll internally. The culprits were `.g-norms` (`repeat(5, 1fr)`, no working breakpoint) and `.g-verdict-row` (a 280px first-column minimum that cannot share a ~318px viewport).

## Testing

Rust tests pin the emitted markup. They carry an explicit scope warning: **they assert markup only** — they never execute `dashboard.js`, and a green run is compatible with the feature being completely broken.

So the behaviour is covered by **two committed Playwright specs** across chromium, firefox and webkit:

- `dashboard-table-filter.spec.ts` — scroll position, focus and caret across the `<main>` swap; full-key search.
- `dashboard-layout.spec.ts` — **computed** layout, because a CSS rule that never applies is indistinguishable from one that works.

Plus `table_filter.test.mjs` (16 checks) for the pure decision functions, run by the `lint-assets` job.

**Nine defects were found this way, and every one was invisible to the Rust suite, clippy and review.** Several were introduced by the fix for the one before it:

1. The filter did not survive the auto-refresh at all — the post-refresh path restored the sort but not the filter.
2. The `.g-norms` fix alone left 15px of overflow.
3. **The fix for that was dead code** — placed in an earlier media block, it lost the cascade to a later base rule and changed nothing.
4. Sorting a collapsed table showed the right *number* of the wrong rows.
5. Pasting a full contract key matched nothing — the cell renders a 12-char abbreviation.
6. Fixing (5) overshot: folding in `title` made the query "key" match every row, and `data-sort` matched raw values that differ from the display.
7. Restoring focus to fix (1) made the page jump on every refresh — **scrollY 3000 → 231**.
8. `preventScroll` does not fix (7) portably: WebKit's deferred scroll-into-view overrode it *and* an explicit scroll reassignment. The shipped fix restores focus only when the box is visible, which needs no engine cooperation.
9. Five stat tiles rendered as three ragged rows with 446px of dead space — **a claim in an earlier version of this description said this was fixed when it was not.** Measuring is what caught it.

Every assertion was mutation-tested, and two were rewritten when the mutation did *not* fail them — the column-count check originally asserted at 320px, where `auto-fit` gives the right answer on its own and the breakpoints could have been deleted with the test still green. 768px is the width that discriminates.

Three races in the tests themselves were fixed rather than tolerated, since each made a green run meaningless.

Final: **54/54** Playwright across three engines with repeats (webkit 30/30 on the scroll test, up from 27/30), 137 Rust tests, prettier and eslint clean.

⚠️ Note: `playwright-shell.yml` is **not a required check** (#5275), so the strongest guard here cannot block a merge. Runs were verified by hand.

## Scope

Presentation only — no node behaviour changes. Third of the local-dashboard review series; follows #5371 and #5373.

[AI-assisted - Claude]
