### PR TITLE
ci: count browser-asset tests toward the fix-PR test requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,12 +537,44 @@ jobs:
             NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
               | grep -E '^\+' | grep -vF '+++' \
               | grep -cE '^\+[[:space:]]*(check|ok|pass|expect)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
-            if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ]; then
+            # Browser-asset fixes have the SAME problem the shell escape hatch
+            # above exists for, and it bit this check the first time a
+            # dashboard fix reached it. The regression tests for
+            # `crates/core/src/server/**/assets/**` are Node `*.test.mjs` and
+            # Playwright `*.spec.ts` — they are never Rust `#[test]`s, because
+            # the code under test is JavaScript the Rust suite cannot execute.
+            # Without this a `fix:` PR carrying real, mutation-tested browser
+            # coverage scores zero and is rejected.
+            #
+            # VOCABULARY IS ENUMERATED, not guessed from the file in front of
+            # me — the comment above records that guessing is how the shell
+            # counter under-counted three times. Measured across all 17
+            # `*.test.mjs` / `*.spec.ts` in the repo at time of writing:
+            # `check` (213 call sites), `expect` (175), `test` (43), `ok` (25,
+            # update_check.test.mjs), `eq` (9, table_filter.test.mjs). Both
+            # `await expect(...)` and bare `expect(...)` occur, hence the
+            # optional `await`.
+            #
+            # RE-RUN THAT ENUMERATION when adding a test file in a new style,
+            # rather than assuming these five names are the whole vocabulary.
+            #
+            # Same known weakness as the shell counter, stated rather than
+            # implied: this counts an assertion's CALL SITE, so a decorative
+            # `test("x", () => {})` satisfies it. What stops a decorative test
+            # is review and mutation-testing, not this grep.
+            NEW_JS_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*.test.mjs' '**/*.spec.ts' \
+              | grep -E '^\+' | grep -vF '+++' \
+              | grep -cE '^\+[[:space:]]*(await[[:space:]]+)?(check|expect|test|ok|eq)[[:space:]]*\(' || true)
+            if [ "$NEW_TESTS" -eq 0 ] && [ "$NEW_SHELL_TESTS" -eq 0 ] && [ "$NEW_JS_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test
           Add a test that reproduces the bug (fails without fix, passes with fix).
           Either satisfies this:
             - a Rust #[test] / #[tokio::test] / etc.
+            - an added assertion in a Node *.test.mjs or Playwright *.spec.ts:
+              'check(...)', 'expect(...)', 'test(...)', 'ok(...)' or 'eq(...)'.
+              Browser-asset fixes have no Rust test to add — the Rust suite
+              cannot execute the JavaScript it serves.
             - an added assertion in a *_test.sh self-test, written with any of the
               conventions those files use: 'check ...', 'ok ...', 'pass ...',
               'expect ...', a 'check_'/'pin_'/'assert_'/'expect_'/'test_'-prefixed helper, a


### PR DESCRIPTION
## Problem

A `fix:` PR must add at least one regression test. The counter in `ci.yml` recognises Rust `#[test]` attributes, plus a shell escape hatch that exists because *fixes to shell tooling have no Rust test to add*.

**Browser-asset fixes have exactly the same problem, and it just bit a real PR.** #5384 was rejected for having no tests while carrying **28 assertions** across a Node `*.test.mjs` and two Playwright `*.spec.ts` files.

Tests for `crates/core/src/server/**/assets/**` are never Rust `#[test]`s, because the code under test is JavaScript the Rust suite cannot execute — the Rust tests there assert *emitted markup* and never run a line of it. That gap is precisely why the browser tests were written in the first place.

So a real, mutation-tested regression test scored zero. That's the counter being wrong, not the PR.

## Solution

A third counter, scoped to `*.test.mjs` and `*.spec.ts`, alongside the existing Rust and shell ones.

**The vocabulary is enumerated, not guessed.** The comment beside the shell counter records that guessing from the file in front of you is how *that* one under-counted three separate times — so this was measured across all 17 browser-asset test files in the repo:

| Name | Call sites |
|---|---|
| `check` | 213 |
| `expect` | 175 |
| `test` | 43 |
| `ok` | 25 |
| `eq` | 9 |

Both `await expect(...)` and bare `expect(...)` occur, hence the optional `await`.

## Known weakness, stated rather than implied

The same one the shell counter has: this counts a call **site**, so a decorative `test("x", () => {})` satisfies it. What stops a decorative test is review and mutation-testing, not a grep. The comment says so where the next editor will read it.

## Testing

Verified against the PR that exposed the gap (#5384): **0** Rust tests, **28** recognised browser assertions — the rejection becomes a pass, and only because real tests are present.

Both existing linter self-tests (`check_banned_patterns.py`, `check_blocking_sends.py`) still pass; this change is to the inline grep, not to either script.

[AI-assisted - Claude]