### PR TITLE
feat(dashboard): add a per-contract detail page (/contract/{key})

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -1627,14 +1627,26 @@ pub struct PeerSnapshot {
 pub struct ContractSnapshot {
     pub key_short: String,
     pub key_full: String,
-    /// `ContractKey.id().to_string()` — the 32-byte content hash
-    /// portion of the key. Distinct from `key_full` which carries
-    /// the full ContractKey encoding (instance id + parameters /
-    /// code-hash bookkeeping). Surfaced so the dashboard can
-    /// cross-reference this contract against
-    /// `GovernanceSnapshot.state_by_id`, which is keyed by
-    /// `ContractInstanceId::to_string()`. Codex review of
-    /// dashboard-polish PR caught the id/key string mismatch.
+    /// `ContractKey.id().to_string()` — the 32-byte instance id.
+    ///
+    /// Surfaced so the dashboard can cross-reference this contract against
+    /// `GovernanceSnapshot`, which is keyed by
+    /// `ContractInstanceId::to_string()`.
+    ///
+    /// NOT distinct from `key_full`, despite what this comment claimed until
+    /// 2026-08-21. `impl Display for ContractKey` delegates to
+    /// `self.instance` and `ContractKey::id()` returns `&self.instance`, so
+    /// `key.to_string()` and `key.id().to_string()` produce the SAME string
+    /// and the code-hash half reaches neither. The old wording ("Distinct
+    /// from `key_full` which carries the full ContractKey encoding") sent
+    /// three separate readers of the contract detail page down the same wrong
+    /// path — twice as a reported blocking bug, once as a fix for a case that
+    /// cannot occur.
+    ///
+    /// The field still earns its place: it states the intent explicitly, and
+    /// it keeps working if the Display impl ever changes. That equality is
+    /// pinned by `contract_key_display_equals_its_instance_id` in
+    /// `server/home_page.rs`, which fails if it stops holding.
     pub instance_id: String,
     pub subscribed_secs: u64,
     pub last_updated_secs: Option<u64>,

--- a/crates/core/src/server/.prettierignore
+++ b/crates/core/src/server/.prettierignore
@@ -8,5 +8,7 @@ node_modules/
 **/assets/home.html
 **/assets/peer.html
 **/assets/peer_not_found.html
+**/assets/contract.html
+**/assets/contract_not_found.html
 **/assets/permission_prompt.html
 **/assets/hosted_import_page.html

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -285,6 +285,10 @@ impl HttpClientApi {
                 "/peer/{address}",
                 axum::routing::get(home_page::peer_detail),
             )
+            .route(
+                "/contract/{key}",
+                axum::routing::get(home_page::contract_detail),
+            )
             // Notification service worker, served at the origin root so its
             // default scope (`/`) covers every contract shell page. The shell
             // registers it to show notifications via showNotification() — the

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3302,6 +3302,80 @@ mod tests {
         );
     }
 
+    /// The abbreviating branch, which nothing else reaches.
+    ///
+    /// `abbreviate()` only runs when a contract has neither a subscription nor
+    /// a hosting record but DOES have a governance one — an Evicted, Banned or
+    /// WouldEvict contract this node no longer holds. That is a real and
+    /// expected state, and every other test supplies a short `key_short` from
+    /// a subscription or hosting entry instead, so the truncation arithmetic
+    /// was never executed.
+    ///
+    /// The multi-byte case is the reason the function uses `.chars()` rather
+    /// than byte slicing: a `&key[..12]` regression would panic on a
+    /// non-ASCII boundary rather than fail politely. Contract keys are base58
+    /// today, so this is defensive — which is exactly why it needs a test
+    /// rather than a reader's confidence.
+    #[test]
+    fn contract_detail_abbreviates_a_long_governance_only_key() {
+        use crate::node::network_status::{ContractGovernanceEntry, GovernanceStateSnapshot};
+
+        let gov_only = |key: &str| {
+            let mut snap = base_snapshot();
+            snap.open_connections = 2;
+            snap.governance.contracts = vec![ContractGovernanceEntry {
+                instance_id: key.to_string(),
+                instance_id_short: key.to_string(),
+                state: GovernanceStateSnapshot::Banned,
+                cost_used: 9.0,
+                benefit_score: 0.1,
+                log_ratio: Some(-2.0),
+                age_secs: 120,
+                last_transition_secs_ago: 30,
+                history: Vec::new(),
+            }];
+            contract_detail_html_from(&Some(snap), key)
+        };
+
+        // 44 base58 characters, the real shape of a contract key.
+        let long = "7WSdxLxjPvKgGZBqDpRuPMuoprnQBmXtnkHkDpTPTdcJ";
+        let html = gov_only(long);
+        assert!(
+            html.contains("7WSdxLxjPvKg…"),
+            "a governance-only contract has no short form to borrow, so the \
+             page must abbreviate the key itself — got:\n{html}"
+        );
+        assert!(
+            html.contains(long),
+            "and must still show the full key, which is what the copy button \
+             and the filter search on — got:\n{html}"
+        );
+
+        // Exactly at the boundary: 12 chars must NOT be truncated.
+        let twelve = "123456789012";
+        let at_boundary = gov_only(twelve);
+        assert!(
+            !at_boundary.contains("123456789012…"),
+            "a key exactly at the cap is not longer than the cap, so it must \
+             not gain an ellipsis — got:\n{at_boundary}"
+        );
+
+        // Multi-byte, to pin that truncation counts CHARACTERS not bytes. A
+        // byte-slicing regression panics here rather than returning something
+        // wrong, which is the failure mode worth catching early.
+        let wide = "ααααααααααααααα";
+        let multibyte = gov_only(wide);
+        let expected: String = "α".repeat(12);
+        assert!(
+            multibyte.contains(&format!("{expected}…")),
+            "a multi-byte key must abbreviate to 12 CHARACTERS, not 12 bytes. \
+             The first version of this assertion was `contains(\"…\")` behind \
+             an `||`, which is true either way — byte slicing yields 6 of \
+             these 2-byte chars and sailed through it. Counting the characters \
+             is what distinguishes the two — got:\n{multibyte}"
+        );
+    }
+
     /// A hosted-only contract CAN be cross-referenced against governance,
     /// and this pins the non-obvious reason why.
     ///

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3176,6 +3176,47 @@ mod tests {
         );
     }
 
+    /// `ContractKey::to_string()` and `ContractKey::id().to_string()` produce
+    /// the SAME string, and this pins it against a real key rather than a
+    /// fixture that assumes it.
+    ///
+    /// This exists because the opposite belief is written down in this
+    /// codebase and has now misled three separate readers. The rustdoc on
+    /// `ContractSnapshot::instance_id` says it is "Distinct from `key_full`
+    /// which carries the full ContractKey encoding (instance id + parameters /
+    /// code-hash bookkeeping)". That is wrong: `impl Display for ContractKey`
+    /// delegates to `self.instance`, and `id()` returns `&self.instance`, so
+    /// the code-hash half never reaches either string.
+    ///
+    /// The consequences of believing otherwise are concrete. Two reviews of
+    /// the contract detail page independently reported a blocking bug — that a
+    /// hosted-only contract cannot be joined to governance, because
+    /// `HostedContractEntry` carries no `instance_id` field — and I acted on it
+    /// once, adding a "cannot be cross-referenced" branch for a case that does
+    /// not exist. The join works precisely because these two strings are the
+    /// same.
+    ///
+    /// If a future stdlib gives `ContractKey` a Display that includes the code
+    /// hash, this fails, and the detail page's governance lookup genuinely
+    /// does need the separate id.
+    #[test]
+    fn contract_key_display_equals_its_instance_id() {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([9u8; 32]),
+        );
+        assert_eq!(
+            key.to_string(),
+            key.id().to_string(),
+            "the dashboard joins hosting/subscription records (keyed by \
+             key.to_string()) against governance records (keyed by \
+             key.id().to_string()); if these ever diverge the contract detail \
+             page silently stops finding governance data"
+        );
+    }
+
     /// A hosted-only contract CAN be cross-referenced against governance,
     /// and this pins the non-obvious reason why.
     ///

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3217,6 +3217,91 @@ mod tests {
         );
     }
 
+    /// The subscribed path — the one the page exists for — rendered end to
+    /// end.
+    ///
+    /// Every other test here drives `subscribed == None` (no snapshot, an
+    /// unknown key, or a hosted-only contract), so the Subscription card's
+    /// actual logic was unexercised: the freshness pill, the in-use flag, the
+    /// never-vs-ago branch on `last_updated_secs`, and the Identity card's
+    /// instance-id row, which only renders when a subscription supplies one.
+    /// Review caught that the primary lookup path had no coverage while four
+    /// secondary paths did.
+    #[test]
+    fn contract_detail_renders_the_subscribed_path() {
+        use crate::node::network_status::ContractSnapshot;
+
+        // Slice to the Subscription card before asserting. The page embeds the
+        // whole stylesheet inline, so `html.contains("fresh-ok")` is true of
+        // every render — the CSS defines `.fresh-ok` whether or not the pill
+        // is emitted. The first version of this test asserted against the full
+        // document and passed vacuously on the positive case; only the
+        // negative case ("stale must NOT contain fresh-ok") exposed it.
+        fn subscription_panel(html: &str) -> String {
+            let start = html
+                .find("<h2>Subscription</h2>")
+                .expect("the Subscription card must be rendered");
+            let end = html[start..]
+                .find("<h2>Hosting</h2>")
+                .map(|i| start + i)
+                .unwrap_or(html.len());
+            html[start..end].to_string()
+        }
+
+        let base = |is_fresh: bool, in_use: bool, last: Option<u64>| {
+            let mut snap = base_snapshot();
+            snap.open_connections = 3;
+            snap.contracts = vec![ContractSnapshot {
+                key_short: "SUBB...".to_string(),
+                key_full: "SUBBED1".to_string(),
+                instance_id: "SUBBED1".to_string(),
+                subscribed_secs: 3600,
+                last_updated_secs: last,
+                is_receiving_updates: is_fresh,
+                in_use,
+            }];
+            contract_detail_html_from(&Some(snap), "SUBBED1")
+        };
+
+        // Fresh, in use, updated recently.
+        let fresh_html = base(true, true, Some(30));
+        let fresh = subscription_panel(&fresh_html);
+        assert!(
+            fresh.contains("fresh-ok") && fresh.contains("receiving updates"),
+            "a contract in the update mesh must show the fresh pill — \
+             got:\n{fresh}"
+        );
+        assert!(
+            fresh.contains("30s ago"),
+            "a known last-update time must be rendered as an age — got:\n{fresh}"
+        );
+        assert!(
+            fresh_html.contains("Instance id"),
+            "the instance-id row renders only when a subscription supplies \
+             one, and this is that case — got:\n{fresh}"
+        );
+
+        // Not receiving updates, not pinned by demand, never updated.
+        let stale_html = base(false, false, None);
+        let stale = subscription_panel(&stale_html);
+        assert!(
+            stale.contains("fresh-stale") && stale.contains("not receiving updates"),
+            "a contract outside the update mesh must NOT show as fresh — \
+             serving a stale copy is the failure invariant 1 forbids, so the \
+             page must not imply freshness it does not have. got:\n{stale}"
+        );
+        assert!(
+            stale.contains("never"),
+            "an absent last-update must read as 'never', not as an age of \
+             zero — got:\n{stale}"
+        );
+        // The two states must be distinguishable, or the pill is decoration.
+        assert!(
+            fresh.contains("fresh-ok") && !stale.contains("fresh-ok"),
+            "the freshness pill must differ between the two states"
+        );
+    }
+
     /// A hosted-only contract CAN be cross-referenced against governance,
     /// and this pins the non-obvious reason why.
     ///

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3176,6 +3176,120 @@ mod tests {
         );
     }
 
+    /// A hosted-only contract CAN be cross-referenced against governance,
+    /// and this pins the non-obvious reason why.
+    ///
+    /// `HostedContractEntry` carries no `instance_id` field, and governance is
+    /// keyed by `ContractInstanceId`, so the join looks impossible. It is not:
+    /// `impl Display for ContractKey` delegates to `self.instance` and
+    /// `ContractKey::id()` returns `&self.instance`, so `key.to_string()` and
+    /// `key.id().to_string()` are THE SAME STRING. The requested key is always
+    /// a valid governance lookup value.
+    ///
+    /// This needs a test because the rustdoc on `ContractSnapshot::instance_id`
+    /// asserts the opposite — "Distinct from `key_full` which carries the full
+    /// ContractKey encoding" — which is wrong, and reading it caused a wrong
+    /// turn on this page: a "cannot be cross-referenced" branch was added for
+    /// a case that does not exist. If the stdlib ever makes the two encodings
+    /// genuinely differ, this fails and says where to look.
+    #[test]
+    fn hosted_only_contract_still_joins_to_governance() {
+        use crate::node::network_status::{ContractGovernanceEntry, GovernanceStateSnapshot};
+
+        let key = "HOSTEDONLYKEY";
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        // Hosted, with NO subscription entry to supply an instance id.
+        snap.hosting.contracts = vec![crate::node::network_status::HostedContractEntry {
+            key_full: key.to_string(),
+            key_short: key.to_string(),
+            size_bytes: 1024,
+            read_count: 0,
+            recency_seq: 0,
+            eviction_eligible: true,
+        }];
+        // Governance knows it under the same string, because that string IS
+        // the instance id.
+        snap.governance.contracts = vec![ContractGovernanceEntry {
+            instance_id: key.to_string(),
+            instance_id_short: key.to_string(),
+            state: GovernanceStateSnapshot::Borderline,
+            cost_used: 3.0,
+            benefit_score: 1.0,
+            log_ratio: Some(-0.4),
+            age_secs: 600,
+            last_transition_secs_ago: 60,
+            history: Vec::new(),
+        }];
+
+        let html = contract_detail_html_from(&Some(snap), key);
+        assert!(
+            html.contains("Borderline"),
+            "a hosted-only contract must still show its governance state — \
+             the requested key is a valid instance id. got:\n{html}"
+        );
+        assert!(
+            !html.contains("Not flagged by the governance manager"),
+            "and must not report it as unflagged when a record was found — \
+             got:\n{html}"
+        );
+    }
+
+    /// Governance history must show the NEWEST transitions.
+    ///
+    /// `GovernanceSnapshot::history` is documented as "newest last", so a
+    /// plain `.take(10)` renders the ten OLDEST and hides everything recent —
+    /// exactly inverted from what someone opening the page wants. The bug is
+    /// invisible until a contract accumulates more than ten transitions, which
+    /// is why it needs a test rather than a look.
+    #[test]
+    fn contract_detail_shows_the_newest_governance_transitions() {
+        use crate::node::network_status::{
+            ContractGovernanceEntry, GovernanceStateSnapshot, GovernanceTransitionEntry,
+            GovernanceTransitionReasonSnapshot,
+        };
+
+        // 14 transitions, oldest first, distinguishable by their age.
+        let history: Vec<GovernanceTransitionEntry> = (0..14)
+            .map(|i| GovernanceTransitionEntry {
+                secs_ago: (14 - i) * 60,
+                from: GovernanceStateSnapshot::Normal,
+                to: GovernanceStateSnapshot::Borderline,
+                reason: GovernanceTransitionReasonSnapshot::ThresholdCrossed,
+            })
+            .collect();
+        let oldest_secs = history[0].secs_ago;
+        let newest_secs = history[13].secs_ago;
+
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.governance.contracts = vec![ContractGovernanceEntry {
+            instance_id: "GOVKEY1".to_string(),
+            instance_id_short: "GOVKEY1".to_string(),
+            state: GovernanceStateSnapshot::Borderline,
+            cost_used: 1.0,
+            benefit_score: 2.0,
+            log_ratio: Some(0.5),
+            age_secs: 900,
+            last_transition_secs_ago: newest_secs,
+            history,
+        }];
+
+        let html = contract_detail_html_from(&Some(snap), "GOVKEY1");
+        let newest = format_duration(newest_secs);
+        let oldest = format_duration(oldest_secs);
+        assert!(
+            html.contains(&format!("{newest} ago")),
+            "the most recent transition ({newest} ago) must be shown — \
+             got:\n{html}"
+        );
+        assert!(
+            !html.contains(&format!("{oldest} ago")),
+            "the oldest transition ({oldest} ago) must have been dropped by \
+             the cap, not the newest — got:\n{html}"
+        );
+    }
+
     /// The hosting panel must NOT imply it is showing the eviction ranking.
     ///
     /// Invariant 3 ranks by local subscriptions, then downstream subscribers,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -5,6 +5,7 @@
 
 mod assets;
 mod cards;
+mod contract_detail;
 mod estimator;
 mod favicon;
 mod peer_detail;
@@ -22,6 +23,7 @@ use cards::{
     build_ban_list_card, build_contracts_card, build_governance_card, build_hosting_card,
     build_ops_card, build_peers_card, build_status_card, build_transfer_card,
 };
+use contract_detail::contract_detail_html;
 use favicon::{build_dashboard_title, build_favicon_data_uri};
 use peer_detail::peer_detail_html;
 
@@ -101,6 +103,13 @@ pub(super) async fn homepage() -> impl IntoResponse {
 /// Handler for `GET /peer/{address}` — returns a detail page for a single peer.
 pub(super) async fn peer_detail(Path(address): Path<String>) -> impl IntoResponse {
     Html(peer_detail_html(&address))
+}
+
+/// Per-contract detail page (#5369). Accepts either the full `ContractKey`
+/// encoding or the `ContractInstanceId`, because the dashboard's own cards key
+/// on different ones and an operator pasting either should land somewhere.
+pub(super) async fn contract_detail(Path(key): Path<String>) -> impl IntoResponse {
+    Html(contract_detail_html(&key))
 }
 
 fn homepage_html() -> String {
@@ -193,6 +202,7 @@ mod tests {
         build_peers_card, build_ring_svg, build_status_card, build_transfer_card, format_bytes,
         format_last_evaluated,
     };
+    use super::contract_detail::contract_detail_html_from;
     use super::estimator::{
         RegKind, build_estimator_chart, build_estimator_chart_or_placeholder,
         build_regression_chart, build_reliability_chart, build_renegade_accuracy_panel,
@@ -1939,8 +1949,18 @@ mod tests {
         // must NOT be lost when we add the button — that tooltip is
         // still useful for hover-only users (e.g. read-only screenshots).
         // Likewise, <code>{short}</code> must stay outside the button so
-        // the abbreviated key keeps its monospace styling without a
-        // hover state on the contract text itself.
+        // the abbreviated key keeps its monospace styling.
+        //
+        // Amended for #5369: the <code> is now wrapped in an <a> to the
+        // per-contract detail page, so it no longer DIRECTLY precedes the
+        // button. That is a deliberate reversal of one clause of the
+        // original intent, which asked for no hover state on the contract
+        // text — written when there was nowhere for the key to link TO.
+        // Now there is, and a link on the key is how the page is reached.
+        // What still holds, and is what these assertions protect, is that
+        // <code> stays OUTSIDE the copy button: nesting it would make the
+        // key text a click target for "copy" rather than for "open", and
+        // would put the monospace styling inside a button's hover state.
         use crate::node::network_status::ContractSnapshot;
         let mut snap = base_snapshot();
         snap.open_connections = 1;
@@ -1962,15 +1982,23 @@ mod tests {
             html.contains("<code>DEAD...</code>"),
             "the abbreviated key must stay as a plain <code> sibling of the button, got: {html}"
         );
-        // Lock in the simplified markup: the <code> element is a sibling
-        // of the button, NOT wrapped inside it.
+        // Lock in the markup: the <code> element is a sibling of the
+        // button, NOT wrapped inside it.
         assert!(
             !html.contains("class=\"copy-key\" data-copy=\"DEADBEEF\" title=\"Copy contract key\" aria-label=\"Copy contract key\">⧉</button><code>"),
             "<code> must come BEFORE the copy button"
         );
         assert!(
-            html.contains("</code><button type=\"button\" class=\"copy-key\""),
-            "<code> must directly precede the <button> sibling, got: {html}"
+            html.contains("</code></a><button type=\"button\" class=\"copy-key\""),
+            "<code> must sit inside the detail link and directly precede the \
+             copy button, got: {html}"
+        );
+        // The link must target the detail page with the FULL key, not the
+        // abbreviation — the abbreviation is ambiguous and the page looks up
+        // by full key or instance id.
+        assert!(
+            html.contains("href=\"/contract/DEADBEEF\""),
+            "the key must link to its detail page by full key, got: {html}"
         );
     }
 
@@ -3100,6 +3128,86 @@ mod tests {
     // either survives the 5s `<main>` swap. A green run here is compatible
     // with the feature being completely broken in a browser. The behaviour is
     // covered by driving a real node with Playwright; see the PR.
+
+    // ─── Contract detail page (#5369) ───────────────────────────────────
+
+    /// A key that reaches this page came straight out of a URL path, so it is
+    /// attacker-controlled text rendered into HTML.
+    ///
+    /// The not-found branch is the dangerous one: it echoes the key back
+    /// verbatim to say what was not found, and it is reachable by ANYONE who
+    /// can load the page with any path at all — no node state required. An
+    /// unescaped echo there is a reflected-XSS hole on the operator's own
+    /// dashboard, which is the origin that also serves every locally-hosted
+    /// app.
+    #[test]
+    fn contract_detail_escapes_a_key_from_the_url() {
+        let payload = "<script>alert(1)</script>";
+        let html = contract_detail_html_from(&None, payload);
+        assert!(
+            !html.contains("<script>alert(1)"),
+            "an unescaped key from the URL is reflected XSS — got:\n{html}"
+        );
+        assert!(
+            html.contains("&lt;script&gt;alert(1)"),
+            "the key should still be shown, escaped, so the operator can see \
+             what was not found — got:\n{html}"
+        );
+    }
+
+    /// Absence on this node is not absence from the network, and the page must
+    /// not imply otherwise.
+    ///
+    /// A node holds what demand routed to it; it has no directory and cannot
+    /// know whether a contract exists elsewhere. "Not found" phrased as a
+    /// global fact would be the same class of falsehood as the eviction card
+    /// describing a ranking the code does not implement.
+    #[test]
+    fn contract_not_found_is_scoped_to_this_node() {
+        let html = contract_detail_html_from(&None, "NOSUCHCONTRACTKEY");
+        assert!(
+            html.contains("Contract Not Found"),
+            "expected the not-found page — got:\n{html}"
+        );
+        assert!(
+            html.contains("THIS node"),
+            "the page must scope its claim to this node rather than implying \
+             the contract is absent from the network — got:\n{html}"
+        );
+    }
+
+    /// The hosting panel must NOT imply it is showing the eviction ranking.
+    ///
+    /// Invariant 3 ranks by local subscriptions, then downstream subscribers,
+    /// then recency. Only recency is in the snapshot; the two counts that
+    /// OUTRANK it are computed during the sweep and are unavailable here. A
+    /// panel that showed recency alone, unqualified, would read as "this is
+    /// why the contract is kept" — which is exactly the falsehood PR #5371
+    /// removed from the eviction card, reintroduced on a new page.
+    #[test]
+    fn contract_detail_says_the_eviction_ranking_is_not_shown() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.hosting.contracts = vec![crate::node::network_status::HostedContractEntry {
+            key_full: "TESTKEY1".to_string(),
+            key_short: "TESTKEY1".to_string(),
+            size_bytes: 4096,
+            read_count: 3,
+            recency_seq: 42,
+            eviction_eligible: true,
+        }];
+        let html = contract_detail_html_from(&Some(snap), "TESTKEY1");
+        assert!(
+            html.contains("not shown"),
+            "the hosting panel must say the ranking keys are missing — \
+             got:\n{html}"
+        );
+        assert!(
+            html.contains("5372"),
+            "and point at the issue tracking them, so the gap is followable \
+             rather than a dead end — got:\n{html}"
+        );
+    }
 
     /// The Playwright fixture's markup must stay in step with what the server
     /// actually emits.

--- a/crates/core/src/server/home_page/assets/contract.html
+++ b/crates/core/src/server/home_page/assets/contract.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contract {key_short} — Freenet</title>
+    <style>{CSS}{PEER_CSS}</style>
+    <script>{JS}</script>
+</head>
+<body>
+    <header>
+        <div class="header-left">
+            <a href="/" class="logo-link"><img src="https://freenet.org/freenet_logo.svg" alt="Freenet" class="logo"></a>
+            <a href="/" class="header-title">FREENET</a>
+            <span class="header-sep">/</span>
+            <span class="header-scope">Contract</span>
+            <span class="header-addr">{key_short}</span>
+            <span class="badge">v{version}</span>
+        </div>
+        <div class="header-right">
+            <button class="theme-btn" id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">
+                <span id="theme-icon">☀️</span>
+            </button>
+        </div>
+    </header>
+    <main>
+        {identity}
+        {subscription}
+        {hosting}
+        {governance}
+        <p style="margin-top:0.25rem"><a href="/" style="color:var(--accent-light);font-family:var(--font-mono);font-size:0.85rem">&larr; Back to dashboard</a></p>
+    </main>
+</body>
+</html>

--- a/crates/core/src/server/home_page/assets/contract_not_found.html
+++ b/crates/core/src/server/home_page/assets/contract_not_found.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Contract Not Found — Freenet</title>
+<style>{CSS}{PEER_CSS}</style><script>{JS}</script>
+</head><body>
+<header>
+    <div class="header-left">
+        <a href="/" class="logo-link"><img src="https://freenet.org/freenet_logo.svg" alt="Freenet" class="logo"></a>
+        <a href="/" class="header-title">FREENET</a>
+        <span class="header-sep">/</span>
+        <span class="header-scope">Contract</span>
+    </div>
+    <div class="header-right">
+        <button class="theme-btn" id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">
+            <span id="theme-icon">☀️</span>
+        </button>
+    </div>
+</header>
+<main>
+    <div class="card"><h2>Contract Not Found</h2>
+    <p class="empty">This node knows nothing about <code class="key-wrap">{key}</code>: no subscription, no hosted copy, and no governance record.</p>
+    <p class="empty" style="margin-top:0.5rem">That is a statement about THIS node only. A contract absent here may be alive and well elsewhere in the network — a node holds what demand routed to it, not a directory.</p>
+    <p style="margin-top:0.75rem"><a href="/" style="color:var(--accent-light);font-family:var(--font-mono);font-size:0.85rem">&larr; Back to dashboard</a></p></div>
+</main></body></html>

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1430,6 +1430,29 @@ table.sortable thead th.sort-desc::after {
 
 /* Freshness / demand pills in the Subscribed Contracts table (replaces the
  * retired MAD-governance column). Same compact shape as `.gov-pill`. */
+/* A full contract key is ~60 characters of unbroken base58 in a monospace
+   font, which is wider than a phone viewport and has no space to break at.
+   Without an explicit break rule it forces the whole page to scroll sideways —
+   the same class of bug the responsive work above fixed for the stat grids.
+   `anywhere` rather than `break-all` so the browser still prefers a sensible
+   break point where one exists. */
+/* The abbreviated key in a contract table links to its detail page. Styled to
+   stay legible as a link without turning the table into a wall of blue: the
+   underline only appears on hover, so the column still reads as data. */
+.key-link {
+  color: inherit;
+  text-decoration: none;
+}
+.key-link:hover code {
+  color: var(--accent-light);
+  text-decoration: underline;
+}
+
+.key-wrap {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .fresh-pill {
   display: inline-block;
   padding: 0.1rem 0.45rem;

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1490,7 +1490,7 @@ pub fn build_hosting_card(snap: &Option<network_status::NetworkStatusSnapshot>) 
             r#" <span class="fresh-pill use-active" title="Pinned by a local client or downstream subscriber. The sweep evicts these last, regardless of this row's position.">in use</span>"#
         };
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}{pin}</td><td class="right" data-sort="{seq}">{recency}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><a href="/contract/{full}" class="key-link"><code>{short}</code></a><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button>{next}{pin}</td><td class="right" data-sort="{seq}">{recency}</td><td class="right" data-sort="{size}">{size_fmt}</td><td class="right" data-sort="{reads}">{reads}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
             next = next_badge,
@@ -1765,7 +1765,7 @@ pub fn build_contracts_card(snap: &Option<network_status::NetworkStatusSnapshot>
         // Sort healthiest-first: freshness weighs more than in-use demand.
         let fresh_sort = (c.is_receiving_updates as u8) * 2 + (c.in_use as u8);
         rows.push_str(&format!(
-            r#"<tr><td title="{full}" data-sort="{full}"><code>{short}</code><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{fresh_sort}"><span class="fresh-pill {fresh_class}">{fresh_label}</span> <span class="fresh-pill {use_class}">{use_label}</span></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
+            r#"<tr><td title="{full}" data-sort="{full}"><a href="/contract/{full}" class="key-link"><code>{short}</code></a><button type="button" class="copy-key" data-copy="{full}" title="Copy contract key" aria-label="Copy contract key">⧉</button></td><td data-sort="{fresh_sort}"><span class="fresh-pill {fresh_class}">{fresh_label}</span> <span class="fresh-pill {use_class}">{use_label}</span></td><td data-sort="{sub_secs}">{subscribed}</td><td data-sort="{last_sort}">{last_update}</td></tr>"#,
             full = html_escape(&c.key_full),
             short = html_escape(&c.key_short),
             fresh_sort = fresh_sort,

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -53,6 +53,18 @@ pub fn contract_detail_html_from(
     let hosted = snap
         .as_ref()
         .and_then(|s| s.hosting.contracts.iter().find(|c| c.key_full == key_str));
+    // Governance is keyed by `ContractInstanceId`. That sounds like it needs a
+    // separate lookup value, and `ContractSnapshot` carries both `key_full` and
+    // `instance_id` as if they differed — but they do not.
+    // `impl Display for ContractKey` delegates to `self.instance`, and
+    // `ContractKey::id()` returns `&self.instance`, so `key.to_string()` and
+    // `key.id().to_string()` produce the SAME string. The requested key is
+    // therefore always a valid governance lookup value, including for a
+    // hosted-only contract that carries no `instance_id` field of its own.
+    //
+    // Worth stating because the rustdoc on `ContractSnapshot::instance_id`
+    // asserts the opposite ("Distinct from `key_full` which carries the full
+    // ContractKey encoding"), which is wrong and cost a wrong turn here.
     let governance = snap.as_ref().and_then(|s| {
         s.governance.contracts.iter().find(|c| {
             c.instance_id == key_str || Some(&c.instance_id) == subscribed.map(|x| &x.instance_id)
@@ -159,7 +171,14 @@ pub fn contract_detail_html_from(
     let governance_card = match governance {
         Some(g) => {
             let mut history = String::new();
-            for t in g.history.iter().take(10) {
+            /* Newest FIRST, and taken from the TAIL. `GovernanceSnapshot`
+               documents this vec as "State history (bounded). Newest last", so
+               a plain `.take(10)` shows the ten OLDEST transitions and hides
+               every recent one — the opposite of what an operator opening this
+               page wants, and it degrades as the contract accumulates history.
+               The cap also preserves `FirstSeen` and drops older non-anchor
+               entries, so the head is not even a stable window. */
+            for t in g.history.iter().rev().take(10) {
                 history.push_str(&format!(
                     r#"<tr><td>{from} &rarr; {to}</td><td>{reason}</td><td class="right">{ago} ago</td></tr>"#,
                     from = html_escape(&format!("{:?}", t.from)),

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -1,0 +1,228 @@
+use super::assets::{CSS, JS, PEER_CSS};
+use super::cards::format_bytes;
+use super::*;
+
+// ─── Contract detail page ────────────────────────────────────────────────────
+
+/// One contract, gathered from the three places the dashboard already knows
+/// about it.
+///
+/// The value here is the JOIN, not any new measurement. A contract's
+/// subscription state lives in `snap.contracts`, its hosting and eviction
+/// state in `snap.hosting.contracts`, and its governance scoring in
+/// `snap.governance.contracts` — three different cards, two of which truncate
+/// (the eviction table showed 20 rows of up to 2,256) and none of which can be
+/// cross-referenced by eye, because they key on different strings: the
+/// subscription and hosting views use the full `ContractKey` encoding while
+/// governance uses `ContractInstanceId`.
+///
+/// Everything below is read from the already-materialised snapshot, and that
+/// is a deliberate constraint rather than an oversight. The two most valuable
+/// fields for this page — the local and downstream subscriber counts that are
+/// invariant 3's PRIMARY eviction ranking key — are not in the snapshot at
+/// all; they are computed transiently during the eviction sweep. Surfacing
+/// them means a live read of `InterestManager`/`HostingCache` on an HTTP
+/// request path, which every other dashboard page avoids, and which needs a
+/// lock-contention check against hot-path PUT/GET/SUBSCRIBE work first.
+/// Tracked as #5372 so the deferral stays visible instead of becoming a silent
+/// scope cut; this page says plainly that the counts are missing rather than
+/// implying the ranking is visible.
+pub fn contract_detail_html(key_str: &str) -> String {
+    contract_detail_html_from(&network_status::get_snapshot(), key_str)
+}
+
+/// The page as a pure function of the snapshot.
+///
+/// Split out so the rendering can be tested without a running node, which is
+/// how every `cards.rs` builder is already shaped (`build_peers_card` takes
+/// `&Option<NetworkStatusSnapshot>`). Reading the global directly would have
+/// made the interesting cases — a hosted-only contract, one the governance
+/// manager has flagged — reachable only by standing up a node and waiting for
+/// it to reach that state.
+pub fn contract_detail_html_from(
+    snap: &Option<network_status::NetworkStatusSnapshot>,
+    key_str: &str,
+) -> String {
+    // Match on the full key OR the instance id, so a link from any card works
+    // and so an operator can paste either form.
+    let subscribed = snap.as_ref().and_then(|s| {
+        s.contracts
+            .iter()
+            .find(|c| c.key_full == key_str || c.instance_id == key_str)
+    });
+    let hosted = snap
+        .as_ref()
+        .and_then(|s| s.hosting.contracts.iter().find(|c| c.key_full == key_str));
+    let governance = snap.as_ref().and_then(|s| {
+        s.governance.contracts.iter().find(|c| {
+            c.instance_id == key_str || Some(&c.instance_id) == subscribed.map(|x| &x.instance_id)
+        })
+    });
+
+    if subscribed.is_none() && hosted.is_none() && governance.is_none() {
+        return format!(
+            include_str!("assets/contract_not_found.html"),
+            CSS = CSS,
+            PEER_CSS = PEER_CSS,
+            JS = JS,
+            key = html_escape(key_str),
+        );
+    }
+
+    let key_enc = html_escape(key_str);
+    let short = subscribed
+        .map(|c| c.key_short.clone())
+        .or_else(|| hosted.map(|c| c.key_short.clone()))
+        .unwrap_or_else(|| abbreviate(key_str));
+
+    let identity_card = format!(
+        r#"<div class="card">
+            <h2>Identity</h2>
+            <div><code>{short}</code><button type="button" class="copy-btn-inline" data-addr="{key_enc}" onclick="copyToClipboard(this.getAttribute('data-addr')).then(function(){{showToast('Contract key copied')}})" title="Copy contract key">⎘</button></div>
+            <div class="info-grid">
+                <div class="info-label">Key</div><div class="info-value"><code class="key-wrap">{key_enc}</code></div>
+                {instance_row}
+            </div>
+        </div>"#,
+        short = html_escape(&short),
+        key_enc = key_enc,
+        instance_row = subscribed
+            .map(|c| format!(
+                r#"<div class="info-label" title="The 32-byte content-hash portion of the key. Governance scores are keyed by this, not by the full key — which is why the two tables could not be cross-referenced by eye.">Instance id</div><div class="info-value"><code class="key-wrap">{}</code></div>"#,
+                html_escape(&c.instance_id)
+            ))
+            .unwrap_or_default(),
+    );
+
+    let subscription_card = match subscribed {
+        Some(c) => format!(
+            r#"<div class="card">
+                <h2>Subscription</h2>
+                <div class="info-grid">
+                    <div class="info-label">Freshness</div><div class="info-value">{fresh}</div>
+                    <div class="info-label" title="Whether real demand pins the contract: a local client subscription or a registered downstream subscriber.">In use</div><div class="info-value">{in_use}</div>
+                    <div class="info-label">Subscribed for</div><div class="info-value">{sub}</div>
+                    <div class="info-label">Last update</div><div class="info-value">{last}</div>
+                </div>
+            </div>"#,
+            fresh = if c.is_receiving_updates {
+                r#"<span class="fresh-pill fresh-ok">receiving updates</span>"#
+            } else {
+                r#"<span class="fresh-pill fresh-stale">not receiving updates</span>"#
+            },
+            in_use = if c.in_use { "yes" } else { "no" },
+            sub = format_duration(c.subscribed_secs),
+            last = c
+                .last_updated_secs
+                .map(|s| format!("{} ago", format_duration(s)))
+                .unwrap_or_else(|| "never".to_string()),
+        ),
+        None => r#"<div class="card">
+                <h2>Subscription</h2>
+                <p class="empty">This node holds no subscription for this contract. It may be hosted without one — a hosted copy with no client subscription still joins anti-entropy, so it is not automatically stale.</p>
+            </div>"#
+            .to_string(),
+    };
+
+    let hosting_card = match hosted {
+        Some(h) => format!(
+            r#"<div class="card">
+                <h2>Hosting</h2>
+                <div class="info-grid">
+                    <div class="info-label">State size</div><div class="info-value">{size}</div>
+                    <div class="info-label" title="GET and SUBSCRIBE accesses observed over this entry's residency in the cache. Reset when the entry is evicted and re-admitted.">Reads</div><div class="info-value">{reads}</div>
+                    <div class="info-label" title="The eviction recency clock: a per-run sequence, higher is more recent. Reset by a real GET or PUT, and ALSO when the contract loses its last subscriber — the sweep deliberately gives a just-unsubscribed contract a grace period. It is therefore NOT purely a last-read time.">Recency</div><div class="info-value">{recency}</div>
+                    <div class="info-label" title="Whether the over-budget sweep would consider this contract at all. A contract pinned by demand — a local client subscription or a registered downstream subscriber — is not a candidate.">Eviction candidate</div><div class="info-value">{eligible}</div>
+                </div>
+                <p class="empty" style="margin-top:0.75rem">The counts that actually decide eviction — local client subscriptions, then downstream subscribers — outrank recency and are <strong>not shown here</strong>: they are computed during the sweep and are not in the snapshot this page reads. See freenet/freenet-core#5372.</p>
+            </div>"#,
+            size = format_bytes(h.size_bytes),
+            reads = h.read_count,
+            eligible = if h.eviction_eligible {
+                "yes"
+            } else {
+                "no — pinned by demand"
+            },
+            recency = if h.recency_seq == 0 {
+                "never".to_string()
+            } else {
+                h.recency_seq.to_string()
+            },
+        ),
+        None => r#"<div class="card">
+                <h2>Hosting</h2>
+                <p class="empty">Not in this node's hosting cache.</p>
+            </div>"#
+            .to_string(),
+    };
+
+    let governance_card = match governance {
+        Some(g) => {
+            let mut history = String::new();
+            for t in g.history.iter().take(10) {
+                history.push_str(&format!(
+                    r#"<tr><td>{from} &rarr; {to}</td><td>{reason}</td><td class="right">{ago} ago</td></tr>"#,
+                    from = html_escape(&format!("{:?}", t.from)),
+                    to = html_escape(&format!("{:?}", t.to)),
+                    reason = html_escape(&format!("{:?}", t.reason)),
+                    ago = format_duration(t.secs_ago),
+                ));
+            }
+            format!(
+                r#"<div class="card">
+                    <h2>Governance</h2>
+                    <div class="info-grid">
+                        <div class="info-label">State</div><div class="info-value">{state}</div>
+                        <div class="info-label">Cost used</div><div class="info-value">{cost:.2}</div>
+                        <div class="info-label">Benefit</div><div class="info-value">{benefit:.2}</div>
+                        <div class="info-label">log-ratio</div><div class="info-value">{ratio}</div>
+                        <div class="info-label">Age</div><div class="info-value">{age}</div>
+                    </div>
+                    {history_block}
+                </div>"#,
+                state = html_escape(&format!("{:?}", g.state)),
+                cost = g.cost_used,
+                benefit = g.benefit_score,
+                ratio = g
+                    .log_ratio
+                    .map(|r| format!("{r:.3}"))
+                    .unwrap_or_else(|| "—".to_string()),
+                age = format_duration(g.age_secs),
+                history_block = if history.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        r#"<div class="table-wrap" style="margin-top:0.75rem"><table><thead><tr><th>Transition</th><th>Reason</th><th class="right">When</th></tr></thead><tbody>{history}</tbody></table></div>"#
+                    )
+                },
+            )
+        }
+        None => r#"<div class="card">
+                <h2>Governance</h2>
+                <p class="empty">Not flagged by the governance manager. Only Borderline / WouldEvict / Evicted / Banned contracts appear in the snapshot — a normal contract being absent here is the expected case, not a gap.</p>
+            </div>"#
+            .to_string(),
+    };
+
+    format!(
+        include_str!("assets/contract.html"),
+        CSS = CSS,
+        PEER_CSS = PEER_CSS,
+        JS = JS,
+        key_short = html_escape(&short),
+        version = env!("CARGO_PKG_VERSION"),
+        identity = identity_card,
+        subscription = subscription_card,
+        hosting = hosting_card,
+        governance = governance_card,
+    )
+}
+
+/// Shorten a key for display when neither card supplied a short form.
+fn abbreviate(key: &str) -> String {
+    if key.chars().count() <= 12 {
+        return key.to_string();
+    }
+    let head: String = key.chars().take(12).collect();
+    format!("{head}…")
+}

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -178,7 +178,7 @@ pub fn contract_detail_html_from(
                page wants, and it degrades as the contract accumulates history.
                The cap also preserves `FirstSeen` and drops older non-anchor
                entries, so the head is not even a stable window. */
-            for t in g.history.iter().rev().take(10) {
+            for t in g.history.iter().rev().take(MAX_HISTORY_ROWS) {
                 history.push_str(&format!(
                     r#"<tr><td>{from} &rarr; {to}</td><td>{reason}</td><td class="right">{ago} ago</td></tr>"#,
                     from = html_escape(&format!("{:?}", t.from)),
@@ -236,6 +236,15 @@ pub fn contract_detail_html_from(
         governance = governance_card,
     )
 }
+
+/// Governance transitions shown on the detail page.
+///
+/// A display truncation, not a safety threshold: the snapshot's history is
+/// already bounded on the producing side. Ten is enough to show the shape of a
+/// contract's recent trajectory without turning the panel into a log. Taken
+/// from the TAIL — see the comment at the call site for why the direction
+/// matters more than the count.
+const MAX_HISTORY_ROWS: usize = 10;
 
 /// Shorten a key for display when neither card supplied a short form.
 fn abbreviate(key: &str) -> String {


### PR DESCRIPTION
## Problem

A contract's state is scattered across three cards that cannot be cross-referenced by eye, and two of them truncate.

- **subscription** state (freshness, in-use, last update) — Subscribed Contracts card
- **hosting and eviction** state (size, reads, recency, whether the sweep would even consider it) — the eviction card, which showed 20 rows of up to 2,256
- **governance** scoring and its transition history — a third card that only lists *flagged* contracts

So answering "why is this contract being evicted, and is governance involved" meant reading three cards, two of which might not show the row at all.

## Solution

One page per contract, joining all three. The value is the join — every field already existed somewhere.

Reached by clicking the abbreviated key in either contract table. Accepts the full key or the instance id, so a pasted value from any card lands somewhere.

## Deliberately NOT shown

The two fields an operator most wants — the **local and downstream subscriber counts**, which are invariant 3's *primary* eviction ranking key — are absent, and the page says so in the panel where they belong rather than quietly omitting them.

They're computed transiently during the eviction sweep and aren't in the snapshot. Surfacing them means a live read of `InterestManager`/`HostingCache` on an HTTP request path, which every other dashboard page avoids and which needs a lock-contention check against hot-path PUT/GET/SUBSCRIBE work first. Tracked as #5372.

Showing recency alone, unqualified, would read as "this is why the contract is kept" — the exact falsehood #5371 removed from the eviction card, reintroduced on a new page. A test pins that the panel says the ranking keys are missing and points at the issue.

## Review findings fixed

Three reviewers (Codex plus two Claude lenses) between them found:

- **Governance history showed the OLDEST ten transitions.** The vec is documented "newest last", so `.take(10)` hid every recent one and degraded as history accumulated. Now taken from the tail, newest first, with a test that fails under the original.
- **Both new HTML templates would have failed `prettier --check`** — they're Rust `format!` templates with `{ident}` placeholders that prettier would rewrite and break, and weren't in `.prettierignore` with the other such templates.
- **`cargo fmt --check` failed** on the governance join.

## One finding that was wrong, and what came of it

Two reviewers independently reported a blocking bug: that a hosted-only contract can't be joined to governance, because `HostedContractEntry` carries no `instance_id`. **I acted on it and added a "cannot be cross-referenced" branch — then reverted it, because the case cannot occur.**

`impl Display for ContractKey` delegates to `self.instance` and `id()` returns `&self.instance`, so `key.to_string()` and `key.id().to_string()` are the **same string**. The join works precisely because of that.

All three of us reasoned correctly from a false premise we each got from the same place: the rustdoc on `ContractSnapshot::instance_id`, which asserted the two were "Distinct". This PR corrects that comment and adds `contract_key_display_equals_its_instance_id`, which asserts the equality against a **real** `ContractKey` — the existing join test built its fixture with the two equal by construction, so it could never have caught a divergence. If a future stdlib puts the code hash into `Display`, the new test fails and the reviewers' finding becomes correct.

## Testing

Six tests, each pinning an invariant rather than wording:

- the key comes from a URL path, so it's attacker-controlled text rendered into HTML. The not-found branch echoes it back and is reachable with **no node state**, making it the widest reflected-XSS surface on an origin that also serves every locally-hosted app. Verified escaped by test and against a live node.
- "not found" is scoped to **this node** — a node holds what demand routed to it and has no directory, so a global claim would be false.
- the hosting panel must not imply it shows the eviction ranking.
- governance history shows the newest transitions.
- a hosted-only contract still joins to governance.
- `ContractKey` display equals its instance id.

`contract_detail_html_from` takes the snapshot as a parameter (matching every `cards.rs` builder) so the interesting cases are testable without standing up a node and waiting for it to reach that state.

One existing test is **amended, not weakened**: `contracts_table_preserves_full_key_tooltip_and_code_markup` pinned "no hover state on the contract text", a deliberate choice made when there was nowhere for the key to link to. The assertions now pin what still holds — `<code>` stays outside the copy button, and the link targets the full key — with the reasoning recorded.

Verified against a live node: all four panels render, the link resolves, `eviction_eligible` reads correctly.

Note `.key-wrap`: a full key is ~60 characters of unbroken base58 with no natural break point, wider than a phone viewport. Without an explicit wrap rule it would reintroduce the horizontal scrolling #5378 just fixed.

## Scope

Implements #5369 (carries `S-needs-design`; @sanity requested contract detail pages directly and the scope decision is recorded on the issue). Deferred half tracked in #5372. Fifth of the local-dashboard review series.

[AI-assisted - Claude]
