### PR TITLE
test(dashboard): stop the browser specs depending on what the node holds

### DIFF
--- a/crates/core/tests/playwright/tests/dashboard-layout.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-layout.spec.ts
@@ -65,6 +65,19 @@ test.describe("dashboard responsive layout", () => {
     await page.setViewportSize({ width: 768, height: 900 });
     await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
 
+    await page.evaluate(() => {
+      if (document.querySelector(".g-norms")) return;
+      const grid = document.createElement("div");
+      grid.className = "g-norms";
+      for (let i = 0; i < 5; i++) {
+        const tile = document.createElement("div");
+        tile.className = "g-norm";
+        tile.textContent = "TILE " + i;
+        grid.appendChild(tile);
+      }
+      document.querySelector("main")!.appendChild(grid);
+    });
+
     const columnCounts = await page.evaluate(() =>
       [...document.querySelectorAll(".g-norms")].map(
         (n) => getComputedStyle(n).gridTemplateColumns.split(" ").length,
@@ -90,6 +103,44 @@ test.describe("dashboard responsive layout", () => {
   }) => {
     await page.setViewportSize({ width: 1440, height: 1000 });
     await page.goto(dashboardUrl!, { waitUntil: "domcontentloaded" });
+
+    /* Build the structure rather than depending on the node having hosting
+       data. The hosting card only renders these rows once the node is hosting
+       contracts, so on a sparse node this test failed its own fixture guard —
+       loudly, which is the designed behaviour, but it made the test a function
+       of node state rather than of the stylesheet.
+
+       The rule under test is static CSS: `.g-verdict-row > .g-norms:only-child`
+       spanning both grid tracks. What matters is that the selector matches the
+       structure `cards.rs` emits, which is a `.g-verdict-row` whose only child
+       is a `.g-norms` of `.g-norm` tiles. Injecting exactly that exercises the
+       real rule; the Rust side pins that the server still emits this shape. */
+    await page.evaluate(() => {
+      /* Check for the SPECIFIC shape under test, not merely for any
+         `.g-verdict-row > .g-norms`. A node can render one that has a verdict
+         box beside it, which is a different case and not what this rule
+         governs — an earlier guard matched that and skipped injection, so the
+         test then failed on its own precondition. */
+      const existingSole = [
+        ...document.querySelectorAll(".g-verdict-row > .g-norms"),
+      ].some((n) => n.parentElement!.children.length === 1);
+      if (existingSole) return;
+      const row = document.createElement("div");
+      row.className = "g-verdict-row";
+      const grid = document.createElement("div");
+      grid.className = "g-norms";
+      for (let i = 0; i < 5; i++) {
+        const tile = document.createElement("div");
+        tile.className = "g-norm";
+        tile.innerHTML =
+          '<div class="g-norm-label">TILE ' +
+          i +
+          '</div><div class="g-norm-value">0</div>';
+        grid.appendChild(tile);
+      }
+      row.appendChild(grid);
+      document.querySelector("main")!.appendChild(row);
+    });
 
     const grids = await page.evaluate(() =>
       [...document.querySelectorAll(".g-verdict-row > .g-norms")].map((n) => {

--- a/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
+++ b/crates/core/tests/playwright/tests/dashboard-table-filter.spec.ts
@@ -215,6 +215,23 @@ test.describe("dashboard long-table filter", () => {
     );
     await expect(filter).toBeAttached();
 
+    /* Page height must come from OUTSIDE <main>, and the fixture's own spacer
+       is not enough. The refresh assigns `main.innerHTML`, which momentarily
+       empties it — including any spacer inside the fixture — so the document
+       collapses to about viewport height for an instant. WebKit clamps
+       scrollY to ~0 during that window and does not restore it when the new
+       content lands; Chromium and Firefox anchor through it. On a CI node
+       with no peers and no contracts, <main> supplies almost no height of its
+       own, so the collapse is total and the anchor row jumped -428 -> 886
+       with the viewport never having been touched by the code under test.
+       A body-level spacer keeps the document tall THROUGHOUT the swap. */
+    await page.evaluate(() => {
+      const spacer = document.createElement("div");
+      spacer.id = "outside-main-spacer";
+      spacer.style.height = "5000px";
+      document.body.appendChild(spacer);
+    });
+
     const input = filter.locator(".tf-input");
     /* Order matters, and getting it wrong made this test fail 1 run in 8.
        WebKit scrolls a newly-focused element into view ASYNCHRONOUSLY, after


### PR DESCRIPTION
## Problem

Two dashboard browser specs on `main` are a function of **node state** rather than of the code they claim to test. Both passed in some environments and failed in others, for reasons unrelated to what they assert.

### 1. The viewport test measured a page collapse, not the viewport

`dashboard-table-filter.spec.ts` supplies its page height from a spacer **inside** the fixture card — which lives inside `<main>`, which the 5s refresh empties via `main.innerHTML = …`.

For an instant the document collapses to roughly viewport height. WebKit clamps `scrollY` to ~0 during that window and does not restore it when the new content lands; Chromium and Firefox anchor through it. On a node with **no peers and no contracts** — which is what CI runs — `<main>` contributes almost no height of its own, so the collapse is total.

Result: the anchor row moved **−428 → 886**, and that motion was attributed to the code under test, which had not touched the viewport at all.

Height now comes from a spacer on `<body>`, outside the element the refresh empties, so it is constant across the swap.

**Removing the noise made the test stronger.** Reverting the focus gate now fails in **all three engines** (−428 → ~1018). Before, the real signal was buried in the collapse and only WebKit surfaced anything.

### 2. The layout test required the node to be hosting contracts

`dashboard-layout.spec.ts` asserted against `.g-verdict-row > .g-norms` rows that the hosting card only renders once the node holds contracts. It passed on CI and failed on a sparse node — failing *loudly*, which is the designed behaviour, but the test was still measuring node state rather than the stylesheet.

It now builds the structure it needs. The rule under test is static CSS (`:only-child` spanning both grid tracks), so injecting exactly the shape `cards.rs` emits exercises the real rule.

The injection guard checks for the **specific** shape — a sole-child grid — not any `.g-norms`. A looser guard matched a two-child row, skipped injection, and then failed the precondition.

## Testing

Verified **both ways**, which is the point: **21/21** against a populated node and **9/9** against a deliberately sparse one. The populated node is precisely the environment that cannot produce the fault, so passing there proves nothing on its own.

## Scope

Test-only. No production code, no node behaviour change.

Split out of #5387 at rule-review's request — correctly, since these fixes stand on their own merits and improve tests already on `main`, independent of the contract detail page.

[AI-assisted - Claude]