### PR TITLE
fix(http): a dead-ended GET on the web route was served as a bare 500

### DIFF
--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -19,6 +19,28 @@ pub(super) enum WebSocketApiError {
     MissingContract {
         instance_id: ContractInstanceId,
     },
+    /// The network GET for this contract exhausted its retries without locating
+    /// it — `ContractResponse::NotFound`.
+    ///
+    /// Its own variant rather than reusing `AxumError(RequestError(Timeout))`,
+    /// for two reasons. It is not a timeout, and saying so in the one type the
+    /// HTTP layer logs and renders from would mislead the next person reading a
+    /// trace. And it must NOT inherit `retry_loading_page`: that page refreshes
+    /// every `RETRY_REFRESH_SECS` forever, which is defensible for a timeout
+    /// (the node has peers and is making progress on THIS get) but not here,
+    /// where the identical reply is produced for a contract that is merely slow
+    /// to propagate AND for a key that will never resolve. A typo'd URL left
+    /// open in a tab would otherwise re-issue a network GET every minute for as
+    /// long as the tab lives — see `.claude/rules/browser-assets.md`, "assume
+    /// every open tab pays the cost".
+    ///
+    /// So: the transient STATUS and headers (503 + `Retry-After`), which is what
+    /// a programmatic client needs in order to come back later instead of
+    /// writing the contract off, with a page that states the situation and lets
+    /// a human retry deliberately.
+    ContractNotFound {
+        instance_id: ContractInstanceId,
+    },
 }
 
 impl WebSocketApiError {
@@ -37,6 +59,12 @@ impl WebSocketApiError {
             WebSocketApiError::AxumError { error } => format!("Server error: {error}"),
             WebSocketApiError::MissingContract { instance_id } => {
                 format!("Missing contract {}", instance_id.encode())
+            }
+            WebSocketApiError::ContractNotFound { instance_id } => {
+                format!(
+                    "Contract not found on the network yet: {}",
+                    instance_id.encode()
+                )
             }
         }
     }
@@ -110,8 +138,15 @@ impl IntoResponse for WebSocketApiError {
         // rather than a message built from request-derived text. Only the
         // latter is escaped — escaping the retry page would render its
         // meta-refresh tag as visible text and break the auto-reload.
+        // Transient for STATUS and headers, but never auto-refreshing — see the
+        // variant's own doc for why this one does not inherit the retry page.
+        let is_not_found_yet = matches!(&self, WebSocketApiError::ContractNotFound { .. });
+
         let mut body_is_trusted_markup = false;
-        let (status, error_message) = if is_transient {
+        let (status, error_message) = if is_not_found_yet {
+            body_is_trusted_markup = true;
+            (StatusCode::SERVICE_UNAVAILABLE, not_found_yet_page())
+        } else if is_transient {
             // Log the cause so operators can distinguish a fast op error
             // from a slow-loading contract without changing the user-facing
             // retry page.
@@ -135,6 +170,12 @@ impl IntoResponse for WebSocketApiError {
                 }
                 err @ WebSocketApiError::MissingContract { .. } => {
                     (StatusCode::NOT_FOUND, err.error_message())
+                }
+                // Handled by the `is_not_found_yet` branch above; this arm only
+                // keeps the match exhaustive. If it ever renders, that branch was
+                // edited out and the explanatory page went with it.
+                err @ WebSocketApiError::ContractNotFound { .. } => {
+                    (StatusCode::SERVICE_UNAVAILABLE, err.error_message())
                 }
                 WebSocketApiError::AxumError { error } => {
                     // Already handled transient cases above; remaining
@@ -161,7 +202,7 @@ impl IntoResponse for WebSocketApiError {
         // Prevent intermediaries/service-workers from pinning a stale retry
         // page, and signal the client when it may retry.
         let mut response = (status, body).into_response();
-        if is_transient {
+        if is_transient || is_not_found_yet {
             response.headers_mut().insert(
                 axum::http::header::CACHE_CONTROL,
                 axum::http::HeaderValue::from_static("no-store"),
@@ -226,6 +267,43 @@ fn retry_loading_page() -> String {
 </html>"##,
         refresh = RETRY_REFRESH_SECS,
     )
+}
+
+/// A 503 page for a contract the network could not locate yet.
+///
+/// Deliberately carries NO `<meta http-equiv="refresh">`. The reply this renders
+/// is produced both for a contract that has not propagated to this node yet and
+/// for one that does not exist at all, and nothing available here tells the two
+/// apart — so an automatic reload would re-issue a network GET every minute, for
+/// the life of the tab, on every mistyped or dead URL. The reload is offered as
+/// a deliberate action instead, and the `Retry-After` header carries the same
+/// advice to programmatic clients, which is where it can be acted on safely.
+fn not_found_yet_page() -> String {
+    r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Contract not found</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+               display: flex; justify-content: center; align-items: center; min-height: 100vh;
+               margin: 0; background: #0c0d0f; color: #edeeef; }
+        .container { text-align: center; padding: 2rem; max-width: 32rem; }
+        h1 { font-size: 1.2rem; font-weight: 500; margin-bottom: 0.5rem; }
+        p { color: #94969a; font-size: 0.85rem; margin-bottom: 0.6rem; line-height: 1.5; }
+        a { color: #0abab5; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Couldn't find this contract on the network</h1>
+        <p>It may not have reached this peer yet — a contract published moments ago
+           can take a while to propagate. It may also not exist.</p>
+        <p><a href="">Try again</a> &middot; <a href="/">Dashboard</a></p>
+    </div>
+</body>
+</html>"##
+        .to_string()
 }
 
 /// Minimal HTML entity escaping for error bodies rendered at the node origin.

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1233,6 +1233,68 @@ async fn handle_get_response(
                 })),
             ..
         })) => Err(WebSocketApiError::MissingContract { instance_id }),
+        // TRANSIENT: the GET's retry loop exhausted without locating the
+        // contract. This is a SUCCESS at the client-API level, not an `Err` —
+        // `operations/get/op_ctx_task.rs` deliberately converts exhaustion into
+        // `ContractResponse::NotFound` so a client can tell that apart from "the
+        // operation failed".
+        //
+        // Read the PRODUCER, not the variant's doc, for what it means. stdlib
+        // documents `NotFound` as "Contract was not found after exhaustive
+        // search ... distinguishes 'contract doesn't exist' from other failure
+        // modes", i.e. as proof of absence. This node emits it on RETRY-LOOP
+        // EXHAUSTION, which is a much weaker claim — "nobody I asked had it",
+        // over a ring that may not yet have propagated the contract at all. The
+        // two do not say the same thing, and that gap is the whole reason this
+        // arm must not answer 404: treating exhaustion as absence is precisely
+        // the error being fixed here.
+        //
+        // Without this arm that distinction was DISCARDED here: `NotFound` is an
+        // `Ok(..)` that no arm matched, so it fell through to the catch-all
+        // below and became `NodeError { "Unexpected response from node: .." }`.
+        // `errors.rs` only maps a `NodeError` to 404 when its message begins
+        // with the literal "Contract not found", which that Debug-formatted
+        // string does not, so every dead-ended GET on the web route was served
+        // as a bare 500 — indistinguishable from a genuine internal failure, and
+        // carrying none of the `Retry-After` / `Cache-Control: no-store` headers
+        // the transient path sets.
+        //
+        // On Freenet a `NotFound` is routinely "not found YET" rather than proof
+        // of absence: a contract published elsewhere is unreachable from this
+        // node until it propagates (the #4404 placement gap), which is a window
+        // of minutes to hours. `WebSocketApiError::ContractNotFound` gives it the
+        // transient STATUS and headers (503 + `Retry-After`), which is what a
+        // programmatic client needs in order to come back later rather than write
+        // the contract off.
+        //
+        // It is a dedicated variant rather than a reuse of the `Err(_)` arm's
+        // `RequestError(Timeout)`, because this is not a timeout and must not
+        // inherit `retry_loading_page`: that page reloads forever, and the same
+        // reply is produced for a key that will never resolve, so a mistyped URL
+        // in an open tab would re-issue a network GET every minute for the life
+        // of the tab. See the variant's doc in `errors.rs`.
+        //
+        // 404 would be the WRONG call and is worse than the 500 it replaces: a
+        // well-behaved crawler treats 404 as terminal (Atlas marks such a
+        // locator seen for good and never retries it), so answering 404 here
+        // would permanently exclude every contract that was merely slow to
+        // propagate. Only answer 404 where absence is locally PROVEN — which is
+        // what the `contract: None` arm above does.
+        Ok(Some(HostCallbackResult::Result {
+            result: Ok(HostResponse::ContractResponse(ContractResponse::NotFound { .. })),
+            ..
+        })) => {
+            // Plain `info!`, like every other diagnostic in this module, so it
+            // lands in the node's log files and NOT in the OTel collector, which
+            // only carries enumerated events. Fine for reading one node's log;
+            // if anyone wants a fleet-wide dead-ended-GET rate, that needs an
+            // enumerated event, not this line.
+            tracing::info!(
+                instance_id = %instance_id.encode(),
+                "contract not found on the network (GET exhausted); serving 503"
+            );
+            Err(WebSocketApiError::ContractNotFound { instance_id })
+        }
         Ok(Some(HostCallbackResult::Result {
             result: Err(err), ..
         })) => {
@@ -4492,6 +4554,159 @@ mod tests {
                 })
             ),
             "30s timeout must map to RequestError(Timeout) (for retry page), got: {result:?}"
+        );
+    }
+
+    /// A GET whose retry loop exhausted comes back as `Ok(ContractResponse::
+    /// NotFound)` — a SUCCESS at the client-API level, produced deliberately so
+    /// a client can tell "absent" apart from "the operation failed". It must be
+    /// classified transient, not swept into the unmatched-response catch-all.
+    ///
+    /// Regression pin. Before the arm existed, `NotFound` matched no arm, fell
+    /// into `Ok(other)`, and became `NodeError { "Unexpected response from node:
+    /// .." }`, which `errors.rs` renders as a bare 500 because the message does
+    /// not begin with "Contract not found". On Freenet a `NotFound` is routinely
+    /// "not found YET" (the #4404 placement gap), so a contract published
+    /// minutes earlier served a dead-looking 500 to every visitor and every
+    /// crawler until it propagated.
+    ///
+    /// The status assertion is the half that matters, so it is made against the
+    /// real `into_response`: asserting only the error VARIANT would still pass
+    /// if `errors.rs` later stopped treating `RequestError(Timeout)` as
+    /// transient, which is exactly the coupling that broke here.
+    #[tokio::test]
+    async fn handle_get_response_maps_network_not_found_to_transient_retry() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x44;
+        let instance_id = ContractInstanceId::new(bytes);
+
+        let recv_result: Result<Option<HostCallbackResult>, tokio::time::error::Elapsed> =
+            Ok(Some(HostCallbackResult::Result {
+                id: crate::client_events::ClientId::next(),
+                result: Ok(HostResponse::ContractResponse(ContractResponse::NotFound {
+                    instance_id,
+                })),
+            }));
+
+        let result = handle_get_response(instance_id, recv_result, &test_webapp_cache()).await;
+        let err = result.expect_err("a network NotFound must not be treated as a successful fetch");
+        assert!(
+            matches!(err, WebSocketApiError::ContractNotFound { .. }),
+            "a dead-ended GET must get its own classification, not fall through to the \
+             unmatched-response catch-all, got: {err:?}"
+        );
+
+        let response = err.into_response();
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "must serve 503 (retry later). 500 is what this bug produced; 404 would be \
+             WORSE than the bug, because a crawler treats 404 as terminal and would \
+             permanently drop a contract that was merely slow to propagate"
+        );
+
+        // The headers are the half a programmatic client acts on, and they are set
+        // by a DIFFERENT file. Asserting the status alone would still pass if
+        // `errors.rs` stopped attaching them to this variant.
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("60"),
+            "503 without Retry-After tells a client to come back but not when"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("no-store"),
+            "an intermediary must not pin this page once the contract arrives"
+        );
+
+        // And it must NOT auto-refresh. The identical node reply is produced for a
+        // key that will never resolve, so a meta-refresh here re-issues a network
+        // GET every minute for the life of any tab left open on a mistyped URL.
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .expect("body must be readable");
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            !body.contains("http-equiv=\"refresh\""),
+            "the not-found page must not reload itself — see browser-assets.md, \
+             'assume every open tab pays the cost'"
+        );
+    }
+
+    /// The catch-all still catches. Carving `NotFound` out of it must not leave it
+    /// dead: a response that genuinely makes no sense for a GET (here a
+    /// `PutResponse`) must still surface as an unmatched-response error.
+    ///
+    /// This arm is where the fixed bug hid, and nothing exercised it before.
+    #[tokio::test]
+    async fn handle_get_response_still_rejects_a_genuinely_unexpected_response() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x45;
+        let instance_id = ContractInstanceId::new(bytes);
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            instance_id,
+            freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+        );
+
+        let recv_result: Result<Option<HostCallbackResult>, tokio::time::error::Elapsed> =
+            Ok(Some(HostCallbackResult::Result {
+                id: crate::client_events::ClientId::next(),
+                result: Ok(HostResponse::ContractResponse(
+                    ContractResponse::PutResponse { key },
+                )),
+            }));
+
+        let result = handle_get_response(instance_id, recv_result, &test_webapp_cache()).await;
+        let err = result.expect_err("a PutResponse is not a valid answer to a GET");
+        assert!(
+            matches!(err, WebSocketApiError::NodeError { .. }),
+            "an unexpected variant must still reach the catch-all, got: {err:?}"
+        );
+        assert_eq!(
+            err.into_response().status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "a genuinely unexpected node response IS a server-side error, and 500 is \
+             the right answer for it — that was never the complaint"
+        );
+    }
+
+    /// A node-returned `Err` keeps its own `ErrorKind`, so `errors.rs` can decide
+    /// transient-vs-terminal from the kind. Pinned because the NotFound arm sits
+    /// directly above this one and a mis-ordered edit would swallow it.
+    #[tokio::test]
+    async fn handle_get_response_preserves_a_node_returned_error_kind() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x3a;
+        bytes[1] = 0x46;
+        let instance_id = ContractInstanceId::new(bytes);
+
+        let recv_result: Result<Option<HostCallbackResult>, tokio::time::error::Elapsed> =
+            Ok(Some(HostCallbackResult::Result {
+                id: crate::client_events::ClientId::next(),
+                result: Err(ErrorKind::OperationError {
+                    cause: "contract banned".into(),
+                }
+                .into()),
+            }));
+
+        let result = handle_get_response(instance_id, recv_result, &test_webapp_cache()).await;
+        let err = result.expect_err("a node error must not be treated as a successful fetch");
+        assert!(
+            matches!(
+                err,
+                WebSocketApiError::AxumError {
+                    error: ErrorKind::OperationError { .. }
+                }
+            ),
+            "the node's own ErrorKind must survive so errors.rs can classify it, got: {err:?}"
         );
     }
 

--- a/crates/core/tests/playwright/tests/contract-not-found.spec.ts
+++ b/crates/core/tests/playwright/tests/contract-not-found.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+// The web route's answer for a contract the node could not locate.
+//
+// Rust-level coverage of this lives in
+// `crates/core/src/server/path_handlers.rs::handle_get_response_maps_network_not_found_to_transient_retry`,
+// but that test calls the handler and `IntoResponse` directly. It cannot see
+// route wiring, and — the reason this file exists — it cannot see whether the
+// page a browser actually receives reloads itself.
+//
+// That property is the whole point of the fix. The node returns the same
+// `ContractResponse::NotFound` for a contract that has not propagated yet and
+// for a key that will never resolve, so an auto-refreshing page would re-issue a
+// network GET every minute for as long as any tab sat on a mistyped URL. See
+// `.claude/rules/browser-assets.md`, "assume every open tab pays the cost".
+
+const shellUrl = process.env.FREENET_SHELL_URL;
+
+test.beforeAll(() => {
+  if (!shellUrl) {
+    throw new Error(
+      "FREENET_SHELL_URL is not set. These tests are normally driven by the " +
+        "Rust harness (crates/core/tests/playwright_shell.rs), which boots a " +
+        "node, publishes the fixture, and exports the shell URL.",
+    );
+  }
+});
+
+// A syntactically VALID contract id that cannot exist: base58 of 32 zero bytes.
+// It has to parse, or the route answers 400 from the key-parsing guard and never
+// reaches the fetch path this test is about.
+const ABSENT_KEY = "1".repeat(32);
+
+function absentContractUrl(): string {
+  const origin = new URL(shellUrl!).origin;
+  return `${origin}/v1/contract/web/${ABSENT_KEY}/`;
+}
+
+test("a contract the node cannot find answers 503 and does not reload itself", async ({
+  page,
+}) => {
+  const response = await page.goto(absentContractUrl(), {
+    waitUntil: "domcontentloaded",
+  });
+  expect(response).not.toBeNull();
+
+  // 503, not 500: a client must be told to come back, because "not found" here
+  // routinely means "not found YET". And not 404, which a crawler treats as
+  // terminal — that would permanently drop a contract that was merely slow to
+  // propagate.
+  expect(response!.status()).toBe(503);
+  expect(response!.headers()["retry-after"]).toBe("60");
+  expect(response!.headers()["cache-control"]).toBe("no-store");
+
+  // No auto-refresh, in the DOM the browser actually parsed.
+  await expect(page.locator('meta[http-equiv="refresh"]')).toHaveCount(0);
+
+  // And the page says which situation this is, rather than reading as a crash.
+  await expect(page.locator("h1")).toContainText(/could ?n[o']t find/i);
+});
+
+test("the not-found page issues no further requests on its own", async ({
+  page,
+}) => {
+  const url = absentContractUrl();
+  const requested: string[] = [];
+  page.on("request", (r) => requested.push(r.url()));
+
+  await page.goto(url, { waitUntil: "networkidle" });
+  const afterLoad = requested.length;
+
+  // A meta-refresh fires on a timer, so settling once proves nothing on its own.
+  // Wait past a refresh interval and assert the count did not move. Kept well
+  // under RETRY_REFRESH_SECS (60s) would prove nothing either, so this waits
+  // long enough to catch a short interval while staying inside the suite budget:
+  // any reload-driven request lands as a repeat of the same URL.
+  await page.waitForTimeout(5_000);
+
+  const repeats = requested.filter((r) => r === url).length;
+  expect(
+    requested.length,
+    `page issued ${requested.length - afterLoad} request(s) after load; ` +
+      `a reloading not-found page costs one network GET per tab per interval`,
+  ).toBe(afterLoad);
+  expect(repeats).toBe(1);
+});


### PR DESCRIPTION
## Problem

`handle_get_response` has no match arm for `ContractResponse::NotFound`, so the one signal the node produces specifically to say *"not found, as distinct from the operation failing"* is discarded by the HTTP layer and served as a generic 500.

A GET whose retry loop exhausts does **not** come back as `Err`. `operations/get/op_ctx_task.rs` deliberately converts exhaustion into `Ok(HostResponse::ContractResponse(ContractResponse::NotFound { .. }))` — its own comment says this exists "so client integrations ... can distinguish 'contract genuinely absent' from 'operation failed'".

Read the producer, not the variant's doc, for what it means. stdlib documents `NotFound` as *"Contract was not found after exhaustive search ... distinguishes 'contract doesn't exist' from other failure modes"* — proof of absence. This node emits it on **retry-loop exhaustion**, a much weaker claim: "nobody I asked had it", over a ring that may not have propagated the contract at all. Reading it by its doc rather than by its producer is how "exhausted the retry loop" turns into "does not exist", which is the error being fixed here. (Caught in review; my first draft asserted the two agreed.)

On the web route that `Ok(..)` matches no arm. It falls through to the `Ok(other)` catch-all and becomes `NodeError { error_cause: "Unexpected response from node: .." }`. `errors.rs` maps a `NodeError` to 404 only when the message begins with the literal string `"Contract not found"` — that Debug-formatted string does not — so it lands on `INTERNAL_SERVER_ERROR`. Neither 500 path sets `Retry-After` or `Cache-Control: no-store`; those are added only on the transient branch.

**Why this matters in practice.** On Freenet a `NotFound` is routinely "not found *yet*": a contract published elsewhere is unreachable from this node until it propagates — the #4404 placement gap — a window of minutes to hours. So every visitor and every crawler that reached a freshly-published site got a dead-looking server error with no retry hint.

Measured on nova. Three sites linked in the official River room returned exactly this:

```
HTTP/1.1 500 Internal Server Error
content-length: 205

Unexpected response from node: Some(Result { id: ClientId(463000017),
  result: Ok(ContractResponse(NotFound { instance_id: ContractInstanceId("6VBUAS…") })) })
```

The GET is real — 0.69 s, a genuine network fetch — and the node is answering honestly. Only the HTTP translation is wrong. One of the affected sites was serving HTTP 200 within a day of being written off.

The exhaustion mechanism is live on this node today, not a historical curiosity:

```
GET client: retry loop exhausted — returning NotFound to client
  tx=01M0K33TC1GM60A15MEFPPD6R2 instance_id=8QPhqz77bBCJZtktjxFvyjTYJEFssxXvjVsFu5DAzJwU
  ring_connections=100 cause=get exhausted all peers after 4 attempts
```

## Approach

Add the missing arm, carried by a dedicated `WebSocketApiError::ContractNotFound`:

- **503 with `Retry-After: 60` and `Cache-Control: no-store`.** This is the half a programmatic client acts on, and the whole reason for the fix — a crawler must come back later rather than write the contract off.
- **A page that explains the situation and offers a deliberate retry, with no `<meta http-equiv="refresh">`.**
- **An honest name** in the one type the HTTP layer logs and renders from.

The first draft reused `RequestError(Timeout)`, which got the right status by borrowing the wrong meaning and inherited `retry_loading_page` — a page that reloads every 60 s with no cap. That is defensible for an actual timeout (the node has peers and is making progress on *that* get) but not here, because the identical reply is produced for a key that will never resolve. A mistyped contract URL left open in a tab would have re-issued a network GET every minute for the life of the tab, which is what `.claude/rules/browser-assets.md` ("assume every open tab pays the cost") exists to prevent. Caught in review; the dedicated variant is the fix.

**Deliberately not 404, which would be worse than the 500 it replaces.** A well-behaved crawler treats 404 as terminal: Atlas marks such a locator seen for good and never retries it. Answering 404 here would permanently exclude every contract that was merely slow to propagate — turning a transient miss into permanent invisibility. 404 stays reserved for the `contract: None` arm, where absence is locally proven.

Note the #3945 gate comment on the sibling cold-cache path says the caller should "serve a 404". On this route that intent would be actively harmful for the reason above; this PR does not change that path, but the comment is worth revisiting separately.

## Testing

**Rust.** `handle_get_response_maps_network_not_found_to_transient_retry` asserts the variant, the status through the real `into_response`, both headers, and that the body carries no meta-refresh. The headers are set in `errors.rs` — a different file — so asserting the status alone would still pass if they were dropped, and that cross-file coupling is exactly what failed here.

Two arms of this function had no test at all, one of them the catch-all the bug hid inside. Both are now covered: carving `NotFound` out must not leave the catch-all dead, and a genuinely nonsensical answer to a GET (a `PutResponse`) must still surface as 500 — that status was never the complaint.

**Browser.** `crates/core/tests/playwright/tests/contract-not-found.spec.ts`, two specs, green on **chromium, firefox and webkit**. The Rust test cannot see route wiring, and cannot see whether the page a browser actually parses reloads itself — which is the property the second commit is about. One spec asserts status, headers, absence of a refresh tag in the parsed DOM, and the page's own wording; the other watches the request log across a wait and asserts the page issues nothing further on its own.

Each assertion discriminates a different wrong answer: the status catches a regression to 500, the `h1` text catches the connecting page (also 503, different text), the refresh checks catch a regression to `retry_loading_page`.

**Mutation-verified.** Deleting the arm reproduces the original production error string verbatim. Pointing it back at `RequestError(Timeout)` fails the not-found test.

479 → 481 tests in `server::` pass; `cargo clippy -p freenet --lib --all-features` clean.

## Review

Four independent lenses; every finding addressed or answered.

- **Codex** (external, non-Claude) raised the unbounded-refresh problem — the strongest objection, and correct. Fixed by giving the reply its own error variant rather than borrowing `RequestError(Timeout)`. It also asked for Playwright coverage per `browser-assets.md`; added.
- **Skeptical lens**: no blocking findings. Confirmed no arm shadowing (enumerated all six `ContractResponse` variants before and after), that `ensure_contract_cached` is the only caller, and that nothing downstream asserts the old 500. Independently raised the same unbounded-refresh tradeoff.
- **Testing lens**: confirmed the mutation claim by reading, and identified why 5000+ tests passed while this shipped — no test ever constructed this variant at the boundary, and every route-level integration test publishes and serves from the same node, so none can produce a genuine `NotFound`. Prompted the two sibling-arm tests.
- **Code-first lens**: built the full reply-to-status mapping from the code before reading the description, and verified each of its claims against `file:line` — including that `Retry-After`/`Cache-Control` really are set on this path. It independently recommended the dedicated local error variant (already landed by then) and caught a stdlib-doc overstatement in an earlier draft, since corrected. Its remaining note: the new `info!` reaches node log files but not the OTel collector, which carries only enumerated events — consistent with every neighbouring diagnostic here, and now stated in the code so nobody builds a fleet-wide metric on it.

One caveat worth stating plainly: the Playwright suite only runs under `FREENET_PLAYWRIGHT=1`, and its workflow is not a required check (#5275). A run without that variable checks that the shell serves and skips every browser spec.

## Not in scope

The same route can also produce an indistinguishable 500 via `ErrorKind::OperationError`, which is dual-use by design (`errors.rs` explains why it must not be blanket-treated as transient — a banned contract would otherwise infinite-reload). That covers the #4345 streaming-assembly-exhaustion case, where existence has already been proven by a header. Worth separating, but it needs a signal that does not exist yet.

[AI-assisted - Claude]


*(Commits squashed to one before merge to satisfy the 72-char subject rule; the tree is byte-identical to the reviewed content.)*
