### PR TITLE
fix: raise per-client subscription cap from 50 to 500

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -74,8 +74,17 @@ pub(crate) const MAX_SUBSCRIBERS_PER_CONTRACT: usize = 256;
 /// subscribe to one contract per discoverable peer/user (e.g. Freebird's discovery
 /// pattern), and the cap was trivially bypassable by opening a second websocket
 /// connection (each connection mints a fresh `ClientId` with its own budget), so it
-/// penalized well-behaved clients while stopping no determined abuser. See the PR that
-/// raised this constant for the worst-case memory arithmetic behind the new value.
+/// penalized well-behaved clients while stopping no determined abuser.
+///
+/// This constant does not bound per-subscription memory, so raising it is safe by the
+/// same argument at any value: each subscription's notification channel
+/// (`SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE`) is bounded by message COUNT, not bytes, and
+/// is drained lossily (`try_send`, dropped when full) rather than growing unbounded. A
+/// queued message can itself carry a full contract-state clone up to `MAX_STATE_SIZE`
+/// (see `wasm_runtime::state_store`), so the per-subscription worst case is already
+/// governed by that channel depth and state-size cap, not by this constant — raising
+/// this value only scales an exposure that exists independently of it. See the PR that
+/// raised this constant to 500 for the full numeric worked example.
 pub(crate) const MAX_SUBSCRIPTIONS_PER_CLIENT: usize = 500;
 
 /// Buffer size for per-subscriber notification channels.

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -63,7 +63,20 @@ pub(crate) const MAX_SUBSCRIBERS_PER_CONTRACT: usize = 256;
 
 /// Maximum total subscriptions a single client may hold across all contracts.
 /// Prevents a single client from spreading thin across many contracts to exhaust resources.
-pub(crate) const MAX_SUBSCRIPTIONS_PER_CLIENT: usize = 50;
+///
+/// This is a hard-coded network-wide constant, not a per-node config option, and that is
+/// deliberate: a configurable cap would mean a dApp works on some peers and not others,
+/// which is exactly the non-uniformity Freenet must avoid (every node must enforce the
+/// same limit so client behavior is predictable network-wide). Do not make this
+/// configurable — that has been proposed and explicitly rejected (Ian, 2026-08-22).
+///
+/// Raised from 50 to 500 (2026-08-22): 50 was hit almost immediately by apps that
+/// subscribe to one contract per discoverable peer/user (e.g. Freebird's discovery
+/// pattern), and the cap was trivially bypassable by opening a second websocket
+/// connection (each connection mints a fresh `ClientId` with its own budget), so it
+/// penalized well-behaved clients while stopping no determined abuser. See the PR that
+/// raised this constant for the worst-case memory arithmetic behind the new value.
+pub(crate) const MAX_SUBSCRIPTIONS_PER_CLIENT: usize = 500;
 
 /// Buffer size for per-subscriber notification channels.
 /// When full, notifications are dropped (lossy) rather than blocking the executor.

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -85,6 +85,12 @@ pub(crate) const MAX_SUBSCRIBERS_PER_CONTRACT: usize = 256;
 /// governed by that channel depth and state-size cap, not by this constant — raising
 /// this value only scales an exposure that exists independently of it. See the PR that
 /// raised this constant to 500 for the full numeric worked example.
+///
+/// Note: the tokio mpsc channel behind each subscription eagerly allocates its first
+/// block (32 slots by default) at creation and allocates further blocks on demand — it
+/// is not fully preallocated to capacity, but an idle subscription is not literally
+/// zero-cost either. The order-of-magnitude conclusion (idle cost is negligible, on the
+/// order of a few hundred bytes per subscription) still holds.
 pub(crate) const MAX_SUBSCRIPTIONS_PER_CLIENT: usize = 500;
 
 /// Buffer size for per-subscriber notification channels.

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -128,6 +128,55 @@ async fn test_per_client_subscription_limit_enforced() {
     );
 }
 
+/// Regression test for raising `MAX_SUBSCRIPTIONS_PER_CLIENT` from 50 to 500
+/// (2026-08-22). Registers a client to more subscriptions than the FORMER cap of 50
+/// allowed; before the raise this would have failed partway through with a
+/// `SubscriberLimit` error. Deliberately uses a literal historical value (not
+/// `MAX_SUBSCRIPTIONS_PER_CLIENT`) so the test keeps pinning "more than the old 50"
+/// even if the constant moves again later.
+#[tokio::test(flavor = "current_thread")]
+async fn test_per_client_limit_allows_more_than_former_cap_of_50() {
+    const SUBSCRIPTIONS_BEYOND_FORMER_CAP: usize = 100;
+    const {
+        assert!(
+            SUBSCRIPTIONS_BEYOND_FORMER_CAP > 50
+                && SUBSCRIPTIONS_BEYOND_FORMER_CAP < MAX_SUBSCRIPTIONS_PER_CLIENT,
+            "test constant must stay between the former cap (50) and the current cap"
+        );
+    }
+
+    let mut executor = create_executor().await;
+    let client_id = ClientId::next();
+    let mut receivers = Vec::new();
+
+    for i in 0..SUBSCRIPTIONS_BEYOND_FORMER_CAP {
+        let seed = format!("beyond_former_cap_test_{i}");
+        let key = store_contract(&mut executor, seed.as_bytes()).await;
+        let instance_id = *key.id();
+        let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE);
+        executor
+            .register_contract_notifier(instance_id, client_id, tx, None)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "registration {i} (of {SUBSCRIPTIONS_BEYOND_FORMER_CAP}, beyond the \
+                     former 50-subscription cap) should succeed under the raised limit: {e}"
+                )
+            });
+        receivers.push(rx);
+    }
+
+    let subs = executor.get_subscription_info();
+    let client_sub_count = subs
+        .iter()
+        .filter(|info| info.client_id == client_id)
+        .count();
+    assert_eq!(
+        client_sub_count, SUBSCRIPTIONS_BEYOND_FORMER_CAP,
+        "client should hold all {SUBSCRIPTIONS_BEYOND_FORMER_CAP} subscriptions, which \
+         exceeds the former cap of 50"
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn test_per_client_limit_does_not_affect_other_clients() {
     let mut executor = create_executor().await;

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -108,14 +108,15 @@ pub(crate) async fn start_client_subscribe(
     //      and exits via `deliver_outcome`.
     //
     // Amplification ceiling: the WS SUBSCRIBE request path enforces
-    // `MAX_SUBSCRIPTIONS_PER_CLIENT = 50` upstream via
+    // `contract::executor::MAX_SUBSCRIPTIONS_PER_CLIENT` upstream via
     // `notify_contract_handler(RegisterSubscriberListener)` →
     // `runtime.rs:623` (Executor::register_subscription), which rejects
     // the registration BEFORE `subscribe_with_id` is called. A client
-    // that tries to open more than 50 in-flight subscribes gets a
-    // `SubscriberLimit` error from the contract handler and never
-    // reaches this spawn site. In-flight task count is therefore
-    // bounded by `num_clients * 50`, not unbounded.
+    // that tries to open more than `MAX_SUBSCRIPTIONS_PER_CLIENT`
+    // in-flight subscribes gets a `SubscriberLimit` error from the
+    // contract handler and never reaches this spawn site. In-flight
+    // task count is therefore bounded by
+    // `num_clients * MAX_SUBSCRIPTIONS_PER_CLIENT`, not unbounded.
     //
     // Leak detection: if the driver somehow gets stuck without exiting
     // any of the four paths above, `test_pending_op_results_bounded`


### PR DESCRIPTION
## Problem

`MAX_SUBSCRIPTIONS_PER_CLIENT` (introduced in #3330, 2026-02-28, alongside `MAX_SUBSCRIBERS_PER_CONTRACT = 256` and `MAX_DOWNSTREAM_SUBSCRIBERS_PER_CONTRACT = 512`) is 50. Real dApps hit this almost immediately: Freebird does discovery by subscribing to one contract per user, so it saturates the cap right away. The cap is also trivially bypassable — opening a second websocket connection mints a fresh `ClientId` with its own budget — so it penalizes well-behaved clients while stopping no determined abuser.

## Approach

Raise `MAX_SUBSCRIPTIONS_PER_CLIENT` from 50 to 500 in `crates/core/src/contract/executor.rs`. Both enforcement sites (`runtime/pool.rs:1228` and `runtime/executor_impl.rs:1198`) reference the constant directly, so no other code changes are needed. The constant is **not** made configurable per-node — that was considered and explicitly rejected: a per-node config option would mean a dApp works on some peers and not others, which is exactly the non-uniformity Freenet must avoid. The cap must be identical across the network. This reasoning is recorded in the constant's doc comment so it doesn't get re-proposed.

### Worst-case memory arithmetic (verified, not assumed)

Each subscription registers a `tokio::sync::mpsc::channel(SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE)` (capacity 64) — see `crates/core/src/client_events/websocket.rs::setup_subscription` (~line 556). Tokio's bounded mpsc channel eagerly allocates its first block (32 slots by default) at creation and allocates further blocks on demand — it is not preallocated to full capacity — so an **idle** subscription costs only that first block plus the channel's own bookkeeping: negligible, on the order of a few hundred bytes. At 500 idle subscriptions that's well under 1 MB of overhead.

The type flowing through the channel is `HostResult = Result<HostResponse, ClientError>` (`client_events/types.rs:15`). For a subscription, the populated variant is `HostResponse::ContractResponse(ContractResponse::UpdateNotification { key, update })`, and `update: UpdateData<'static>` **can be `UpdateData::State(State)`** — i.e. a full clone of the contract's state, not just a diff. Confirmed at the call site: `runtime/executor_impl.rs:2751` sends `UpdateData::State(full_state.clone())` whenever no cached summary exists for a subscriber or the per-fanout delta-computation cap (`MAX_DELTA_COMPUTATIONS_PER_FANOUT = 32`) is exceeded. Per-message size is therefore bounded only by `MAX_STATE_SIZE = 50 MiB` (`wasm_runtime/state_store.rs:40`), enforced on every state write.

Notifications are sent with `try_send` and dropped (not queued beyond capacity) when a subscriber's channel is full — confirmed at both `executor_impl.rs:2751` and `:2928`. So the channel genuinely caps at 64 in-flight messages per subscription, never more.

**Absolute theoretical worst case per subscription:** 64 messages × 50 MiB = 3.125 GiB, if 64 near-max-size updates land back-to-back on one contract before the client drains any of them.

**Absolute theoretical worst case at 500 subscriptions** (to 500 distinct contracts, all simultaneously flooded to the same degree): 500 × 3.125 GiB ≈ 1.53 TiB.

This number is not a reason to reject 500. It already breaks at the **current** cap of 50 (50 × 3.125 GiB ≈ 156 GiB — far beyond any real node's memory, including the 2 GiB case), and even at a cap of 1 a single flooded subscription's theoretical worst case (3.125 GiB) already exceeds a 2 GiB-capped node. `MAX_SUBSCRIPTIONS_PER_CLIENT` was never the mechanism bounding this scenario — the per-message size cap (`MAX_STATE_SIZE`) and channel depth (`SUBSCRIBER_NOTIFICATION_CHANNEL_SIZE`) are the only knobs that bound a single subscription's worst case, and raising the client-subscription cap only scales an exposure that already existed. Reaching it in practice requires an adversarial contract owner to push dozens of near-50-MiB updates to the same contract faster than the network's own operation pipeline can deliver them and faster than any subscriber reads its socket — a scenario gated by transport/op throughput, not by this constant.

Under a realistic threat model (typical app payloads in the KB range, not adversarial 50 MiB states), memory at full queue depth across 500 subscriptions stays in the tens of MB, comfortably within a 2 GiB node.

**Conclusion: 500 is the right number for what this cap is actually meant to bound** (a client spreading thin across many contracts to consume disproportionate per-subscription overhead). It does not, and cannot by itself, bound the separate max-message-size amplification vector — that already exists today and is orthogonal to this constant.

### Hosting cost (added after review — separate from the channel arithmetic above)

The arithmetic above covers the per-subscription notification channel only. SUBSCRIBE itself also has a hosting-side cost this constant scales:

- `operations/subscribe.rs:385` calls `op_manager.interest_manager.add_local_client(&key)` — the LOCAL-client demand signal. Per `.claude/rules/hosting-invariants.md` invariant 3, a local client subscription ranks **highest** in the eviction ordering (ascending `local_subscription_count, downstream_subscriber_count, recency, key bytes`): a locally-subscribed contract is evicted **last**, ahead of everything else the peer holds.
- `operations/subscribe.rs:404-448` (`fetch_contract_if_missing`) issues a network GET to pull the contract body if the peer doesn't already have it.

So one client subscribing to 500 distinct, not-yet-hosted contracts — exactly the Freebird discovery pattern that motivates this PR — can make a node fetch, store, and eviction-protect up to 10x more of its hosting budget than it could under the old cap of 50, through entirely legitimate use. `.claude/rules/code-style.md:104-112` names this constant's purpose as preventing exactly this kind of resource-spreading, so this is a real instance of the threat model the constant exists for, not a new one this PR introduces.

Mitigating factor: the commonly-cited "~1 MB/contract" resident-cost figure is a known simplification. Per freenet-core#5348 (open, measured 2026-08-16), resident cost tracks distinct **WASM module** count (~8-12 MB/module), not contract count — the module cache is keyed by code hash and is shared. A discovery pattern subscribing to many contracts of the *same app* pays for one shared module, not 500. The true incremental cost of the extra subscriptions is per-contract bookkeeping, state bytes, and update fan-out — real, but materially smaller than a naive "500 × 1 MB" estimate would suggest. State bytes and fan-out do still scale per contract, so the concern is real; it's smaller than it first looks, not absent.

This is a hosting/placement design question — how the eviction budget accounts for subscription-driven fetches at this scale — not a memory-safety defect in the channel arithmetic above. It's noted here for visibility; hosting/placement sign-off is being handled separately per `.claude/rules/hosting-invariants.md`.

## Testing

- `crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs` and `subscriber_stress_tests.rs` already parameterize on `MAX_SUBSCRIPTIONS_PER_CLIENT` rather than hardcoding 50, so no edits were needed to make the existing tests pass at the new value.
- **New regression test**: `test_per_client_limit_allows_more_than_former_cap_of_50` registers 100 subscriptions for one client (100 > the former cap of 50, well under the new 500) and asserts all 100 are accepted — the accept-half of the regression, which would have failed before this change. A `const { assert!(...) }` compile-time guard keeps the test constant between the former and current caps. The existing `test_per_client_subscription_limit_enforced` (parameterized on the constant) is the reject-half, confirming the cap still binds at the new ceiling (501st registration rejected).
- Re-ran both modules against the new value:
  - `subscriber_limit_tests`: 20/20 passed.
  - `subscriber_stress_tests`: 9/9 passed, including `test_per_client_churn_with_limit` and `test_client_churn_with_limit_enforcement`.
- `cargo fmt --check` and `cargo clippy --lib --tests -- -D warnings` both clean.
- Fixed a stale comment in `operations/subscribe/op_ctx_task.rs` that hard-coded the old cap value in three places (10x wrong after the raise); it now references `MAX_SUBSCRIPTIONS_PER_CLIENT` symbolically so it can't go stale again on the next change.

## Important caveat

Raising this constant does **not** help apps until the network upgrades, and there is currently no capability negotiation between client and node: `ApiVersion` V1/V2 is URL-path routing whose field is explicitly marked "not yet read," and `encodingProtocol` is a format switch, not a version. A client cannot detect which cap a node enforces. This PR alone does not fix Freebird — the near-term unblock for apps (making `subscribe()` actually reject, giving the limit error a truthful contract key, and per-contract unsubscribe) is separate work already in flight.

[AI-assisted - Claude]
