### PR TITLE
fix(dashboard): replace the health verdict with a measured GET success rate

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3195,6 +3195,11 @@ mod tests {
             html.contains("1 of 2"),
             "the counts are still worth showing — got:\n{html}"
         );
+        assert!(
+            html.contains("does not by itself"),
+            "the caveat must appear even when there is no rate to qualify — \
+             got:\n{html}"
+        );
     }
 
     /// The number the whole change exists to surface.
@@ -3211,11 +3216,11 @@ mod tests {
         let html = build_status_card(&Some(snap));
 
         assert!(
-            html.contains("1%"),
+            html.contains("1% answered"),
             "2 of 153 is 1% and must be shown as such — got:\n{html}"
         );
         assert!(
-            html.contains("2 of 153 requests"),
+            html.contains("2 of 153"),
             "the sample size must accompany the percentage, so the reader can \
              tell 1% of 153 from 1% of 3 — got:\n{html}"
         );
@@ -3224,6 +3229,35 @@ mod tests {
             "the figure is lifetime, not a recent window, and must say so — \
              got:\n{html}"
         );
+    }
+
+    /// The caveat must be UNCONDITIONAL, at every rate.
+    ///
+    /// An unanswered GET is frequently the network failing to route rather
+    /// than this node failing to serve — dead-ends dominate the not-found
+    /// mode. Without the caveat, "GET requests 1% answered" invites the
+    /// operator to conclude their own node is broken and report it, and the
+    /// support burden would be built out of our own phrasing.
+    ///
+    /// Showing it only when the number looks bad would be a threshold in
+    /// disguise, and picking that threshold is precisely the judgement this
+    /// panel exists to avoid. So it is pinned at a healthy rate too: if a
+    /// future change makes it conditional, this fails.
+    #[test]
+    fn get_success_caveat_is_shown_at_every_rate() {
+        for (ok, failed, label) in [(2u32, 151u32, "very low"), (150, 3, "very high")] {
+            let mut snap = base_snapshot();
+            snap.open_connections = 6;
+            snap.health = crate::node::network_status::HealthLevel::Healthy;
+            snap.elapsed_secs = 3600 * 4;
+            snap.op_stats.gets = (ok, failed);
+            let html = build_status_card(&Some(snap));
+            assert!(
+                html.contains("could not route"),
+                "the caveat must appear at a {label} rate too, or it becomes a \
+                 threshold in disguise — got:\n{html}"
+            );
+        }
     }
 
     /// The rate must not be styled as a verdict.

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3282,6 +3282,27 @@ mod tests {
             "0 of 50 really is 0% — got:\n{zero}"
         );
 
+        // Exactly at MIN_SAMPLE. The gate is `total < MIN_SAMPLE`, so 20 must
+        // take the rate branch — the one boundary value the other cases do not
+        // pin, and an off-by-one here would silently withhold the number from
+        // every node sitting at the threshold.
+        let at_min = render(10, 20);
+        assert!(
+            at_min.contains("50% answered"),
+            "20 requests is exactly the minimum sample, so it must be rated — \
+             got:\n{at_min}"
+        );
+        assert!(
+            !at_min.contains("too few to rate"),
+            "and must not be refused — got:\n{at_min}"
+        );
+        let below_min = render(9, 19);
+        assert!(
+            below_min.contains("too few to rate"),
+            "19 requests is below the minimum and must be refused — \
+             got:\n{below_min}"
+        );
+
         // And an ordinary value is unaffected: the 1.3% gateway from #5370.
         let gateway = render(2, 153);
         assert!(

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3304,7 +3304,15 @@ mod tests {
     /// future change makes it conditional, this fails.
     #[test]
     fn get_success_caveat_is_shown_at_every_rate() {
-        for (ok, failed, label) in [(2u32, 151u32, "very low"), (150, 3, "very high")] {
+        // Includes the total == 0 branch. Review noted it was the one case
+        // the caveat's own test never exercised — and it is the state a
+        // freshly-started node sits in, so it is the branch most operators
+        // see first.
+        for (ok, failed, label) in [
+            (2u32, 151u32, "very low"),
+            (150, 3, "very high"),
+            (0, 0, "no requests yet"),
+        ] {
             let mut snap = base_snapshot();
             snap.open_connections = 6;
             snap.health = crate::node::network_status::HealthLevel::Healthy;

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -555,7 +555,20 @@ mod tests {
         snap.open_connections = 3;
         let html = build_status_card(&Some(snap));
         assert!(html.contains("health-good"), "healthy banner missing");
-        assert!(html.contains("Node is healthy"));
+        // Superseded by #5370: the banner no longer declares the node healthy.
+        // Four live v0.2.128 peers showed "Node is healthy" while answering
+        // between 1.3% and 89% of their GETs, because the four inputs behind
+        // the verdict are all connectivity and none of them can see whether
+        // the node serves reads. The banner now states the connection count,
+        // which is a fact, and the measured GET rate carries the rest.
+        assert!(
+            html.contains("Connected to 3 peers"),
+            "the healthy state must still state its connection count, got: {html}"
+        );
+        assert!(
+            !html.contains("Node is healthy"),
+            "the verdict must not come back, got: {html}"
+        );
 
         // Degraded
         let mut snap = base_snapshot();
@@ -3128,6 +3141,124 @@ mod tests {
     // either survives the 5s `<main>` swap. A green run here is compatible
     // with the feature being completely broken in a browser. The behaviour is
     // covered by driving a real node with Playwright; see the PR.
+
+    // ─── GET success rate (#5370) ───────────────────────────────────────
+
+    /// The banner must not call the node healthy.
+    ///
+    /// It did, on four connectivity inputs that say nothing about whether the
+    /// node can serve reads: four live v0.2.128 peers displayed "Node is
+    /// healthy" while answering between 1.3% and 89% of their GETs. A verdict
+    /// is an assertion, and unsupported assertions are what this page keeps
+    /// getting wrong. The connection COUNT is a fact and stays.
+    #[test]
+    fn status_card_states_connections_instead_of_declaring_health() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 5;
+        snap.health = crate::node::network_status::HealthLevel::Healthy;
+        let html = build_status_card(&Some(snap));
+
+        assert!(
+            !html.contains("is healthy"),
+            "the banner must not declare the node healthy — got:\n{html}"
+        );
+        assert!(
+            html.contains("Connected to 5 peers"),
+            "the connection count is a fact and must survive — got:\n{html}"
+        );
+    }
+
+    /// A percentage over a handful of requests is theatre.
+    ///
+    /// Peers issue only a few GETs an hour, so a fresh node sits at a tiny
+    /// denominator for a long time. At two requests one outcome moves the
+    /// figure fifty points, which looks like a measurement and is not.
+    #[test]
+    fn get_success_rate_refuses_to_rate_a_tiny_sample() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 3;
+        snap.health = crate::node::network_status::HealthLevel::Healthy;
+        snap.elapsed_secs = 600;
+        snap.op_stats.gets = (1, 1);
+        let html = build_status_card(&Some(snap));
+
+        assert!(
+            html.contains("too few to rate"),
+            "a 2-request sample must not be rendered as a percentage — \
+             got:\n{html}"
+        );
+        assert!(
+            !html.contains("50%"),
+            "and specifically not as 50% — got:\n{html}"
+        );
+        assert!(
+            html.contains("1 of 2"),
+            "the counts are still worth showing — got:\n{html}"
+        );
+    }
+
+    /// The number the whole change exists to surface.
+    ///
+    /// The production gateway in #5370 answered 2 of 153 GETs and displayed
+    /// "Node is healthy". It must now read 1%.
+    #[test]
+    fn get_success_rate_reports_the_measured_share() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 12;
+        snap.health = crate::node::network_status::HealthLevel::Healthy;
+        snap.elapsed_secs = 3600 * 5;
+        snap.op_stats.gets = (2, 151);
+        let html = build_status_card(&Some(snap));
+
+        assert!(
+            html.contains("1%"),
+            "2 of 153 is 1% and must be shown as such — got:\n{html}"
+        );
+        assert!(
+            html.contains("2 of 153 requests"),
+            "the sample size must accompany the percentage, so the reader can \
+             tell 1% of 153 from 1% of 3 — got:\n{html}"
+        );
+        assert!(
+            html.contains("since start"),
+            "the figure is lifetime, not a recent window, and must say so — \
+             got:\n{html}"
+        );
+    }
+
+    /// The rate must not be styled as a verdict.
+    ///
+    /// Colouring it green or red would reintroduce through CSS exactly the
+    /// judgement the change removed from the markup — and the threshold for
+    /// that colour is the number nobody could justify picking, which is why
+    /// the verdict went in the first place.
+    #[test]
+    fn get_success_rate_carries_no_pass_fail_styling() {
+        let mut snap = base_snapshot();
+        snap.open_connections = 4;
+        snap.health = crate::node::network_status::HealthLevel::Healthy;
+        snap.elapsed_secs = 3600;
+        snap.op_stats.gets = (10, 90);
+        let html = build_status_card(&Some(snap));
+
+        let line_start = html
+            .find("get-success-rate")
+            .expect("the rate line must be rendered");
+        let line = &html[line_start..html[line_start..].find("</p>").unwrap() + line_start];
+        for verdict_class in [
+            "health-good",
+            "health-trouble",
+            "health-degraded",
+            "op-ok",
+            "op-fail",
+        ] {
+            assert!(
+                !line.contains(verdict_class),
+                "the rate line must not carry the pass/fail class \
+                 `{verdict_class}` — got:\n{line}"
+            );
+        }
+    }
 
     // ─── Contract detail page (#5369) ───────────────────────────────────
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3231,6 +3231,65 @@ mod tests {
         );
     }
 
+    /// Rounding must never assert something that did not happen.
+    ///
+    /// `{:.0}` alone renders 199/200 as "100%" and 1/200 as "0%". Both are
+    /// false in the way this panel exists to prevent: "100% answered" when a
+    /// request failed is the same unearned absolute as "Node is healthy" was,
+    /// and an operator who reads 100% stops looking.
+    ///
+    /// 100% and 0% are therefore reserved for the cases that earn them, and
+    /// the bands beside them say which side of the boundary they are on
+    /// instead of rounding across it.
+    #[test]
+    fn answered_share_never_rounds_across_an_absolute() {
+        let render = |ok: u32, total: u32| {
+            let mut snap = base_snapshot();
+            snap.open_connections = 4;
+            snap.health = crate::node::network_status::HealthLevel::Healthy;
+            snap.elapsed_secs = 3600;
+            snap.op_stats.gets = (ok, total - ok);
+            build_status_card(&Some(snap))
+        };
+
+        // A single failure must not render as a perfect score.
+        let near_perfect = render(199, 200);
+        assert!(
+            near_perfect.contains("&gt;99% answered") || near_perfect.contains(">99% answered"),
+            "199 of 200 must not claim 100% — got:\n{near_perfect}"
+        );
+        assert!(
+            !near_perfect.contains("100% answered"),
+            "199 of 200 rounds to 100 and must be caught — got:\n{near_perfect}"
+        );
+
+        // A single success must not render as total failure.
+        let near_zero = render(1, 200);
+        assert!(
+            near_zero.contains("&lt;1% answered") || near_zero.contains("<1% answered"),
+            "1 of 200 must not claim 0% — got:\n{near_zero}"
+        );
+
+        // The absolutes are still available when genuinely earned.
+        let perfect = render(50, 50);
+        assert!(
+            perfect.contains("100% answered"),
+            "50 of 50 really is 100% — got:\n{perfect}"
+        );
+        let zero = render(0, 50);
+        assert!(
+            zero.contains("0% answered"),
+            "0 of 50 really is 0% — got:\n{zero}"
+        );
+
+        // And an ordinary value is unaffected: the 1.3% gateway from #5370.
+        let gateway = render(2, 153);
+        assert!(
+            gateway.contains("1% answered"),
+            "2 of 153 is 1.3%, which rounds honestly to 1% — got:\n{gateway}"
+        );
+    }
+
     /// The caveat must be UNCONDITIONAL, at every rate.
     ///
     /// An unanswered GET is frequently the network failing to route rather

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1479,6 +1479,16 @@ table.sortable thead th.sort-desc::after {
   color: var(--text-muted);
   font-size: 0.75rem;
 }
+/* The caveat is deliberately quiet but always present. It exists so a low
+   share is not misread as "my node is broken" — an unanswered GET is often
+   the network failing to route rather than this node failing to serve. */
+.get-success-caveat {
+  margin: 0 0 0.4rem;
+  font-size: 0.7rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+  max-width: 62ch;
+}
 
 .key-wrap {
   overflow-wrap: anywhere;

--- a/crates/core/src/server/home_page/assets/style.css
+++ b/crates/core/src/server/home_page/assets/style.css
@@ -1448,6 +1448,38 @@ table.sortable thead th.sort-desc::after {
   text-decoration: underline;
 }
 
+/* Measured GET success rate (#5370). Deliberately styled as a READING, not a
+   status: no green/red, no icon. The page replaced a healthy/unhealthy verdict
+   with this number precisely because a verdict asserts something the four
+   connectivity inputs behind it could not support, and colouring the number
+   would smuggle the verdict back in through the stylesheet. */
+.get-success-rate {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin: 0.5rem 0 0.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.gsr-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+.gsr-value {
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+}
+.gsr-detail,
+.gsr-none {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
 .key-wrap {
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -11,6 +11,15 @@ use super::*;
 /// them, and the bands next to them say which side of the boundary they are
 /// on rather than rounding across it.
 fn answered_share(ok: u32, total: u32) -> String {
+    // Defence in depth. The only caller gates on `total >= MIN_SAMPLE`, so
+    // zero cannot reach here today — but without this the `ok == total` arm
+    // below would answer "100%" for nothing at all, which is the worst
+    // possible wrong answer from a panel whose entire purpose is not
+    // overstating success. A future caller that forgets the guard should get
+    // an honest dash, not a perfect score.
+    if total == 0 {
+        return "—".to_string();
+    }
     if ok == total {
         return "100%".to_string();
     }

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -84,7 +84,11 @@ fn build_get_success_line(snap: &network_status::NetworkStatusSnapshot) -> Strin
     // judgement this panel exists to avoid making. So it is unconditional,
     // and it says "not by itself" rather than "not your fault", because on a
     // node with no connections it genuinely is this node.
-    let caveat = r#"<span class="gsr-caveat">Unanswered includes requests the network could not route, so a low share does not by itself mean this node is faulty.</span>"#;
+    // Plain text, not a <span>. An earlier draft wrapped this in
+    // `class="gsr-caveat"`, which no stylesheet rule ever matched — a dead
+    // class name reads as if it carries styling and invites someone to
+    // "restore" formatting that never existed. The wrapping <p> is styled.
+    let caveat = "Unanswered includes requests the network could not route, so a low share does not by itself mean this node is faulty.";
 
     format!(
         r#"<p class="get-success-rate" title="Of the GET requests this node has issued, the share that came back with contract state, over the whole time it has been running. Not a recent window: peers issue only a handful of GETs an hour, so a short window would nearly always be empty. A request that dead-ends in the network counts as unanswered.">

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1,5 +1,50 @@
 use super::*;
 
+/// Contracts read successfully, as a measured rate rather than a verdict.
+///
+/// Deliberately reports the LIFETIME rate with the period it covers, not a
+/// recent window, and that is a data constraint rather than a shortcut.
+/// Measured on three live nodes: a hosted-mode peer did 101 GETs in 17h55m
+/// (~5.6/hour), a gateway 7 in 28m (~15/hour), and a third none at all. A
+/// fifteen-minute window would hold one to four requests, and even an hour
+/// holds about six, where a single failure moves the number seventeen points.
+/// A window short enough to mean "now" is empty almost all the time, so it
+/// would report nothing far more often than it reported anything.
+///
+/// The cost of using lifetime is real and worth naming: a node broken early
+/// and fine since shows a blended figure. The uptime is printed alongside so
+/// the reader can see what the number covers, and `record_op_result` keeps no
+/// history that would allow better.
+fn build_get_success_line(snap: &network_status::NetworkStatusSnapshot) -> String {
+    let (ok, failed) = snap.op_stats.gets;
+    let total = ok.saturating_add(failed);
+    let period = format_duration(snap.elapsed_secs);
+
+    // Below this, a percentage is theatre: at one or two requests it swings by
+    // fifty points per outcome. Show the counts and say why there is no rate,
+    // rather than printing a number that looks like a measurement.
+    const MIN_SAMPLE: u32 = 20;
+
+    let body = if total == 0 {
+        "<span class=\"gsr-none\">no GETs yet</span>".to_string()
+    } else if total < MIN_SAMPLE {
+        format!(
+            r#"<span class="gsr-none">too few to rate</span> <span class="gsr-detail">{ok} of {total} succeeded in {period}</span>"#
+        )
+    } else {
+        let pct = (ok as f64 / total as f64) * 100.0;
+        format!(
+            r#"<span class="gsr-value">{pct:.0}%</span> <span class="gsr-detail">{ok} of {total} requests, since start &middot; {period}</span>"#
+        )
+    };
+
+    format!(
+        r#"<p class="get-success-rate" title="The share of this node's own GET requests that returned state, over the whole time it has been running. Not a recent window: peers issue only a handful of GETs an hour, so a short window would usually be empty. A GET that dead-ends counts as a failure.">
+            <span class="gsr-label">GET success</span> {body}
+        </p>"#
+    )
+}
+
 pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> String {
     let Some(snap) = snap else {
         return r#"<div class="card">
@@ -13,12 +58,22 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
     // Health banner — the primary "everything looks good" indicator
     let health_banner = match snap.health {
         network_status::HealthLevel::Healthy => {
+            // Deliberately NOT a verdict. This used to read "Node is healthy",
+            // with a tick, on the strength of four connectivity inputs that
+            // say nothing about whether the node can actually serve reads —
+            // four live v0.2.128 peers displayed it while answering between
+            // 1.3% and 89% of their GETs (#5370).
+            //
+            // A verdict is an assertion, and asserting things that are not
+            // true is this page's recurring failure. State the connection
+            // count, which is a fact, and let the measured GET rate below
+            // speak for whether the node is working.
             let n = snap.open_connections;
             let label = if n == 1 { "peer" } else { "peers" };
             format!(
                 r#"<div class="health-banner health-good">
-                    <span class="health-icon">&#x2714;</span>
-                    <span>Node is healthy — connected to {n} {label}</span>
+                    <span class="health-icon">&#x25CF;</span>
+                    <span>Connected to {n} {label}</span>
                 </div>"#,
             )
         }
@@ -58,6 +113,8 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
             )
         }
     };
+
+    let get_success = build_get_success_line(snap);
 
     // External address info (shown once discovered via NAT traversal)
     let external_addr_html = if let Some(addr) = snap.external_address {
@@ -333,6 +390,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
         r#"<div class="card">
             <h2>Connection Status</h2>
             {health_banner}
+            {get_success}
             {ring_stats_html}
             {lattice_html}
             {rate_limit_html}
@@ -344,6 +402,7 @@ pub fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -
             {failures_html}
         </div>"#,
         health_banner = health_banner,
+        get_success = get_success,
         ring_stats_html = ring_stats_html,
         lattice_html = lattice_html,
         rate_limit_html = rate_limit_html,

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+/// Format a success share so the ROUNDING never asserts something false.
+///
+/// `{:.0}` alone renders 199/200 as "100%" and 1/200 as "0%". Both are lies of
+/// exactly the kind this panel exists to remove: "100% answered" when a
+/// request failed is the same shape of absolute, unearned claim as "Node is
+/// healthy" was. An operator reading 100% will stop looking.
+///
+/// So the two absolute values are reserved for the cases that genuinely earn
+/// them, and the bands next to them say which side of the boundary they are
+/// on rather than rounding across it.
+fn answered_share(ok: u32, total: u32) -> String {
+    if ok == total {
+        return "100%".to_string();
+    }
+    if ok == 0 {
+        return "0%".to_string();
+    }
+    // Inspect what would ACTUALLY be displayed rather than reasoning about
+    // where the boundary falls. Comparing against 99.5 / 0.5 by hand gets the
+    // exact-half case wrong — 1 of 200 is precisely 0.5%, and Rust's `{:.0}`
+    // rounds half to even, so it renders "0" while a hand-written `pct < 0.5`
+    // does not catch it. Formatting first removes the second guess.
+    let pct = (ok as f64 / total as f64) * 100.0;
+    let rendered = format!("{pct:.0}");
+    match rendered.as_str() {
+        // Would display as an absolute, but the counts say otherwise.
+        "100" => ">99%".to_string(),
+        "0" => "<1%".to_string(),
+        other => format!("{other}%"),
+    }
+}
+
 /// Contracts read successfully, as a measured rate rather than a verdict.
 ///
 /// Deliberately reports the LIFETIME rate with the period it covers, not a
@@ -32,9 +64,9 @@ fn build_get_success_line(snap: &network_status::NetworkStatusSnapshot) -> Strin
             r#"<span class="gsr-none">too few to rate</span> <span class="gsr-detail">{ok} of {total} answered in {period}</span>"#
         )
     } else {
-        let pct = (ok as f64 / total as f64) * 100.0;
         format!(
-            r#"<span class="gsr-value">{pct:.0}% answered</span> <span class="gsr-detail">{ok} of {total} &middot; since start {period}</span>"#
+            r#"<span class="gsr-value">{share} answered</span> <span class="gsr-detail">{ok} of {total} &middot; since start {period}</span>"#,
+            share = answered_share(ok, total),
         )
     };
 

--- a/crates/core/src/server/home_page/cards.rs
+++ b/crates/core/src/server/home_page/cards.rs
@@ -26,22 +26,39 @@ fn build_get_success_line(snap: &network_status::NetworkStatusSnapshot) -> Strin
     const MIN_SAMPLE: u32 = 20;
 
     let body = if total == 0 {
-        "<span class=\"gsr-none\">no GETs yet</span>".to_string()
+        "<span class=\"gsr-none\">none yet</span>".to_string()
     } else if total < MIN_SAMPLE {
         format!(
-            r#"<span class="gsr-none">too few to rate</span> <span class="gsr-detail">{ok} of {total} succeeded in {period}</span>"#
+            r#"<span class="gsr-none">too few to rate</span> <span class="gsr-detail">{ok} of {total} answered in {period}</span>"#
         )
     } else {
         let pct = (ok as f64 / total as f64) * 100.0;
         format!(
-            r#"<span class="gsr-value">{pct:.0}%</span> <span class="gsr-detail">{ok} of {total} requests, since start &middot; {period}</span>"#
+            r#"<span class="gsr-value">{pct:.0}% answered</span> <span class="gsr-detail">{ok} of {total} &middot; since start {period}</span>"#
         )
     };
 
+    // A caveat that is always shown, never conditional on the number being
+    // low. Two reasons it has to be visible rather than a tooltip.
+    //
+    // First, an unanswered GET is frequently the NETWORK failing to route,
+    // not this node failing to serve — dead-ends dominate the not-found mode
+    // today. A bare "GET success 1%" invites the operator to conclude their
+    // own node is broken and report it, which is a support burden built out
+    // of our own phrasing.
+    //
+    // Second, showing the caveat only when the figure looks bad would be a
+    // threshold in disguise, and choosing that threshold is exactly the
+    // judgement this panel exists to avoid making. So it is unconditional,
+    // and it says "not by itself" rather than "not your fault", because on a
+    // node with no connections it genuinely is this node.
+    let caveat = r#"<span class="gsr-caveat">Unanswered includes requests the network could not route, so a low share does not by itself mean this node is faulty.</span>"#;
+
     format!(
-        r#"<p class="get-success-rate" title="The share of this node's own GET requests that returned state, over the whole time it has been running. Not a recent window: peers issue only a handful of GETs an hour, so a short window would usually be empty. A GET that dead-ends counts as a failure.">
-            <span class="gsr-label">GET success</span> {body}
-        </p>"#
+        r#"<p class="get-success-rate" title="Of the GET requests this node has issued, the share that came back with contract state, over the whole time it has been running. Not a recent window: peers issue only a handful of GETs an hour, so a short window would nearly always be empty. A request that dead-ends in the network counts as unanswered.">
+            <span class="gsr-label">GET requests</span> {body}
+        </p>
+        <p class="get-success-caveat">{caveat}</p>"#
     )
 }
 


### PR DESCRIPTION
## Problem

The dashboard's most prominent element declared **"Node is healthy"** based on four inputs — gateway version mismatch, zero connections, gateway-only connectivity, all-NAT-failing — none of which can see whether the node actually serves reads.

Measured on four live v0.2.128 peers. **Every one displayed that verdict:**

| Node | GET ok | GET fail | Success |
|---|---|---|---|
| Production gateway | 2 | 151 | **1.3%** |
| Hosted-mode peer | 131 | 305 | 30% |
| Conformance capture | 169 | 153 | 52% |
| NATed home peer | 145 | 18 | 89% |

A node answering 1.3% of its GETs is not healthy in any sense an operator cares about.

## Why a measurement and not a threshold

Healthy nodes legitimately run below 100% — routing dead-ends and the ~5–9% near-miss floor — so any threshold either cries wolf or stays silent on a genuinely sick node, and there's no distribution to site one on.

A displayed measurement can't be wrong and needs no boundary. It also fits what keeps going wrong on this page: **a verdict is an assertion; a measurement isn't.** @sanity chose this shape over three threshold variants.

## Why lifetime and not a recent window

The brief asked for the last 15 minutes. The counters are cumulative with no time dimension — but adding bucketing isn't what stops this. **The volume does.**

| Node | Uptime | GETs | Rate |
|---|---|---|---|
| Hosted-mode peer | 17h 55m | 101 | **~5.6/hour** |
| Gateway (0.2.129) | 28m | 7 | **~15/hour** |
| Conformance capture | 21h 56m | 0 | 0 |

A 15-minute window holds **one to four requests**. Even an hour holds ~6, where a single failure moves the figure 17 points; reaching a denominator of 30 takes about five hours. A window short enough to mean "now" would be empty far more often than not.

So the figure is lifetime, labelled "since start" with the uptime beside it. The cost is named in the code: a node broken early and fine since shows a blended number.

Below 20 requests it says "too few to rate" and shows the counts, because at two requests a percentage swings 50 points per outcome.

## What it renders

```
● Connected to 3 peers
GET REQUESTS  1% answered   2 of 153 · since start 5h 0m
Unanswered includes requests the network could not route, so a low
share does not by itself mean this node is faulty.
```

**The caveat exists so a low number isn't misread as the operator's fault** — an unanswered GET is frequently the network failing to route. It's visible rather than a tooltip (tooltips don't exist on mobile, and that's exactly the reader who'd otherwise file a bug), it says "not by itself" rather than "not your fault" (on a node with no connections it genuinely *is* that node), and it's **unconditional** — showing it only when the number looks bad would be a threshold in disguise.

## Rounding that would have lied

`{:.0}` renders **199/200 as "100%"** and **1/200 as "0%"**. Both are false in the way this panel exists to prevent — "100% answered" when a request failed is the same unearned absolute as "Node is healthy" was.

`100%`/`0%` are now reserved for `ok == total` / `ok == 0`; anything that would round across shows `>99%` or `<1%`. The band is computed from the **rendered string**, not by comparing against 99.5/0.5 by hand — that got the exact-half case wrong, since 1/200 is precisely 0.5% and Rust rounds half to even.

## Scope

The three concrete banner states are untouched. Version mismatch, zero connections and gateway-only/NAT-failing are **facts, not verdicts**, and each is genuinely useful. Only the "healthy" conclusion is gone; the connection count it carried stays.

## Testing

Six tests pinning invariants rather than wording: no health verdict; a tiny sample is refused; 2 of 153 renders as 1% *with* its denominator; the line carries no pass/fail CSS class (colouring it would smuggle the verdict back through the stylesheet); the caveat appears at every rate including zero requests; and the rounding never crosses an absolute.

`health_banner_shown_for_each_level` is **amended, not weakened** — it now pins that the connection count survives *and* that the verdict does not return.

Verified on a live node, and at 320/390/768px with six-digit counts and a 41-day uptime forced in, since the counts are unbounded and that's the shape that caused horizontal scrolling earlier in this series.

Closes #5370. Last of the local-dashboard review series.

[AI-assisted - Claude]
