### PR TITLE
refactor(fdev): rename conformance to verify-merge and say what a failure costs

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -520,7 +520,7 @@ When you write a branch that drops an input:
 2. **Carry the count into the artefact, not just the log.** Logs rotate; a corpus is
    replayed months later on another machine. If the only record of "this is
    incomplete" is a log line, the replay reads as a clean bill of health.
-3. **Make it reach the documented consumer.** `fdev conformance --bundle` dropped
+3. **Make it reach the documented consumer.** `fdev verify-merge --bundle` dropped
    `bundle.note` entirely, so the durable record existed and was invisible to the one
    workflow meant to read it. Check the whole path, not just the write.
 4. **Test it by deleting the counter and asserting the test fails.** A refusal

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -194,7 +194,7 @@ State merging rules:
     checks deltas, but reports them at `Severity::Diagnostic` so the check
     can never justify removing a contract while the question is open.
     Whether any deployed contract actually relies on the unsafe pattern is
-    empirical and unanswered; `fdev conformance` against deployed WASM is
+    empirical and unanswered; `fdev verify-merge` against deployed WASM is
     how it gets answered. Do not treat either side as decided until it is.
   - Invalid merges should return error, not panic
 ```

--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -8,7 +8,7 @@
 //! exactly that.
 //!
 //! This module is the *single* implementation of what "conformance" means. The
-//! offline `fdev conformance` harness and (later) the node-side checker both call
+//! offline `fdev verify-merge` harness and (later) the node-side checker both call
 //! [`verify_case`], so the developer-facing answer and the network-facing answer
 //! cannot disagree.
 //!

--- a/crates/core/src/conformance/bundle.rs
+++ b/crates/core/src/conformance/bundle.rs
@@ -75,7 +75,7 @@ pub struct Transition {
 /// and the states, deltas, summaries and transitions observed for it.
 ///
 /// This is the unit that moves between a peer and an offline analysis: capture on a
-/// node writes one, `fdev conformance --bundle` reads one, and a bundle archived
+/// node writes one, `fdev verify-merge --bundle` reads one, and a bundle archived
 /// today must still replay against a later build. That is why it carries its own
 /// magic and schema version, and why it stays separate from any internal on-disk
 /// sampler format, which is free to change.

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -42,7 +42,7 @@ pub enum ConformanceProperty {
     /// The RFC is the newer and more specific document, so the check exists. But
     /// whether any deployed first-party contract actually relies on non-idempotent
     /// deltas is an empirical question that cannot be settled by reading code, and
-    /// it must be answered by running `fdev conformance` against deployed WASM
+    /// it must be answered by running `fdev verify-merge` against deployed WASM
     /// before this property is ever allowed to influence anything on the network.
     /// Until then it is a reporting signal for contract authors.
     DeltaIdempotence,

--- a/crates/core/src/conformance/runtime_oracle.rs
+++ b/crates/core/src/conformance/runtime_oracle.rs
@@ -3,7 +3,7 @@
 //! Conformance findings are only worth anything if they were produced by the same
 //! runtime configuration the network actually runs. A check that passes under a
 //! permissive test harness and fails in production (or the reverse) would make
-//! `fdev conformance` an unreliable oracle for authors and, later, would make peers
+//! `fdev verify-merge` an unreliable oracle for authors and, later, would make peers
 //! disagree about the same evidence. So this wraps [`crate::wasm_runtime::Runtime`]
 //! directly rather than reimplementing anything.
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,7 +9,7 @@ mod contract;
 
 /// Contract conformance: the shared verifier and evidence model (RFC #5320).
 ///
-/// Public because `fdev conformance` runs the *same* verifier the network does.
+/// Public because `fdev verify-merge` runs the *same* verifier the network does.
 /// A developer-facing check that could disagree with the network-facing one would
 /// be worse than no check at all.
 pub mod conformance;

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -75,12 +75,20 @@ pub enum SubCommand {
         #[clap(subcommand)]
         command: crate::website::WebsiteCommand,
     },
-    /// Check a contract against the conformance laws (RFC #5320): merge
-    /// commutativity/associativity/idempotence, delta idempotence, and more.
+    /// Check that a contract's merge obeys the laws the network requires: that
+    /// merging is order-independent, groups the same way whichever pairing is used,
+    /// and applying the same change twice does nothing the second time.
     ///
-    /// Runs the *same* verifier the network runs (`freenet::conformance`), so
-    /// a finding here means the same thing it would mean on the network.
-    Conformance(crate::conformance::ConformanceConfig),
+    /// A contract that breaks these cannot converge — two peers given the same
+    /// updates in different orders end up with different state, never agree, and
+    /// retry indefinitely. That is what this looks for.
+    ///
+    /// Runs the *same* verifier the network runs, so a finding here means exactly
+    /// what it would mean on the network.
+    ///
+    /// Named `conformance` before 0.2.131; that spelling still works.
+    #[clap(alias = "conformance")]
+    VerifyMerge(crate::conformance::ConformanceConfig),
 }
 
 impl SubCommand {

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -86,7 +86,7 @@ pub enum SubCommand {
     /// Runs the *same* verifier the network runs, so a finding here means exactly
     /// what it would mean on the network.
     ///
-    /// Named `conformance` before 0.2.131; that spelling still works.
+    /// Previously named `conformance`; that spelling still works.
     #[clap(alias = "conformance")]
     VerifyMerge(crate::conformance::ConformanceConfig),
 }

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -224,7 +224,7 @@ fn write_bundle(
     bundle.deltas = corpus.deltas.iter().map(|d| d.to_vec()).collect();
     bundle.summaries = corpus.summaries.iter().map(|s| s.to_vec()).collect();
     bundle.note = Some(format!(
-        "captured by fdev conformance {}",
+        "captured by fdev verify-merge {}",
         env!("CARGO_PKG_VERSION")
     ));
     bundle
@@ -244,7 +244,10 @@ fn write_bundle(
 /// can tell "this contract is unsound" apart from "the check could not run" — a
 /// distinction CI needs and a single exit code cannot express.
 #[derive(Debug, thiserror::Error)]
-#[error("{count} enforceable conformance violation(s) found")]
+#[error(
+    "{count} merge-law violation(s) found: this contract cannot converge, so peers \
+     holding it will disagree and keep retrying"
+)]
 pub struct ConformanceViolations {
     pub count: usize,
 }
@@ -762,11 +765,11 @@ impl Report {
 
     fn print_human(&self) {
         println!(
-            "conformance: {} state(s), {} delta(s), {} summary/summaries in the corpus",
+            "merge check: {} state(s), {} delta(s), {} summary/summaries in the corpus",
             self.corpus_states, self.corpus_deltas, self.corpus_summaries
         );
         println!(
-            "conformance: {} case(s) run \u{2014} {} held, {} violation(s) ({} enforceable, {} diagnostic-only), {} inconclusive",
+            "merge check: {} case(s) run \u{2014} {} held, {} violation(s) ({} enforceable, {} diagnostic-only), {} inconclusive",
             self.cases_run,
             self.holds,
             self.violations,
@@ -796,7 +799,7 @@ impl Report {
         // code.
         if !self.inconclusive_reasons.is_empty() {
             println!(
-                "\ninconclusive ({} total, not failures \u{2014} see freenet::conformance::Inconclusive):",
+                "\ninconclusive ({} total \u{2014} NOT passes: these cases reached no verdict, so they say nothing about the contract):",
                 self.inconclusive
             );
             for r in &self.inconclusive_reasons {

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1,4 +1,7 @@
-//! `fdev conformance`: run the contract conformance verifier offline (RFC #5320).
+//! `fdev verify-merge`: check a contract's merge laws offline (RFC #5320).
+//!
+//! A contract that breaks them cannot converge — peers given the same updates
+//! in different orders end up with different state and never agree.
 //!
 //! This is a thin CLI wrapper around `freenet::conformance` and does not
 //! reimplement any of the laws itself. That is the whole point: `fdev
@@ -10,10 +13,10 @@
 //!
 //! ```text
 //! # Check a contract directly against a handful of observed states
-//! fdev conformance --wasm contract.wasm --state s1.bin --state s2.bin
+//! fdev verify-merge --wasm contract.wasm --state s1.bin --state s2.bin
 //!
 //! # Replay a bundle captured from the network (or an earlier `fdev` run)
-//! fdev conformance --bundle observed.bin
+//! fdev verify-merge --bundle observed.bin
 //! ```
 
 use std::collections::{HashMap, HashSet};
@@ -505,7 +508,7 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
         if let Some(note) = bundle.note.as_deref() {
             // STDERR deliberately. `--json` writes one JSON document to stdout, and a
             // plain line ahead of it corrupts the stream for anything parsing it -
-            // `fdev conformance --bundle x --json | jq` would simply fail. `write_bundle`
+            // `fdev verify-merge --bundle x --json | jq` would simply fail. `write_bundle`
             // in this same file already uses `eprintln!` for its status line for
             // exactly this reason; the first version of this did not follow it.
             //
@@ -875,7 +878,7 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
 /// `--json` promises a machine-readable report, which means stdout must carry ONE JSON
 /// document and nothing else. `load_inputs` runs before the report is emitted, so
 /// anything it prints to stdout lands ahead of that document and breaks every consumer
-/// that parses it — `fdev conformance --bundle x --json | jq` simply fails.
+/// that parses it — `fdev verify-merge --bundle x --json | jq` simply fails.
 ///
 /// That shipped once: the bundle note was printed with `println!`, and because every
 /// bundle this codebase writes always sets a note, it fired on essentially every

--- a/crates/fdev/src/main.rs
+++ b/crates/fdev/src/main.rs
@@ -91,7 +91,7 @@ fn conformance_log_level(
     sub_command: &SubCommand,
     rust_log_is_set: bool,
 ) -> Option<tracing::level_filters::LevelFilter> {
-    let SubCommand::Conformance(config) = sub_command else {
+    let SubCommand::VerifyMerge(config) = sub_command else {
         return None;
     };
     if rust_log_is_set {
@@ -179,7 +179,7 @@ fn main() -> anyhow::Result<()> {
             SubCommand::VerifyState(verify_config) => {
                 verify_state::verify_state(verify_config).await
             }
-            SubCommand::Conformance(conformance_config) => {
+            SubCommand::VerifyMerge(conformance_config) => {
                 conformance::conformance(conformance_config).await
             }
             SubCommand::Website { command } => match command {
@@ -230,6 +230,37 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Both spellings parse, and both reach the same subcommand.
+    ///
+    /// `fdev conformance` shipped in v0.2.129 and anything scripted against it must
+    /// keep working — a rename that silently breaks a released command is worse than
+    /// the naming it fixes. `verify-merge` is the name going forward because
+    /// "conformance" never said what was being checked: it is the merge laws, and a
+    /// contract that breaks them cannot converge.
+    #[test]
+    fn both_the_new_and_released_subcommand_names_parse() {
+        use clap::Parser;
+
+        for name in ["verify-merge", "conformance"] {
+            let parsed = super::config::Config::try_parse_from([
+                "fdev",
+                name,
+                "--wasm",
+                "/nonexistent.wasm",
+                "--state",
+                "/nonexistent.state",
+            ])
+            .unwrap_or_else(|e| panic!("`fdev {name}` no longer parses: {e}"));
+            assert!(
+                matches!(
+                    parsed.sub_command,
+                    super::config::SubCommand::VerifyMerge(_)
+                ),
+                "`fdev {name}` parsed to the wrong subcommand"
+            );
+        }
+    }
     use super::{EXIT_RESPONSE_TIMEOUT, exit_code_for_error};
     use crate::commands::ResponseTimeout;
     use std::time::Duration;
@@ -288,7 +319,7 @@ mod tests {
     /// runtime logging.
     #[test]
     fn conformance_quiets_default_log_level_when_rust_log_unset() {
-        let sub = super::SubCommand::Conformance(empty_conformance_config());
+        let sub = super::SubCommand::VerifyMerge(empty_conformance_config());
         assert_eq!(
             super::conformance_log_level(&sub, false),
             Some(tracing::level_filters::LevelFilter::INFO)
@@ -306,7 +337,7 @@ mod tests {
     fn conformance_silences_logging_entirely_for_json_output() {
         let mut config = empty_conformance_config();
         config.json = true;
-        let sub = super::SubCommand::Conformance(config);
+        let sub = super::SubCommand::VerifyMerge(config);
         assert_eq!(
             super::conformance_log_level(&sub, false),
             Some(tracing::level_filters::LevelFilter::OFF),
@@ -317,7 +348,7 @@ mod tests {
     /// An explicit `RUST_LOG` from the user must always win.
     #[test]
     fn conformance_defers_to_explicit_rust_log() {
-        let sub = super::SubCommand::Conformance(empty_conformance_config());
+        let sub = super::SubCommand::VerifyMerge(empty_conformance_config());
         assert_eq!(super::conformance_log_level(&sub, true), None);
     }
 


### PR DESCRIPTION
## Problem

"Conformance" is borrowed from protocol-standards testing and doesn't say what is being checked. To a contract author it reads as a compliance checkbox; on a dashboard "conformance violation" tells an operator nothing; and someone whose contract is misbehaving searches for "my state is diverging", not for this word.

## Approach

Two terms, each doing work at the level where it belongs:

- **merge laws** — what is checked: commutativity, associativity, idempotence.
- **cannot converge** — what it costs: two peers given the same updates in different orders end up with different state, never agree, and retry indefinitely.

So a contract **violates a merge law** and the consequence is that it **cannot converge**. That is the observable symptom, and it is exactly what gateway logs show for the two contracts found this week.

### Scope: user-facing surface only

- `fdev conformance` → `fdev verify-merge`, matching the existing `verify-state`.
- The author-facing failure now names the law and the consequence rather than a count of abstract "violations".
- Inconclusive output says plainly these are **not passes** — cases that reached no verdict say nothing about the contract. That distinction has already cost real time: an unjudgeable contract renders identically to a clean one.

The internal module keeps `conformance`. It is accurate in the protocol-testing sense and is read only by core developers who have the RFC alongside it, so renaming would be churn with no reader-facing gain. **A deliberate layering, not a half-done rename.**

## The released spelling still works

`fdev conformance` shipped in v0.2.129 and remains as an alias — a rename that silently breaks a released command is worse than the naming it fixes.

Pinned by a test that parses **both** spellings and asserts they reach the same subcommand. Mutation-verified: removing the alias turns it red.

## Why now

Nothing references the command yet — the dapp-builder skill doesn't mention it — so the cost is near zero today and rises the moment authors are told to use it. This is the week to do it.

Refs #5320

[AI-assisted - Claude]