### PR TITLE
feat(conformance): publish merge-check status for the dashboard to read

### DIFF
--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -108,6 +108,7 @@ pub mod property;
 pub mod runtime_oracle;
 pub mod sampler;
 pub mod shadow;
+pub mod status;
 pub mod verifier;
 
 #[cfg(test)]

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -804,6 +804,28 @@ async fn run_writer(
                         scope = scope.as_str(),
                         "conformance shadow tick selected nothing to probe"
                     );
+                    // Published too, with no records and nothing judged.
+                    //
+                    // This branch is the ordinary warm-up state — focus has picked
+                    // contracts but the sampler holds nothing for them yet — and it
+                    // used to return without publishing, leaving the PREVIOUS tick's
+                    // snapshot standing unchanged. Three of these in a row is 45
+                    // minutes, past `status::STALE_AFTER`, so a peer that had one
+                    // healthy tick and then went barren kept rendering that tick as a
+                    // current result with no age advancing and no stale note: the
+                    // frozen-checker failure the publish time was added to prevent,
+                    // reached by a path that never calls the thing carrying it.
+                    //
+                    // `awaiting_samples` is the honest unjudged count here. When
+                    // `work` is empty, `ShadowRunner::select` returns
+                    // `focus.selected.len()` for it, so it is every contract this tick
+                    // formed no opinion about — which is all of them.
+                    crate::conformance::status::publish(
+                        Vec::new(),
+                        0,
+                        awaiting_samples,
+                        tokio::time::Instant::now(),
+                    );
                 } else {
                     let store = contract_store().cloned();
                     let mode = shadow.mode();
@@ -917,7 +939,7 @@ async fn run_writer(
                     crate::conformance::status::checked_contracts(&report.judged, &findings),
                     report.judged.len(),
                     report.without_verdict,
-                    std::time::Instant::now(),
+                    tokio::time::Instant::now(),
                 );
             }
         }
@@ -2176,7 +2198,49 @@ mod probe_wiring_pins {
         );
     }
 
-    /// The arguments of the ONE `status::publish` call, in order.
+    /// How many places in `run_writer` call `status::publish`, and in what order.
+    ///
+    /// 0. the barren tick — `work.is_empty()`, the warm-up state. Publishes nothing
+    ///    but a fresh timestamp, so the snapshot ages instead of the previous tick
+    ///    standing as a current result.
+    /// 1. the completed probe — the tick that actually establishes something.
+    ///
+    /// Pinned as a COUNT because `publish_call_args` selects positionally: adding a
+    /// third call site would otherwise repoint every pin below at a different call
+    /// without any of them failing, which is the half-inert-pin failure this file has
+    /// already shipped twice. A new call site must land here deliberately.
+    const PUBLISH_CALL_SITES: usize = 2;
+
+    /// Index of the completed-probe publish in source order — see
+    /// [`PUBLISH_CALL_SITES`].
+    const PROBE_PUBLISH: usize = 1;
+
+    /// Index of the barren-tick publish in source order.
+    const BARREN_PUBLISH: usize = 0;
+
+    /// Every `status::publish` call site in `run_writer`, in source order.
+    fn publish_call_sites() -> Vec<usize> {
+        let body = run_writer_code_only();
+        let anchor = "status::publish(";
+        let mut at = Vec::new();
+        let mut from = 0usize;
+        while let Some(found) = body[from..].find(anchor) {
+            at.push(from + found + anchor.len());
+            from += found + anchor.len();
+        }
+        assert_eq!(
+            at.len(),
+            PUBLISH_CALL_SITES,
+            "run_writer calls status::publish {} times, not {PUBLISH_CALL_SITES}. \
+             `publish_call_args` selects positionally, so the pins below are now \
+             asserting about a different call than the one they name — decide which \
+             index each pin means and update PUBLISH_CALL_SITES deliberately",
+            at.len()
+        );
+        at
+    }
+
+    /// The arguments of ONE `status::publish` call, in order.
     ///
     /// Bounded to the call itself rather than to all of `run_writer`, and that bound
     /// is the whole point of the helper. The previous pins asserted
@@ -2186,13 +2250,9 @@ mod probe_wiring_pins {
     /// call, so replacing the third argument with `0` left the pin green. Positional,
     /// because the sibling pin could not see a SWAP either: passing `report.probed`
     /// where `report.judged.len()` belongs kept every assertion happy.
-    fn publish_call_args() -> Vec<String> {
+    fn publish_call_args(nth: usize) -> Vec<String> {
         let body = run_writer_code_only();
-        let anchor = "status::publish(";
-        let start = body
-            .find(anchor)
-            .expect("run_writer no longer calls status::publish at all")
-            + anchor.len();
+        let start = publish_call_sites()[nth];
         // Split on TOP-LEVEL commas only: an argument may itself be a call with its
         // own comma-separated arguments.
         let mut depth = 0usize;
@@ -2245,7 +2305,7 @@ mod probe_wiring_pins {
     /// window renders clean while violating.
     #[test]
     fn dashboard_checked_window_is_fed_judged_contracts_with_their_findings() {
-        let args = publish_call_args();
+        let args = publish_call_args(PROBE_PUBLISH);
         assert!(
             args[0].contains("checked_contracts(&report.judged, &findings)"),
             "the first argument no longer builds per-contract records from the judged \
@@ -2271,7 +2331,7 @@ mod probe_wiring_pins {
     /// wrong values type-check and both render as plausible numbers.
     #[test]
     fn dashboard_tick_counts_are_the_report_fields_positionally() {
-        let args = publish_call_args();
+        let args = publish_call_args(PROBE_PUBLISH);
         assert_eq!(
             args[1], "report.judged.len()",
             "the judged-this-tick count is no longer `report.judged.len()`; \
@@ -2286,6 +2346,81 @@ mod probe_wiring_pins {
         );
     }
 
+    /// The block `run_writer` runs when a tick selects nothing to probe.
+    ///
+    /// Sliced to the branch rather than searched for across `run_writer`: the whole
+    /// question this pin asks is WHICH branch publishes, and a whole-body `contains`
+    /// is answered by the completed-probe call site eighty lines further down.
+    fn work_is_empty_block() -> String {
+        let body = run_writer_code_only();
+        let anchor = "if work.is_empty() {";
+        let start = body
+            .find(anchor)
+            .expect("run_writer no longer branches on an empty work set")
+            + anchor.len()
+            - 1;
+        let mut depth = 0usize;
+        for (offset, ch) in body[start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return body[start..start + offset + 1].to_string();
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("the empty-work branch is not brace-balanced");
+    }
+
+    /// #5403 M3: a tick that selects nothing must still publish.
+    ///
+    /// This branch is the ordinary warm-up state — focus has picked contracts and the
+    /// sampler holds nothing for them yet — and it used to return without publishing,
+    /// leaving the previous snapshot standing with its age frozen. Three barren ticks
+    /// is 45 minutes, past `status::STALE_AFTER`, so a peer that had one healthy tick
+    /// and then went barren kept rendering that tick as a current "no violation
+    /// found", never aged past the staleness threshold and never carrying the stale
+    /// note. The unjudged contracts of a barren tick also never reached
+    /// `without_verdict_last_tick`, so nothing said they had not been judged either.
+    ///
+    /// Pinned rather than tested end to end because `run_writer` is a select loop no
+    /// test can call — which is also exactly why a call site inside it can go missing
+    /// unnoticed.
+    #[test]
+    fn a_tick_that_selects_nothing_still_publishes() {
+        let block = work_is_empty_block();
+        assert!(
+            block.contains("status::publish("),
+            "the empty-work branch returns without publishing, so a peer whose ticks \
+             have gone barren keeps serving its last healthy tick as a current \
+             result, with the snapshot's age frozen so it never reads as stale. \
+             got:\n{block}"
+        );
+
+        let args = publish_call_args(BARREN_PUBLISH);
+        assert_eq!(
+            args[1], "0",
+            "a tick that probed nothing must publish zero contracts judged; anything \
+             else reports established results from a tick that established none"
+        );
+        assert_eq!(
+            args[2], "awaiting_samples",
+            "the barren tick's unjudged count must be `awaiting_samples`, which is \
+             `focus.selected.len()` when the work set is empty — every contract this \
+             tick formed no opinion about. A zero here renders a barren tick as one \
+             with nothing left unjudged"
+        );
+        assert!(
+            args[3].contains("Instant::now()"),
+            "the barren tick's snapshot carries no publish time, so it cannot age and \
+             the frozen-checker note never fires. got: {}",
+            args[3]
+        );
+    }
+
     /// The snapshot must carry a publish time.
     ///
     /// `publish` is reached from one place, and two live paths above skip it
@@ -2295,7 +2430,7 @@ mod probe_wiring_pins {
     /// found".
     #[test]
     fn the_published_snapshot_carries_its_publish_time() {
-        let args = publish_call_args();
+        let args = publish_call_args(PROBE_PUBLISH);
         assert!(
             args[3].contains("Instant::now()"),
             "the published snapshot no longer carries a publish time, so a frozen \

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -2383,22 +2383,21 @@ mod probe_wiring_pins {
     fn count_awaiting_samples_args() -> Vec<String> {
         let body = run_writer_code_only();
         let anchor = "count_awaiting_samples(";
-        // One call, so `find` is unambiguous. A second one would mean the writer
-        // adjusts these counters twice, which is the double-count the sibling
-        // open-coding assertions below exist to forbid.
+        // EXACTLY one call, checked before `find` so both directions are diagnosed.
+        // Zero means the completed-probe arm no longer folds the warming-up focus
+        // contracts into the tick's counts at all, so a warming-up focus set reports
+        // as a smaller, fully-checked one and the dashboard's unjudged total silently
+        // omits them. Two means the writer adjusts these counters twice, which is the
+        // double-count the sibling open-coding assertions below exist to forbid — and
+        // a double-count reads as a plausible number.
+        let calls = body.matches(anchor).count();
         assert_eq!(
-            body.matches(anchor).count(),
-            1,
-            "run_writer calls `count_awaiting_samples` more than once, so the \
-             warming-up focus contracts are folded into the tick's counts twice — a \
-             double-count reads as a plausible number"
+            calls, 1,
+            "run_writer calls `count_awaiting_samples` {calls} times, not once. Zero \
+             drops the warming-up focus contracts from the tick's counts; more than \
+             one folds them in twice"
         );
-        let start = body.find(anchor).expect(
-            "the completed-probe arm no longer folds the warming-up focus \
-                 contracts into the tick's counts, so a warming-up focus set reports \
-                 as a smaller, fully-checked one and the dashboard's unjudged total \
-                 silently omits them",
-        ) + anchor.len();
+        let start = body.find(anchor).expect("checked just above") + anchor.len();
         let args = call_args_at(&body, start, "count_awaiting_samples");
         assert_eq!(
             args.len(),
@@ -2438,26 +2437,40 @@ mod probe_wiring_pins {
         );
         // TWO guards, because each sees what the other cannot.
         //
-        // The whole-body one below catches selection MATERIALISED FIRST: bind
-        // `last_focus.selected.iter().copied()` to a local and pass the local, and
-        // every argument-scoped check below sees only the local's name and stays
-        // green (mutation-verified). It costs nothing to keep — `last_focus.selected`
-        // appears in `run_writer` only inside a comment, which `run_writer_code_only`
-        // strips — so it has no false-positive surface here.
+        // The whole-body one below catches selection MATERIALISED FIRST. Every check
+        // scoped to an argument sees only the argument EXPRESSION, so building the
+        // record set from selection anywhere upstream — into a local, or straight
+        // over `report.judged`, which keeps `args[0]` byte-identical — leaves all four
+        // positional pins green while the checked window is fed selection anyway
+        // (mutation-verified). It costs nothing to keep: `last_focus.selected` appears
+        // in `run_writer` only inside a comment, which `run_writer_code_only` strips,
+        // so there is no false-positive surface here.
+        //
+        // Matched against a whitespace-STRIPPED body, and that is load-bearing rather
+        // than tidiness. The guard this restores named the contiguous spelling
+        // `last_focus.selected.iter().copied()`; `cargo fmt` breaks a chain that long
+        // across five lines, so the `report.judged` overwrite this was mutation-tested
+        // against stayed GREEN under the restored guard until it was normalised — a
+        // rustfmt reflow, not even an edit, disarmed it. Named on the RECEIVER too:
+        // the chained spelling is one of several ways to write the same
+        // materialisation, and `last_focus.selected` is the part that must not be
+        // read at all.
+        let whitespace_free: String = body.chars().filter(|c| !c.is_whitespace()).collect();
         assert!(
-            !body.contains("last_focus.selected.iter().copied()"),
-            "run_writer materialises focus SELECTION as a record set. Whether or not \
-             it is passed to `status::publish` directly, that is the one thing this \
-             list must not be built from: a selected contract can be skipped before \
-             probing (no code, no samples) or probed and never reach a verdict"
+            !whitespace_free.contains("last_focus.selected"),
+            "run_writer reads focus SELECTION out of `last_focus`. Wherever the read \
+             happens, that is the one thing the checked window must not be built \
+             from: a selected contract can be skipped before probing (no code, no \
+             samples) or probed and never reach a verdict, and it would render on the \
+             per-contract page as 'checked, no violation found'"
         );
-        // The per-call-site loop catches what the whole-body guard cannot NAME. It
-        // named one spelling at one binding: in the barren branch the in-scope
-        // binding is `focus`, not `last_focus`, so a future edit feeding selection
-        // into the barren publish would write `focus.selected…` and go unseen — and
-        // a whole-body guard cannot name `focus.selected` at all, because the scope
-        // assignment legitimately uses it two lines above the branch. Scoping to the
-        // argument is what makes that sayable.
+        // The per-call-site loop catches what the whole-body guard cannot NAME. That
+        // guard can only speak about the `last_focus` binding: in the barren branch
+        // the in-scope binding is `focus`, so a future edit feeding selection into the
+        // barren publish would write `focus.selected…` and go unseen — and no
+        // whole-body guard can name `focus.selected`, because the scope assignment
+        // legitimately uses it two lines above that branch. Scoping to the argument is
+        // what makes that sayable at all.
         for nth in 0..PUBLISH_CALL_SITES {
             let first = &publish_call_args(nth)[0];
             assert!(

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -554,6 +554,14 @@ pub fn start(dir: PathBuf) -> std::io::Result<CaptureHandle> {
     // Tell the dashboard checking is ON before any tick has run. Without this, the
     // first interval renders as "not enabled", which is the one thing the panel must
     // never say wrongly — absence and success must not look alike.
+    //
+    // Deliberately LAST: both fallible steps above (the runtime check and
+    // `create_dir_all`) have already returned by the time this runs, so the flag is
+    // never set for a capture that failed to start. Both the call and its position are
+    // covered by `the_page_reports_what_the_status_global_says_and_capture_start_sets_it`
+    // in `server::home_page::contract_detail`, which owns this process-global's one
+    // transition for the whole test binary — read its doc comment before adding a
+    // second caller of `mark_enabled` anywhere in the crate or its tests.
     crate::conformance::status::mark_enabled();
     tokio::spawn(run_writer(dir, rx, dropped, queued_bytes));
     Ok(handle)

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -551,6 +551,10 @@ pub fn start(dir: PathBuf) -> std::io::Result<CaptureHandle> {
         directory = %dir.display(),
         "conformance capture enabled: recording contract merges for offline replay"
     );
+    // Tell the dashboard checking is ON before any tick has run. Without this, the
+    // first interval renders as "not enabled", which is the one thing the panel must
+    // never say wrongly — absence and success must not look alike.
+    crate::conformance::status::mark_enabled();
     tokio::spawn(run_writer(dir, rx, dropped, queued_bytes));
     Ok(handle)
 }
@@ -869,6 +873,24 @@ async fn run_writer(
                     skipped_no_samples = report.skipped_no_samples,
                     timed_out = report.timed_out,
                     "conformance shadow tick"
+                );
+
+                // Same numbers the line above reports, so the dashboard and the log
+                // cannot disagree about what happened. Published here rather than
+                // derived by a reader: a count re-computed at the call site is how
+                // this project has produced wrong metrics before.
+                crate::conformance::status::publish(
+                    report.probed,
+                    report.skipped_no_code + report.skipped_no_samples,
+                    report.cases,
+                    findings.iter().map(|finding| {
+                        crate::conformance::status::MergeFinding {
+                            contract: finding.contract,
+                            property: finding.violation.property.as_str(),
+                            severity: finding.violation.property.severity(),
+                            would_remove: finding.would_remove,
+                        }
+                    }),
                 );
             }
         }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -880,6 +880,7 @@ async fn run_writer(
                 // derived by a reader: a count re-computed at the call site is how
                 // this project has produced wrong metrics before.
                 crate::conformance::status::publish(
+                    last_focus.selected.iter().copied(),
                     report.probed,
                     report.skipped_no_code + report.skipped_no_samples,
                     report.cases,

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -900,19 +900,24 @@ async fn run_writer(
                 // skipped_no_samples` — is the complement of `judged` over the
                 // focus set: it also counts a probed contract whose every case was
                 // inconclusive, which the skip counters never see.
+                //
+                // One record per judged contract, carrying that contract's own case
+                // counts AND its own findings — see `status::checked_contracts`. The
+                // first version of this kept the checked list and the findings list
+                // separate and capped them differently, so a contract inside one and
+                // evicted from the other rendered a green "no violation found" pill
+                // for a contract found violating.
+                //
+                // The publish TIME is carried too. Two live paths above skip this call
+                // indefinitely (a tick that selected no work, and a probe task that
+                // died) while the previous snapshot stands, so without an age on the
+                // snapshot a peer whose probe has been panicking for a week keeps
+                // serving a week-old tick as a current clean result.
                 crate::conformance::status::publish(
-                    report.judged.iter().copied(),
+                    crate::conformance::status::checked_contracts(&report.judged, &findings),
                     report.judged.len(),
                     report.without_verdict,
-                    report.cases,
-                    findings.iter().map(|finding| {
-                        crate::conformance::status::MergeFinding {
-                            contract: finding.contract,
-                            property: finding.violation.property.as_str(),
-                            severity: finding.violation.property.severity(),
-                            would_remove: finding.would_remove,
-                        }
-                    }),
+                    std::time::Instant::now(),
                 );
             }
         }
@@ -2146,6 +2151,17 @@ mod probe_wiring_pins {
             body.contains("report.skipped_no_samples += awaiting_samples"),
             "focus contracts still awaiting samples are no longer reported as skipped"
         );
+        // The third of the trio, and the one that was unpinned: deleting it left every
+        // test and both source pins green while the dashboard under-reported unjudged
+        // contracts by the whole warm-up count. `judged`/`without_verdict` are
+        // complements over the focus set, and a warming-up contract is in neither half
+        // unless this line puts it in one.
+        assert!(
+            body.contains("report.without_verdict += awaiting_samples"),
+            "focus contracts still awaiting samples no longer count toward \
+             `without_verdict`, so the dashboard's unjudged total silently omits them \
+             and they render as contracts nobody had a question about"
+        );
     }
 
     #[test]
@@ -2160,8 +2176,60 @@ mod probe_wiring_pins {
         );
     }
 
-    /// The dashboard's `recently_checked` must be fed the contracts that actually
-    /// reached a verdict, never focus SELECTION.
+    /// The arguments of the ONE `status::publish` call, in order.
+    ///
+    /// Bounded to the call itself rather than to all of `run_writer`, and that bound
+    /// is the whole point of the helper. The previous pins asserted
+    /// `body.contains("report.without_verdict")` over the entire function body, which
+    /// is satisfied by `report.without_verdict += awaiting_samples` sixty lines
+    /// earlier and by the `tracing::info!` field — both independent of the publish
+    /// call, so replacing the third argument with `0` left the pin green. Positional,
+    /// because the sibling pin could not see a SWAP either: passing `report.probed`
+    /// where `report.judged.len()` belongs kept every assertion happy.
+    fn publish_call_args() -> Vec<String> {
+        let body = run_writer_code_only();
+        let anchor = "status::publish(";
+        let start = body
+            .find(anchor)
+            .expect("run_writer no longer calls status::publish at all")
+            + anchor.len();
+        // Split on TOP-LEVEL commas only: an argument may itself be a call with its
+        // own comma-separated arguments.
+        let mut depth = 0usize;
+        let mut args: Vec<String> = Vec::new();
+        let mut current = String::new();
+        for ch in body[start..].chars() {
+            match ch {
+                '(' | '[' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' if depth == 0 => break,
+                ')' | ']' => {
+                    depth -= 1;
+                    current.push(ch);
+                }
+                ',' if depth == 0 => {
+                    args.push(current.trim().to_string());
+                    current.clear();
+                }
+                _ => current.push(ch),
+            }
+        }
+        if !current.trim().is_empty() {
+            args.push(current.trim().to_string());
+        }
+        assert_eq!(
+            args.len(),
+            4,
+            "status::publish's argument list changed shape, so the positional pins \
+             below are asserting about the wrong arguments: {args:?}"
+        );
+        args
+    }
+
+    /// The dashboard's checked window must be fed the contracts that actually reached
+    /// a verdict, never focus SELECTION — with each contract's own findings attached.
     ///
     /// The #5403 review defect: `status::publish` was fed `last_focus.selected`, so a
     /// contract focus merely picked — including one skipped before probing (no code,
@@ -2170,13 +2238,23 @@ mod probe_wiring_pins {
     /// populated only when at least one case reached `Holds` or `Violated`
     /// (`shadow::probe_one`), so feeding it here is what makes "recently checked"
     /// mean "we formed an opinion" rather than "focus looked this way".
+    ///
+    /// `checked_contracts` is what attaches each contract's findings to ITS record.
+    /// Feeding the judged ids alone would restore the two-window split whose eviction
+    /// mismatch was H1: a contract inside the checked window and outside the findings
+    /// window renders clean while violating.
     #[test]
-    fn dashboard_recently_checked_is_fed_judged_contracts_not_focus_selection() {
-        let body = run_writer_code_only();
+    fn dashboard_checked_window_is_fed_judged_contracts_with_their_findings() {
+        let args = publish_call_args();
         assert!(
-            body.contains("report.judged.iter().copied()"),
-            "status::publish is no longer fed the contracts that reached a verdict"
+            args[0].contains("checked_contracts(&report.judged, &findings)"),
+            "the first argument no longer builds per-contract records from the judged \
+             contracts AND their findings, so either an unjudged contract renders as \
+             checked, or findings live in a window that can evict independently of \
+             the contract they belong to (#5403 H1). got: {}",
+            args[0]
         );
+        let body = run_writer_code_only();
         assert!(
             !body.contains("last_focus.selected.iter().copied()"),
             "status::publish must not be fed focus SELECTION — a selected contract \
@@ -2184,28 +2262,45 @@ mod probe_wiring_pins {
         );
     }
 
-    /// The dashboard's `contracts_without_verdict` must be the complement of
-    /// `judged` over the focus set, not `skipped_no_code + skipped_no_samples`.
+    /// The tick's two headline counts must be the report's own, positionally.
     ///
-    /// The #5403 review defect's sibling: a contract that IS probed but whose every
-    /// case comes back `Inconclusive` is not counted by either skip counter, so
-    /// `skipped_no_code + skipped_no_samples` silently missed it and it rendered as
-    /// a clean result. `report.without_verdict` is incremented directly at every
-    /// terminal branch in `shadow::probe_one`/`probe_with_budget` that does NOT
-    /// reach a verdict, including the inconclusive-only case.
+    /// `judged_last_tick` and `without_verdict_last_tick` are complements over the
+    /// focus set. `report.probed` is NOT the first of them (a contract can be probed
+    /// and reach no verdict), and `skipped_no_code + skipped_no_samples` is not the
+    /// second (neither skip counter sees a probed-but-inconclusive contract). Both
+    /// wrong values type-check and both render as plausible numbers.
     #[test]
-    fn dashboard_without_verdict_is_report_field_not_skip_counter_sum() {
-        let body = run_writer_code_only();
-        assert!(
-            body.contains("report.without_verdict"),
-            "status::publish is no longer fed report.without_verdict, so a probed \
-             contract whose every case was inconclusive no longer counts toward the \
-             fleet-wide unjudged total"
+    fn dashboard_tick_counts_are_the_report_fields_positionally() {
+        let args = publish_call_args();
+        assert_eq!(
+            args[1], "report.judged.len()",
+            "the judged-this-tick count is no longer `report.judged.len()`; \
+             `report.probed` counts contracts that ran cases without forming an \
+             opinion and would overstate what was established"
         );
+        assert_eq!(
+            args[2], "report.without_verdict",
+            "the unjudged count is no longer `report.without_verdict`, so a probed \
+             contract whose every case was inconclusive stops counting toward the \
+             fleet-wide unjudged total and renders as a clean result"
+        );
+    }
+
+    /// The snapshot must carry a publish time.
+    ///
+    /// `publish` is reached from one place, and two live paths above skip it
+    /// indefinitely while the previous snapshot stands: a tick that selected no work,
+    /// and a probe task that panicked. Without an age, a peer whose probe has been
+    /// dead for a week keeps serving that week-old tick as a current "no violation
+    /// found".
+    #[test]
+    fn the_published_snapshot_carries_its_publish_time() {
+        let args = publish_call_args();
         assert!(
-            !body.contains("report.skipped_no_code + report.skipped_no_samples"),
-            "status::publish reverted to deriving the unjudged count from the skip \
-             counters, which cannot see a probed-but-inconclusive contract"
+            args[3].contains("Instant::now()"),
+            "the published snapshot no longer carries a publish time, so a frozen \
+             checker renders identically to a live clean one. got: {}",
+            args[3]
         );
     }
 }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -2177,22 +2177,32 @@ mod probe_wiring_pins {
     /// Warm-up is the normal state now that focus draws from the hosted set rather than
     /// from what was already sampled, so this hid the common case.
     ///
-    /// Only the DELEGATION is pinned here. The three counters used to be open-coded
-    /// in `run_writer`, which is why this pin had to name each of them and why the
-    /// `probe_fixture_contract` seam could silently apply none of them; they now live
-    /// in `shadow::count_awaiting_samples`, whose behaviour is tested directly in
-    /// `shadow`'s own test module rather than scraped. What no test but a source pin
-    /// can see is whether `run_writer` still CALLS it.
+    /// Only the DELEGATION and its arguments are pinned here. The three counters used
+    /// to be open-coded in `run_writer`, which is why this pin had to name each of
+    /// them and why the `probe_fixture_contract` seam could silently apply none of
+    /// them; they now live in `shadow::count_awaiting_samples`, whose behaviour is
+    /// tested directly in `shadow`'s own test module rather than scraped. What no test
+    /// but a source pin can see is whether `run_writer` still CALLS it, and with what.
     #[test]
     fn contracts_awaiting_samples_are_counted_in_the_tick() {
         let body = run_writer_code_only();
-        assert!(
-            body.contains("count_awaiting_samples(")
-                && body.contains("&mut report,")
-                && body.contains("awaiting_samples,"),
-            "the completed-probe arm no longer folds the warming-up focus contracts \
-             into the tick's counts, so a warming-up focus set reports as a smaller, \
-             fully-checked one and the dashboard's unjudged total silently omits them"
+        // Positional, and scoped to the call's own argument list — see
+        // `count_awaiting_samples_args`. Passing the tick's report but a literal `0`
+        // for the count type-checks, folds nothing in, and renders as a warming-up
+        // focus set that was fully judged.
+        let args = count_awaiting_samples_args();
+        assert_eq!(
+            args[0], "&mut report",
+            "the warming-up counters are folded into something other than THIS tick's \
+             report, so the numbers the dashboard is fed below describe a different \
+             object than the one the log line reports"
+        );
+        assert_eq!(
+            args[1], "awaiting_samples",
+            "the warming-up count passed to `count_awaiting_samples` is no longer \
+             `awaiting_samples`, so the focus contracts that had nothing to check yet \
+             are dropped from the tick's counts and a warming-up focus set reports as \
+             a smaller, fully-checked one"
         );
         // Not re-inlined alongside the call: two places that both adjust these
         // counters is how the writer and the seam came to disagree in the first
@@ -2263,7 +2273,10 @@ mod probe_wiring_pins {
         // under "the count must not be derived from the marker it audits".
         //
         // `publish(` also matches inside `status::publish(`, so equality here says
-        // exactly "every call spelled `publish(` is the qualified one".
+        // exactly "every call spelled `publish(` is the qualified one". It is a
+        // PREFIX match, so it over-counts a `something.publish(` or a `republish(`
+        // — which fails safe, naming a discrepancy that is not one — and it is blind
+        // to a `use … as` rename, which both counters miss together.
         let any_spelling = body.matches("publish(").count();
         assert_eq!(
             any_spelling,
@@ -2300,6 +2313,25 @@ mod probe_wiring_pins {
     fn publish_call_args(nth: usize) -> Vec<String> {
         let body = run_writer_code_only();
         let start = publish_call_sites()[nth];
+        let args = call_args_at(&body, start, &format!("status::publish call {nth}"));
+        assert_eq!(
+            args.len(),
+            4,
+            "status::publish's argument list changed shape, so the positional pins \
+             below are asserting about the wrong arguments: {args:?}"
+        );
+        args
+    }
+
+    /// The arguments of the call whose opening paren ends at `start`, in order.
+    ///
+    /// Shared by every argument-scoped pin in this module, because the bound is the
+    /// whole point. A free-floating `body.contains("some_arg,")` is satisfied by any
+    /// other occurrence of that text anywhere in `run_writer` — a `tracing` field, a
+    /// nearby assignment, a sibling call — so it cannot see a wrong argument at the
+    /// call it names. `label` names the call in the panic below, which is the only
+    /// diagnostic a reader gets when an anchor stops landing on a call.
+    fn call_args_at(body: &str, start: usize, label: &str) -> Vec<String> {
         // Split on TOP-LEVEL commas only: an argument may itself be a call with its
         // own comma-separated arguments.
         let mut depth = 0usize;
@@ -2319,10 +2351,9 @@ mod probe_wiring_pins {
                 // overflow`, which names arithmetic and sends the next reader nowhere
                 // near the anchor that actually broke.
                 ']' if depth == 0 => panic!(
-                    "unbalanced `]` while slicing status::publish call {nth}'s \
-                     arguments: the anchor no longer lands on the call's opening \
-                     paren, so nothing below is asserting about a publish call. \
-                     parsed so far: {args:?} + {current:?}"
+                    "unbalanced `]` while slicing {label}'s arguments: the anchor no \
+                     longer lands on that call's opening paren, so nothing below is \
+                     asserting about it. parsed so far: {args:?} + {current:?}"
                 ),
                 ')' | ']' => {
                     depth -= 1;
@@ -2338,11 +2369,42 @@ mod probe_wiring_pins {
         if !current.trim().is_empty() {
             args.push(current.trim().to_string());
         }
+        args
+    }
+
+    /// The arguments of `run_writer`'s sole `count_awaiting_samples` call, in order.
+    ///
+    /// Bounded to the call for the same reason `publish_call_args` is. The three
+    /// unscoped `body.contains` this replaced could not see the call's arguments at
+    /// all: `"awaiting_samples,"` occurs three times in `run_writer` — the barren
+    /// tick's `without_verdict` log field, the barren publish's third argument, and
+    /// this call — so that conjunct was satisfied whatever this call was passed, and
+    /// `count_awaiting_samples(&mut report, 0)` left the pin green (mutation-verified).
+    fn count_awaiting_samples_args() -> Vec<String> {
+        let body = run_writer_code_only();
+        let anchor = "count_awaiting_samples(";
+        // One call, so `find` is unambiguous. A second one would mean the writer
+        // adjusts these counters twice, which is the double-count the sibling
+        // open-coding assertions below exist to forbid.
+        assert_eq!(
+            body.matches(anchor).count(),
+            1,
+            "run_writer calls `count_awaiting_samples` more than once, so the \
+             warming-up focus contracts are folded into the tick's counts twice — a \
+             double-count reads as a plausible number"
+        );
+        let start = body.find(anchor).expect(
+            "the completed-probe arm no longer folds the warming-up focus \
+                 contracts into the tick's counts, so a warming-up focus set reports \
+                 as a smaller, fully-checked one and the dashboard's unjudged total \
+                 silently omits them",
+        ) + anchor.len();
+        let args = call_args_at(&body, start, "count_awaiting_samples");
         assert_eq!(
             args.len(),
-            4,
-            "status::publish's argument list changed shape, so the positional pins \
-             below are asserting about the wrong arguments: {args:?}"
+            2,
+            "count_awaiting_samples's argument list changed shape, so the positional \
+             pins below are asserting about the wrong arguments: {args:?}"
         );
         args
     }
@@ -2364,6 +2426,7 @@ mod probe_wiring_pins {
     /// window renders clean while violating.
     #[test]
     fn dashboard_checked_window_is_fed_judged_contracts_with_their_findings() {
+        let body = run_writer_code_only();
         let args = publish_call_args(PROBE_PUBLISH);
         assert!(
             args[0].contains("checked_contracts(&report.judged, &findings)"),
@@ -2373,14 +2436,28 @@ mod probe_wiring_pins {
              the contract they belong to (#5403 H1). got: {}",
             args[0]
         );
-        // Every call site, and bounded to the ARGUMENT rather than to the whole body.
-        // The old guard was `!body.contains("last_focus.selected.iter().copied()")`,
-        // which names one spelling at one binding: in the barren branch the in-scope
+        // TWO guards, because each sees what the other cannot.
+        //
+        // The whole-body one below catches selection MATERIALISED FIRST: bind
+        // `last_focus.selected.iter().copied()` to a local and pass the local, and
+        // every argument-scoped check below sees only the local's name and stays
+        // green (mutation-verified). It costs nothing to keep — `last_focus.selected`
+        // appears in `run_writer` only inside a comment, which `run_writer_code_only`
+        // strips — so it has no false-positive surface here.
+        assert!(
+            !body.contains("last_focus.selected.iter().copied()"),
+            "run_writer materialises focus SELECTION as a record set. Whether or not \
+             it is passed to `status::publish` directly, that is the one thing this \
+             list must not be built from: a selected contract can be skipped before \
+             probing (no code, no samples) or probed and never reach a verdict"
+        );
+        // The per-call-site loop catches what the whole-body guard cannot NAME. It
+        // named one spelling at one binding: in the barren branch the in-scope
         // binding is `focus`, not `last_focus`, so a future edit feeding selection
-        // into the barren publish would write `focus.selected…` and the guard would
-        // not see it. A whole-body guard also cannot name `focus.selected` at all —
-        // the scope assignment legitimately uses it two lines above the branch — so
-        // it has to be scoped to the call to be able to say this at all.
+        // into the barren publish would write `focus.selected…` and go unseen — and
+        // a whole-body guard cannot name `focus.selected` at all, because the scope
+        // assignment legitimately uses it two lines above the branch. Scoping to the
+        // argument is what makes that sayable.
         for nth in 0..PUBLISH_CALL_SITES {
             let first = &publish_call_args(nth)[0];
             assert!(

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -837,9 +837,11 @@ async fn run_writer(
                 };
                 // Focus picked these; they simply had nothing to check yet. Counted
                 // in both, so `focused` is the size of the focus set rather than the
-                // size of the subset that happened to have samples.
+                // size of the subset that happened to have samples. No case ran for
+                // them, so no opinion was formed either — see `ShadowReport::judged`.
                 report.focused += awaiting_samples;
                 report.skipped_no_samples += awaiting_samples;
+                report.without_verdict += awaiting_samples;
                 shadow.record(&findings);
                 // Reported even when nothing was checked. A shadow period that finds
                 // nothing and a shadow period that never ran look identical in a
@@ -872,6 +874,13 @@ async fn run_writer(
                     skipped_no_code = report.skipped_no_code,
                     skipped_no_samples = report.skipped_no_samples,
                     timed_out = report.timed_out,
+                    // `judged`/`without_verdict` are narrower than `probed`: a focus
+                    // contract can be probed and run every case without forming an
+                    // opinion (every case `Inconclusive`). These are the numbers fed
+                    // to the dashboard below, so a reader comparing the log to the
+                    // per-contract page must see the same two counts here.
+                    judged = report.judged.len(),
+                    without_verdict = report.without_verdict,
                     "conformance shadow tick"
                 );
 
@@ -879,10 +888,22 @@ async fn run_writer(
                 // cannot disagree about what happened. Published here rather than
                 // derived by a reader: a count re-computed at the call site is how
                 // this project has produced wrong metrics before.
+                //
+                // `report.judged` — not `last_focus.selected` — is what feeds
+                // `recently_checked`: focus selection only names candidates, and a
+                // selected contract can be skipped before probing (no code, no
+                // samples) or probed and never reach a verdict (every case
+                // `Inconclusive`). Feeding selection here would render an
+                // unjudged contract as "checked, no violation found", which is the
+                // exact conflation this subsystem exists to prevent. Likewise
+                // `report.without_verdict` — not `skipped_no_code +
+                // skipped_no_samples` — is the complement of `judged` over the
+                // focus set: it also counts a probed contract whose every case was
+                // inconclusive, which the skip counters never see.
                 crate::conformance::status::publish(
-                    last_focus.selected.iter().copied(),
-                    report.probed,
-                    report.skipped_no_code + report.skipped_no_samples,
+                    report.judged.iter().copied(),
+                    report.judged.len(),
+                    report.without_verdict,
                     report.cases,
                     findings.iter().map(|finding| {
                         crate::conformance::status::MergeFinding {
@@ -2136,6 +2157,55 @@ mod probe_wiring_pins {
              flight, so a probe that overran its interval would have another stacked \
              on top of it — unbounded concurrent WASM execution from a job whose \
              entire justification is that it is bounded"
+        );
+    }
+
+    /// The dashboard's `recently_checked` must be fed the contracts that actually
+    /// reached a verdict, never focus SELECTION.
+    ///
+    /// The #5403 review defect: `status::publish` was fed `last_focus.selected`, so a
+    /// contract focus merely picked — including one skipped before probing (no code,
+    /// no samples) or probed and left with every case `Inconclusive` — rendered on
+    /// the per-contract page as "checked, no violation found". `report.judged` is
+    /// populated only when at least one case reached `Holds` or `Violated`
+    /// (`shadow::probe_one`), so feeding it here is what makes "recently checked"
+    /// mean "we formed an opinion" rather than "focus looked this way".
+    #[test]
+    fn dashboard_recently_checked_is_fed_judged_contracts_not_focus_selection() {
+        let body = run_writer_code_only();
+        assert!(
+            body.contains("report.judged.iter().copied()"),
+            "status::publish is no longer fed the contracts that reached a verdict"
+        );
+        assert!(
+            !body.contains("last_focus.selected.iter().copied()"),
+            "status::publish must not be fed focus SELECTION — a selected contract \
+             can be skipped before probing, or probed and never reach a verdict"
+        );
+    }
+
+    /// The dashboard's `contracts_without_verdict` must be the complement of
+    /// `judged` over the focus set, not `skipped_no_code + skipped_no_samples`.
+    ///
+    /// The #5403 review defect's sibling: a contract that IS probed but whose every
+    /// case comes back `Inconclusive` is not counted by either skip counter, so
+    /// `skipped_no_code + skipped_no_samples` silently missed it and it rendered as
+    /// a clean result. `report.without_verdict` is incremented directly at every
+    /// terminal branch in `shadow::probe_one`/`probe_with_budget` that does NOT
+    /// reach a verdict, including the inconclusive-only case.
+    #[test]
+    fn dashboard_without_verdict_is_report_field_not_skip_counter_sum() {
+        let body = run_writer_code_only();
+        assert!(
+            body.contains("report.without_verdict"),
+            "status::publish is no longer fed report.without_verdict, so a probed \
+             contract whose every case was inconclusive no longer counts toward the \
+             fleet-wide unjudged total"
+        );
+        assert!(
+            !body.contains("report.skipped_no_code + report.skipped_no_samples"),
+            "status::publish reverted to deriving the unjudged count from the skip \
+             counters, which cannot see a probed-but-inconclusive contract"
         );
     }
 }

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -802,6 +802,17 @@ async fn run_writer(
                         candidate_source = focus.source.as_str(),
                         focused = focus.selected.len(),
                         scope = scope.as_str(),
+                        // The two counts the dashboard is fed just below, under the
+                        // names the completed-probe line uses for them. Without these
+                        // a barren tick reported neither, so an operator comparing the
+                        // log against the per-contract page had nothing to compare on
+                        // the one tick shape where the page shows every focus contract
+                        // as unjudged. Zero and `awaiting_samples` are literally what
+                        // is published; when `work` is empty `select` returns
+                        // `focus.selected.len()` for the latter, so it also matches
+                        // `focused` on this line by construction.
+                        judged = 0,
+                        without_verdict = awaiting_samples,
                         "conformance shadow tick selected nothing to probe"
                     );
                     // Published too, with no records and nothing judged.
@@ -857,13 +868,14 @@ async fn run_writer(
                         continue;
                     }
                 };
-                // Focus picked these; they simply had nothing to check yet. Counted
-                // in both, so `focused` is the size of the focus set rather than the
-                // size of the subset that happened to have samples. No case ran for
-                // them, so no opinion was formed either — see `ShadowReport::judged`.
-                report.focused += awaiting_samples;
-                report.skipped_no_samples += awaiting_samples;
-                report.without_verdict += awaiting_samples;
+                // Focus picked these; they simply had nothing to check yet. All three
+                // counters have to be told — see `shadow::count_awaiting_samples`,
+                // which is shared with the `probe_fixture_contract` test seam so a
+                // test cannot be fed a report production would never publish.
+                crate::conformance::shadow::count_awaiting_samples(
+                    &mut report,
+                    awaiting_samples,
+                );
                 shadow.record(&findings);
                 // Reported even when nothing was checked. A shadow period that finds
                 // nothing and a shadow period that never ran look identical in a
@@ -930,10 +942,13 @@ async fn run_writer(
                 // evicted from the other rendered a green "no violation found" pill
                 // for a contract found violating.
                 //
-                // The publish TIME is carried too. Two live paths above skip this call
-                // indefinitely (a tick that selected no work, and a probe task that
-                // died) while the previous snapshot stands, so without an age on the
-                // snapshot a peer whose probe has been panicking for a week keeps
+                // The publish TIME is carried too. A tick that selects no work now
+                // publishes as well, so barrenness is no longer a way to freeze the
+                // snapshot — but a peer can still stop reaching EITHER call site
+                // indefinitely while the previous one stands: the probe task can die
+                // (the `Err` arm above `continue`s), a probe can hang so `in_flight`
+                // never clears and no further tick starts, or this writer task can be
+                // gone entirely. Without an age on the snapshot, any of those keeps
                 // serving a week-old tick as a current clean result.
                 crate::conformance::status::publish(
                     crate::conformance::status::checked_contracts(&report.judged, &findings),
@@ -2161,29 +2176,39 @@ mod probe_wiring_pins {
     /// `focused=1, skipped_no_samples=0`, which reads as "one contract, fully checked".
     /// Warm-up is the normal state now that focus draws from the hosted set rather than
     /// from what was already sampled, so this hid the common case.
+    ///
+    /// Only the DELEGATION is pinned here. The three counters used to be open-coded
+    /// in `run_writer`, which is why this pin had to name each of them and why the
+    /// `probe_fixture_contract` seam could silently apply none of them; they now live
+    /// in `shadow::count_awaiting_samples`, whose behaviour is tested directly in
+    /// `shadow`'s own test module rather than scraped. What no test but a source pin
+    /// can see is whether `run_writer` still CALLS it.
     #[test]
     fn contracts_awaiting_samples_are_counted_in_the_tick() {
         let body = run_writer_code_only();
         assert!(
-            body.contains("report.focused += awaiting_samples"),
-            "focus contracts still awaiting samples no longer count toward `focused`, \
-             so a warming-up focus set reports as a smaller, fully-checked one"
+            body.contains("count_awaiting_samples(")
+                && body.contains("&mut report,")
+                && body.contains("awaiting_samples,"),
+            "the completed-probe arm no longer folds the warming-up focus contracts \
+             into the tick's counts, so a warming-up focus set reports as a smaller, \
+             fully-checked one and the dashboard's unjudged total silently omits them"
         );
-        assert!(
-            body.contains("report.skipped_no_samples += awaiting_samples"),
-            "focus contracts still awaiting samples are no longer reported as skipped"
-        );
-        // The third of the trio, and the one that was unpinned: deleting it left every
-        // test and both source pins green while the dashboard under-reported unjudged
-        // contracts by the whole warm-up count. `judged`/`without_verdict` are
-        // complements over the focus set, and a warming-up contract is in neither half
-        // unless this line puts it in one.
-        assert!(
-            body.contains("report.without_verdict += awaiting_samples"),
-            "focus contracts still awaiting samples no longer count toward \
-             `without_verdict`, so the dashboard's unjudged total silently omits them \
-             and they render as contracts nobody had a question about"
-        );
+        // Not re-inlined alongside the call: two places that both adjust these
+        // counters is how the writer and the seam came to disagree in the first
+        // place, and a double-count reads as a plausible number.
+        for open_coded in [
+            "report.focused +=",
+            "report.skipped_no_samples +=",
+            "report.without_verdict +=",
+        ] {
+            assert!(
+                !body.contains(open_coded),
+                "`{open_coded}` is open-coded in run_writer again alongside \
+                 `count_awaiting_samples`, so the warm-up contracts are counted twice \
+                 — or, worse, the helper's own version has drifted from it"
+            );
+        }
     }
 
     #[test]
@@ -2228,6 +2253,28 @@ mod probe_wiring_pins {
             at.push(from + found + anchor.len());
             from += found + anchor.len();
         }
+        // Checked BEFORE the count, and against an anchor the qualified spelling
+        // cannot influence. `PUBLISH_CALL_SITES` is hand-written and the search
+        // anchor is `status::publish(`, so a third call site reached through a `use`
+        // import — `publish(...)`, or `st::publish(...)` — is invisible to BOTH: the
+        // count matches, every positional pin stays green, and all four are asserting
+        // about a set that no longer contains the call they name. Two errors that
+        // cancel, which is the shape `.claude/rules/bug-prevention-patterns.md` names
+        // under "the count must not be derived from the marker it audits".
+        //
+        // `publish(` also matches inside `status::publish(`, so equality here says
+        // exactly "every call spelled `publish(` is the qualified one".
+        let any_spelling = body.matches("publish(").count();
+        assert_eq!(
+            any_spelling,
+            at.len(),
+            "run_writer calls `publish(` {any_spelling} times but only {} of them are \
+             spelled `status::publish(`. A call reached through a `use` import is \
+             invisible to this anchor AND to PUBLISH_CALL_SITES, so the positional \
+             pins below would keep passing while asserting about the wrong set. \
+             Spell it `status::publish(` at every call site",
+            at.len()
+        );
         assert_eq!(
             at.len(),
             PUBLISH_CALL_SITES,
@@ -2265,6 +2312,18 @@ mod probe_wiring_pins {
                     current.push(ch);
                 }
                 ')' if depth == 0 => break,
+                // A `]` at depth zero cannot be balanced by anything inside this
+                // argument list, so the slice is not the call it claims to be — the
+                // anchor moved, or the call is not brace-balanced. Diagnosed rather
+                // than left to `depth -= 1` panicking with `attempt to subtract with
+                // overflow`, which names arithmetic and sends the next reader nowhere
+                // near the anchor that actually broke.
+                ']' if depth == 0 => panic!(
+                    "unbalanced `]` while slicing status::publish call {nth}'s \
+                     arguments: the anchor no longer lands on the call's opening \
+                     paren, so nothing below is asserting about a publish call. \
+                     parsed so far: {args:?} + {current:?}"
+                ),
                 ')' | ']' => {
                     depth -= 1;
                     current.push(ch);
@@ -2314,12 +2373,24 @@ mod probe_wiring_pins {
              the contract they belong to (#5403 H1). got: {}",
             args[0]
         );
-        let body = run_writer_code_only();
-        assert!(
-            !body.contains("last_focus.selected.iter().copied()"),
-            "status::publish must not be fed focus SELECTION — a selected contract \
-             can be skipped before probing, or probed and never reach a verdict"
-        );
+        // Every call site, and bounded to the ARGUMENT rather than to the whole body.
+        // The old guard was `!body.contains("last_focus.selected.iter().copied()")`,
+        // which names one spelling at one binding: in the barren branch the in-scope
+        // binding is `focus`, not `last_focus`, so a future edit feeding selection
+        // into the barren publish would write `focus.selected…` and the guard would
+        // not see it. A whole-body guard also cannot name `focus.selected` at all —
+        // the scope assignment legitimately uses it two lines above the branch — so
+        // it has to be scoped to the call to be able to say this at all.
+        for nth in 0..PUBLISH_CALL_SITES {
+            let first = &publish_call_args(nth)[0];
+            assert!(
+                !first.contains("selected"),
+                "status::publish call {nth} is fed focus SELECTION (`{first}`). A \
+                 selected contract can be skipped before probing (no code, no \
+                 samples) or probed and never reach a verdict, and it would render on \
+                 the per-contract page as 'checked, no violation found'"
+            );
+        }
     }
 
     /// The tick's two headline counts must be the report's own, positionally.
@@ -2402,6 +2473,15 @@ mod probe_wiring_pins {
 
         let args = publish_call_args(BARREN_PUBLISH);
         assert_eq!(
+            args[0], "Vec::new()",
+            "a tick that probed nothing must publish an EMPTY record set. Anything \
+             else — focus selection most plausibly, since `focus` is in scope right \
+             here — puts contracts the tick formed no opinion about into the checked \
+             window, where the per-contract page renders them as 'checked, no \
+             violation found'. Un-asserted, this argument was the one position of the \
+             four that a wrong value could occupy silently"
+        );
+        assert_eq!(
             args[1], "0",
             "a tick that probed nothing must publish zero contracts judged; anything \
              else reports established results from a tick that established none"
@@ -2423,11 +2503,12 @@ mod probe_wiring_pins {
 
     /// The snapshot must carry a publish time.
     ///
-    /// `publish` is reached from one place, and two live paths above skip it
-    /// indefinitely while the previous snapshot stands: a tick that selected no work,
-    /// and a probe task that panicked. Without an age, a peer whose probe has been
-    /// dead for a week keeps serving that week-old tick as a current "no violation
-    /// found".
+    /// `publish` is reached from two places — the barren tick and the completed probe
+    /// — and a peer can stop reaching either indefinitely while the previous snapshot
+    /// stands: the probe task can panic, a probe can hang so `in_flight` never clears
+    /// and no further tick starts, or the writer task can be gone. Without an age, a
+    /// peer whose probe has been dead for a week keeps serving that week-old tick as a
+    /// current "no violation found".
     #[test]
     fn the_published_snapshot_carries_its_publish_time() {
         let args = publish_call_args(PROBE_PUBLISH);

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -139,7 +139,7 @@ pub struct ShadowReport {
     /// be built from this list, not from focus selection or from `probed`: selection
     /// only says a contract was a *candidate* to look at, and `probed` only says the
     /// code and samples were usable, neither says an opinion was formed.
-    pub judged: Vec<ContractInstanceId>,
+    pub judged: Vec<JudgedContract>,
     /// Focus contracts we formed NO opinion about: skipped before probing (no code, no
     /// samples), a probe whose blocking task died or whose time budget was exhausted
     /// before any case ran, or a probe that ran cases but every one came back
@@ -147,6 +147,34 @@ pub struct ShadowReport {
     /// lands in exactly one of the two, which is what makes them checkable against
     /// each other.
     pub without_verdict: usize,
+}
+
+/// One contract that reached a verdict, and how much looking that took.
+///
+/// The counts travel WITH the contract rather than being summed into the tick's
+/// fleet-wide `cases`/`inconclusive` totals alone. The dashboard needs to say how
+/// much was established about THIS contract: a contract with one verdict and 199
+/// inconclusive cases rendered byte-identically to one with 200 verdicts while the
+/// page could only reach the fleet-wide number, which is the same conflation of
+/// "barely looked at" with "clean" that `conformance::status` exists to stop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JudgedContract {
+    pub contract: ContractInstanceId,
+    /// Cases that came back `Holds` or `Violated` for this contract this tick.
+    pub verdicts: usize,
+    /// Cases that came back `Inconclusive` for this contract this tick.
+    pub inconclusive: usize,
+}
+
+impl ShadowReport {
+    /// Whether this tick reached a verdict on `contract`.
+    ///
+    /// A helper rather than `judged.contains(..)`, which stopped compiling when the
+    /// list gained its per-contract counts — and which callers would otherwise
+    /// re-implement one `iter().any()` at a time.
+    pub fn judged_contains(&self, contract: &ContractInstanceId) -> bool {
+        self.judged.iter().any(|j| j.contract == *contract)
+    }
 }
 
 /// The shadow loop's state, owned by the capture writer task.
@@ -581,7 +609,15 @@ async fn probe_one(
     // "checked, no violation found" is exactly the conflation this subsystem exists to
     // prevent. See `ShadowReport::judged` / `without_verdict`.
     if outcome.reached_verdict {
-        report.judged.push(instance_copy);
+        // The counts go with the contract, not only into the tick's totals: the
+        // dashboard's clean branch has to say how much looking THIS contract got, and
+        // a fleet-wide case count cannot answer that for a contract last probed forty
+        // ticks ago. `verdicts` is what the case loop did NOT call inconclusive.
+        report.judged.push(JudgedContract {
+            contract: instance_copy,
+            verdicts: outcome.cases.saturating_sub(outcome.inconclusive),
+            inconclusive: outcome.inconclusive,
+        });
     } else {
         report.without_verdict += 1;
     }
@@ -1396,14 +1432,34 @@ mod tests {
              the fixture no longer exercises this failure mode: {report:?}"
         );
         assert!(
-            !report.judged.contains(&unjudged_id),
+            !report.judged_contains(&unjudged_id),
             "a contract whose every case was inconclusive was recorded as judged: \
              {report:?}"
         );
         assert!(
-            report.judged.contains(&judged_id),
+            report.judged_contains(&judged_id),
             "a contract that genuinely reached a verdict on every case was NOT \
              recorded as judged: {report:?}"
+        );
+        // The per-contract counts the dashboard's clean branch renders. The judged
+        // sibling's cases all reached a verdict; if that ever stops being true the
+        // page would claim more was established about it than was.
+        let judged_record = report
+            .judged
+            .iter()
+            .find(|j| j.contract == judged_id)
+            .expect("the conforming sibling is judged");
+        assert!(
+            judged_record.verdicts > 0,
+            "a judged contract carries no verdict count, so its page can only report \
+             the node-wide number and cannot say how much looking IT got: {report:?}"
+        );
+        assert_eq!(
+            judged_record.verdicts,
+            report.cases - report.inconclusive,
+            "the only contract to reach a verdict this tick must own every one of the \
+             tick's verdicts; its per-contract count disagrees with the totals, so \
+             the page and the log would report different things: {report:?}"
         );
         assert_eq!(
             report.judged.len(),

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -149,6 +149,31 @@ pub struct ShadowReport {
     pub without_verdict: usize,
 }
 
+/// Fold the focus contracts that had no samples yet into a tick's counts.
+///
+/// [`ShadowRunner::select`] returns them separately from the work set, because
+/// [`probe`] cannot see them at all: no case ran for them, so nothing downstream of
+/// the probe knows they existed. Every one of the three counters has to be told.
+/// `focused` so it is the size of the focus SET rather than of the subset that
+/// happened to have samples; `skipped_no_samples` so the reason is legible; and
+/// `without_verdict` because `judged`/`without_verdict` are complements over the
+/// focus set, and a warming-up contract lands in neither half unless it is put in
+/// one. Warm-up is the ordinary state now that focus draws from the hosted set, so
+/// this is the common path, not a corner.
+///
+/// A shared function rather than three lines at each caller. `capture::run_writer`
+/// and the `probe_fixture_contract` test seam both hand a `ShadowReport` onward —
+/// the writer to `status::publish`, the seam to whatever a test does with it — and
+/// while the seam open-coded nothing at all, tests fed `report.without_verdict`
+/// straight into `MergeCheckStatus::record` as a tick's unjudged count, a value
+/// production would never publish while any focus contract was warming up. One
+/// function is the only shape in which the seam cannot drift from the writer.
+pub(crate) fn count_awaiting_samples(report: &mut ShadowReport, awaiting: usize) {
+    report.focused += awaiting;
+    report.skipped_no_samples += awaiting;
+    report.without_verdict += awaiting;
+}
+
 /// One contract that reached a verdict, and how much looking that took.
 ///
 /// The counts travel WITH the contract rather than being summed into the tick's
@@ -797,15 +822,21 @@ fn store_epoch(dir: &Path, epoch: u64) {
 /// Tests reach the real inputs through here so a fixture cannot quietly disagree with
 /// what a probe emits.
 ///
-/// `mode` selects the fixture's defect — see `tests/test-contract-conformance`. Mode 1
-/// (LAST_WRITE_WINS) breaks several merge laws on nearly every generated case, which
-/// is what makes it the input that distinguishes a deduplicating assembly from one
-/// that appends.
+/// `mode` selects the fixture's defect — see `tests/test-contract-conformance`. Every
+/// caller today passes mode 6 (NEVER_SETTLES), which breaks more than one merge law on
+/// most generated cases and repeats each of them across the tick's cases: the input
+/// that distinguishes a deduplicating assembly both from one that appends and from one
+/// that collapses everything onto the contract. (This doc named mode 1,
+/// LAST_WRITE_WINS, which nothing calls it with — a reader checking the fixture would
+/// have found a different defect than the tests actually exercise.)
 ///
 /// Returns the fixture's instance id alongside the probe's own two outputs, which are
-/// exactly the pair `capture::run_writer` hands to `status::publish`. The temp
-/// directories are dropped before returning: the probe resolves and compiles the code
-/// while it runs, so nothing here outlives the call.
+/// exactly the pair `capture::run_writer` hands to `status::publish` — and the report
+/// has been through `count_awaiting_samples`, the same fold the writer applies, so a
+/// test feeding `report.without_verdict` to `MergeCheckStatus::record` is feeding a
+/// number production would actually publish. The temp directories are dropped before
+/// returning: the probe resolves and compiles the code while it runs, so nothing here
+/// outlives the call.
 #[cfg(test)]
 pub(crate) async fn probe_fixture_contract(
     mode: u8,
@@ -862,18 +893,25 @@ pub(crate) async fn probe_fixture_contract(
     let dir = tempfile::TempDir::new()?;
     let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
     let focus = runner.focus(None, &samplers.keys().copied().collect::<Vec<_>>());
-    let (work, _awaiting) = runner.select(&focus, &samplers);
+    let (work, awaiting) = runner.select(&focus, &samplers);
     assert!(
         !work.is_empty(),
-        "the fixture contract was not selected, so a probe never ran and any          assertion downstream of this proves nothing"
+        "the fixture contract was not selected, so a probe never ran and any \
+         assertion downstream of this proves nothing"
     );
 
-    let (report, findings) = probe(
+    let (mut report, findings) = probe(
         work,
         Some(store_dir.path().to_path_buf()),
         EnforcementMode::Shadow,
     )
     .await;
+    // The same fold `capture::run_writer` applies before publishing. Discarding it
+    // here made the seam diverge from production in exactly the counts tests read:
+    // `report.without_verdict` fed to `MergeCheckStatus::record` would have been a
+    // tick's unjudged count that a live peer could not produce while any focus
+    // contract was still warming up.
+    count_awaiting_samples(&mut report, awaiting);
     Ok((id, report, findings))
 }
 
@@ -896,10 +934,54 @@ mod tests {
         // to the sampler keys - which is exactly the fallback path production reports
         // as `candidate_source=sampler`.
         let focus = runner.focus(None, &samplers.keys().copied().collect::<Vec<_>>());
-        let (work, _awaiting) = runner.select(&focus, samplers);
-        let (report, findings) = probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
+        let (work, awaiting) = runner.select(&focus, samplers);
+        let (mut report, findings) =
+            probe(work, store.map(|p| p.to_path_buf()), runner.mode()).await;
+        // The writer's own fold, for the same reason `probe_fixture_contract` applies
+        // it: a report that skipped it is one no live peer publishes.
+        count_awaiting_samples(&mut report, awaiting);
         runner.record(&findings);
         report
+    }
+
+    /// The warm-up fold has to reach all three counters.
+    ///
+    /// `judged` and `without_verdict` are complements over the focus set, so a
+    /// contract focus picked but the sampler had nothing for lands in NEITHER half
+    /// unless this puts it in one — and the dashboard's unjudged total then silently
+    /// omits it, rendering it as a contract nobody had a question about. Warm-up is
+    /// the ordinary state now that focus draws from the hosted set, so this is the
+    /// common path.
+    ///
+    /// Tested against the function rather than scraped out of `run_writer`: while the
+    /// three lines lived at the call site, the only guard was a source pin, and the
+    /// `probe_fixture_contract` seam applied none of them at all.
+    #[test]
+    fn awaiting_samples_reach_focused_skipped_and_without_verdict() {
+        let mut report = ShadowReport {
+            focused: 1,
+            skipped_no_samples: 0,
+            without_verdict: 0,
+            probed: 1,
+            ..Default::default()
+        };
+        count_awaiting_samples(&mut report, 3);
+        assert_eq!(
+            (
+                report.focused,
+                report.skipped_no_samples,
+                report.without_verdict
+            ),
+            (4, 3, 3),
+            "a warming-up focus contract must reach `focused` (or the focus set \
+             reports as the smaller subset that had samples), `skipped_no_samples` \
+             (or the reason is unstated) and `without_verdict` (or it counts as \
+             neither judged nor unjudged): {report:?}"
+        );
+        assert_eq!(
+            report.probed, 1,
+            "the fold must not touch `probed` — no case ran for a warming-up contract"
+        );
     }
 
     /// A fresh `FocusTick` must NOT claim the hosted source is already in use.

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -1294,7 +1294,14 @@ mod tests {
     }
 
     /// A contract that is genuinely probed, and runs every one of its cases, but
-    /// reaches NO verdict on any of them, must not be recorded as judged.
+    /// reaches NO verdict on any of them, must not be recorded as judged — and a
+    /// SIBLING contract probed in the same tick that DOES reach a verdict must
+    /// still land in `judged`. Both halves run in one tick on purpose: a version
+    /// of the fix that stopped populating `judged` entirely (rather than
+    /// correctly excluding the inconclusive-only contract) would still pass an
+    /// inconclusive-only-contract-not-judged assertion in isolation, so the
+    /// positive half is what actually pins the mechanism rather than just its
+    /// absence.
     ///
     /// The #5403 review defect: `probe_one` incremented `report.probed` before any
     /// case ran and nothing distinguished "every case was `Inconclusive`" from "at
@@ -1302,11 +1309,12 @@ mod tests {
     /// caller that only had `probed`, so a contract nothing was ever concluded about
     /// rendered on the dashboard exactly like a contract checked and found clean.
     ///
-    /// Mode 7 (`REQUIRES_RELATED`) is the fixture built for this: `validate_state`
-    /// asks for another contract's state, and `samplers_for` never supplies any
-    /// (`related: Vec::new()`), so every case dead-ends at
+    /// Mode 7 (`REQUIRES_RELATED`) is the fixture built for the inconclusive half:
+    /// `validate_state` asks for another contract's state, and `samplers_for` never
+    /// supplies any (`related: Vec::new()`), so every case dead-ends at
     /// `Inconclusive::RelatedRequired` — a real, unforced instance of the failure
-    /// mode, not a hand-built stub.
+    /// mode, not a hand-built stub. Mode 0 (`CONFORMING`) is the sibling that
+    /// reaches `Holds` on every case.
     #[tokio::test(flavor = "multi_thread")]
     async fn a_contract_whose_every_case_is_inconclusive_is_not_judged()
     -> Result<(), Box<dyn std::error::Error>> {
@@ -1316,6 +1324,7 @@ mod tests {
         use std::sync::Arc;
 
         // Keep in sync with `tests/test-contract-conformance/src/lib.rs`.
+        const CONFORMING: u8 = 0;
         const REQUIRES_RELATED: u8 = 7;
 
         let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
@@ -1327,20 +1336,46 @@ mod tests {
         let mut store =
             crate::wasm_runtime::ContractStore::new(store_dir.path().into(), 10_000_000, db)?;
 
-        let parameters: Parameters<'static> = Parameters::from(vec![REQUIRES_RELATED]);
-        let contract = WrappedContract::new(Arc::new(ContractCode::from(wasm)), parameters.clone());
-        let id = *contract.key().id();
-        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
-            contract,
-        )))?;
+        let transitions = &[(vec![1u8], vec![1u8, 2]), (vec![2u8], vec![2u8, 3])];
 
         // No `related` state is attached to any transition, so `validate_state`
         // never gets what it asks for and every case is inconclusive.
-        let samplers = samplers_for(
-            id,
-            vec![REQUIRES_RELATED],
+        let unjudged_parameters: Parameters<'static> = Parameters::from(vec![REQUIRES_RELATED]);
+        let unjudged_contract = WrappedContract::new(
+            Arc::new(ContractCode::from(wasm.clone())),
+            unjudged_parameters.clone(),
+        );
+        let unjudged_id = *unjudged_contract.key().id();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            unjudged_contract,
+        )))?;
+        let mut samplers =
+            samplers_for(unjudged_id, vec![REQUIRES_RELATED], code_hash, transitions);
+
+        // A genuinely conforming sibling, probed in the SAME tick, must still be
+        // recorded as judged.
+        let judged_parameters: Parameters<'static> = Parameters::from(vec![CONFORMING]);
+        let judged_contract = WrappedContract::new(
+            Arc::new(ContractCode::from(wasm)),
+            judged_parameters.clone(),
+        );
+        let judged_id = *judged_contract.key().id();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            judged_contract,
+        )))?;
+        samplers.extend(samplers_for(
+            judged_id,
+            vec![CONFORMING],
             code_hash,
-            &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
+            transitions,
+        ));
+
+        // Both candidates fit within MAX_FOCUS_CONTRACTS, so both are selected —
+        // this is not testing which one focus happened to pick.
+        assert_eq!(
+            samplers.len(),
+            2,
+            "test setup did not produce two distinct contracts"
         );
 
         let dir = tempfile::TempDir::new()?;
@@ -1348,22 +1383,32 @@ mod tests {
         let report = tick(&mut runner, &samplers, Some(store_dir.path())).await;
 
         assert_eq!(
-            report.probed, 1,
-            "the contract was not probed at all, so this proves nothing: {report:?}"
+            report.probed, 2,
+            "both contracts were not probed, so this proves nothing: {report:?}"
         );
         assert!(
             report.cases > 0,
             "no case ran, so this proves nothing: {report:?}"
         );
-        assert_eq!(
-            report.inconclusive, report.cases,
-            "expected every case to be inconclusive, or the fixture no longer \
-             exercises this failure mode: {report:?}"
+        assert!(
+            report.inconclusive > 0,
+            "expected the REQUIRES_RELATED contract's cases to be inconclusive, or \
+             the fixture no longer exercises this failure mode: {report:?}"
         );
         assert!(
-            report.judged.is_empty(),
+            !report.judged.contains(&unjudged_id),
             "a contract whose every case was inconclusive was recorded as judged: \
              {report:?}"
+        );
+        assert!(
+            report.judged.contains(&judged_id),
+            "a contract that genuinely reached a verdict on every case was NOT \
+             recorded as judged: {report:?}"
+        );
+        assert_eq!(
+            report.judged.len(),
+            1,
+            "expected exactly the conforming sibling to be judged: {report:?}"
         );
         assert_eq!(
             report.without_verdict, 1,

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -131,6 +131,22 @@ pub struct ShadowReport {
     pub reported: usize,
     /// Probes cut short by [`PROBE_TIME_BUDGET`].
     pub timed_out: usize,
+    /// Focus contracts that reached a verdict: at least one case came back `Holds` or
+    /// `Violated`. This is deliberately narrower than `probed` — a contract can be
+    /// probed, run every one of its cases, and still form no opinion (every case
+    /// `Inconclusive`), and `probed` alone cannot tell that apart from a contract that
+    /// was genuinely judged and found clean. `recently_checked` on the dashboard must
+    /// be built from this list, not from focus selection or from `probed`: selection
+    /// only says a contract was a *candidate* to look at, and `probed` only says the
+    /// code and samples were usable, neither says an opinion was formed.
+    pub judged: Vec<ContractInstanceId>,
+    /// Focus contracts we formed NO opinion about: skipped before probing (no code, no
+    /// samples), a probe whose blocking task died or whose time budget was exhausted
+    /// before any case ran, or a probe that ran cases but every one came back
+    /// `Inconclusive`. Complements `judged` over the focus set — every focus contract
+    /// lands in exactly one of the two, which is what makes them checkable against
+    /// each other.
+    pub without_verdict: usize,
 }
 
 /// The shadow loop's state, owned by the capture writer task.
@@ -423,6 +439,7 @@ pub(crate) async fn probe_with_budget(
         // a skip rather than returned as an empty report, which would read as a clean
         // run for contracts nobody could execute.
         report.skipped_no_code = work.len();
+        report.without_verdict += work.len();
         return (report, findings);
     };
 
@@ -463,6 +480,8 @@ async fn probe_one(
     let corpus = bundle.to_corpus();
     if corpus.is_empty() {
         report.skipped_no_samples += 1;
+        // No cases means no opinion was formed. See `ShadowReport::without_verdict`.
+        report.without_verdict += 1;
         return;
     }
 
@@ -475,6 +494,7 @@ async fn probe_one(
             // violations.
             tracing::debug!(%instance, error = %err, "shadow probe has no code for a focus contract");
             report.skipped_no_code += 1;
+            report.without_verdict += 1;
             return;
         }
     };
@@ -485,6 +505,7 @@ async fn probe_one(
             // A contract whose WASM will not load is not a conformance finding either.
             tracing::debug!(%instance, error = %err, "shadow probe could not build an oracle");
             report.skipped_no_code += 1;
+            report.without_verdict += 1;
             return;
         }
     };
@@ -509,6 +530,8 @@ async fn probe_one(
     // Only what setup did not already spend.
     let Some(remaining) = budget.checked_sub(started.elapsed()) else {
         report.timed_out += 1;
+        // Setup alone exhausted the budget: no case ran, so no opinion was formed.
+        report.without_verdict += 1;
         return;
     };
     let joined = tokio::task::spawn_blocking(move || {
@@ -522,7 +545,14 @@ async fn probe_one(
             let outcome = verify_case(&mut oracle, case);
             out.cases += 1;
             out.decisions.push(decide(mode, &outcome));
-            out.inconclusive += usize::from(matches!(outcome, PropertyOutcome::Inconclusive(_)));
+            let inconclusive = matches!(outcome, PropertyOutcome::Inconclusive(_));
+            out.inconclusive += usize::from(inconclusive);
+            // A verdict is `Holds` or `Violated` — anything that is not `Inconclusive`.
+            // One is enough: the contract is no longer merely a candidate we looked at,
+            // it is one we formed an opinion about.
+            if !inconclusive {
+                out.reached_verdict = true;
+            }
         }
         out
     })
@@ -531,8 +561,10 @@ async fn probe_one(
     let outcome = match joined {
         Ok(outcome) => outcome,
         Err(err) => {
-            // A probe that died is not a finding about the contract.
+            // A probe that died is not a finding about the contract, and it formed no
+            // opinion either — counted as such rather than silently dropped.
             tracing::warn!(%instance, error = %err, "shadow probe thread failed");
+            report.without_verdict += 1;
             return;
         }
     };
@@ -541,6 +573,17 @@ async fn probe_one(
     report.inconclusive += outcome.inconclusive;
     if outcome.timed_out {
         report.timed_out += 1;
+    }
+
+    // `recently_checked` on the dashboard must mean "we formed an opinion", not "we
+    // looked". A contract whose every case came back `Inconclusive` was probed — it
+    // consumed a full case budget — but reached no verdict, and rendering it as
+    // "checked, no violation found" is exactly the conflation this subsystem exists to
+    // prevent. See `ShadowReport::judged` / `without_verdict`.
+    if outcome.reached_verdict {
+        report.judged.push(instance_copy);
+    } else {
+        report.without_verdict += 1;
     }
 
     for action in outcome.decisions {
@@ -590,6 +633,9 @@ struct ProbeOutcome {
     inconclusive: usize,
     timed_out: bool,
     decisions: Vec<ConformanceAction>,
+    /// Whether any case in this batch reached `Holds` or `Violated`. See
+    /// `ShadowReport::judged`.
+    reached_verdict: bool,
 }
 
 /// Read this peer's focus salt, creating one if it does not exist.
@@ -990,6 +1036,25 @@ mod tests {
             "cases were checked without any contract code"
         );
         assert_eq!(report.would_remove, 0);
+        // The #5403 review defect: a contract skipped before probing must not be
+        // recorded as judged, and must count toward `without_verdict` — otherwise the
+        // dashboard's `recently_checked` would carry a contract nothing looked at, and
+        // its card would read "no violation found" for a contract with no code to run.
+        assert!(
+            report.judged.is_empty(),
+            "a contract with no resolvable code was recorded as judged: {report:?}"
+        );
+        assert_eq!(
+            report.without_verdict, report.focused,
+            "a contract skipped for no code did not count toward without_verdict: \
+             {report:?}"
+        );
+        assert_eq!(
+            report.judged.len() + report.without_verdict,
+            report.focused,
+            "judged and without_verdict must be complements over the focus set, or \
+             the dashboard silently under- or over-reports: {report:?}"
+        );
     }
 
     /// `Disabled` means nothing runs at all — not "runs but reports nothing".
@@ -1199,6 +1264,22 @@ mod tests {
         let broken = &outcomes[0].1;
         let honest = &outcomes[1].1;
 
+        for (mode, report) in [(LAST_WRITE_WINS, broken), (CONFORMING, honest)] {
+            assert_eq!(
+                report.judged.len() + report.without_verdict,
+                report.focused,
+                "mode {mode}: judged and without_verdict must be complements over \
+                 the focus set, or the dashboard silently under- or over-reports: \
+                 {report:?}"
+            );
+            assert_eq!(
+                report.judged.len(),
+                1,
+                "mode {mode} reached a verdict but was not recorded as judged: \
+                 {report:?}"
+            );
+        }
+
         assert!(
             broken.would_remove > 0,
             "a contract that provably breaks commutativity produced no prospective \
@@ -1208,6 +1289,92 @@ mod tests {
             honest.would_remove, 0,
             "a conforming contract produced a prospective removal, which is the false \
              positive the whole deployment plan is gated on not happening: {honest:?}"
+        );
+        Ok(())
+    }
+
+    /// A contract that is genuinely probed, and runs every one of its cases, but
+    /// reaches NO verdict on any of them, must not be recorded as judged.
+    ///
+    /// The #5403 review defect: `probe_one` incremented `report.probed` before any
+    /// case ran and nothing distinguished "every case was `Inconclusive`" from "at
+    /// least one case reached `Holds` or `Violated`". Both looked identical to a
+    /// caller that only had `probed`, so a contract nothing was ever concluded about
+    /// rendered on the dashboard exactly like a contract checked and found clean.
+    ///
+    /// Mode 7 (`REQUIRES_RELATED`) is the fixture built for this: `validate_state`
+    /// asks for another contract's state, and `samplers_for` never supplies any
+    /// (`related: Vec::new()`), so every case dead-ends at
+    /// `Inconclusive::RelatedRequired` — a real, unforced instance of the failure
+    /// mode, not a hand-built stub.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_contract_whose_every_case_is_inconclusive_is_not_judged()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use freenet_stdlib::prelude::{
+            ContractCode, ContractContainer, ContractWasmAPIVersion, Parameters, WrappedContract,
+        };
+        use std::sync::Arc;
+
+        // Keep in sync with `tests/test-contract-conformance/src/lib.rs`.
+        const REQUIRES_RELATED: u8 = 7;
+
+        let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
+        let code_hash = *blake3::hash(&wasm).as_bytes();
+
+        let store_dir = crate::util::tests::get_temp_dir();
+        std::fs::create_dir_all(store_dir.path())?;
+        let db = crate::contract::storages::Storage::new(store_dir.path()).await?;
+        let mut store =
+            crate::wasm_runtime::ContractStore::new(store_dir.path().into(), 10_000_000, db)?;
+
+        let parameters: Parameters<'static> = Parameters::from(vec![REQUIRES_RELATED]);
+        let contract = WrappedContract::new(Arc::new(ContractCode::from(wasm)), parameters.clone());
+        let id = *contract.key().id();
+        store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+            contract,
+        )))?;
+
+        // No `related` state is attached to any transition, so `validate_state`
+        // never gets what it asks for and every case is inconclusive.
+        let samplers = samplers_for(
+            id,
+            vec![REQUIRES_RELATED],
+            code_hash,
+            &[(vec![1], vec![1, 2]), (vec![2], vec![2, 3])],
+        );
+
+        let dir = tempfile::TempDir::new()?;
+        let mut runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+        let report = tick(&mut runner, &samplers, Some(store_dir.path())).await;
+
+        assert_eq!(
+            report.probed, 1,
+            "the contract was not probed at all, so this proves nothing: {report:?}"
+        );
+        assert!(
+            report.cases > 0,
+            "no case ran, so this proves nothing: {report:?}"
+        );
+        assert_eq!(
+            report.inconclusive, report.cases,
+            "expected every case to be inconclusive, or the fixture no longer \
+             exercises this failure mode: {report:?}"
+        );
+        assert!(
+            report.judged.is_empty(),
+            "a contract whose every case was inconclusive was recorded as judged: \
+             {report:?}"
+        );
+        assert_eq!(
+            report.without_verdict, 1,
+            "a probed contract that never reached a verdict did not count toward \
+             without_verdict: {report:?}"
+        );
+        assert_eq!(
+            report.judged.len() + report.without_verdict,
+            report.focused,
+            "judged and without_verdict must be complements over the focus set, or \
+             the dashboard silently under- or over-reports: {report:?}"
         );
         Ok(())
     }

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -786,6 +786,97 @@ fn store_epoch(dir: &Path, epoch: u64) {
     }
 }
 
+/// Drive a REAL probe of the deliberately-defective fixture contract, end to end.
+///
+/// A seam, not a convenience. Everything downstream of a probe — `checked_contracts`,
+/// `MergeCheckStatus::record`, `view_for`, the contract-detail card — was tested only
+/// against hand-built `CheckedContract`s, so the assembly production actually runs had
+/// no test touching it, and three review rounds of #5403 each found a defect somewhere
+/// along it (focus selection fed in place of judged contracts; findings evicting
+/// independently of their contract; duplicate rows on a contract's first record).
+/// Tests reach the real inputs through here so a fixture cannot quietly disagree with
+/// what a probe emits.
+///
+/// `mode` selects the fixture's defect — see `tests/test-contract-conformance`. Mode 1
+/// (LAST_WRITE_WINS) breaks several merge laws on nearly every generated case, which
+/// is what makes it the input that distinguishes a deduplicating assembly from one
+/// that appends.
+///
+/// Returns the fixture's instance id alongside the probe's own two outputs, which are
+/// exactly the pair `capture::run_writer` hands to `status::publish`. The temp
+/// directories are dropped before returning: the probe resolves and compiles the code
+/// while it runs, so nothing here outlives the call.
+#[cfg(test)]
+pub(crate) async fn probe_fixture_contract(
+    mode: u8,
+) -> Result<(ContractInstanceId, ShadowReport, Vec<Finding>), Box<dyn std::error::Error>> {
+    use freenet_stdlib::prelude::{
+        ContractCode, ContractContainer, ContractWasmAPIVersion, Parameters, WrappedContract,
+    };
+    use std::sync::Arc;
+
+    use crate::conformance::capture::{Observation, SamplingScope, TrackedContract, record};
+
+    let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
+    let code_hash = *blake3::hash(&wasm).as_bytes();
+    let store_dir = crate::util::tests::get_temp_dir();
+    std::fs::create_dir_all(store_dir.path())?;
+    let db = crate::contract::storages::Storage::new(store_dir.path()).await?;
+    let mut store =
+        crate::wasm_runtime::ContractStore::new(store_dir.path().into(), 10_000_000, db)?;
+
+    let parameters: Parameters<'static> = Parameters::from(vec![mode]);
+    let contract = WrappedContract::new(Arc::new(ContractCode::from(wasm)), parameters.clone());
+    let id = *contract.key().id();
+    store.store_contract(ContractContainer::Wasm(ContractWasmAPIVersion::V1(
+        contract,
+    )))?;
+
+    // Several distinct merges, so the generator has a corpus wide enough to build
+    // many cases from. The fixture's state is a canonical (sorted, deduplicated)
+    // byte set, which is what its own `validate_state` accepts.
+    let transitions: &[(Vec<u8>, Vec<u8>)] = &[
+        (vec![1], vec![1, 2]),
+        (vec![2], vec![2, 3]),
+        (vec![3], vec![3, 4]),
+        (vec![1, 2], vec![1, 2, 5]),
+    ];
+    let mut samplers: HashMap<ContractInstanceId, TrackedContract> = HashMap::new();
+    for (base, result) in transitions {
+        let _evicted = record(
+            &mut samplers,
+            &SamplingScope::Wide,
+            Observation {
+                contract: id,
+                code_hash,
+                parameters: parameters.as_ref().to_vec(),
+                base_state: base.clone(),
+                incoming_state: Some(result.clone()),
+                delta: None,
+                result_state: result.clone(),
+                related: Vec::new(),
+            },
+        );
+    }
+
+    let dir = tempfile::TempDir::new()?;
+    let runner = ShadowRunner::new(dir.path(), EnforcementMode::Shadow);
+    let focus = runner.focus(None, &samplers.keys().copied().collect::<Vec<_>>());
+    let (work, _awaiting) = runner.select(&focus, &samplers);
+    assert!(
+        !work.is_empty(),
+        "the fixture contract was not selected, so a probe never ran and any          assertion downstream of this proves nothing"
+    );
+
+    let (report, findings) = probe(
+        work,
+        Some(store_dir.path().to_path_buf()),
+        EnforcementMode::Shadow,
+    )
+    .await;
+    Ok((id, report, findings))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -43,16 +43,37 @@
 //! # Bounded
 //!
 //! The window is capped at [`MAX_REMEMBERED_CHECKED`] contracts. Per-contract findings
-//! need no separate cap: they are deduplicated on the property that broke, and
-//! `ConformanceProperty` is a closed enum of twelve, so one contract can hold at most
-//! twelve. A reader who needs the full picture should replay the corpus rather than
-//! scroll a web page.
+//! need no separate cap, but only because of a property that has to be maintained
+//! rather than assumed: every finding enters a record through
+//! [`CheckedContract::note_finding`], which deduplicates on the property that broke,
+//! and `ConformanceProperty` is a closed enum of twelve — so one contract holds at
+//! most twelve findings.
+//!
+//! That claim was written here before it was true, and stood for three review rounds
+//! while it was false. [`checked_contracts`] appended one finding per violating CASE,
+//! and a probe runs up to `shadow::MAX_CASES_PER_PROBE` (64) of them, so one broken
+//! law produced up to 64 identical rows on a contract's first record — the normal
+//! path, since the first probe is where a violation is found. A justification comment
+//! that is merely aspirational is worse than none: it tells the next reader the
+//! question is settled. If a second way to add a finding is ever introduced, this
+//! paragraph stops being true again, which is why `note_finding` is the only one.
+//!
+//! A reader who needs the full picture should replay the corpus rather than scroll a
+//! web page.
 
 use std::sync::OnceLock;
-use std::time::Instant;
 
 use freenet_stdlib::prelude::ContractInstanceId;
+// tokio's clock rather than `std`'s, matching `shadow.rs`. `std::time::Instant::now()`
+// is banned in `crates/core/src/` (`.claude/rules/testing.md`, enforced by
+// `.github/scripts/check_banned_patterns.py`) because it cannot be controlled from a
+// test; tokio's honours `tokio::time::pause()`, which is the sanctioned alternative in
+// async code. The whole module moves rather than the one line CI flagged: the lint's
+// regex matches only the fully-qualified spelling, so an `Instant::now()` reached
+// through a `use std::time::Instant` passed by accident of spelling rather than by
+// being correct (#5407).
 use parking_lot::RwLock;
+use tokio::time::Instant;
 
 use super::property::Severity;
 use super::shadow::{Finding, JudgedContract};
@@ -60,12 +81,19 @@ use super::shadow::{Finding, JudgedContract};
 /// How many recently-checked contracts to remember.
 ///
 /// Sized against what one record can cost now that findings live inside it: a
-/// `CheckedContract` is ~72 bytes plus at most twelve `MergeFinding`s of ~56 bytes,
+/// `CheckedContract` is ~88 bytes plus at most twelve `MergeFinding`s of ~56 bytes,
 /// so the worst case — every remembered contract breaking every law — is around
-/// 180 KB, and the realistic case (findings are rare) is a few tens of KB. That is
+/// 190 KB, and the realistic case (findings are rare) is a few tens of KB. That is
 /// affordable, and the render cost that used to argue for a smaller number is gone:
 /// [`view_for`] clones ONE record rather than the whole set, so a contract-detail
 /// page no longer pays for the window's size.
+///
+/// The "at most twelve" half of that arithmetic is a consequence of
+/// [`CheckedContract::note_finding`] being the only way a finding reaches a record,
+/// not a standing fact. While [`checked_contracts`] appended without deduplicating,
+/// one record could hold up to `shadow::MAX_CASES_PER_PROBE` (64) findings and the
+/// real worst case was nearer 0.9 MB — a bound stated in a comment is only as good as
+/// the invariant it rests on, and this one was stated before that invariant held.
 ///
 /// Kept large for coverage rather than shrunk for safety. Focus probes at most
 /// `shadow::MAX_FOCUS_CONTRACTS` (two) contracts per fifteen-minute tick, so 256
@@ -115,7 +143,53 @@ pub struct CheckedContract {
     pub inconclusive: usize,
     /// Findings for THIS contract, newest first. Deduplicated on the property that
     /// broke, so the length is bounded by the property count.
+    ///
+    /// Only ever added to through [`CheckedContract::note_finding`] — see its doc for
+    /// why the deduplication is not repeated at each call site.
     pub findings: Vec<MergeFinding>,
+    /// When the most recent tick that judged THIS contract published.
+    ///
+    /// Per contract, not per node. The card used to answer "when was this contract
+    /// last checked?" with [`MergeCheckStatus::published_at`], the node's most recent
+    /// tick — so a contract judged twenty hours ago rendered as checked three minutes
+    /// ago, beside a sentence saying no violation was found "the last time it was
+    /// checked". That is the same misattribution the PR that added this field had
+    /// already fixed for the case COUNTS (see
+    /// [`MergeCheckStatus::judged_last_tick`]), reappearing one row lower.
+    ///
+    /// Stamped by [`MergeCheckStatus::record`] from the tick's publish time, in both
+    /// its arms, so re-checking a contract refreshes it.
+    pub checked_at: Instant,
+}
+
+impl CheckedContract {
+    /// Add one finding to this record, deduplicated on the property that broke.
+    ///
+    /// The ONE place a finding is added to a record. It was previously open-coded in
+    /// `MergeCheckStatus::record`'s merge arm and NOT in [`checked_contracts`], which
+    /// is #5403 H1: `record`'s merge arm only runs once the contract is already in
+    /// the window, so a violating contract's FIRST record — the one where the
+    /// violation is actually found, and therefore the normal case — was assembled
+    /// with no deduplication at all. `probe_one` pushes one `Finding` per violating
+    /// case and a probe runs up to `shadow::MAX_CASES_PER_PROBE` (64) of them, so one
+    /// broken law rendered as up to 64 identical table rows, which then persisted for
+    /// the record's whole residency because later ticks deduplicate AGAINST them.
+    ///
+    /// Deduplicating on the PROPERTY rather than on the contract is the point: a
+    /// contract failing the same law in forty cases is one finding reported forty
+    /// times, but a contract failing two different laws is two facts an operator
+    /// needs.
+    ///
+    /// Findings are never dropped when a later tick fails to reproduce them. A probe
+    /// runs a bounded sample of cases, so "not seen this tick" is not evidence of
+    /// absence, and forgetting a confirmed violation because the next sample missed
+    /// it is the green-pill failure in a slower form.
+    pub(crate) fn note_finding(&mut self, finding: MergeFinding) {
+        if self.findings.iter().any(|f| f.property == finding.property) {
+            return;
+        }
+        self.findings.insert(0, finding);
+    }
 }
 
 /// What the checker has established on this node.
@@ -182,6 +256,15 @@ pub struct MergeCheckView {
     pub stale: bool,
     /// This contract's record, or `None` if it is outside the window.
     pub contract: Option<CheckedContract>,
+    /// How long ago the tick that last judged THIS contract published, or `None` when
+    /// there is no record — the two are produced together in [`view_for`] from one
+    /// `Option`, so a page can never show an age for a contract it has no record of.
+    ///
+    /// Separate from [`Self::published_secs_ago`], which is node-wide. Rendering the
+    /// node-wide one against a per-contract sentence ("no violation found ... the last
+    /// time it was checked") is what made a contract judged twenty hours ago read as
+    /// checked three minutes ago.
+    pub checked_secs_ago: Option<u64>,
 }
 
 impl MergeCheckStatus {
@@ -215,12 +298,22 @@ impl MergeCheckStatus {
     /// from a test without waiting three probe intervals.
     pub fn view_for(&self, contract: Option<&ContractInstanceId>, now: Instant) -> MergeCheckView {
         let age = now.saturating_duration_since(self.published_at);
+        // Both derived from ONE lookup, so `contract` and `checked_secs_ago` cannot
+        // describe different contracts or disagree about whether there is a record at
+        // all — the "paired fields that must co-occur" remedy from
+        // `.claude/rules/bug-prevention-patterns.md`, which this module has already
+        // been bitten by once (the two-window split).
+        let record = contract.and_then(|id| self.record_for(id)).cloned();
+        let checked_secs_ago = record
+            .as_ref()
+            .map(|r| now.saturating_duration_since(r.checked_at).as_secs());
         MergeCheckView {
             judged_last_tick: self.judged_last_tick,
             without_verdict_last_tick: self.without_verdict_last_tick,
             published_secs_ago: age.as_secs(),
             stale: age >= STALE_AFTER,
-            contract: contract.and_then(|id| self.record_for(id)).cloned(),
+            contract: record,
+            checked_secs_ago,
         }
     }
 }
@@ -279,33 +372,29 @@ impl MergeCheckStatus {
                 .iter()
                 .position(|c| c.contract == record.contract)
                 .map(|at| self.checked.remove(at));
-            let merged = match existing {
+            let mut merged = match existing {
                 // Counts accumulate over the contract's residency in the window, so a
                 // page can say how much looking has actually happened for THIS
                 // contract rather than reporting one tick's slice of it.
                 Some(mut prev) => {
                     prev.verdicts = prev.verdicts.saturating_add(record.verdicts);
                     prev.inconclusive = prev.inconclusive.saturating_add(record.inconclusive);
+                    // Through `note_finding`, the same call `checked_contracts` makes.
+                    // Open-coding the deduplication here and not there is #5403 H1:
+                    // this arm cannot run until the contract is already in the window,
+                    // so the tick that FINDS a violation never reached it.
                     for finding in record.findings {
-                        // Deduplicated on property: a contract failing the same law in
-                        // forty cases is one finding reported forty times, which is
-                        // harder to read rather than more informative. Deduplicating
-                        // on the CONTRACT alone would hide that it breaks more than
-                        // one law.
-                        //
-                        // Findings are not dropped when a later tick fails to
-                        // reproduce them. A probe runs a bounded sample of cases, so
-                        // "not seen this tick" is not evidence of absence, and
-                        // forgetting a confirmed violation because the next sample
-                        // missed it is the green-pill failure in a slower form.
-                        if !prev.findings.iter().any(|f| f.property == finding.property) {
-                            prev.findings.insert(0, finding);
-                        }
+                        prev.note_finding(finding);
                     }
                     prev
                 }
                 None => record,
             };
+            // In BOTH arms, from the tick's own publish time: "when was this contract
+            // last checked?" is per-contract, and answering it with the node's most
+            // recent tick is how a contract judged twenty hours ago came to render as
+            // checked three minutes ago.
+            merged.checked_at = published_at;
             self.checked.insert(0, merged);
         }
         self.checked.truncate(MAX_REMEMBERED_CHECKED);
@@ -321,6 +410,11 @@ pub(crate) fn checked_contracts(
     judged: &[JudgedContract],
     findings: &[Finding],
 ) -> Vec<CheckedContract> {
+    // Overwritten by `record` with the tick's own publish time, in both its arms. Set
+    // here rather than left unset because an unstamped record has no honest rendering
+    // — and this value is microseconds from the one that replaces it, so the field is
+    // never briefly wrong, only briefly its own approximation.
+    let checked_at = Instant::now();
     let mut out: Vec<CheckedContract> = judged
         .iter()
         .map(|j| CheckedContract {
@@ -328,6 +422,7 @@ pub(crate) fn checked_contracts(
             verdicts: j.verdicts,
             inconclusive: j.inconclusive,
             findings: Vec::new(),
+            checked_at,
         })
         .collect();
     for finding in findings {
@@ -338,7 +433,16 @@ pub(crate) fn checked_contracts(
             would_remove: finding.would_remove,
         };
         match out.iter_mut().find(|c| c.contract == finding.contract) {
-            Some(record) => record.findings.push(merge),
+            // Through `note_finding`, which deduplicates on the property. `probe_one`
+            // pushes one `Finding` per violating CASE and a probe runs up to
+            // `shadow::MAX_CASES_PER_PROBE` (64) of them, so appending here rendered
+            // one broken law as up to 64 identical rows — and this is the FIRST record
+            // for a violating contract, which is the normal path, since the first
+            // probe is where a violation is found. `record`'s own deduplication could
+            // not help: its merge arm runs only once the contract is already in the
+            // window, by which time the duplicates are what later ticks deduplicate
+            // against. (#5403 H1)
+            Some(record) => record.note_finding(merge),
             None => {
                 // Structurally unreachable — a finding comes from a `Violated`
                 // outcome, which IS a verdict, so its contract is in `judged`. Kept
@@ -352,9 +456,19 @@ pub(crate) fn checked_contracts(
                 );
                 out.push(CheckedContract {
                     contract: finding.contract,
-                    verdicts: 0,
+                    // ONE, not zero. A finding IS a verdict — it comes from a
+                    // `Violated` outcome — so a record carrying a violation and
+                    // `verdicts: 0` renders "0 reached a verdict" directly beside a
+                    // Violation row, which reads as a page contradicting itself and
+                    // gives an operator no way to tell which half to believe. One is
+                    // the honest floor: at least the case that produced this finding
+                    // reached a verdict. Any further findings for the same contract
+                    // take the `Some` arm above, so this is not a per-finding count
+                    // and does not claim to be.
+                    verdicts: 1,
                     inconclusive: 0,
                     findings: vec![merge],
+                    checked_at,
                 });
             }
         }
@@ -363,7 +477,13 @@ pub(crate) fn checked_contracts(
 }
 
 /// Publish a tick's outcome. Called by the shadow loop; cheap and non-blocking.
-pub fn publish(
+///
+/// `pub(crate)`: the only legitimate caller is `capture::run_writer`, and the shape of
+/// what belongs in a snapshot is decided there (which counts, assembled by
+/// [`checked_contracts`], stamped with the tick's publish time). A caller outside this
+/// crate could only publish a snapshot that had not been through that assembly, which
+/// is the class of defect this module keeps finding.
+pub(crate) fn publish(
     checked: impl IntoIterator<Item = CheckedContract>,
     judged_last_tick: usize,
     without_verdict_last_tick: usize,
@@ -414,7 +534,212 @@ mod tests {
             verdicts: 1,
             inconclusive: 0,
             findings,
+            // Overwritten by `record` with the tick's publish time, as in production.
+            checked_at: Instant::now(),
         }
+    }
+
+    /// The fixture contract's NEVER_SETTLES mode — see
+    /// `tests/test-contract-conformance/src/lib.rs`. Breaks state idempotence and
+    /// state associativity on most generated cases, so one probe of it returns many
+    /// findings across MORE THAN ONE property: the input that tells a deduplicating
+    /// assembly apart both from one that appends and from one that collapses
+    /// everything onto the contract.
+    const NEVER_SETTLES: u8 = 6;
+
+    /// #5403 H1: the FIRST record for a violating contract must carry one finding
+    /// per broken law, not one per violating case.
+    ///
+    /// This is the first test in this module to run the assembly production runs.
+    /// Every other test here hand-builds a `CheckedContract`, which is why
+    /// `checked_contracts` — the function that turns a tick into records — had no
+    /// direct coverage at all, and why three review rounds each found a defect on
+    /// this path.
+    ///
+    /// The input is a real probe of the deliberately-defective fixture contract in
+    /// mode 6 (NEVER_SETTLES), which breaks two merge laws on most generated cases.
+    /// `probe_one` pushes one `Finding` per violating case and `generate_cases`
+    /// produces up to `MAX_CASES_PER_PROBE` (64) of them, so the tick that ARRIVES
+    /// here legitimately repeats a property many times; deduplicating it is the
+    /// assembly's job. Before the fix this produced thirteen findings on the record,
+    /// eleven of them duplicates, which the card renders as eleven identical rows —
+    /// and which then persist for the record's whole residency, because later ticks
+    /// deduplicate AGAINST them.
+    ///
+    /// The first probe of a violating contract is where the violation is found, so
+    /// the un-deduplicated path was the normal path, not a corner: `record`'s
+    /// deduplication lives only in its merge arm, which cannot run until the
+    /// contract is already in the window.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_first_record_carries_one_finding_per_broken_law_not_per_case()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (id, report, findings) =
+            crate::conformance::shadow::probe_fixture_contract(NEVER_SETTLES).await?;
+
+        // The input must genuinely repeat, or this test cannot distinguish a
+        // deduplicating assembly from one that appends. Established from the probe's
+        // own output rather than declared.
+        let distinct: std::collections::BTreeSet<&str> = findings
+            .iter()
+            .map(|f| f.violation.property.as_str())
+            .collect();
+        assert!(
+            distinct.len() > 1,
+            "the fixture stopped breaking more than one law, so this test can no \
+             longer tell deduplication from collapsing everything into one row: \
+             {distinct:?}"
+        );
+        assert!(
+            findings.len() > distinct.len(),
+            "the probe returned no repeated property ({} findings, {} distinct), so \
+             this test would pass against an assembly that never deduplicates",
+            findings.len(),
+            distinct.len()
+        );
+
+        // The production assembly, on the production inputs.
+        let records = checked_contracts(&report.judged, &findings);
+        assert_eq!(
+            records.len(),
+            1,
+            "one probed contract must produce exactly one record: {records:?}"
+        );
+        let record = &records[0];
+        assert_eq!(record.contract, id);
+
+        let rendered: Vec<&str> = record.findings.iter().map(|f| f.property).collect();
+        assert_eq!(
+            rendered.len(),
+            distinct.len(),
+            "the first record for a violating contract carried one finding per \
+             violating CASE, so its card renders {} rows for {} broken laws — and \
+             they persist, because later ticks deduplicate against them. got: \
+             {rendered:?}",
+            rendered.len(),
+            distinct.len()
+        );
+        for property in &distinct {
+            assert_eq!(
+                rendered.iter().filter(|p| *p == property).count(),
+                1,
+                "{property} appears {} times on the record",
+                rendered.iter().filter(|p| *p == property).count()
+            );
+        }
+
+        // And through the window and the view the page actually reads.
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            records,
+            report.judged.len(),
+            report.without_verdict,
+            Instant::now(),
+        );
+        let view = status.view_for(Some(&id), Instant::now());
+        let seen = view.contract.expect("the probed contract is in the window");
+        assert_eq!(
+            seen.findings.len(),
+            distinct.len(),
+            "the view the contract-detail page reads carried duplicate findings"
+        );
+        assert_eq!(
+            (seen.verdicts, seen.inconclusive),
+            (report.judged[0].verdicts, report.judged[0].inconclusive),
+            "the record's case counts are not the probe's own"
+        );
+        Ok(())
+    }
+
+    /// The first record and a re-record must agree.
+    ///
+    /// `record` has two arms — insert and merge — and only the merge arm ever
+    /// deduplicated. Feeding the SAME tick twice drives both, so an assembly that
+    /// deduplicates in one place and not the other shows up as the two arms
+    /// disagreeing rather than as a number a reader has to know is wrong.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn re_recording_a_tick_does_not_change_what_the_page_shows()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (id, report, findings) =
+            crate::conformance::shadow::probe_fixture_contract(NEVER_SETTLES).await?;
+
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            checked_contracts(&report.judged, &findings),
+            report.judged.len(),
+            report.without_verdict,
+            Instant::now(),
+        );
+        let after_first = status
+            .record_for(&id)
+            .expect("the probed contract is in the window")
+            .findings
+            .len();
+
+        status.record(
+            checked_contracts(&report.judged, &findings),
+            report.judged.len(),
+            report.without_verdict,
+            Instant::now(),
+        );
+        let after_second = status
+            .record_for(&id)
+            .expect("the probed contract is still in the window")
+            .findings
+            .len();
+
+        assert_eq!(
+            after_first, after_second,
+            "the insert arm and the merge arm disagree about how many findings one \
+             contract has, so what an operator sees depends on whether this is the \
+             tick that first caught the contract"
+        );
+        Ok(())
+    }
+
+    /// #5403 L1: the unreachable branch must not build a self-contradictory record.
+    ///
+    /// `checked_contracts` handles a finding whose contract is not in `judged`. That
+    /// is structurally unreachable today — a finding comes from a `Violated` outcome,
+    /// which IS a verdict, so `probe_one` always puts its contract in `judged` — and
+    /// it is kept deliberately, because dropping the finding would render a real
+    /// violation as a contract nobody looked at.
+    ///
+    /// It built the record with `verdicts: 0`, so if it ever fired the card would say
+    /// "0 reached a verdict" directly beside a Violation row: a page contradicting
+    /// itself, with nothing to tell the operator which half to believe. The branch
+    /// exists precisely for the case where an assumption has already broken, which is
+    /// the worst moment for the output to be incoherent.
+    #[test]
+    fn a_finding_for_an_unjudged_contract_does_not_render_as_zero_verdicts() {
+        use crate::conformance::property::{ConformanceProperty, OutputDigest, Violation};
+
+        let orphan = instance(200);
+        let finding = Finding {
+            contract: orphan,
+            violation: Violation {
+                property: ConformanceProperty::StateCommutativity,
+                severity: Severity::Violation,
+                left: OutputDigest::of(b"a"),
+                right: OutputDigest::of(b"b"),
+                detail: "synthesised for the unreachable branch".to_string(),
+            },
+            would_remove: true,
+        };
+
+        // Deliberately empty: that is what makes this the branch under test.
+        let records = checked_contracts(&[], std::slice::from_ref(&finding));
+        let record = records.iter().find(|c| c.contract == orphan).expect(
+            "the finding must not be dropped — a discarded violation renders \
+                     as a contract nobody looked at",
+        );
+        assert_eq!(record.findings.len(), 1);
+        assert!(
+            record.verdicts >= 1,
+            "a record carrying a violation reported {} verdicts, so the card would \
+             render '0 reached a verdict' beside a Violation row — a finding IS a \
+             verdict",
+            record.verdicts
+        );
     }
 
     fn record_one(s: &mut MergeCheckStatus, c: CheckedContract) {
@@ -522,6 +847,7 @@ mod tests {
                 verdicts: 2,
                 inconclusive: 5,
                 findings: Vec::new(),
+                checked_at: Instant::now(),
             }],
             1,
             0,
@@ -533,6 +859,7 @@ mod tests {
                 verdicts: 3,
                 inconclusive: 1,
                 findings: Vec::new(),
+                checked_at: Instant::now(),
             }],
             1,
             0,

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -19,31 +19,68 @@
 //! Deliberately not a provider closure like `ring_stats`: the checker's state lives in
 //! a task, so there is nothing for a closure to read on demand — the task has to push.
 //!
+//! # One window, not two
+//!
+//! Everything known about a contract lives in ONE [`CheckedContract`] record: whether
+//! it was checked, how many of its cases reached a verdict, and what was found. This
+//! is not tidiness. The first version of this module kept two independent windows — a
+//! 256-entry "recently checked" list and a 64-entry findings list — and the card
+//! picked its branch from the first while reading the second. A contract present in
+//! one and evicted from the other rendered a green pill reading "no merge-law
+//! violation was found for this contract", for a contract the checker had positively
+//! found violating.
+//!
+//! That was the steady state rather than a corner: a re-detected finding was
+//! deduplicated rather than moved to the front, so a contract caught every tick
+//! drifted monotonically toward the tail of the 64-entry list while being re-inserted
+//! at the head of the 256-entry one. The *persistently broken* contract was the
+//! likeliest to lose its finding. `.claude/rules/bug-prevention-patterns.md` names
+//! this class ("paired fields that must co-occur") and prescribes the remedy applied
+//! here: bundle them so the type system forbids the mismatch. `was_checked` and
+//! `findings_for` now answer from the same record by construction, so the conflation
+//! is unrepresentable rather than arithmetically avoided.
+//!
 //! # Bounded
 //!
-//! Findings are capped. A peer that hosts many broken contracts must not turn this
-//! into an unbounded allocation, and a reader who needs the full picture should replay
-//! the corpus rather than scroll a web page.
+//! The window is capped at [`MAX_REMEMBERED_CHECKED`] contracts. Per-contract findings
+//! need no separate cap: they are deduplicated on the property that broke, and
+//! `ConformanceProperty` is a closed enum of twelve, so one contract can hold at most
+//! twelve. A reader who needs the full picture should replay the corpus rather than
+//! scroll a web page.
 
 use std::sync::OnceLock;
+use std::time::Instant;
 
 use freenet_stdlib::prelude::ContractInstanceId;
 use parking_lot::RwLock;
 
 use super::property::Severity;
-
-/// Most findings retained for display.
-///
-/// Small on purpose. The dashboard answers "is anything wrong here, and with what?",
-/// not "give me the whole corpus" — that question is answered by `fdev verify-merge`
-/// against a bundle, which can afford to be exhaustive.
-const MAX_DISPLAYED_FINDINGS: usize = 64;
+use super::shadow::{Finding, JudgedContract};
 
 /// How many recently-checked contracts to remember.
 ///
-/// Larger than the finding cap because most checks find nothing, and "this one was
-/// looked at and was fine" is the common answer a per-contract page needs to give.
+/// Sized against what one record can cost now that findings live inside it: a
+/// `CheckedContract` is ~72 bytes plus at most twelve `MergeFinding`s of ~56 bytes,
+/// so the worst case — every remembered contract breaking every law — is around
+/// 180 KB, and the realistic case (findings are rare) is a few tens of KB. That is
+/// affordable, and the render cost that used to argue for a smaller number is gone:
+/// [`view_for`] clones ONE record rather than the whole set, so a contract-detail
+/// page no longer pays for the window's size.
+///
+/// Kept large for coverage rather than shrunk for safety. Focus probes at most
+/// `shadow::MAX_FOCUS_CONTRACTS` (two) contracts per fifteen-minute tick, so 256
+/// entries is roughly thirty hours of the peer's history — and "this one was looked
+/// at and was fine" is the common answer a per-contract page needs to give.
 const MAX_REMEMBERED_CHECKED: usize = 256;
+
+/// Past this long since the last publish, the card says the checker may be stuck
+/// rather than presenting its last tick as a current result.
+///
+/// Derived from the probe interval rather than hardcoded, per
+/// `.claude/rules/code-style.md`: three missed ticks is well outside ordinary jitter
+/// and cheap to be wrong about, since the card shows the age either way.
+const STALE_AFTER: std::time::Duration =
+    std::time::Duration::from_secs(super::shadow::PROBE_INTERVAL.as_secs() * 3);
 
 /// One contract's failure to obey a merge law.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,28 +96,92 @@ pub struct MergeFinding {
     pub would_remove: bool,
 }
 
+/// Everything the checker knows about ONE contract.
+///
+/// The unit of the window, so "was this checked?" and "what was found?" cannot be
+/// answered from different windows — see the module doc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedContract {
+    pub contract: ContractInstanceId,
+    /// Cases that reached `Holds` or `Violated`, accumulated over this contract's
+    /// residency in the window.
+    ///
+    /// Carried per contract because the fleet-wide case count cannot stand in for it:
+    /// a contract with one verdict and 199 inconclusive cases rendered byte-identically
+    /// to one with 200 verdicts, which is the same conflation of "unmeasured" with
+    /// "clean" this module exists to stop.
+    pub verdicts: usize,
+    /// Cases that came back `Inconclusive`, accumulated the same way.
+    pub inconclusive: usize,
+    /// Findings for THIS contract, newest first. Deduplicated on the property that
+    /// broke, so the length is bounded by the property count.
+    pub findings: Vec<MergeFinding>,
+}
+
 /// What the checker has established on this node.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MergeCheckStatus {
-    /// Contracts that reached a verdict, either way.
-    pub contracts_checked: usize,
-    /// Contracts checked that reached NO verdict on any case.
+    /// Contracts that reached a verdict in the most recent tick.
+    ///
+    /// A per-TICK number, and named so. The un-suffixed name it used to carry read as
+    /// a standing property of the node, which is how the card came to present a
+    /// fleet-wide most-recent-tick count as evidence about a contract last looked at
+    /// forty ticks ago.
+    pub judged_last_tick: usize,
+    /// Contracts checked in the most recent tick that reached NO verdict on any case.
     ///
     /// The number most likely to be misread by its absence. An unjudgeable contract
     /// renders identically to a clean one, so a panel reporting only "0 violations"
     /// would be actively misleading — on the live capture peer 17% of hosted contracts
     /// could not be judged at all and nothing said so.
-    pub contracts_without_verdict: usize,
-    /// Cases checked in the most recent tick.
-    pub cases_last_tick: usize,
-    /// Findings, newest first, capped at [`MAX_DISPLAYED_FINDINGS`].
-    pub findings: Vec<MergeFinding>,
-    /// Contracts recently checked, newest first, capped at [`MAX_REMEMBERED_CHECKED`].
+    pub without_verdict_last_tick: usize,
+    /// Contracts checked, newest first, capped at [`MAX_REMEMBERED_CHECKED`].
     ///
     /// Without this a per-contract view cannot tell "checked, and clean" from "never
     /// looked at", and would render them the same way — which is the conflation this
     /// whole subsystem exists to stop, displayed on a page an operator will act on.
-    pub recently_checked: Vec<ContractInstanceId>,
+    pub checked: Vec<CheckedContract>,
+    /// When the last tick published.
+    ///
+    /// Carried because nothing else on the snapshot ages. `publish` is reached from
+    /// one place and two live paths skip it indefinitely while the old snapshot stands
+    /// (a tick that selected no work, and a probe task that died), so a peer whose
+    /// probe has been panicking for a week would otherwise keep serving "no violation
+    /// found" from a week-old tick with nothing on the page saying so.
+    pub published_at: Instant,
+}
+
+impl Default for MergeCheckStatus {
+    fn default() -> Self {
+        Self {
+            judged_last_tick: 0,
+            without_verdict_last_tick: 0,
+            checked: Vec::new(),
+            // Overwritten by the first `record`; a default-constructed status has
+            // published nothing, and the global is only created by `publish`.
+            published_at: Instant::now(),
+        }
+    }
+}
+
+/// What one contract-detail render needs, cloned out of the window.
+///
+/// Deliberately NOT the whole snapshot. The window holds up to
+/// [`MAX_REMEMBERED_CHECKED`] records with their findings, and the card needs exactly
+/// one of them plus the fleet-wide numbers; cloning the set on every page render would
+/// make the page's cost grow with the peer's history for no reader benefit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergeCheckView {
+    /// See [`MergeCheckStatus::judged_last_tick`].
+    pub judged_last_tick: usize,
+    /// See [`MergeCheckStatus::without_verdict_last_tick`].
+    pub without_verdict_last_tick: usize,
+    /// How long ago the checker last published a tick.
+    pub published_secs_ago: u64,
+    /// Whether that is long enough ago to distrust — see [`STALE_AFTER`].
+    pub stale: bool,
+    /// This contract's record, or `None` if it is outside the window.
+    pub contract: Option<CheckedContract>,
 }
 
 impl MergeCheckStatus {
@@ -90,7 +191,12 @@ impl MergeCheckStatus {
     /// is bounded. A caller must phrase it as absence of knowledge rather than as a
     /// clean bill of health.
     pub fn was_checked(&self, contract: &ContractInstanceId) -> bool {
-        self.recently_checked.contains(contract)
+        self.record_for(contract).is_some()
+    }
+
+    /// This contract's record, if it is in the window.
+    pub fn record_for(&self, contract: &ContractInstanceId) -> Option<&CheckedContract> {
+        self.checked.iter().find(|c| c.contract == *contract)
     }
 
     /// Findings recorded against one contract.
@@ -98,9 +204,24 @@ impl MergeCheckStatus {
         &'a self,
         contract: &'a ContractInstanceId,
     ) -> impl Iterator<Item = &'a MergeFinding> + 'a {
-        self.findings
-            .iter()
-            .filter(move |f| f.contract == *contract)
+        self.record_for(contract)
+            .into_iter()
+            .flat_map(|c| c.findings.iter())
+    }
+
+    /// The one record a contract-detail page needs, plus the fleet-wide numbers.
+    ///
+    /// Takes `now` rather than reading the clock, so the staleness branch is reachable
+    /// from a test without waiting three probe intervals.
+    pub fn view_for(&self, contract: Option<&ContractInstanceId>, now: Instant) -> MergeCheckView {
+        let age = now.saturating_duration_since(self.published_at);
+        MergeCheckView {
+            judged_last_tick: self.judged_last_tick,
+            without_verdict_last_tick: self.without_verdict_last_tick,
+            published_secs_ago: age.as_secs(),
+            stale: age >= STALE_AFTER,
+            contract: contract.and_then(|id| self.record_for(id)).cloned(),
+        }
     }
 }
 
@@ -139,60 +260,135 @@ impl MergeCheckStatus {
     /// rather than prevents.
     pub fn record(
         &mut self,
-        checked: impl IntoIterator<Item = ContractInstanceId>,
-        contracts_checked: usize,
-        contracts_without_verdict: usize,
-        cases_last_tick: usize,
-        new_findings: impl IntoIterator<Item = MergeFinding>,
+        checked: impl IntoIterator<Item = CheckedContract>,
+        judged_last_tick: usize,
+        without_verdict_last_tick: usize,
+        published_at: Instant,
     ) {
-        for contract in checked {
-            self.recently_checked.retain(|c| *c != contract);
-            self.recently_checked.insert(0, contract);
-        }
-        self.recently_checked.truncate(MAX_REMEMBERED_CHECKED);
-        self.contracts_checked = contracts_checked;
-        self.contracts_without_verdict = contracts_without_verdict;
-        self.cases_last_tick = cases_last_tick;
-        for finding in new_findings {
-            // Newest first, and deduplicated on (contract, property): a contract
-            // failing the same law in forty cases is one finding reported forty times,
-            // which is harder to read rather than more informative. Deduplicating on
-            // contract ALONE would hide that a contract breaks more than one law.
-            if !self
-                .findings
+        self.judged_last_tick = judged_last_tick;
+        self.without_verdict_last_tick = without_verdict_last_tick;
+        self.published_at = published_at;
+        for record in checked {
+            // Move to the FRONT and merge, never dedup-and-leave-in-place. The old
+            // two-list version skipped a re-detected finding entirely, so a contract
+            // caught on every tick sank toward the tail while its "recently checked"
+            // entry was refreshed — the persistently broken contract was the first to
+            // lose its finding.
+            let existing = self
+                .checked
                 .iter()
-                .any(|f| f.contract == finding.contract && f.property == finding.property)
-            {
-                self.findings.insert(0, finding);
+                .position(|c| c.contract == record.contract)
+                .map(|at| self.checked.remove(at));
+            let merged = match existing {
+                // Counts accumulate over the contract's residency in the window, so a
+                // page can say how much looking has actually happened for THIS
+                // contract rather than reporting one tick's slice of it.
+                Some(mut prev) => {
+                    prev.verdicts = prev.verdicts.saturating_add(record.verdicts);
+                    prev.inconclusive = prev.inconclusive.saturating_add(record.inconclusive);
+                    for finding in record.findings {
+                        // Deduplicated on property: a contract failing the same law in
+                        // forty cases is one finding reported forty times, which is
+                        // harder to read rather than more informative. Deduplicating
+                        // on the CONTRACT alone would hide that it breaks more than
+                        // one law.
+                        //
+                        // Findings are not dropped when a later tick fails to
+                        // reproduce them. A probe runs a bounded sample of cases, so
+                        // "not seen this tick" is not evidence of absence, and
+                        // forgetting a confirmed violation because the next sample
+                        // missed it is the green-pill failure in a slower form.
+                        if !prev.findings.iter().any(|f| f.property == finding.property) {
+                            prev.findings.insert(0, finding);
+                        }
+                    }
+                    prev
+                }
+                None => record,
+            };
+            self.checked.insert(0, merged);
+        }
+        self.checked.truncate(MAX_REMEMBERED_CHECKED);
+    }
+}
+
+/// Turn one tick's shadow output into the per-contract records this module stores.
+///
+/// A free function rather than logic at the publish call site: that call site lives
+/// inside `capture::run_writer`'s select loop, which no test can call, so anything
+/// assembled there is testable only by scraping source.
+pub(crate) fn checked_contracts(
+    judged: &[JudgedContract],
+    findings: &[Finding],
+) -> Vec<CheckedContract> {
+    let mut out: Vec<CheckedContract> = judged
+        .iter()
+        .map(|j| CheckedContract {
+            contract: j.contract,
+            verdicts: j.verdicts,
+            inconclusive: j.inconclusive,
+            findings: Vec::new(),
+        })
+        .collect();
+    for finding in findings {
+        let merge = MergeFinding {
+            contract: finding.contract,
+            property: finding.violation.property.as_str(),
+            severity: finding.violation.property.severity(),
+            would_remove: finding.would_remove,
+        };
+        match out.iter_mut().find(|c| c.contract == finding.contract) {
+            Some(record) => record.findings.push(merge),
+            None => {
+                // Structurally unreachable — a finding comes from a `Violated`
+                // outcome, which IS a verdict, so its contract is in `judged`. Kept
+                // anyway, and kept LOUD: dropping it would make a real violation
+                // render as a contract nobody looked at, and an uncounted discard is
+                // the failure `.claude/rules/bug-prevention-patterns.md` opens with.
+                tracing::warn!(
+                    contract = %finding.contract,
+                    property = merge.property,
+                    "merge finding for a contract the tick did not record as judged"
+                );
+                out.push(CheckedContract {
+                    contract: finding.contract,
+                    verdicts: 0,
+                    inconclusive: 0,
+                    findings: vec![merge],
+                });
             }
         }
-        self.findings.truncate(MAX_DISPLAYED_FINDINGS);
     }
+    out
 }
 
 /// Publish a tick's outcome. Called by the shadow loop; cheap and non-blocking.
 pub fn publish(
-    checked: impl IntoIterator<Item = ContractInstanceId>,
-    contracts_checked: usize,
-    contracts_without_verdict: usize,
-    cases_last_tick: usize,
-    new_findings: impl IntoIterator<Item = MergeFinding>,
+    checked: impl IntoIterator<Item = CheckedContract>,
+    judged_last_tick: usize,
+    without_verdict_last_tick: usize,
+    published_at: Instant,
 ) {
     STATUS
         .write()
         .get_or_insert_with(MergeCheckStatus::default)
         .record(
             checked,
-            contracts_checked,
-            contracts_without_verdict,
-            cases_last_tick,
-            new_findings,
+            judged_last_tick,
+            without_verdict_last_tick,
+            published_at,
         );
 }
 
-/// The current snapshot, or `None` if the checker is not running on this node.
-pub fn snapshot() -> Option<MergeCheckStatus> {
-    STATUS.read().clone()
+/// What the contract-detail page needs about ONE contract, or `None` if the checker
+/// has not published on this node.
+///
+/// Clones a single record rather than the window — see [`MergeCheckView`].
+pub fn view_for(contract: Option<&ContractInstanceId>) -> Option<MergeCheckView> {
+    STATUS
+        .read()
+        .as_ref()
+        .map(|s| s.view_for(contract, Instant::now()))
 }
 
 #[cfg(test)]
@@ -212,14 +408,27 @@ mod tests {
         }
     }
 
+    fn checked(n: u8, findings: Vec<MergeFinding>) -> CheckedContract {
+        CheckedContract {
+            contract: instance(n),
+            verdicts: 1,
+            inconclusive: 0,
+            findings,
+        }
+    }
+
+    fn record_one(s: &mut MergeCheckStatus, c: CheckedContract) {
+        s.record([c], 1, 0, Instant::now());
+    }
+
     /// The same contract failing the same law repeatedly is one row, not forty.
     #[test]
     fn repeated_findings_for_one_contract_and_property_collapse() {
         let mut s = MergeCheckStatus::default();
-        s.record([], 1, 0, 10, [finding(1, "state_commutativity")]);
-        s.record([], 1, 0, 10, [finding(1, "state_commutativity")]);
+        record_one(&mut s, checked(1, vec![finding(1, "state_commutativity")]));
+        record_one(&mut s, checked(1, vec![finding(1, "state_commutativity")]));
         assert_eq!(
-            s.findings.len(),
+            s.findings_for(&instance(1)).count(),
             1,
             "the same law failing twice produced two rows"
         );
@@ -230,28 +439,109 @@ mod tests {
     #[test]
     fn different_properties_on_one_contract_stay_separate() {
         let mut s = MergeCheckStatus::default();
-        s.record([], 1, 0, 10, [finding(2, "state_commutativity")]);
-        s.record([], 1, 0, 10, [finding(2, "state_associativity")]);
+        record_one(&mut s, checked(2, vec![finding(2, "state_commutativity")]));
+        record_one(&mut s, checked(2, vec![finding(2, "state_associativity")]));
         assert_eq!(
-            s.findings.len(),
+            s.findings_for(&instance(2)).count(),
             2,
             "two different broken laws collapsed into one row"
         );
     }
 
-    /// Findings are capped, so a peer hosting many broken contracts cannot grow this
+    /// The window is capped, so a peer that checks many contracts cannot grow this
     /// without bound.
     #[test]
-    fn findings_are_bounded() {
+    fn the_checked_window_is_bounded() {
         let mut s = MergeCheckStatus::default();
-        for i in 0..(MAX_DISPLAYED_FINDINGS + 40) {
-            s.record([], 1, 0, 1, [finding((i % 251) as u8, "state_idempotence")]);
+        for i in 0..(MAX_REMEMBERED_CHECKED + 40) {
+            let n = (i % 251) as u8;
+            record_one(&mut s, checked(n, vec![finding(n, "state_idempotence")]));
         }
         assert!(
-            s.findings.len() <= MAX_DISPLAYED_FINDINGS,
-            "findings grew past the cap: {}",
-            s.findings.len()
+            s.checked.len() <= MAX_REMEMBERED_CHECKED,
+            "the checked window grew past the cap: {}",
+            s.checked.len()
         );
+    }
+
+    /// #5403 H1: a finding must not be lost while its contract is still remembered
+    /// as checked.
+    ///
+    /// The two-list version kept a 256-entry checked list and a 64-entry findings
+    /// list, so a contract that stayed inside the first and fell out of the second
+    /// rendered as "checked, no violation found" — for a contract the checker had
+    /// positively found violating. This asserts the property that made it possible is
+    /// gone: while the contract is in the window at all, its findings are with it.
+    #[test]
+    fn a_finding_survives_other_contracts_filling_the_window() {
+        let mut s = MergeCheckStatus::default();
+        record_one(&mut s, checked(1, vec![finding(1, "state_commutativity")]));
+        // Well past the old 64-entry findings cap, and short of the window cap, so the
+        // contract is unambiguously still "recently checked".
+        for i in 0..100u8 {
+            let n = i + 2;
+            record_one(&mut s, checked(n, vec![finding(n, "state_idempotence")]));
+        }
+        assert!(
+            s.was_checked(&instance(1)),
+            "the contract fell out of the checked window, so this test no longer \
+             exercises the case it names"
+        );
+        assert_eq!(
+            s.findings_for(&instance(1)).count(),
+            1,
+            "a remembered contract lost its finding, so its page renders a green \
+             'no violation found' pill for a contract found violating"
+        );
+    }
+
+    /// Re-checking moves a contract to the front, so the window evicts by
+    /// least-recently-checked rather than by first-seen.
+    #[test]
+    fn rechecking_a_contract_moves_it_to_the_front() {
+        let mut s = MergeCheckStatus::default();
+        record_one(&mut s, checked(1, vec![]));
+        record_one(&mut s, checked(2, vec![]));
+        record_one(&mut s, checked(1, vec![]));
+        assert_eq!(
+            s.checked.first().map(|c| c.contract),
+            Some(instance(1)),
+            "a re-checked contract was left where it was, so a contract checked every \
+             tick sinks toward eviction while an idle one is retained"
+        );
+    }
+
+    /// Per-contract case counts accumulate, so the page can say how much looking
+    /// actually happened for THIS contract.
+    #[test]
+    fn per_contract_case_counts_accumulate_across_ticks() {
+        let mut s = MergeCheckStatus::default();
+        s.record(
+            [CheckedContract {
+                contract: instance(1),
+                verdicts: 2,
+                inconclusive: 5,
+                findings: Vec::new(),
+            }],
+            1,
+            0,
+            Instant::now(),
+        );
+        s.record(
+            [CheckedContract {
+                contract: instance(1),
+                verdicts: 3,
+                inconclusive: 1,
+                findings: Vec::new(),
+            }],
+            1,
+            0,
+            Instant::now(),
+        );
+        let record = s
+            .record_for(&instance(1))
+            .expect("contract is in the window");
+        assert_eq!((record.verdicts, record.inconclusive), (5, 6));
     }
 
     /// The unjudgeable count is carried, not inferred.
@@ -262,23 +552,55 @@ mod tests {
     #[test]
     fn contracts_without_a_verdict_are_reported_separately() {
         let mut s = MergeCheckStatus::default();
-        s.record([], 10, 3, 400, []);
-        assert_eq!(s.contracts_without_verdict, 3);
+        s.record([], 10, 3, Instant::now());
+        assert_eq!(s.without_verdict_last_tick, 3);
         assert!(
-            s.findings.is_empty(),
-            "no findings, which is exactly why the unjudgeable count has to be its own \
+            s.checked.is_empty(),
+            "no records, which is exactly why the unjudged count has to be its own \
              number rather than inferred from an empty list"
         );
     }
 
-    /// A node that never publishes reads as absent, not clean.
+    /// A snapshot ages. A checker that stopped publishing must not keep presenting
+    /// its last tick as a current result.
     #[test]
-    fn enabled_and_published_are_different_questions() {
-        // `is_enabled` is set when the checker starts; a snapshot only exists after a
-        // tick. During the first interval the honest answer is "on, nothing yet".
+    fn a_stale_snapshot_says_so() {
+        let mut s = MergeCheckStatus::default();
+        let published = Instant::now();
+        record_one(&mut s, checked(1, vec![]));
+        s.published_at = published;
+
+        let fresh = s.view_for(Some(&instance(1)), published + STALE_AFTER / 2);
+        assert!(!fresh.stale, "a tick within the window read as stale");
+
+        let old = s.view_for(Some(&instance(1)), published + STALE_AFTER * 2);
         assert!(
-            !is_enabled() || snapshot().is_some() || snapshot().is_none(),
-            "unreachable; documents that the two states are independent"
+            old.stale,
+            "a snapshot older than {STALE_AFTER:?} did not report itself stale, so a \
+             peer whose probe has been dead for a week keeps serving its last tick as \
+             a current clean result"
+        );
+        assert!(old.published_secs_ago >= STALE_AFTER.as_secs() * 2);
+    }
+
+    /// A view carries the requested contract's record and nothing else's.
+    #[test]
+    fn a_view_clones_one_record_not_the_window() {
+        let mut s = MergeCheckStatus::default();
+        record_one(&mut s, checked(1, vec![finding(1, "state_commutativity")]));
+        record_one(&mut s, checked(2, vec![finding(2, "delta_idempotence")]));
+
+        let view = s.view_for(Some(&instance(1)), Instant::now());
+        let record = view.contract.expect("contract 1 is in the window");
+        assert_eq!(record.contract, instance(1));
+        assert_eq!(record.findings.len(), 1);
+        assert_eq!(record.findings[0].property, "state_commutativity");
+
+        assert!(
+            s.view_for(Some(&instance(9)), Instant::now())
+                .contract
+                .is_none(),
+            "a contract outside the window must read as absent, not as clean"
         );
     }
 }

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -43,11 +43,12 @@
 //! # Bounded
 //!
 //! The window is capped at [`MAX_REMEMBERED_CHECKED`] contracts. Per-contract findings
-//! need no separate cap, but only because of a property that has to be maintained
-//! rather than assumed: every finding enters a record through
+//! need no separate cap, because every finding enters a record through
 //! [`CheckedContract::note_finding`], which deduplicates on the property that broke,
 //! and `ConformanceProperty` is a closed enum of twelve — so one contract holds at
-//! most twelve findings.
+//! most twelve findings. That is enforced rather than agreed: `CheckedContract`'s
+//! `findings` field is PRIVATE and [`CheckedContract::new`] starts it empty, so
+//! `note_finding` is not merely the only current way in, it is the only way in.
 //!
 //! That claim was written here before it was true, and stood for three review rounds
 //! while it was false. [`checked_contracts`] appended one finding per violating CASE,
@@ -55,8 +56,10 @@
 //! law produced up to 64 identical rows on a contract's first record — the normal
 //! path, since the first probe is where a violation is found. A justification comment
 //! that is merely aspirational is worse than none: it tells the next reader the
-//! question is settled. If a second way to add a finding is ever introduced, this
-//! paragraph stops being true again, which is why `note_finding` is the only one.
+//! question is settled. It was aspirational a second time after that, while the
+//! `findings` field was still `pub` — the claim held only by convention, and the
+//! orphan branch of [`checked_contracts`] was already breaking it. Privacy is what
+//! makes the paragraph a fact rather than a request.
 //!
 //! A reader who needs the full picture should replay the corpus rather than scroll a
 //! web page.
@@ -89,8 +92,9 @@ use super::shadow::{Finding, JudgedContract};
 /// page no longer pays for the window's size.
 ///
 /// The "at most twelve" half of that arithmetic is a consequence of
-/// [`CheckedContract::note_finding`] being the only way a finding reaches a record,
-/// not a standing fact. While [`checked_contracts`] appended without deduplicating,
+/// [`CheckedContract::note_finding`] being the only way a finding reaches a record —
+/// which the private `findings` field now guarantees rather than merely asks for.
+/// While [`checked_contracts`] appended without deduplicating,
 /// one record could hold up to `shadow::MAX_CASES_PER_PROBE` (64) findings and the
 /// real worst case was nearer 0.9 MB — a bound stated in a comment is only as good as
 /// the invariant it rests on, and this one was stated before that invariant held.
@@ -144,9 +148,18 @@ pub struct CheckedContract {
     /// Findings for THIS contract, newest first. Deduplicated on the property that
     /// broke, so the length is bounded by the property count.
     ///
-    /// Only ever added to through [`CheckedContract::note_finding`] — see its doc for
-    /// why the deduplication is not repeated at each call site.
-    pub findings: Vec<MergeFinding>,
+    /// PRIVATE, and that privacy is the whole guarantee.
+    /// [`CheckedContract::note_finding`] is the only way a finding gets in, and the
+    /// module doc, [`MAX_REMEMBERED_CHECKED`] and [`MergeCheckStatus::record`] all
+    /// rest on that. While the field was `pub` in a `pub mod`, any caller could hand
+    /// [`MergeCheckStatus::record`] a hand-built record carrying duplicate
+    /// properties, and `record`'s INSERT arm does not deduplicate — only its merge
+    /// arm does — so those duplicates would be stored and every later tick would
+    /// deduplicate AGAINST them. That is #5403 H1 verbatim, unreachable only because
+    /// [`checked_contracts`] happened to be the sole producer. Build records with
+    /// [`CheckedContract::new`] and read them through
+    /// [`CheckedContract::findings`].
+    findings: Vec<MergeFinding>,
     /// When the most recent tick that judged THIS contract published.
     ///
     /// Per contract, not per node. The card used to answer "when was this contract
@@ -163,6 +176,37 @@ pub struct CheckedContract {
 }
 
 impl CheckedContract {
+    /// A record with no findings yet — the ONLY way to build one.
+    ///
+    /// Pairs with the private `findings` field. A record cannot come into existence
+    /// already holding an un-deduplicated finding list, so
+    /// [`MergeCheckStatus::record`]'s insert arm — which does not deduplicate, and
+    /// which is the arm a violating contract's first tick takes — has nothing
+    /// un-deduplicated it could be handed. The invariant is enforced by construction
+    /// rather than by every producer remembering it, which is what three review
+    /// rounds of #5403 established it cannot be.
+    pub(crate) fn new(
+        contract: ContractInstanceId,
+        verdicts: usize,
+        inconclusive: usize,
+        checked_at: Instant,
+    ) -> Self {
+        Self {
+            contract,
+            verdicts,
+            inconclusive,
+            findings: Vec::new(),
+            checked_at,
+        }
+    }
+
+    /// This contract's findings, newest first.
+    ///
+    /// Read-only by design — see the field's doc.
+    pub fn findings(&self) -> &[MergeFinding] {
+        &self.findings
+    }
+
     /// Add one finding to this record, deduplicated on the property that broke.
     ///
     /// The ONE place a finding is added to a record. It was previously open-coded in
@@ -218,10 +262,12 @@ pub struct MergeCheckStatus {
     /// When the last tick published.
     ///
     /// Carried because nothing else on the snapshot ages. `publish` is reached from
-    /// one place and two live paths skip it indefinitely while the old snapshot stands
-    /// (a tick that selected no work, and a probe task that died), so a peer whose
-    /// probe has been panicking for a week would otherwise keep serving "no violation
-    /// found" from a week-old tick with nothing on the page saying so.
+    /// two places in `capture::run_writer` — the barren tick and the completed probe —
+    /// and a peer can stop reaching either indefinitely while the old snapshot stands:
+    /// the probe task can die, a probe can hang so `in_flight` never clears and no
+    /// further tick starts, or the writer task itself can be gone. In any of those a
+    /// peer would otherwise keep serving "no violation found" from a week-old tick
+    /// with nothing on the page saying so.
     pub published_at: Instant,
 }
 
@@ -351,6 +397,13 @@ impl MergeCheckStatus {
     /// one test's findings appeared in another's assertions — which is the failure
     /// `.claude/rules/testing.md` describes and which per-process isolation hides
     /// rather than prevents.
+    ///
+    /// The INSERT arm below stores the incoming record as-is; only the merge arm
+    /// deduplicates. That is safe because a `CheckedContract` cannot be built holding
+    /// findings — [`CheckedContract::new`] starts empty and the field is private — so
+    /// no caller can hand this an un-deduplicated list. Do not make `findings` public
+    /// to "simplify a test"; the insert arm would then store whatever it was given,
+    /// and every later tick would deduplicate against those duplicates.
     pub fn record(
         &mut self,
         checked: impl IntoIterator<Item = CheckedContract>,
@@ -417,13 +470,7 @@ pub(crate) fn checked_contracts(
     let checked_at = Instant::now();
     let mut out: Vec<CheckedContract> = judged
         .iter()
-        .map(|j| CheckedContract {
-            contract: j.contract,
-            verdicts: j.verdicts,
-            inconclusive: j.inconclusive,
-            findings: Vec::new(),
-            checked_at,
-        })
+        .map(|j| CheckedContract::new(j.contract, j.verdicts, j.inconclusive, checked_at))
         .collect();
     for finding in findings {
         let merge = MergeFinding {
@@ -454,22 +501,25 @@ pub(crate) fn checked_contracts(
                     property = merge.property,
                     "merge finding for a contract the tick did not record as judged"
                 );
-                out.push(CheckedContract {
-                    contract: finding.contract,
-                    // ONE, not zero. A finding IS a verdict — it comes from a
-                    // `Violated` outcome — so a record carrying a violation and
-                    // `verdicts: 0` renders "0 reached a verdict" directly beside a
-                    // Violation row, which reads as a page contradicting itself and
-                    // gives an operator no way to tell which half to believe. One is
-                    // the honest floor: at least the case that produced this finding
-                    // reached a verdict. Any further findings for the same contract
-                    // take the `Some` arm above, so this is not a per-finding count
-                    // and does not claim to be.
-                    verdicts: 1,
-                    inconclusive: 0,
-                    findings: vec![merge],
-                    checked_at,
-                });
+                // ONE verdict, not zero. A finding IS a verdict — it comes from a
+                // `Violated` outcome — so a record carrying a violation and
+                // `verdicts: 0` renders "0 reached a verdict" directly beside a
+                // Violation row, which reads as a page contradicting itself and gives
+                // an operator no way to tell which half to believe. One is the honest
+                // floor: at least the case that produced this finding reached a
+                // verdict. Any further findings for the same contract take the `Some`
+                // arm above, so this is not a per-finding count and does not claim to
+                // be.
+                let mut record = CheckedContract::new(finding.contract, 1, 0, checked_at);
+                // Through `note_finding`, like every other producer. This branch used
+                // to build the vec directly (`findings: vec![merge]`) — the one place
+                // in the module that contradicted the "note_finding is the only way
+                // in" claim that the module doc, `MAX_REMEMBERED_CHECKED` and
+                // `record`'s un-deduplicating insert arm all rest on. It is also the
+                // branch that exists precisely for the case where an assumption has
+                // already broken, which is the worst place to keep a second way in.
+                record.note_finding(merge);
+                out.push(record);
             }
         }
     }
@@ -528,15 +578,19 @@ mod tests {
         }
     }
 
+    /// A record, built the only way production can build one.
+    ///
+    /// Goes through `new` + `note_finding` rather than a struct literal — which the
+    /// private `findings` field now forbids anyway. A hand-built literal was how a
+    /// test could construct a record production never could, which is what let the
+    /// insert arm's missing deduplication sit unnoticed.
     fn checked(n: u8, findings: Vec<MergeFinding>) -> CheckedContract {
-        CheckedContract {
-            contract: instance(n),
-            verdicts: 1,
-            inconclusive: 0,
-            findings,
-            // Overwritten by `record` with the tick's publish time, as in production.
-            checked_at: Instant::now(),
+        // Overwritten by `record` with the tick's publish time, as in production.
+        let mut record = CheckedContract::new(instance(n), 1, 0, Instant::now());
+        for finding in findings {
+            record.note_finding(finding);
         }
+        record
     }
 
     /// The fixture contract's NEVER_SETTLES mode — see
@@ -842,25 +896,13 @@ mod tests {
     fn per_contract_case_counts_accumulate_across_ticks() {
         let mut s = MergeCheckStatus::default();
         s.record(
-            [CheckedContract {
-                contract: instance(1),
-                verdicts: 2,
-                inconclusive: 5,
-                findings: Vec::new(),
-                checked_at: Instant::now(),
-            }],
+            [CheckedContract::new(instance(1), 2, 5, Instant::now())],
             1,
             0,
             Instant::now(),
         );
         s.record(
-            [CheckedContract {
-                contract: instance(1),
-                verdicts: 3,
-                inconclusive: 1,
-                findings: Vec::new(),
-                checked_at: Instant::now(),
-            }],
+            [CheckedContract::new(instance(1), 3, 1, Instant::now())],
             1,
             0,
             Instant::now(),

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -39,6 +39,12 @@ use super::property::Severity;
 /// against a bundle, which can afford to be exhaustive.
 const MAX_DISPLAYED_FINDINGS: usize = 64;
 
+/// How many recently-checked contracts to remember.
+///
+/// Larger than the finding cap because most checks find nothing, and "this one was
+/// looked at and was fine" is the common answer a per-contract page needs to give.
+const MAX_REMEMBERED_CHECKED: usize = 256;
+
 /// One contract's failure to obey a merge law.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MergeFinding {
@@ -69,6 +75,33 @@ pub struct MergeCheckStatus {
     pub cases_last_tick: usize,
     /// Findings, newest first, capped at [`MAX_DISPLAYED_FINDINGS`].
     pub findings: Vec<MergeFinding>,
+    /// Contracts recently checked, newest first, capped at [`MAX_REMEMBERED_CHECKED`].
+    ///
+    /// Without this a per-contract view cannot tell "checked, and clean" from "never
+    /// looked at", and would render them the same way — which is the conflation this
+    /// whole subsystem exists to stop, displayed on a page an operator will act on.
+    pub recently_checked: Vec<ContractInstanceId>,
+}
+
+impl MergeCheckStatus {
+    /// Whether this contract is known to have been checked.
+    ///
+    /// `false` means "not in the recent window", NOT "not checked ever" — the window
+    /// is bounded. A caller must phrase it as absence of knowledge rather than as a
+    /// clean bill of health.
+    pub fn was_checked(&self, contract: &ContractInstanceId) -> bool {
+        self.recently_checked.contains(contract)
+    }
+
+    /// Findings recorded against one contract.
+    pub fn findings_for<'a>(
+        &'a self,
+        contract: &'a ContractInstanceId,
+    ) -> impl Iterator<Item = &'a MergeFinding> + 'a {
+        self.findings
+            .iter()
+            .filter(move |f| f.contract == *contract)
+    }
 }
 
 /// `None` until the checker publishes, which it only does when capture is enabled.
@@ -106,11 +139,17 @@ impl MergeCheckStatus {
     /// rather than prevents.
     pub fn record(
         &mut self,
+        checked: impl IntoIterator<Item = ContractInstanceId>,
         contracts_checked: usize,
         contracts_without_verdict: usize,
         cases_last_tick: usize,
         new_findings: impl IntoIterator<Item = MergeFinding>,
     ) {
+        for contract in checked {
+            self.recently_checked.retain(|c| *c != contract);
+            self.recently_checked.insert(0, contract);
+        }
+        self.recently_checked.truncate(MAX_REMEMBERED_CHECKED);
         self.contracts_checked = contracts_checked;
         self.contracts_without_verdict = contracts_without_verdict;
         self.cases_last_tick = cases_last_tick;
@@ -133,6 +172,7 @@ impl MergeCheckStatus {
 
 /// Publish a tick's outcome. Called by the shadow loop; cheap and non-blocking.
 pub fn publish(
+    checked: impl IntoIterator<Item = ContractInstanceId>,
     contracts_checked: usize,
     contracts_without_verdict: usize,
     cases_last_tick: usize,
@@ -142,6 +182,7 @@ pub fn publish(
         .write()
         .get_or_insert_with(MergeCheckStatus::default)
         .record(
+            checked,
             contracts_checked,
             contracts_without_verdict,
             cases_last_tick,
@@ -175,8 +216,8 @@ mod tests {
     #[test]
     fn repeated_findings_for_one_contract_and_property_collapse() {
         let mut s = MergeCheckStatus::default();
-        s.record(1, 0, 10, [finding(1, "state_commutativity")]);
-        s.record(1, 0, 10, [finding(1, "state_commutativity")]);
+        s.record([], 1, 0, 10, [finding(1, "state_commutativity")]);
+        s.record([], 1, 0, 10, [finding(1, "state_commutativity")]);
         assert_eq!(
             s.findings.len(),
             1,
@@ -189,8 +230,8 @@ mod tests {
     #[test]
     fn different_properties_on_one_contract_stay_separate() {
         let mut s = MergeCheckStatus::default();
-        s.record(1, 0, 10, [finding(2, "state_commutativity")]);
-        s.record(1, 0, 10, [finding(2, "state_associativity")]);
+        s.record([], 1, 0, 10, [finding(2, "state_commutativity")]);
+        s.record([], 1, 0, 10, [finding(2, "state_associativity")]);
         assert_eq!(
             s.findings.len(),
             2,
@@ -204,7 +245,7 @@ mod tests {
     fn findings_are_bounded() {
         let mut s = MergeCheckStatus::default();
         for i in 0..(MAX_DISPLAYED_FINDINGS + 40) {
-            s.record(1, 0, 1, [finding((i % 251) as u8, "state_idempotence")]);
+            s.record([], 1, 0, 1, [finding((i % 251) as u8, "state_idempotence")]);
         }
         assert!(
             s.findings.len() <= MAX_DISPLAYED_FINDINGS,
@@ -221,7 +262,7 @@ mod tests {
     #[test]
     fn contracts_without_a_verdict_are_reported_separately() {
         let mut s = MergeCheckStatus::default();
-        s.record(10, 3, 400, []);
+        s.record([], 10, 3, 400, []);
         assert_eq!(s.contracts_without_verdict, 3);
         assert!(
             s.findings.is_empty(),

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -578,12 +578,54 @@ mod tests {
         }
     }
 
+    /// The `findings` field must stay private — the guarantee, not a convention.
+    ///
+    /// `note_finding` being the only way a finding reaches a record is what the module
+    /// doc, `MAX_REMEMBERED_CHECKED` and `record`'s un-deduplicating INSERT arm all
+    /// rest on, and it held by convention through three review rounds of #5403 before
+    /// the field was made private. Re-adding `pub` here breaks NOTHING at compile
+    /// time on its own: the visibility only bites once some caller also writes a
+    /// struct literal, and at that point the invariant is already gone. So the
+    /// privacy itself is what has to be asserted.
+    ///
+    /// Scoped to the struct's own body. A whole-file search would be answered by any
+    /// other `pub` field, and — the failure this file's sibling pins were written
+    /// against — by this test's own assertion string.
+    #[test]
+    fn the_findings_field_stays_private() {
+        let src = include_str!("status.rs");
+        let anchor = "pub struct CheckedContract {";
+        let start = src
+            .find(anchor)
+            .expect("CheckedContract is no longer declared here; this pin reads nothing")
+            + anchor.len();
+        let end = start
+            + src[start..]
+                .find("\n}\n")
+                .expect("CheckedContract's declaration is not brace-balanced");
+        let decl = &src[start..end];
+        assert!(
+            decl.contains("\n    findings: Vec<MergeFinding>,"),
+            "CheckedContract no longer declares `findings` privately. While it was \
+             `pub` in a `pub mod`, any caller could hand `record` a hand-built record \
+             carrying duplicate properties, and the insert arm does not deduplicate — \
+             that is #5403 H1 verbatim. Build records with `CheckedContract::new` and \
+             read them through `findings()`. got:{decl}"
+        );
+    }
+
     /// A record, built the only way production can build one.
     ///
     /// Goes through `new` + `note_finding` rather than a struct literal — which the
     /// private `findings` field now forbids anyway. A hand-built literal was how a
     /// test could construct a record production never could, which is what let the
     /// insert arm's missing deduplication sit unnoticed.
+    ///
+    /// Note what `note_finding` does to `findings` on the way in: it inserts at the
+    /// FRONT and drops a property already present. So the record comes back with the
+    /// list reversed and any duplicate property gone — the signature reads like "these
+    /// findings, in this order" and it is not. Nothing asserts on order today; do not
+    /// write an order-dependent assertion against this helper without reading that.
     fn checked(n: u8, findings: Vec<MergeFinding>) -> CheckedContract {
         // Overwritten by `record` with the tick's publish time, as in production.
         let mut record = CheckedContract::new(instance(n), 1, 0, Instant::now());

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -1,0 +1,243 @@
+//! What the merge-law checker has found, in a form the dashboard can read.
+//!
+//! Everything the checker knows lives in the capture writer task and reaches the
+//! outside world only as `tracing` output. Those logs rotate hourly and the lines are
+//! not enumerated event kinds, so they never reach the telemetry collector either. The
+//! one place an operator would look shows nothing.
+//!
+//! That matters more than a missing view usually would. Removal is not enabled yet,
+//! and the RFC's gate for enabling it requires that every prospective deletion "has
+//! been understood" — a statement about what a human has been able to inspect. If the
+//! only route to that is grepping a peer's log files before they rotate, the gate is
+//! being argued from evidence most operators cannot reach, and an operator whose
+//! contract is about to be deleted has no way to find out why, or to disagree, before
+//! it happens. **Visibility has to precede automatic deletion.**
+//!
+//! # Shape
+//!
+//! A snapshot the shadow loop publishes after each probe tick and the dashboard reads.
+//! Deliberately not a provider closure like `ring_stats`: the checker's state lives in
+//! a task, so there is nothing for a closure to read on demand — the task has to push.
+//!
+//! # Bounded
+//!
+//! Findings are capped. A peer that hosts many broken contracts must not turn this
+//! into an unbounded allocation, and a reader who needs the full picture should replay
+//! the corpus rather than scroll a web page.
+
+use std::sync::OnceLock;
+
+use freenet_stdlib::prelude::ContractInstanceId;
+use parking_lot::RwLock;
+
+use super::property::Severity;
+
+/// Most findings retained for display.
+///
+/// Small on purpose. The dashboard answers "is anything wrong here, and with what?",
+/// not "give me the whole corpus" — that question is answered by `fdev verify-merge`
+/// against a bundle, which can afford to be exhaustive.
+const MAX_DISPLAYED_FINDINGS: usize = 64;
+
+/// One contract's failure to obey a merge law.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergeFinding {
+    pub contract: ContractInstanceId,
+    /// The law that was broken, e.g. `state_commutativity`.
+    pub property: &'static str,
+    /// `Violation` means the contract cannot converge. `Diagnostic` means it is legal
+    /// but wasteful — the distinction an operator most needs, because only the first
+    /// would ever justify removal.
+    pub severity: Severity,
+    /// Whether enforcement, were it enabled, would have removed the contract for this.
+    pub would_remove: bool,
+}
+
+/// What the checker has established on this node.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MergeCheckStatus {
+    /// Contracts that reached a verdict, either way.
+    pub contracts_checked: usize,
+    /// Contracts checked that reached NO verdict on any case.
+    ///
+    /// The number most likely to be misread by its absence. An unjudgeable contract
+    /// renders identically to a clean one, so a panel reporting only "0 violations"
+    /// would be actively misleading — on the live capture peer 17% of hosted contracts
+    /// could not be judged at all and nothing said so.
+    pub contracts_without_verdict: usize,
+    /// Cases checked in the most recent tick.
+    pub cases_last_tick: usize,
+    /// Findings, newest first, capped at [`MAX_DISPLAYED_FINDINGS`].
+    pub findings: Vec<MergeFinding>,
+}
+
+/// `None` until the checker publishes, which it only does when capture is enabled.
+///
+/// The distinction is load-bearing for the reader: "not enabled on this node" and "no
+/// problems found" must not render the same way. Absence and success looking alike is
+/// the failure this whole subsystem keeps rediscovering.
+static STATUS: RwLock<Option<MergeCheckStatus>> = RwLock::new(None);
+
+/// Set once when the checker starts, so the dashboard can say "checking is on, nothing
+/// found yet" rather than falling back to "not enabled" during the first interval.
+static ENABLED: OnceLock<()> = OnceLock::new();
+
+/// Called by the checker at startup.
+pub fn mark_enabled() {
+    // Idempotent: capture starts once per process, and a second call is a no-op
+    // rather than an error worth surfacing.
+    if ENABLED.set(()).is_err() {
+        tracing::debug!("merge-check status already marked enabled");
+    }
+}
+
+/// Whether merge-law checking is running on this node at all.
+pub fn is_enabled() -> bool {
+    ENABLED.get().is_some()
+}
+
+impl MergeCheckStatus {
+    /// Fold one tick's outcome in.
+    ///
+    /// The logic lives here rather than inside [`publish`] so it can be tested without
+    /// the process-global. Tests that shared that global interfered with each other —
+    /// one test's findings appeared in another's assertions — which is the failure
+    /// `.claude/rules/testing.md` describes and which per-process isolation hides
+    /// rather than prevents.
+    pub fn record(
+        &mut self,
+        contracts_checked: usize,
+        contracts_without_verdict: usize,
+        cases_last_tick: usize,
+        new_findings: impl IntoIterator<Item = MergeFinding>,
+    ) {
+        self.contracts_checked = contracts_checked;
+        self.contracts_without_verdict = contracts_without_verdict;
+        self.cases_last_tick = cases_last_tick;
+        for finding in new_findings {
+            // Newest first, and deduplicated on (contract, property): a contract
+            // failing the same law in forty cases is one finding reported forty times,
+            // which is harder to read rather than more informative. Deduplicating on
+            // contract ALONE would hide that a contract breaks more than one law.
+            if !self
+                .findings
+                .iter()
+                .any(|f| f.contract == finding.contract && f.property == finding.property)
+            {
+                self.findings.insert(0, finding);
+            }
+        }
+        self.findings.truncate(MAX_DISPLAYED_FINDINGS);
+    }
+}
+
+/// Publish a tick's outcome. Called by the shadow loop; cheap and non-blocking.
+pub fn publish(
+    contracts_checked: usize,
+    contracts_without_verdict: usize,
+    cases_last_tick: usize,
+    new_findings: impl IntoIterator<Item = MergeFinding>,
+) {
+    STATUS
+        .write()
+        .get_or_insert_with(MergeCheckStatus::default)
+        .record(
+            contracts_checked,
+            contracts_without_verdict,
+            cases_last_tick,
+            new_findings,
+        );
+}
+
+/// The current snapshot, or `None` if the checker is not running on this node.
+pub fn snapshot() -> Option<MergeCheckStatus> {
+    STATUS.read().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instance(n: u8) -> ContractInstanceId {
+        ContractInstanceId::new([n; 32])
+    }
+
+    fn finding(n: u8, property: &'static str) -> MergeFinding {
+        MergeFinding {
+            contract: instance(n),
+            property,
+            severity: Severity::Violation,
+            would_remove: true,
+        }
+    }
+
+    /// The same contract failing the same law repeatedly is one row, not forty.
+    #[test]
+    fn repeated_findings_for_one_contract_and_property_collapse() {
+        let mut s = MergeCheckStatus::default();
+        s.record(1, 0, 10, [finding(1, "state_commutativity")]);
+        s.record(1, 0, 10, [finding(1, "state_commutativity")]);
+        assert_eq!(
+            s.findings.len(),
+            1,
+            "the same law failing twice produced two rows"
+        );
+    }
+
+    /// Distinct laws on one contract stay distinct — collapsing on contract alone
+    /// would hide that a contract breaks more than one rule.
+    #[test]
+    fn different_properties_on_one_contract_stay_separate() {
+        let mut s = MergeCheckStatus::default();
+        s.record(1, 0, 10, [finding(2, "state_commutativity")]);
+        s.record(1, 0, 10, [finding(2, "state_associativity")]);
+        assert_eq!(
+            s.findings.len(),
+            2,
+            "two different broken laws collapsed into one row"
+        );
+    }
+
+    /// Findings are capped, so a peer hosting many broken contracts cannot grow this
+    /// without bound.
+    #[test]
+    fn findings_are_bounded() {
+        let mut s = MergeCheckStatus::default();
+        for i in 0..(MAX_DISPLAYED_FINDINGS + 40) {
+            s.record(1, 0, 1, [finding((i % 251) as u8, "state_idempotence")]);
+        }
+        assert!(
+            s.findings.len() <= MAX_DISPLAYED_FINDINGS,
+            "findings grew past the cap: {}",
+            s.findings.len()
+        );
+    }
+
+    /// The unjudgeable count is carried, not inferred.
+    ///
+    /// An unjudgeable contract renders identically to a clean one, so a panel showing
+    /// only "0 violations" would be actively misleading. On the live capture peer 17%
+    /// of hosted contracts could not be judged at all and nothing said so.
+    #[test]
+    fn contracts_without_a_verdict_are_reported_separately() {
+        let mut s = MergeCheckStatus::default();
+        s.record(10, 3, 400, []);
+        assert_eq!(s.contracts_without_verdict, 3);
+        assert!(
+            s.findings.is_empty(),
+            "no findings, which is exactly why the unjudgeable count has to be its own \
+             number rather than inferred from an empty list"
+        );
+    }
+
+    /// A node that never publishes reads as absent, not clean.
+    #[test]
+    fn enabled_and_published_are_different_questions() {
+        // `is_enabled` is set when the checker starts; a snapshot only exists after a
+        // tick. During the first interval the honest answer is "on, nothing yet".
+        assert!(
+            !is_enabled() || snapshot().is_some() || snapshot().is_none(),
+            "unreachable; documents that the two states are independent"
+        );
+    }
+}

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4479,6 +4479,65 @@ mod tests {
         );
     }
 
+    /// #5403 L6: every property name these card tests plant must be one the checker
+    /// can actually emit.
+    ///
+    /// `merge_card_lists_findings_with_severity_and_removal_distinguished` asserted on
+    /// `self_delta_size`, which `ConformanceProperty::as_str` cannot produce — the
+    /// real name is `self_delta_empty`. The test was internally consistent (it planted
+    /// the string and then found it), so it passed while asserting about a card state
+    /// no node will ever render, and the property it claimed to cover — that a
+    /// Diagnostic renders distinguishably from a Violation — was never exercised
+    /// against a real Diagnostic property at all.
+    ///
+    /// Fixing the one literal would leave the class open, so this reads every
+    /// `MergeFinding` property literal planted in this file and checks it against
+    /// `ConformanceProperty::ALL`. A future fixture invented out of thin air fails
+    /// here instead of quietly testing nothing.
+    ///
+    /// Nothing in this doc comment may spell the scrape's needle, or the scrape finds
+    /// its own prose — which it did on the first run, and failed loudly rather than
+    /// silently, because an unreal name is exactly what it rejects.
+    #[test]
+    fn merge_card_fixtures_only_use_property_names_the_checker_can_emit() {
+        use crate::conformance::property::ConformanceProperty;
+
+        let real: std::collections::BTreeSet<&str> = ConformanceProperty::ALL
+            .iter()
+            .map(|p| p.as_str())
+            .collect();
+
+        let src = include_str!("home_page.rs");
+        let needle = "property: \"";
+        let mut planted: Vec<&str> = Vec::new();
+        let mut from = 0usize;
+        while let Some(found) = src[from..].find(needle) {
+            let start = from + found + needle.len();
+            let end = start
+                + src[start..]
+                    .find('"')
+                    .expect("an unterminated string literal in this file's own source");
+            planted.push(&src[start..end]);
+            from = end;
+        }
+
+        assert!(
+            !planted.is_empty(),
+            "no `property: \"…\"` fixture was found in this file, so this test has \
+             stopped reading what it claims to read — the fixtures were probably \
+             renamed or moved, and it is now vacuous"
+        );
+        for name in &planted {
+            assert!(
+                real.contains(name),
+                "the merge-card fixtures plant `{name}`, which no \
+                 ConformanceProperty produces. A card test built on a name the \
+                 checker cannot emit asserts about a state no node will ever render. \
+                 Real names: {real:?}"
+            );
+        }
+    }
+
     /// The Playwright fixture's markup must stay in step with what the server
     /// actually emits.
     ///

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3798,21 +3798,30 @@ mod tests {
     }
 
     /// One checked-contract record, the shape `conformance::status` stores.
+    ///
+    /// Built through `CheckedContract::new` + `note_finding`, the only route
+    /// production has and — since `findings` became private — the only route
+    /// anything has. A struct literal here would let a test construct a record
+    /// production could not, which is precisely what hid `record`'s
+    /// un-deduplicating insert arm.
     fn checked_record(
         contract: freenet_stdlib::prelude::ContractInstanceId,
         verdicts: usize,
         inconclusive: usize,
         findings: Vec<MergeFinding>,
     ) -> CheckedContract {
-        CheckedContract {
+        // The timestamp is overwritten by `record` with the tick's publish time,
+        // exactly as `status::checked_contracts` does in production.
+        let mut record = CheckedContract::new(
             contract,
             verdicts,
             inconclusive,
-            findings,
-            // Overwritten by `record` with the tick's publish time, exactly as
-            // `status::checked_contracts` does in production.
-            checked_at: tokio::time::Instant::now(),
+            tokio::time::Instant::now(),
+        );
+        for finding in findings {
+            record.note_finding(finding);
         }
+        record
     }
 
     /// What the page reads: one contract's record plus the node-wide numbers.
@@ -4257,11 +4266,13 @@ mod tests {
     /// A checker that has stopped publishing must say so, not present its last
     /// tick as a current result.
     ///
-    /// `status::publish` is reached from one place, and two live paths skip it
-    /// indefinitely while the old snapshot stands: a tick that selects no work,
-    /// and a probe task that panicked. A peer whose probe has been dead for a
-    /// week would otherwise keep serving that week-old "no violation found"
-    /// with nothing on the page to say when it was established.
+    /// `status::publish` is reached from two places in `capture::run_writer`, and
+    /// a peer can stop reaching either indefinitely while the old snapshot
+    /// stands: the probe task can panic, a probe can hang so `in_flight` never
+    /// clears and no further tick starts, or the writer task can be gone. A peer
+    /// whose probe has been dead for a week would otherwise keep serving that
+    /// week-old "no violation found" with nothing on the page to say when it was
+    /// established.
     #[test]
     fn merge_card_reports_a_frozen_checker_rather_than_a_current_clean_result() {
         use freenet_stdlib::prelude::ContractInstanceId;
@@ -4433,6 +4444,138 @@ mod tests {
             "the node-wide tick age must remain: a frozen checker is a different \
              fault from a stale record, and the card has to be able to show both — \
              got:\n{panel}"
+        );
+    }
+
+    /// The value rendered against one `info-label` in the merge card.
+    ///
+    /// Both ages sit in the same `info-grid` and both end in " ago", so a
+    /// `panel.contains("5m")` cannot tell which of them it matched — and the whole
+    /// question these two tests ask is which clock answered which label.
+    fn info_value(panel: &str, label: &str) -> String {
+        let anchor = format!(r#">{label}</div><div class="info-value">"#);
+        let start = panel
+            .find(&anchor)
+            .unwrap_or_else(|| panic!("the card renders no `{label}` row:\n{panel}"))
+            + anchor.len();
+        let end = panel[start..]
+            .find("</div>")
+            .expect("an info-value must be closed");
+        panel[start..start + end].to_string()
+    }
+
+    /// #5403 L3: re-checking a contract must refresh its per-contract age.
+    ///
+    /// `MergeCheckStatus::record` stamps `checked_at` in BOTH of its arms. Confining
+    /// that assignment to the insert (`None`) arm compiles, and the test above cannot
+    /// see it: that test records the contract ONCE, so it only ever drives the insert
+    /// arm. A contract the checker looks at every tick would then render with the age
+    /// of the first time it was ever seen, growing without bound while the checker
+    /// was in fact judging it every fifteen minutes — M2's mirror image (there the
+    /// per-contract age was too fresh; here it would be too stale), and the same
+    /// fault of the card answering one question with another clock.
+    #[test]
+    fn re_checking_a_contract_refreshes_its_per_contract_age() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([26u8; 32]);
+        let key = key_id.to_string();
+        let first_seen = tokio::time::Instant::now();
+        let twenty_hours = std::time::Duration::from_secs(20 * 60 * 60);
+        let five_minutes = std::time::Duration::from_secs(5 * 60);
+
+        let mut status = MergeCheckStatus::default();
+        // First sight: the insert arm.
+        status.record([checked_record(key_id, 12, 0, vec![])], 1, 0, first_seen);
+        // Twenty hours later the checker comes back to the SAME contract: the merge
+        // arm, which is the arm nothing covered.
+        status.record(
+            [checked_record(key_id, 3, 0, vec![])],
+            1,
+            0,
+            first_seen + twenty_hours,
+        );
+
+        let snap = hosted_snap(&key);
+        let view = status.view_for(Some(&key_id), first_seen + twenty_hours + five_minutes);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+
+        let per_contract = info_value(&panel, "This contract last checked");
+        let node_wide = info_value(&panel, "Last checker tick");
+        assert_eq!(
+            per_contract, node_wide,
+            "the contract was re-checked by the most recent tick, so its own age and \
+             the node's must agree. They do not, which means the merge arm left \
+             `checked_at` at first sight: a contract judged every tick renders as one \
+             last looked at hours or days ago — got {per_contract:?} against \
+             {node_wide:?} in:\n{panel}"
+        );
+        assert!(
+            !per_contract.contains("20h"),
+            "the re-checked contract is aged from when it was FIRST seen, not from \
+             the tick that last judged it — got {per_contract:?} in:\n{panel}"
+        );
+        // The accumulation the merge arm also owns, so this test fails loudly rather
+        // than vacuously if a refactor stops merging records at all.
+        assert!(
+            panel.contains("15 reached a verdict"),
+            "the two ticks' case counts did not accumulate, so the merge arm did not \
+             run and this test proves nothing about it — got:\n{panel}"
+        );
+    }
+
+    /// #5403 L2: a contract with no record must still show how old the snapshot is.
+    ///
+    /// The card's own doc says every state that has a snapshot renders when that
+    /// snapshot was published. The no-record branch did not: the publish age reached
+    /// it only through the staleness note, which fires at three missed ticks. Below
+    /// that threshold — a checker that died fourteen minutes ago — "this contract has
+    /// not been checked recently" carried no age at all, and a busy checker that has
+    /// simply not got round to this contract rendered identically to one that had
+    /// stopped. That is the same absence-reads-as-fine conflation this subsystem
+    /// exists to stop, in the one state where the page has nothing else to say.
+    #[test]
+    fn a_contract_with_no_record_still_shows_how_old_the_snapshot_is() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([27u8; 32]);
+        let other = ContractInstanceId::new([28u8; 32]);
+        let key = key_id.to_string();
+        let published = tokio::time::Instant::now();
+
+        // The checker HAS published — for a different contract, so the requested one
+        // has no record.
+        let mut status = MergeCheckStatus::default();
+        status.record([checked_record(other, 5, 0, vec![])], 1, 0, published);
+
+        // Well inside `STALE_AFTER` (45 minutes), so the staleness note does NOT
+        // fire and cannot supply the age on this branch's behalf. That is the whole
+        // window the branch was blind in.
+        let view = status.view_for(
+            Some(&key_id),
+            published + std::time::Duration::from_secs(840),
+        );
+        assert!(
+            view.contract.is_none() && !view.stale,
+            "this test only means anything for a fresh snapshot with no record for \
+             the requested contract"
+        );
+
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+
+        assert!(
+            panel.contains("has not been checked recently"),
+            "this test must be reading the no-record branch — got:\n{panel}"
+        );
+        assert_eq!(
+            info_value(&panel, "Last checker tick"),
+            "14m ago",
+            "the no-record state renders no snapshot age, so an operator cannot tell \
+             a busy checker that has not reached this contract from one that stopped \
+             fourteen minutes ago — got:\n{panel}"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -211,7 +211,9 @@ mod tests {
     use super::favicon::{build_dashboard_title, build_favicon_data_uri};
     use super::peer_detail::peer_detail_html;
     use crate::conformance::property::Severity;
-    use crate::conformance::status::{MergeCheckStatus, MergeFinding};
+    use crate::conformance::status::{
+        CheckedContract, MergeCheckStatus, MergeCheckView, MergeFinding,
+    };
     use crate::node::network_status::{
         FailureSnapshot, HealthLevel, NatStatsSnapshot, NetworkStatusSnapshot, OpStatsSnapshot,
         RingStatsSnapshot,
@@ -3795,6 +3797,34 @@ mod tests {
         html[start..end].to_string()
     }
 
+    /// One checked-contract record, the shape `conformance::status` stores.
+    fn checked_record(
+        contract: freenet_stdlib::prelude::ContractInstanceId,
+        verdicts: usize,
+        inconclusive: usize,
+        findings: Vec<MergeFinding>,
+    ) -> CheckedContract {
+        CheckedContract {
+            contract,
+            verdicts,
+            inconclusive,
+            findings,
+        }
+    }
+
+    /// What the page reads: one contract's record plus the node-wide numbers.
+    ///
+    /// Goes through `MergeCheckStatus::view_for`, the same call the wrapper
+    /// makes, rather than building a `MergeCheckView` by hand — a hand-built
+    /// view would let a test assert about a record the real lookup would never
+    /// have returned.
+    fn merge_view(
+        status: &MergeCheckStatus,
+        contract: &freenet_stdlib::prelude::ContractInstanceId,
+    ) -> MergeCheckView {
+        status.view_for(Some(contract), std::time::Instant::now())
+    }
+
     /// Text with the markup stripped, so "no digit in the visible content"
     /// assertions aren't defeated by the `2` in every `<h2>` tag.
     fn visible_text(html: &str) -> String {
@@ -3868,14 +3898,21 @@ mod tests {
     fn merge_card_reports_not_recently_checked_as_unknown_not_clean() {
         use freenet_stdlib::prelude::ContractInstanceId;
 
-        let key = ContractInstanceId::new([2u8; 32]).to_string();
+        let key_id = ContractInstanceId::new([2u8; 32]);
+        let key = key_id.to_string();
         // A DIFFERENT contract was checked; this one was not.
         let other = ContractInstanceId::new([9u8; 32]);
         let mut status = MergeCheckStatus::default();
-        status.record([other], 1, 0, 5, []);
+        status.record(
+            [checked_record(other, 5, 0, vec![])],
+            1,
+            0,
+            std::time::Instant::now(),
+        );
 
         let snap = hosted_snap(&key);
-        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
             panel.contains("has not been checked recently"),
@@ -3930,10 +3967,16 @@ mod tests {
         let key_id = ContractInstanceId::new([4u8; 32]);
         let key = key_id.to_string();
         let mut status = MergeCheckStatus::default();
-        status.record([key_id], 7, 0, 250, []);
+        status.record(
+            [checked_record(key_id, 250, 4, vec![])],
+            1,
+            0,
+            std::time::Instant::now(),
+        );
 
         let snap = hosted_snap(&key);
-        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
             panel
@@ -3942,9 +3985,15 @@ mod tests {
             "a clean, checked contract must say so plainly — got:\n{panel}"
         );
         assert!(
-            panel.contains("250"),
-            "must show the case count so a clean result can be judged for \
-             how meaningful it is — got:\n{panel}"
+            panel.contains("250 reached a verdict"),
+            "must show how many of THIS contract's cases reached a verdict, so a \
+             clean result can be judged for how meaningful it is — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("4 inconclusive"),
+            "must show this contract's inconclusive count too: a contract with one \
+             verdict and 199 inconclusive cases must not render like one with 200 \
+             verdicts — got:\n{panel}"
         );
         assert!(
             !panel
@@ -3971,28 +4020,33 @@ mod tests {
         let key = key_id.to_string();
         let mut status = MergeCheckStatus::default();
         status.record(
-            [key_id],
+            [checked_record(
+                key_id,
+                40,
+                0,
+                vec![
+                    MergeFinding {
+                        contract: key_id,
+                        property: "state_commutativity",
+                        severity: Severity::Violation,
+                        would_remove: true,
+                    },
+                    MergeFinding {
+                        contract: key_id,
+                        property: "self_delta_size",
+                        severity: Severity::Diagnostic,
+                        would_remove: false,
+                    },
+                ],
+            )],
             1,
             0,
-            40,
-            [
-                MergeFinding {
-                    contract: key_id,
-                    property: "state_commutativity",
-                    severity: Severity::Violation,
-                    would_remove: true,
-                },
-                MergeFinding {
-                    contract: key_id,
-                    property: "self_delta_size",
-                    severity: Severity::Diagnostic,
-                    would_remove: false,
-                },
-            ],
+            std::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
-        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
             panel.contains("state_commutativity") && panel.contains("self_delta_size"),
@@ -4020,10 +4074,16 @@ mod tests {
         let key_id = ContractInstanceId::new([6u8; 32]);
         let key = key_id.to_string();
         let mut status = MergeCheckStatus::default();
-        status.record([key_id], 10, 3, 400, []);
+        status.record(
+            [checked_record(key_id, 400, 0, vec![])],
+            10,
+            3,
+            std::time::Instant::now(),
+        );
 
         let snap = hosted_snap(&key);
-        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
             panel.contains('3'),
@@ -4036,6 +4096,130 @@ mod tests {
                 .contains("could not reach a verdict"),
             "must be phrased as an inability to judge, not folded silently \
              into the clean result above it — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("most recent tick"),
+            "the unjudged count is a per-TICK number and must be phrased as one. \
+             The earlier wording ('on this node') read as a standing property of \
+             the peer — got:\n{panel}"
+        );
+    }
+
+    /// #5403 H1: a contract with a finding must never render the green pill,
+    /// however many other contracts have been checked since.
+    ///
+    /// The two-window version kept a 256-entry checked list and a 64-entry
+    /// findings list. `merge_law_card` picked its branch from the first and
+    /// read the second, so a contract inside one and evicted from the other
+    /// rendered "no merge-law violation was found for this contract" — for a
+    /// contract the checker had positively found violating. Worse, that was
+    /// the steady state: a re-detected finding was deduplicated rather than
+    /// moved to the front, so the contract caught on every tick was the one
+    /// likeliest to lose its finding while its checked entry was refreshed.
+    ///
+    /// A hundred intervening contracts is well past the old findings cap and
+    /// well short of the checked cap, which is exactly the gap the bug lived
+    /// in. This test fails against the two-list code.
+    #[test]
+    fn merge_card_keeps_a_finding_after_the_old_findings_cap_would_have_evicted_it() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([7u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [checked_record(
+                key_id,
+                12,
+                0,
+                vec![MergeFinding {
+                    contract: key_id,
+                    property: "state_commutativity",
+                    severity: Severity::Violation,
+                    would_remove: true,
+                }],
+            )],
+            1,
+            0,
+            std::time::Instant::now(),
+        );
+        for i in 0..100u8 {
+            let other = ContractInstanceId::new([100u8.wrapping_add(i); 32]);
+            status.record(
+                [checked_record(
+                    other,
+                    3,
+                    0,
+                    vec![MergeFinding {
+                        contract: other,
+                        property: "state_idempotence",
+                        severity: Severity::Violation,
+                        would_remove: true,
+                    }],
+                )],
+                1,
+                0,
+                std::time::Instant::now(),
+            );
+        }
+
+        let snap = hosted_snap(&key);
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+        assert!(
+            !panel
+                .to_ascii_lowercase()
+                .contains("no merge-law violation"),
+            "a contract the checker FOUND violating rendered a clean result \
+             because later contracts pushed its finding out of a separately \
+             capped list — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("state_commutativity"),
+            "the finding must still be listed while the contract is still in \
+             the checked window — got:\n{panel}"
+        );
+    }
+
+    /// A checker that has stopped publishing must say so, not present its last
+    /// tick as a current result.
+    ///
+    /// `status::publish` is reached from one place, and two live paths skip it
+    /// indefinitely while the old snapshot stands: a tick that selects no work,
+    /// and a probe task that panicked. A peer whose probe has been dead for a
+    /// week would otherwise keep serving that week-old "no violation found"
+    /// with nothing on the page to say when it was established.
+    #[test]
+    fn merge_card_reports_a_frozen_checker_rather_than_a_current_clean_result() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([8u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [checked_record(key_id, 30, 0, vec![])],
+            1,
+            0,
+            std::time::Instant::now(),
+        );
+
+        let snap = hosted_snap(&key);
+        // A week later. `view_for` takes `now` so the staleness branch does not
+        // need a week of wall clock to reach.
+        let a_week = std::time::Duration::from_secs(7 * 24 * 60 * 60);
+        let view = status.view_for(Some(&key_id), std::time::Instant::now() + a_week);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains("has not published"),
+            "a week-old snapshot rendered as a current result, with nothing on \
+             the card saying when the checker last ran — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("Last checker tick"),
+            "every state with a snapshot must show how old that snapshot is — \
+             got:\n{panel}"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3804,6 +3804,13 @@ mod tests {
     /// anything has. A struct literal here would let a test construct a record
     /// production could not, which is precisely what hid `record`'s
     /// un-deduplicating insert arm.
+    ///
+    /// Note what `note_finding` does to `findings` on the way in: it inserts at the
+    /// FRONT and drops a property already present. So the record comes back with the
+    /// list reversed and any duplicate property gone — the signature reads like "these
+    /// findings, in this order" and it is not. Today's callers assert presence, not
+    /// order; do not write an order-dependent assertion against this helper without
+    /// reading that.
     fn checked_record(
         contract: freenet_stdlib::prelude::ContractInstanceId,
         verdicts: usize,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -210,6 +210,8 @@ mod tests {
     };
     use super::favicon::{build_dashboard_title, build_favicon_data_uri};
     use super::peer_detail::peer_detail_html;
+    use crate::conformance::property::Severity;
+    use crate::conformance::status::{MergeCheckStatus, MergeFinding};
     use crate::node::network_status::{
         FailureSnapshot, HealthLevel, NatStatsSnapshot, NetworkStatusSnapshot, OpStatsSnapshot,
         RingStatsSnapshot,
@@ -3396,7 +3398,7 @@ mod tests {
     #[test]
     fn contract_detail_escapes_a_key_from_the_url() {
         let payload = "<script>alert(1)</script>";
-        let html = contract_detail_html_from(&None, payload);
+        let html = contract_detail_html_from(&None, payload, false, None);
         assert!(
             !html.contains("<script>alert(1)"),
             "an unescaped key from the URL is reflected XSS — got:\n{html}"
@@ -3417,7 +3419,7 @@ mod tests {
     /// describing a ranking the code does not implement.
     #[test]
     fn contract_not_found_is_scoped_to_this_node() {
-        let html = contract_detail_html_from(&None, "NOSUCHCONTRACTKEY");
+        let html = contract_detail_html_from(&None, "NOSUCHCONTRACTKEY", false, None);
         assert!(
             html.contains("Contract Not Found"),
             "expected the not-found page — got:\n{html}"
@@ -3513,7 +3515,7 @@ mod tests {
                 is_receiving_updates: is_fresh,
                 in_use,
             }];
-            contract_detail_html_from(&Some(snap), "SUBBED1")
+            contract_detail_html_from(&Some(snap), "SUBBED1", false, None)
         };
 
         // Fresh, in use, updated recently.
@@ -3587,7 +3589,7 @@ mod tests {
                 last_transition_secs_ago: 30,
                 history: Vec::new(),
             }];
-            contract_detail_html_from(&Some(snap), key)
+            contract_detail_html_from(&Some(snap), key, false, None)
         };
 
         // 44 base58 characters, the real shape of a contract key.
@@ -3675,7 +3677,7 @@ mod tests {
             history: Vec::new(),
         }];
 
-        let html = contract_detail_html_from(&Some(snap), key);
+        let html = contract_detail_html_from(&Some(snap), key, false, None);
         assert!(
             html.contains("Borderline"),
             "a hosted-only contract must still show its governance state — \
@@ -3728,7 +3730,7 @@ mod tests {
             history,
         }];
 
-        let html = contract_detail_html_from(&Some(snap), "GOVKEY1");
+        let html = contract_detail_html_from(&Some(snap), "GOVKEY1", false, None);
         let newest = format_duration(newest_secs);
         let oldest = format_duration(oldest_secs);
         assert!(
@@ -3763,7 +3765,7 @@ mod tests {
             recency_seq: 42,
             eviction_eligible: true,
         }];
-        let html = contract_detail_html_from(&Some(snap), "TESTKEY1");
+        let html = contract_detail_html_from(&Some(snap), "TESTKEY1", false, None);
         assert!(
             html.contains("not shown"),
             "the hosting panel must say the ranking keys are missing — \
@@ -3773,6 +3775,267 @@ mod tests {
             html.contains("5372"),
             "and point at the issue tracking them, so the gap is followable \
              rather than a dead end — got:\n{html}"
+        );
+    }
+
+    // ─── Merge-law card (#5397) ──────────────────────────────────────────
+
+    /// Extracts the Merge laws card. The whole stylesheet is inlined into
+    /// every render, so a bare `html.contains("fresh-ok")` is true whether or
+    /// not this card actually used that class — see `subscription_panel`
+    /// above, which exists for the identical reason.
+    fn merge_panel(html: &str) -> String {
+        let start = html
+            .find("<h2>Merge laws</h2>")
+            .expect("the Merge laws card must be rendered");
+        let end = html[start..]
+            .find("<h2>Governance</h2>")
+            .map(|i| start + i)
+            .unwrap_or(html.len());
+        html[start..end].to_string()
+    }
+
+    /// Text with the markup stripped, so "no digit in the visible content"
+    /// assertions aren't defeated by the `2` in every `<h2>` tag.
+    fn visible_text(html: &str) -> String {
+        let mut out = String::new();
+        let mut in_tag = false;
+        for c in html.chars() {
+            match c {
+                '<' => in_tag = true,
+                '>' => in_tag = false,
+                _ if !in_tag => out.push(c),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// A hosted-only contract: the cheapest fixture that reaches any card at
+    /// all. A key with no subscription, hosting, or governance record
+    /// short-circuits to the "not found" page before the Merge laws card (or
+    /// any other card) ever renders.
+    fn hosted_snap(key: &str) -> NetworkStatusSnapshot {
+        let mut snap = base_snapshot();
+        snap.open_connections = 2;
+        snap.hosting.contracts = vec![crate::node::network_status::HostedContractEntry {
+            key_full: key.to_string(),
+            key_short: key.to_string(),
+            size_bytes: 1024,
+            read_count: 0,
+            recency_seq: 0,
+            eviction_eligible: true,
+        }];
+        snap
+    }
+
+    /// State 1: merge-law checking is not running on this node at all.
+    ///
+    /// Must say so plainly, and must render NO count at all — not even a
+    /// zero. A rendered "0" here would read as "0 violations found", which is
+    /// indistinguishable from a clean bill of health and is exactly the
+    /// conflation `conformance::status`'s module doc exists to prevent.
+    #[test]
+    fn merge_card_reports_checking_disabled_with_no_digits() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key = ContractInstanceId::new([1u8; 32]).to_string();
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, false, None);
+        let panel = merge_panel(&html);
+        assert!(
+            panel.to_ascii_lowercase().contains("not enabled"),
+            "must say plainly that checking is off — got:\n{panel}"
+        );
+        assert!(
+            panel.to_ascii_lowercase().contains("default"),
+            "must say this is the default state, not a fault — got:\n{panel}"
+        );
+        assert!(
+            !visible_text(&panel).chars().any(|c| c.is_ascii_digit()),
+            "no digit may appear in the VISIBLE text when checking is off — \
+             a rendered count (even a zero) would read as a clean result \
+             rather than as unmeasured. got:\n{panel}"
+        );
+    }
+
+    /// State 2a: checking is running, but this contract falls outside the
+    /// bounded recently-checked window.
+    ///
+    /// Must NOT be read as clean — the window is bounded, so absence here is
+    /// absence of knowledge, not a clean bill of health.
+    #[test]
+    fn merge_card_reports_not_recently_checked_as_unknown_not_clean() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key = ContractInstanceId::new([2u8; 32]).to_string();
+        // A DIFFERENT contract was checked; this one was not.
+        let other = ContractInstanceId::new([9u8; 32]);
+        let mut status = MergeCheckStatus::default();
+        status.record([other], 1, 0, 5, []);
+
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains("has not been checked recently"),
+            "must say the contract fell outside the checked window — \
+             got:\n{panel}"
+        );
+        assert!(
+            !panel
+                .to_ascii_lowercase()
+                .contains("no merge-law violation"),
+            "must not claim a clean result for a contract the checker never \
+             looked at — got:\n{panel}"
+        );
+    }
+
+    /// State 2b: checking is running, but has not published its first tick
+    /// yet (`snapshot()` is still `None`).
+    ///
+    /// This must render the same "not checked recently" message as 2a, not
+    /// "not enabled" — the checker IS on, it simply has nothing to report
+    /// yet. Conflating this with "off" would misreport a starting node as one
+    /// with checking disabled.
+    #[test]
+    fn merge_card_reports_not_checked_before_first_publish() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key = ContractInstanceId::new([3u8; 32]).to_string();
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, None);
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains("has not been checked recently"),
+            "before the first tick publishes, the honest answer is 'on, \
+             nothing established yet', which must read the same as the \
+             bounded-window case above — got:\n{panel}"
+        );
+        assert!(
+            !panel.to_ascii_lowercase().contains("not enabled"),
+            "must not be conflated with checking being off — got:\n{panel}"
+        );
+    }
+
+    /// State 3: checked, no findings for this contract.
+    ///
+    /// Must say plainly that no violation was found AND show how many cases
+    /// ran, so the reader can judge whether a clean result reflects a
+    /// meaningful sample or barely having looked.
+    #[test]
+    fn merge_card_reports_clean_result_with_case_count() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([4u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record([key_id], 7, 0, 250, []);
+
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let panel = merge_panel(&html);
+        assert!(
+            panel
+                .to_ascii_lowercase()
+                .contains("no merge-law violation"),
+            "a clean, checked contract must say so plainly — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("250"),
+            "must show the case count so a clean result can be judged for \
+             how meaningful it is — got:\n{panel}"
+        );
+        assert!(
+            !panel
+                .to_ascii_lowercase()
+                .contains("could not reach a verdict"),
+            "the fleet-wide unjudged note must NOT appear when the count is \
+             zero — got:\n{panel}"
+        );
+    }
+
+    /// State 4: checked, with findings — the state the whole card exists for.
+    ///
+    /// Each finding must show its property, and a `Violation` must read as
+    /// visibly more serious than a `Diagnostic`: the former means the
+    /// contract cannot converge (peers disagree and retry indefinitely), the
+    /// latter is legal but wasteful. A panel that only printed the bare enum
+    /// name would satisfy "shows severity" without making the distinction an
+    /// operator actually needs.
+    #[test]
+    fn merge_card_lists_findings_with_severity_and_removal_distinguished() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([5u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [key_id],
+            1,
+            0,
+            40,
+            [
+                MergeFinding {
+                    contract: key_id,
+                    property: "state_commutativity",
+                    severity: Severity::Violation,
+                    would_remove: true,
+                },
+                MergeFinding {
+                    contract: key_id,
+                    property: "self_delta_size",
+                    severity: Severity::Diagnostic,
+                    would_remove: false,
+                },
+            ],
+        );
+
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains("state_commutativity") && panel.contains("self_delta_size"),
+            "both findings for this contract must be listed — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("cannot converge"),
+            "a Violation must be explained, not just labelled with the bare \
+             enum name — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("legal but wasteful"),
+            "a Diagnostic must be visibly distinguished from a Violation, \
+             not merely a different word for the same thing — got:\n{panel}"
+        );
+    }
+
+    /// The fleet-wide "could not judge" count must be surfaced when non-zero,
+    /// independent of this contract's own state — it is information the
+    /// operator needs regardless of which contract's page they are viewing.
+    #[test]
+    fn merge_card_surfaces_contracts_without_verdict_fleet_wide() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([6u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record([key_id], 10, 3, 400, []);
+
+        let snap = hosted_snap(&key);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&status));
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains('3'),
+            "the unjudged count must be surfaced when non-zero — \
+             got:\n{panel}"
+        );
+        assert!(
+            panel
+                .to_ascii_lowercase()
+                .contains("could not reach a verdict"),
+            "must be phrased as an inability to judge, not folded silently \
+             into the clean result above it — got:\n{panel}"
         );
     }
 

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -3809,6 +3809,9 @@ mod tests {
             verdicts,
             inconclusive,
             findings,
+            // Overwritten by `record` with the tick's publish time, exactly as
+            // `status::checked_contracts` does in production.
+            checked_at: tokio::time::Instant::now(),
         }
     }
 
@@ -3822,7 +3825,7 @@ mod tests {
         status: &MergeCheckStatus,
         contract: &freenet_stdlib::prelude::ContractInstanceId,
     ) -> MergeCheckView {
-        status.view_for(Some(contract), std::time::Instant::now())
+        status.view_for(Some(contract), tokio::time::Instant::now())
     }
 
     /// Text with the markup stripped, so "no digit in the visible content"
@@ -3907,7 +3910,7 @@ mod tests {
             [checked_record(other, 5, 0, vec![])],
             1,
             0,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
@@ -3971,7 +3974,7 @@ mod tests {
             [checked_record(key_id, 250, 4, vec![])],
             1,
             0,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
@@ -4033,7 +4036,7 @@ mod tests {
                     },
                     MergeFinding {
                         contract: key_id,
-                        property: "self_delta_size",
+                        property: "self_delta_empty",
                         severity: Severity::Diagnostic,
                         would_remove: false,
                     },
@@ -4041,7 +4044,7 @@ mod tests {
             )],
             1,
             0,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
@@ -4049,7 +4052,7 @@ mod tests {
         let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
-            panel.contains("state_commutativity") && panel.contains("self_delta_size"),
+            panel.contains("state_commutativity") && panel.contains("self_delta_empty"),
             "both findings for this contract must be listed — got:\n{panel}"
         );
         assert!(
@@ -4078,7 +4081,7 @@ mod tests {
             [checked_record(key_id, 400, 0, vec![])],
             10,
             3,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
@@ -4141,7 +4144,7 @@ mod tests {
             )],
             1,
             0,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
         for i in 0..100u8 {
             let other = ContractInstanceId::new([100u8.wrapping_add(i); 32]);
@@ -4159,7 +4162,7 @@ mod tests {
                 )],
                 1,
                 0,
-                std::time::Instant::now(),
+                tokio::time::Instant::now(),
             );
         }
 
@@ -4182,6 +4185,75 @@ mod tests {
         );
     }
 
+    /// #5403 H1, at the surface an operator reads: the card shows one row per
+    /// broken law, not one per violating case.
+    ///
+    /// Driven end to end through the production assembly — a real probe of the
+    /// deliberately-defective fixture contract, then `status::checked_contracts`,
+    /// `MergeCheckStatus::record`, `view_for`, and the real page function. Every
+    /// other merge-card test above hand-builds a `CheckedContract`, so none of them
+    /// could see a defect in the code that BUILDS one; three review rounds each
+    /// found a defect on that path and no test failed.
+    ///
+    /// Mode 6 (NEVER_SETTLES) breaks two merge laws on most generated cases, and one
+    /// probe returns thirteen findings across those two. Before the fix the card
+    /// rendered thirteen rows, eleven of them byte-identical duplicates, which then
+    /// persisted for the record's whole residency in the window because later ticks
+    /// deduplicate AGAINST them.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_card_renders_one_row_per_broken_law_from_a_real_probe()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Keep in sync with the mode constants in
+        // `tests/test-contract-conformance/src/lib.rs`.
+        const NEVER_SETTLES: u8 = 6;
+
+        let (id, report, findings) =
+            crate::conformance::shadow::probe_fixture_contract(NEVER_SETTLES).await?;
+        let distinct: std::collections::BTreeSet<&str> = findings
+            .iter()
+            .map(|f| f.violation.property.as_str())
+            .collect();
+        assert!(
+            findings.len() > distinct.len() && distinct.len() > 1,
+            "the probe returned {} findings across {} properties, so this test can \
+             no longer tell one row per LAW from one row per CASE",
+            findings.len(),
+            distinct.len()
+        );
+
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            crate::conformance::status::checked_contracts(&report.judged, &findings),
+            report.judged.len(),
+            report.without_verdict,
+            tokio::time::Instant::now(),
+        );
+
+        let key = id.to_string();
+        let snap = hosted_snap(&key);
+        let view = merge_view(&status, &id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+
+        let rows = panel.matches("<tr><td>").count();
+        assert_eq!(
+            rows,
+            distinct.len(),
+            "the card rendered {rows} finding rows for {} broken laws — a single \
+             broken law repeated across a probe's cases becomes a wall of identical \
+             rows. got:\n{panel}",
+            distinct.len()
+        );
+        for property in &distinct {
+            assert_eq!(
+                panel.matches(property).count(),
+                1,
+                "{property} appears more than once on the card:\n{panel}"
+            );
+        }
+        Ok(())
+    }
+
     /// A checker that has stopped publishing must say so, not present its last
     /// tick as a current result.
     ///
@@ -4201,14 +4273,14 @@ mod tests {
             [checked_record(key_id, 30, 0, vec![])],
             1,
             0,
-            std::time::Instant::now(),
+            tokio::time::Instant::now(),
         );
 
         let snap = hosted_snap(&key);
         // A week later. `view_for` takes `now` so the staleness branch does not
         // need a week of wall clock to reach.
         let a_week = std::time::Duration::from_secs(7 * 24 * 60 * 60);
-        let view = status.view_for(Some(&key_id), std::time::Instant::now() + a_week);
+        let view = status.view_for(Some(&key_id), tokio::time::Instant::now() + a_week);
         let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
         let panel = merge_panel(&html);
         assert!(
@@ -4219,6 +4291,190 @@ mod tests {
         assert!(
             panel.contains("Last checker tick"),
             "every state with a snapshot must show how old that snapshot is — \
+             got:\n{panel}"
+        );
+    }
+
+    /// #5403 M1: a contract the checker has FOUND VIOLATING must not render as one
+    /// this node has never heard of.
+    ///
+    /// The page short-circuited to `contract_not_found.html` — "This node knows
+    /// nothing about &lt;key&gt;" — whenever the contract was absent from the
+    /// subscribed, hosted and governance sections of the snapshot, and threw the
+    /// already-computed merge view away. Those three empty and a merge record present
+    /// is not a corner: the checked window holds ~32 hours while the hosting cache
+    /// evicts under budget pressure well inside that, and
+    /// `network_status::get_snapshot()` returning `None` empties all three at once.
+    /// So the state the page denied all knowledge of is exactly the state where it
+    /// had the most alarming thing to say.
+    #[test]
+    fn a_contract_absent_from_the_snapshot_but_found_violating_is_not_reported_unknown() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([21u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [checked_record(
+                key_id,
+                8,
+                0,
+                vec![MergeFinding {
+                    contract: key_id,
+                    property: "state_commutativity",
+                    severity: Severity::Violation,
+                    would_remove: true,
+                }],
+            )],
+            1,
+            0,
+            tokio::time::Instant::now(),
+        );
+        let view = merge_view(&status, &key_id);
+
+        // No snapshot at all: the harshest form of the case, and one a live node
+        // reaches whenever `get_snapshot()` returns None.
+        let html = contract_detail_html_from(&None, &key, true, Some(&view));
+        assert!(
+            !html.contains("knows nothing about"),
+            "the page denied all knowledge of a contract it had positively found \
+             violating a merge law — got:\n{html}"
+        );
+        let panel = merge_panel(&html);
+        assert!(
+            panel.contains("state_commutativity"),
+            "the finding must still be shown when the contract is absent from the \
+             snapshot's other sections — got:\n{panel}"
+        );
+    }
+
+    /// The not-found page must still be reachable, or the fix above would simply
+    /// have deleted a state.
+    ///
+    /// A key nothing knows anything about — no snapshot entry AND no merge record —
+    /// is genuinely unknown and must say so, rather than rendering an empty detail
+    /// page that reads as a contract with nothing wrong with it.
+    #[test]
+    fn a_contract_nothing_knows_about_is_still_reported_unknown() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([22u8; 32]);
+        let other = ContractInstanceId::new([23u8; 32]);
+        let key = key_id.to_string();
+        // The checker HAS published, and has a record — for a different contract.
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [checked_record(other, 5, 0, vec![])],
+            1,
+            0,
+            tokio::time::Instant::now(),
+        );
+        let view = merge_view(&status, &key_id);
+        assert!(
+            view.contract.is_none(),
+            "this test only means something while the requested contract has no record"
+        );
+
+        let html = contract_detail_html_from(&None, &key, true, Some(&view));
+        assert!(
+            html.contains("knows nothing about"),
+            "a genuinely unknown contract stopped being reported as unknown, so the \
+             merge-record exemption swallowed the not-found state entirely — \
+             got:\n{html}"
+        );
+    }
+
+    /// #5403 M2: "when was THIS contract last checked?" must be answered with this
+    /// contract's own record, not with the node's most recent tick.
+    ///
+    /// The card put node-wide `published_secs_ago` in the same info-grid as the
+    /// per-contract case counts, immediately beside "No merge-law violation was found
+    /// for this contract the last time it was checked". The checker probes at most two
+    /// contracts per fifteen-minute tick against a window holding 256, so a contract
+    /// judged twenty hours ago rendered as checked three minutes ago — a confident
+    /// freshness claim about a stale result. It is the same misattribution the PR had
+    /// already fixed one row up for the COUNTS; see `status::judged_last_tick`.
+    #[test]
+    fn merge_card_ages_this_contract_from_its_own_record_not_the_last_node_tick() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([24u8; 32]);
+        let key = key_id.to_string();
+        let judged_at = tokio::time::Instant::now();
+        // Added rather than subtracted: `Instant` is monotonic from boot, so
+        // `now - 20h` panics on a host that has been up for less than that.
+        let twenty_hours = std::time::Duration::from_secs(20 * 60 * 60);
+
+        let mut status = MergeCheckStatus::default();
+        status.record([checked_record(key_id, 12, 0, vec![])], 1, 0, judged_at);
+        // Twenty hours of ticks that never touched this contract. The node is
+        // perfectly healthy; the record is not fresh.
+        status.record([], 2, 0, judged_at + twenty_hours);
+
+        let snap = hosted_snap(&key);
+        let view = status.view_for(Some(&key_id), judged_at + twenty_hours);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+
+        assert!(
+            panel.contains("This contract last checked"),
+            "the card gives no per-contract age at all, so the only age on it is the \
+             node's — got:\n{panel}"
+        );
+        assert!(
+            panel.contains("20h"),
+            "a contract judged twenty hours ago is rendered as checked at the node's \
+             most recent tick, beside a sentence about what was found 'the last time \
+             it was checked' — got:\n{panel}"
+        );
+        // And the node-wide number is still there, still labelled as node-wide.
+        assert!(
+            panel.contains("Last checker tick"),
+            "the node-wide tick age must remain: a frozen checker is a different \
+             fault from a stale record, and the card has to be able to show both — \
+             got:\n{panel}"
+        );
+    }
+
+    /// #5403 M4: the unjudged count's explanation must name what it actually counts.
+    ///
+    /// It was explained as "every case it tried was inconclusive, or related state
+    /// exceeded its budget", which names the two rarest entries on the list
+    /// `shadow::ShadowReport::without_verdict` accumulates. That list also holds: no
+    /// contract store, an empty corpus, code that would not resolve, an oracle that
+    /// would not build, setup that exhausted the time budget before one case ran, a
+    /// dead probe task, and `awaiting_samples` — for most of which ZERO cases were
+    /// tried, and on a warming-up peer `awaiting_samples` dominates outright. An
+    /// operator reading the old sentence would go looking for contracts whose cases
+    /// were all inconclusive and find none.
+    #[test]
+    fn merge_card_explains_the_unjudged_count_by_what_it_counts() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let key_id = ContractInstanceId::new([25u8; 32]);
+        let key = key_id.to_string();
+        let mut status = MergeCheckStatus::default();
+        status.record(
+            [checked_record(key_id, 40, 0, vec![])],
+            1,
+            4,
+            tokio::time::Instant::now(),
+        );
+
+        let snap = hosted_snap(&key);
+        let view = merge_view(&status, &key_id);
+        let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+        let panel = merge_panel(&html);
+
+        assert!(
+            panel.contains("no samples collected"),
+            "the dominant cause on a warming-up peer — focus picked a contract the \
+             sampler holds nothing for — is not named at all — got:\n{panel}"
+        );
+        assert!(
+            !panel.contains("every case it tried was inconclusive"),
+            "the explanation still asserts that every unjudged contract ran cases, \
+             which is false for most of them and for all of the common ones — \
              got:\n{panel}"
         );
     }

--- a/crates/core/src/server/home_page/assets/contract.html
+++ b/crates/core/src/server/home_page/assets/contract.html
@@ -27,6 +27,7 @@
         {identity}
         {subscription}
         {hosting}
+        {merge}
         {governance}
         <p style="margin-top:0.25rem"><a href="/" style="color:var(--accent-light);font-family:var(--font-mono);font-size:0.85rem">&larr; Back to dashboard</a></p>
     </main>

--- a/crates/core/src/server/home_page/assets/contract_not_found.html
+++ b/crates/core/src/server/home_page/assets/contract_not_found.html
@@ -19,7 +19,7 @@
 </header>
 <main>
     <div class="card"><h2>Contract Not Found</h2>
-    <p class="empty">This node knows nothing about <code class="key-wrap">{key}</code>: no subscription, no hosted copy, and no governance record.</p>
+    <p class="empty">This node knows nothing about <code class="key-wrap">{key}</code>: no subscription, no hosted copy, no governance record, and no merge-law check on record for it either.</p>
     <p class="empty" style="margin-top:0.5rem">That is a statement about THIS node only. A contract absent here may be alive and well elsewhere in the network — a node holds what demand routed to it, not a directory.</p>
     <p style="margin-top:0.75rem"><a href="/" style="color:var(--accent-light);font-family:var(--font-mono);font-size:0.85rem">&larr; Back to dashboard</a></p></div>
 </main></body></html>

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -103,7 +103,16 @@ pub fn contract_detail_html_from(
         })
     });
 
-    if subscribed.is_none() && hosted.is_none() && governance.is_none() {
+    // The merge-law window is a FOURTH place this node knows about a contract, and it
+    // outlives the other three. The checked window holds ~32 hours (256 records at two
+    // per fifteen-minute tick) while the hosting cache evicts under budget pressure
+    // well inside that, and `network_status::get_snapshot()` returning `None` empties
+    // all three at once. Without this, the page asserted "This node knows nothing
+    // about <key>" while holding a recorded merge-law VIOLATION for it — the strongest
+    // statement the checker ever makes, rendered as an absence. `merge_view` was
+    // already computed at the call site and thrown away.
+    let merge_record_known = merge_view.is_some_and(|v| v.contract.is_some());
+    if subscribed.is_none() && hosted.is_none() && governance.is_none() && !merge_record_known {
         return format!(
             include_str!("assets/contract_not_found.html"),
             CSS = CSS,
@@ -291,19 +300,31 @@ pub fn contract_detail_html_from(
 /// 4. Checked, with one or more findings, each carrying the property that
 ///    broke, its severity, and whether enforcement would remove it.
 ///
-/// `without_verdict_last_tick` — contracts the checker looked at in its most
-/// recent tick but could reach no verdict on for any case — is surfaced
+/// `without_verdict_last_tick` — focus contracts the checker formed no opinion
+/// about in its most recent tick — is surfaced
 /// whenever non-zero, independent of which of states 2-4 this particular
 /// contract is in: it is node-wide information the operator needs regardless
 /// of this contract's own status. It is phrased as a statement about that
 /// tick, because that is what it measures; the earlier "on this node"
 /// phrasing read as a standing property.
 ///
+/// Its CAUSES are stated the way `shadow::ShadowReport::without_verdict` counts
+/// them, which is broader than the wording it first shipped with. "Every case
+/// was inconclusive, or related state exceeded its budget" named the two rarest
+/// entries on a list that also holds: no contract store on this node, an empty
+/// corpus, code that would not resolve, an oracle that would not build, setup
+/// that exhausted the time budget before a single case ran, a probe task that
+/// died, and `awaiting_samples` — for most of which ZERO cases were tried. On a
+/// warming-up peer `awaiting_samples` dominates outright, so the old wording
+/// described the least likely cause as though it were the only one.
+///
 /// Every state that has a snapshot at all also renders WHEN the snapshot was
-/// published. Two live paths in `capture::run_writer` skip `status::publish`
-/// indefinitely while the old snapshot stands — a tick that selects no work,
-/// and a probe task that panicked — so without an age a peer whose probe has
-/// been dead for a week keeps serving that week-old tick as a current result.
+/// published, and — for a contract with a record — when THAT CONTRACT was last
+/// checked, which is a different and usually much older number. The node-wide
+/// age is needed because `status::publish` is reached from two places in
+/// `capture::run_writer` and a probe task that panicked skips both, so without
+/// it a peer whose probe has been dead for a week keeps serving that week-old
+/// tick as a current result.
 fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckView>) -> String {
     if !merge_enabled {
         return r#"<div class="card">
@@ -329,7 +350,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     let mut note = String::new();
     if view.without_verdict_last_tick > 0 {
         note.push_str(&format!(
-            r#"<p class="empty" style="margin-top:0.5rem">In its most recent tick the checker judged {judged} contract(s) and could not reach a verdict on {n} — every case it tried was inconclusive, or related state exceeded its budget. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
+            r#"<p class="empty" style="margin-top:0.5rem">In its most recent tick the checker judged {judged} contract(s) could not reach a verdict on {n} — most often because there was nothing yet to check (no samples collected for them, or no contract code on this node), and sometimes because every case it did try came back inconclusive. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
             judged = view.judged_last_tick,
             n = view.without_verdict_last_tick,
         ));
@@ -357,11 +378,30 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     // get?": a contract with one verdict and 199 inconclusive cases rendered
     // byte-identically to one with 200 verdicts, and a contract last probed
     // forty ticks ago was shown a count from a tick that never touched it.
+    //
+    // The per-contract age is the record's OWN `checked_at`, not the node's most
+    // recent tick. Those are different clocks: the checker probes at most two
+    // contracts per fifteen-minute tick against a window holding 256, so a contract
+    // judged twenty hours ago sat beside "Last checker tick: 3 minutes" and a sentence
+    // saying no violation was found "the last time it was checked". That is the same
+    // misattribution already fixed one row up for the COUNTS (see
+    // `status::MergeCheckStatus::judged_last_tick`), and both numbers are kept because
+    // both are worth knowing — what was wrong was one of them answering the other's
+    // question.
     let cases_row = format!(
         r#"<div class="info-label" title="Cases run against THIS contract while it has been in the checked window. A verdict is a case that came back Holds or Violated; an inconclusive case established nothing, so a clean result resting mostly on those is barely a result.">Cases for this contract</div><div class="info-value">{verdicts} reached a verdict, {inconclusive} inconclusive</div>
-                    <div class="info-label" title="How long ago the merge-law checker last published a tick. It probes every 15 minutes when healthy.">Last checker tick</div><div class="info-value">{ago} ago</div>"#,
+                    <div class="info-label" title="How long ago the tick that last judged THIS contract published. The checker probes at most two contracts per tick out of a window holding 256, so this can be far older than the node's last tick below.">This contract last checked</div><div class="info-value">{checked} ago</div>
+                    <div class="info-label" title="How long ago the merge-law checker last published a tick on this NODE — about any contract, not necessarily this one. It probes every 15 minutes when healthy.">Last checker tick</div><div class="info-value">{ago} ago</div>"#,
         verdicts = record.verdicts,
         inconclusive = record.inconclusive,
+        checked = view
+            .checked_secs_ago
+            .map(format_duration)
+            // Unreachable: `checked_secs_ago` is `Some` exactly when `view.contract`
+            // is, and this branch is inside `Some(record)`. Rendered as unknown rather
+            // than as a zero, because "0 seconds ago" would be a confident claim that
+            // this contract was checked just now.
+            .unwrap_or_else(|| "an unknown time".to_string()),
         ago = format_duration(view.published_secs_ago),
     );
 

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -32,17 +32,29 @@ use std::str::FromStr;
 /// scope cut; this page says plainly that the counts are missing rather than
 /// implying the ranking is visible.
 pub fn contract_detail_html(key_str: &str) -> String {
+    // `ContractKey`'s `Display` and `ContractInstanceId`'s `Display` produce
+    // the same string (see the comment on the `governance` lookup below), so
+    // `key_str` — whichever form the operator pasted — is always a valid
+    // instance id to query the merge-check status by, when it parses at all.
+    // A key from a URL path can be anything, so a parse failure here means
+    // "not a real instance id" and must render as "not checked", never panic.
+    let merge_id = ContractInstanceId::from_str(key_str).ok();
     // Two separate reads, deliberately not collapsed into one: `is_enabled()`
-    // and `snapshot()` answer different questions, and can disagree during
+    // and `view_for()` answer different questions, and can disagree during
     // the checker's very first interval — enabled, but nothing published
     // yet. That state must render as "not checked recently", not as "off",
     // so both flow into the pure renderer below rather than being merged
     // here into a single bool.
+    //
+    // A VIEW, not the whole snapshot: the checked window holds up to 256
+    // records with their findings, and this page needs one of them. Cloning
+    // the set on every render made the page's cost grow with the peer's
+    // history for no reader benefit.
     contract_detail_html_from(
         &network_status::get_snapshot(),
         key_str,
         status::is_enabled(),
-        status::snapshot().as_ref(),
+        status::view_for(merge_id.as_ref()).as_ref(),
     )
 }
 
@@ -54,14 +66,14 @@ pub fn contract_detail_html(key_str: &str) -> String {
 /// made the interesting cases — a hosted-only contract, one the governance
 /// manager has flagged, one the merge-law checker has or hasn't looked at —
 /// reachable only by standing up a node and waiting for it to reach that
-/// state. `merge_enabled` and `merge_status` are the wrapper's two reads of
+/// state. `merge_enabled` and `merge_view` are the wrapper's two reads of
 /// `conformance::status` (see the doc comment at the call site above for why
 /// they stay separate parameters).
 pub fn contract_detail_html_from(
     snap: &Option<network_status::NetworkStatusSnapshot>,
     key_str: &str,
     merge_enabled: bool,
-    merge_status: Option<&status::MergeCheckStatus>,
+    merge_view: Option<&status::MergeCheckView>,
 ) -> String {
     // Match on the full key OR the instance id, so a link from any card works
     // and so an operator can paste either form.
@@ -243,14 +255,7 @@ pub fn contract_detail_html_from(
             .to_string(),
     };
 
-    // `ContractKey`'s `Display` and `ContractInstanceId`'s `Display` produce
-    // the same string (see the comment on the `governance` lookup above), so
-    // `key_str` — whichever form the operator pasted — is always a valid
-    // instance id to query the merge-check status by, when it parses at all.
-    // A key from a URL path can be anything, so a parse failure here means
-    // "not a real instance id" and must render as "not checked", never panic.
-    let merge_id = ContractInstanceId::from_str(key_str).ok();
-    let merge_card = merge_law_card(merge_enabled, merge_status, merge_id.as_ref());
+    let merge_card = merge_law_card(merge_enabled, merge_view);
 
     format!(
         include_str!("assets/contract.html"),
@@ -286,30 +291,20 @@ pub fn contract_detail_html_from(
 /// 4. Checked, with one or more findings, each carrying the property that
 ///    broke, its severity, and whether enforcement would remove it.
 ///
-/// `contracts_without_verdict` — contracts the checker looked at but could
-/// reach no verdict on for any case — is surfaced whenever non-zero,
-/// independent of which of states 2-4 this particular contract is in: it is
-/// fleet-wide information the operator needs regardless of this contract's
-/// own status.
-fn merge_law_card(
-    merge_enabled: bool,
-    merge_status: Option<&status::MergeCheckStatus>,
-    merge_id: Option<&ContractInstanceId>,
-) -> String {
-    // Fleet-wide "some contracts could not be judged at all" note. Shown
-    // whenever the checker has published a tick and the count is non-zero,
-    // regardless of this contract's own state — see the doc comment above.
-    let unjudged_note = |s: &status::MergeCheckStatus| -> String {
-        if s.contracts_without_verdict == 0 {
-            String::new()
-        } else {
-            format!(
-                r#"<p class="empty" style="margin-top:0.5rem">The checker could not reach a verdict on {n} contract(s) on this node — every case it tried was inconclusive, or related state exceeded its budget. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
-                n = s.contracts_without_verdict,
-            )
-        }
-    };
-
+/// `without_verdict_last_tick` — contracts the checker looked at in its most
+/// recent tick but could reach no verdict on for any case — is surfaced
+/// whenever non-zero, independent of which of states 2-4 this particular
+/// contract is in: it is node-wide information the operator needs regardless
+/// of this contract's own status. It is phrased as a statement about that
+/// tick, because that is what it measures; the earlier "on this node"
+/// phrasing read as a standing property.
+///
+/// Every state that has a snapshot at all also renders WHEN the snapshot was
+/// published. Two live paths in `capture::run_writer` skip `status::publish`
+/// indefinitely while the old snapshot stands — a tick that selects no work,
+/// and a probe task that panicked — so without an age a peer whose probe has
+/// been dead for a week keeps serving that week-old tick as a current result.
+fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckView>) -> String {
     if !merge_enabled {
         return r#"<div class="card">
                 <h2>Merge laws</h2>
@@ -318,13 +313,35 @@ fn merge_law_card(
             .to_string();
     }
 
-    let was_checked = match (merge_status, merge_id) {
-        (Some(s), Some(id)) => s.was_checked(id),
-        _ => false,
+    // Everything below needs a published snapshot. Without one the checker is
+    // on but has not finished its first interval, which must read as "not
+    // looked at yet" rather than as "off" or as "clean".
+    let Some(view) = merge_view else {
+        return r#"<div class="card">
+                <h2>Merge laws</h2>
+                <p class="empty">This contract has not been checked recently. The checked window is bounded, so this is <strong>not</strong> a statement that the contract is fine — the checker has simply not looked at it lately.</p>
+            </div>"#
+            .to_string();
     };
 
-    if !was_checked {
-        let note = merge_status.map(unjudged_note).unwrap_or_default();
+    // Node-wide "some contracts could not be judged at all" note, plus how old
+    // the tick it describes is.
+    let mut note = String::new();
+    if view.without_verdict_last_tick > 0 {
+        note.push_str(&format!(
+            r#"<p class="empty" style="margin-top:0.5rem">In its most recent tick the checker judged {judged} contract(s) and could not reach a verdict on {n} — every case it tried was inconclusive, or related state exceeded its budget. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
+            judged = view.judged_last_tick,
+            n = view.without_verdict_last_tick,
+        ));
+    }
+    if view.stale {
+        note.push_str(&format!(
+            r#"<p class="empty" style="margin-top:0.5rem"><strong>The checker has not published for {ago}.</strong> It runs every 15 minutes when healthy, so everything on this card may be stale — a probe that dies, or a tick that finds nothing to select, leaves the previous result standing with nothing else to say so.</p>"#,
+            ago = format_duration(view.published_secs_ago),
+        ));
+    }
+
+    let Some(record) = view.contract.as_ref() else {
         return format!(
             r#"<div class="card">
                 <h2>Merge laws</h2>
@@ -333,32 +350,38 @@ fn merge_law_card(
             </div>"#,
             note = note,
         );
-    }
+    };
 
-    // `was_checked` only returns `true` when both are `Some` (see the match
-    // above), so these cannot fail.
-    let merge_status = merge_status.expect("was_checked implies a published status");
-    let merge_id = merge_id.expect("was_checked implies a parsed contract id");
-    let findings: Vec<&status::MergeFinding> = merge_status.findings_for(merge_id).collect();
-    let note = unjudged_note(merge_status);
+    // THIS contract's own case counts, not the node's most recent tick. The
+    // fleet-wide number cannot answer "how much looking did this contract
+    // get?": a contract with one verdict and 199 inconclusive cases rendered
+    // byte-identically to one with 200 verdicts, and a contract last probed
+    // forty ticks ago was shown a count from a tick that never touched it.
+    let cases_row = format!(
+        r#"<div class="info-label" title="Cases run against THIS contract while it has been in the checked window. A verdict is a case that came back Holds or Violated; an inconclusive case established nothing, so a clean result resting mostly on those is barely a result.">Cases for this contract</div><div class="info-value">{verdicts} reached a verdict, {inconclusive} inconclusive</div>
+                    <div class="info-label" title="How long ago the merge-law checker last published a tick. It probes every 15 minutes when healthy.">Last checker tick</div><div class="info-value">{ago} ago</div>"#,
+        verdicts = record.verdicts,
+        inconclusive = record.inconclusive,
+        ago = format_duration(view.published_secs_ago),
+    );
 
-    if findings.is_empty() {
+    if record.findings.is_empty() {
         format!(
             r#"<div class="card">
                 <h2>Merge laws</h2>
                 <div class="info-grid">
                     <div class="info-label">Result</div><div class="info-value"><span class="fresh-pill fresh-ok">no violation found</span></div>
-                    <div class="info-label" title="How many cases the checker ran, fleet-wide, in its most recent tick — so a clean result here can be judged against how much looking actually happened.">Cases last tick</div><div class="info-value">{cases}</div>
+                    {cases_row}
                 </div>
                 <p class="empty" style="margin-top:0.75rem">No merge-law violation was found for this contract the last time it was checked.</p>
                 {note}
             </div>"#,
-            cases = merge_status.cases_last_tick,
+            cases_row = cases_row,
             note = note,
         )
     } else {
         let mut rows = String::new();
-        for f in &findings {
+        for f in &record.findings {
             let (pill_class, label) = match f.severity {
                 Severity::Violation => ("fresh-stale", "Violation — cannot converge"),
                 Severity::Diagnostic => ("use-idle", "Diagnostic — legal but wasteful"),
@@ -373,10 +396,14 @@ fn merge_law_card(
             r#"<div class="card">
                 <h2>Merge laws</h2>
                 <div class="table-wrap"><table><thead><tr><th>Property</th><th>Severity</th><th class="right">Would remove</th></tr></thead><tbody>{rows}</tbody></table></div>
+                <div class="info-grid" style="margin-top:0.75rem">
+                    {cases_row}
+                </div>
                 <p class="empty" style="margin-top:0.75rem"><strong>Violation</strong> means the contract cannot converge: peers holding it disagree and retry indefinitely. <strong>Diagnostic</strong> is legal but wasteful — it never justifies removal on its own.</p>
                 {note}
             </div>"#,
             rows = rows,
+            cases_row = cases_row,
             note = note,
         )
     }

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -350,7 +350,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     let mut note = String::new();
     if view.without_verdict_last_tick > 0 {
         note.push_str(&format!(
-            r#"<p class="empty" style="margin-top:0.5rem">In its most recent tick the checker judged {judged} contract(s) could not reach a verdict on {n} — most often because there was nothing yet to check (no samples collected for them, or no contract code on this node), and sometimes because every case it did try came back inconclusive. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
+            r#"<p class="empty" style="margin-top:0.5rem">In its most recent tick the checker judged {judged} contract(s) and could not reach a verdict on {n} — most often because there was nothing yet to check (no samples collected for them, or no contract code on this node), and sometimes because every case it did try came back inconclusive. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
             judged = view.judged_last_tick,
             n = view.without_verdict_last_tick,
         ));

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -358,7 +358,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     }
     if view.stale {
         note.push_str(&format!(
-            r#"<p class="empty" style="margin-top:0.5rem"><strong>The checker has not published for {ago}.</strong> It runs every 15 minutes when healthy, so everything on this card may be stale — a probe that died, a probe still running that blocks every later tick from starting, or a capture writer that is gone, each leaves the previous result standing with nothing else to say so. The node's log is where to look next.</p>"#,
+            r#"<p class="empty" style="margin-top:0.5rem"><strong>The checker has not published for {ago}.</strong> It runs every 15 minutes when healthy, so everything on this card may be stale — a probe that died, a probe still running (no later tick starts while one is in flight, and a probe that stalls outside contract code has no deadline of its own), or a capture writer that is gone, each leaves the previous result standing with nothing else to say so. The node's log is where to look next.</p>"#,
             ago = format_duration(view.published_secs_ago),
         ));
     }

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -318,13 +318,14 @@ pub fn contract_detail_html_from(
 /// warming-up peer `awaiting_samples` dominates outright, so the old wording
 /// described the least likely cause as though it were the only one.
 ///
-/// Every state that has a snapshot at all also renders WHEN the snapshot was
-/// published, and — for a contract with a record — when THAT CONTRACT was last
-/// checked, which is a different and usually much older number. The node-wide
-/// age is needed because `status::publish` is reached from two places in
-/// `capture::run_writer` and a probe task that panicked skips both, so without
-/// it a peer whose probe has been dead for a week keeps serving that week-old
-/// tick as a current result.
+/// Every state that has a snapshot at all — states 2, 3 and 4 — renders WHEN
+/// the snapshot was published, including the no-record state, where it is the
+/// only age there is. For a contract with a record it also renders when THAT
+/// CONTRACT was last checked, a different and usually much older number. The
+/// node-wide age is needed because a peer can stop publishing indefinitely
+/// while the old snapshot stands (a probe task that panicked, a probe that hangs
+/// so no later tick starts, a writer task that is gone), and without it that
+/// peer keeps serving a week-old tick as a current result.
 fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckView>) -> String {
     if !merge_enabled {
         return r#"<div class="card">
@@ -357,18 +358,28 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     }
     if view.stale {
         note.push_str(&format!(
-            r#"<p class="empty" style="margin-top:0.5rem"><strong>The checker has not published for {ago}.</strong> It runs every 15 minutes when healthy, so everything on this card may be stale — a probe that dies, or a tick that finds nothing to select, leaves the previous result standing with nothing else to say so.</p>"#,
+            r#"<p class="empty" style="margin-top:0.5rem"><strong>The checker has not published for {ago}.</strong> It runs every 15 minutes when healthy, so everything on this card may be stale — a probe that died, a probe still running that blocks every later tick from starting, or a capture writer that is gone, each leaves the previous result standing with nothing else to say so. The node's log is where to look next.</p>"#,
             ago = format_duration(view.published_secs_ago),
         ));
     }
 
     let Some(record) = view.contract.as_ref() else {
+        // The node-wide tick age is rendered HERE too, not only in the stale note.
+        // "Not checked recently" has two very different explanations — a busy checker
+        // that has not got round to this contract, and a checker that stopped — and
+        // without the age the page cannot tell them apart at all below the staleness
+        // threshold, which is where a checker that died fourteen minutes ago sits.
+        // There is no per-contract age to show, because there is no record.
         return format!(
             r#"<div class="card">
                 <h2>Merge laws</h2>
                 <p class="empty">This contract has not been checked recently. The checked window is bounded, so this is <strong>not</strong> a statement that the contract is fine — the checker has simply not looked at it lately.</p>
+                <div class="info-grid" style="margin-top:0.75rem">
+                    <div class="info-label" title="How long ago the merge-law checker last published a tick on this NODE — about any contract, not this one, which it has no record of. It probes every 15 minutes when healthy.">Last checker tick</div><div class="info-value">{ago} ago</div>
+                </div>
                 {note}
             </div>"#,
+            ago = format_duration(view.published_secs_ago),
             note = note,
         );
     };
@@ -405,7 +416,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
         ago = format_duration(view.published_secs_ago),
     );
 
-    if record.findings.is_empty() {
+    if record.findings().is_empty() {
         format!(
             r#"<div class="card">
                 <h2>Merge laws</h2>
@@ -421,7 +432,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
         )
     } else {
         let mut rows = String::new();
-        for f in &record.findings {
+        for f in record.findings() {
             let (pill_class, label) = match f.severity {
                 Severity::Violation => ("fresh-stale", "Violation — cannot converge"),
                 Severity::Diagnostic => ("use-idle", "Diagnostic — legal but wasteful"),

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -1,10 +1,12 @@
+use std::str::FromStr;
+
+use freenet_stdlib::prelude::ContractInstanceId;
+
 use super::assets::{CSS, JS, PEER_CSS};
 use super::cards::format_bytes;
 use super::*;
 use crate::conformance::property::Severity;
 use crate::conformance::status;
-use freenet_stdlib::prelude::ContractInstanceId;
-use std::str::FromStr;
 
 // ─── Contract detail page ────────────────────────────────────────────────────
 
@@ -476,4 +478,169 @@ fn abbreviate(key: &str) -> String {
     }
     let head: String = key.chars().take(12).collect();
     format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conformance::capture;
+    use crate::conformance::status::{CheckedContract, MergeFinding};
+
+    /// The law this page reports when it has one to report.
+    const PROPERTY: &str = "state_commutativity";
+
+    /// The wrapper's two reads of the process-global merge status — and the one
+    /// write anywhere in production that makes them mean anything.
+    ///
+    /// Every other test on this page drives [`contract_detail_html_from`], which
+    /// takes both values as parameters, so the tested surface is not the
+    /// production surface. [`contract_detail_html`] is what the HTTP route calls
+    /// and the only caller of `status::is_enabled` and `status::view_for`: a
+    /// refactor that dropped either read, or replaced it with a constant, changed
+    /// nothing any test could see. The same "the parameterized function is what's
+    /// tested, the wrapper is what runs" gap produced three blocking defects
+    /// earlier in this change.
+    ///
+    /// **One test rather than four, deliberately.** `status`'s `ENABLED` is a
+    /// `OnceLock` with no reset, so whichever test flips it decides what every
+    /// later test in the same process sees — and `cargo test` runs the lib tests
+    /// in ONE process while nextest (what CI runs) gives each its own. Split
+    /// across tests, the "off" assertions would be deterministic in CI and
+    /// order-dependent locally, which is the worst of both. Sequenced inside a
+    /// single test, both halves are deterministic under either runner.
+    ///
+    /// This is therefore the ONLY place in the crate that reaches
+    /// `status::mark_enabled`, directly or through [`capture::start`]. The
+    /// pre-condition is asserted rather than assumed so that a second enabler
+    /// added later fails HERE, with an explanation, instead of quietly making the
+    /// "off" half of this test unable to fail.
+    ///
+    /// It doubles as the coverage for `capture::start`'s `mark_enabled()` call
+    /// and for that call's POSITION. `start` must never claim checking is on for
+    /// a capture that then failed to start, so the flag is checked after each of
+    /// `start`'s two failure paths (no tokio runtime, unusable directory) as well
+    /// as after the success path.
+    #[tokio::test]
+    async fn the_page_reports_what_the_status_global_says_and_capture_start_sets_it() {
+        assert!(
+            !status::is_enabled(),
+            "merge-check status was already enabled before this test enabled it, so \
+             something else in this test binary now reaches status::mark_enabled(). \
+             The 'checking is off' half of this test can no longer fail; either make \
+             that other test stop enabling the process-global, or fold its case in \
+             here — do not delete this assertion"
+        );
+
+        let checked = ContractInstanceId::new([0x5a; 32]);
+        let unchecked = ContractInstanceId::new([0x17; 32]);
+        let mut record = CheckedContract::new(checked, 7, 2, tokio::time::Instant::now());
+        record.note_finding(MergeFinding {
+            contract: checked,
+            property: PROPERTY,
+            severity: Severity::Violation,
+            would_remove: false,
+        });
+        status::publish([record], 1, 0, tokio::time::Instant::now());
+
+        // No node is running, so `network_status::get_snapshot()` is `None` and
+        // this contract has no subscription, no hosted copy and no governance
+        // record. The published merge record is the ONLY thing that can keep the
+        // page off the "this node knows nothing about it" branch — so rendering
+        // anything else is proof the wrapper fetched it.
+        let html = contract_detail_html(&checked.to_string());
+        assert!(
+            !html.contains("Contract Not Found"),
+            "the page rendered as 'this node knows nothing about it' for a contract \
+             with a published merge-law record, so the wrapper is not reading \
+             status::view_for — got:\n{html}"
+        );
+        assert!(
+            html.contains("not enabled on this node"),
+            "checking is off in this process and the card did not say so, so the \
+             wrapper is not reading status::is_enabled — got:\n{html}"
+        );
+        assert!(
+            !html.contains(PROPERTY),
+            "the card reported a finding while checking is off. A count or a finding \
+             shown here reads as a measured result rather than as unmeasured, which \
+             is the conflation conformance::status exists to prevent — got:\n{html}"
+        );
+
+        // …and the lookup uses the REQUESTED key, not merely "some record was
+        // published". A contract outside the window still gets the absence page.
+        let other = contract_detail_html(&unchecked.to_string());
+        assert!(
+            other.contains("Contract Not Found"),
+            "a contract with no record of any kind rendered a detail page, so the \
+             wrapper is not passing the requested key to status::view_for — \
+             got:\n{other}"
+        );
+
+        // ── capture::start is what turns the flag on, and only once it cannot fail ──
+
+        let root = tempfile::TempDir::new().expect("tempdir");
+
+        // Failure path 1: no tokio runtime, so there is nothing to spawn the
+        // writer on and `start` refuses before doing anything else.
+        let no_runtime_dir = root.path().join("no-runtime");
+        let refused = std::thread::spawn({
+            let dir = no_runtime_dir.clone();
+            move || capture::start(dir)
+        })
+        .join()
+        .expect("the thread that called capture::start panicked");
+        assert!(
+            refused.is_err(),
+            "capture::start must refuse outside a tokio runtime rather than start a \
+             writer that can never run"
+        );
+        assert!(
+            !status::is_enabled(),
+            "capture::start marked checking enabled from a thread with no tokio \
+             runtime, where it had already refused to start. mark_enabled() must \
+             stay AFTER the runtime check — the dashboard would otherwise report a \
+             capture that is not running"
+        );
+
+        // Failure path 2: inside a runtime, but the directory cannot be created —
+        // its parent is a regular file.
+        let blocker = root.path().join("not-a-directory");
+        std::fs::write(&blocker, b"a file where a directory would have to be").expect("write");
+        assert!(
+            capture::start(blocker.join("capture")).is_err(),
+            "capture::start must fail when its directory cannot be created"
+        );
+        assert!(
+            !status::is_enabled(),
+            "capture::start marked checking enabled after create_dir_all failed. \
+             mark_enabled() must stay AFTER the fallible directory creation, or the \
+             dashboard reports a capture that never started"
+        );
+
+        // The success path.
+        let _handle = capture::start(root.path().join("capture"))
+            .expect("capture must start against a fresh temp directory inside a runtime");
+        assert!(
+            status::is_enabled(),
+            "capture::start did not mark the dashboard status enabled, so every \
+             render before the checker's first tick says 'not enabled' for a node \
+             that IS checking — absence and success must not look alike"
+        );
+
+        // Same contract, same published record, flag now on: the card must switch
+        // from "not enabled" to the finding it has been holding all along.
+        let enabled_html = contract_detail_html(&checked.to_string());
+        assert!(
+            !enabled_html.contains("not enabled on this node"),
+            "the card still said checking is off after capture::start enabled it, so \
+             the wrapper is not reading status::is_enabled — got:\n{enabled_html}"
+        );
+        assert_eq!(
+            enabled_html.matches(PROPERTY).count(),
+            1,
+            "the card did not render the one finding on the published record, so the \
+             wrapper's status::view_for result is not reaching the renderer — \
+             got:\n{enabled_html}"
+        );
+    }
 }

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -1,6 +1,10 @@
 use super::assets::{CSS, JS, PEER_CSS};
 use super::cards::format_bytes;
 use super::*;
+use crate::conformance::property::Severity;
+use crate::conformance::status;
+use freenet_stdlib::prelude::ContractInstanceId;
+use std::str::FromStr;
 
 // ─── Contract detail page ────────────────────────────────────────────────────
 
@@ -28,7 +32,18 @@ use super::*;
 /// scope cut; this page says plainly that the counts are missing rather than
 /// implying the ranking is visible.
 pub fn contract_detail_html(key_str: &str) -> String {
-    contract_detail_html_from(&network_status::get_snapshot(), key_str)
+    // Two separate reads, deliberately not collapsed into one: `is_enabled()`
+    // and `snapshot()` answer different questions, and can disagree during
+    // the checker's very first interval — enabled, but nothing published
+    // yet. That state must render as "not checked recently", not as "off",
+    // so both flow into the pure renderer below rather than being merged
+    // here into a single bool.
+    contract_detail_html_from(
+        &network_status::get_snapshot(),
+        key_str,
+        status::is_enabled(),
+        status::snapshot().as_ref(),
+    )
 }
 
 /// The page as a pure function of the snapshot.
@@ -37,11 +52,16 @@ pub fn contract_detail_html(key_str: &str) -> String {
 /// how every `cards.rs` builder is already shaped (`build_peers_card` takes
 /// `&Option<NetworkStatusSnapshot>`). Reading the global directly would have
 /// made the interesting cases — a hosted-only contract, one the governance
-/// manager has flagged — reachable only by standing up a node and waiting for
-/// it to reach that state.
+/// manager has flagged, one the merge-law checker has or hasn't looked at —
+/// reachable only by standing up a node and waiting for it to reach that
+/// state. `merge_enabled` and `merge_status` are the wrapper's two reads of
+/// `conformance::status` (see the doc comment at the call site above for why
+/// they stay separate parameters).
 pub fn contract_detail_html_from(
     snap: &Option<network_status::NetworkStatusSnapshot>,
     key_str: &str,
+    merge_enabled: bool,
+    merge_status: Option<&status::MergeCheckStatus>,
 ) -> String {
     // Match on the full key OR the instance id, so a link from any card works
     // and so an operator can paste either form.
@@ -223,6 +243,15 @@ pub fn contract_detail_html_from(
             .to_string(),
     };
 
+    // `ContractKey`'s `Display` and `ContractInstanceId`'s `Display` produce
+    // the same string (see the comment on the `governance` lookup above), so
+    // `key_str` — whichever form the operator pasted — is always a valid
+    // instance id to query the merge-check status by, when it parses at all.
+    // A key from a URL path can be anything, so a parse failure here means
+    // "not a real instance id" and must render as "not checked", never panic.
+    let merge_id = ContractInstanceId::from_str(key_str).ok();
+    let merge_card = merge_law_card(merge_enabled, merge_status, merge_id.as_ref());
+
     format!(
         include_str!("assets/contract.html"),
         CSS = CSS,
@@ -233,8 +262,124 @@ pub fn contract_detail_html_from(
         identity = identity_card,
         subscription = subscription_card,
         hosting = hosting_card,
+        merge = merge_card,
         governance = governance_card,
     )
+}
+
+/// The "Merge laws" card: what `conformance::status` — the shadow merge-law
+/// checker's published snapshot — has established about THIS contract.
+///
+/// Four states, and getting them right without conflating any two of them is
+/// the entire point of the card (see `conformance::status`'s module doc for
+/// the production incident this is guarding against: an unjudgeable contract
+/// rendering identically to a clean one). In order of how alarming they are
+/// NOT:
+///
+/// 1. Checking isn't running on this node at all (`!merge_enabled`) — no
+///    counts are shown, because a zero here would read as "clean" rather
+///    than "unmeasured".
+/// 2. Checking is running, but this contract is outside the bounded recently-
+///    checked window (or the checker hasn't published its first tick yet) —
+///    explicitly NOT reported as fine.
+/// 3. Checked, no findings for this contract.
+/// 4. Checked, with one or more findings, each carrying the property that
+///    broke, its severity, and whether enforcement would remove it.
+///
+/// `contracts_without_verdict` — contracts the checker looked at but could
+/// reach no verdict on for any case — is surfaced whenever non-zero,
+/// independent of which of states 2-4 this particular contract is in: it is
+/// fleet-wide information the operator needs regardless of this contract's
+/// own status.
+fn merge_law_card(
+    merge_enabled: bool,
+    merge_status: Option<&status::MergeCheckStatus>,
+    merge_id: Option<&ContractInstanceId>,
+) -> String {
+    // Fleet-wide "some contracts could not be judged at all" note. Shown
+    // whenever the checker has published a tick and the count is non-zero,
+    // regardless of this contract's own state — see the doc comment above.
+    let unjudged_note = |s: &status::MergeCheckStatus| -> String {
+        if s.contracts_without_verdict == 0 {
+            String::new()
+        } else {
+            format!(
+                r#"<p class="empty" style="margin-top:0.5rem">The checker could not reach a verdict on {n} contract(s) on this node — every case it tried was inconclusive, or related state exceeded its budget. Those contracts are neither clean nor flagged; they simply were not judged.</p>"#,
+                n = s.contracts_without_verdict,
+            )
+        }
+    };
+
+    if !merge_enabled {
+        return r#"<div class="card">
+                <h2>Merge laws</h2>
+                <p class="empty">Merge-law checking is not enabled on this node — that is the default. No merge-law information is available here, which is not the same as this contract being clean.</p>
+            </div>"#
+            .to_string();
+    }
+
+    let was_checked = match (merge_status, merge_id) {
+        (Some(s), Some(id)) => s.was_checked(id),
+        _ => false,
+    };
+
+    if !was_checked {
+        let note = merge_status.map(unjudged_note).unwrap_or_default();
+        return format!(
+            r#"<div class="card">
+                <h2>Merge laws</h2>
+                <p class="empty">This contract has not been checked recently. The checked window is bounded, so this is <strong>not</strong> a statement that the contract is fine — the checker has simply not looked at it lately.</p>
+                {note}
+            </div>"#,
+            note = note,
+        );
+    }
+
+    // `was_checked` only returns `true` when both are `Some` (see the match
+    // above), so these cannot fail.
+    let merge_status = merge_status.expect("was_checked implies a published status");
+    let merge_id = merge_id.expect("was_checked implies a parsed contract id");
+    let findings: Vec<&status::MergeFinding> = merge_status.findings_for(merge_id).collect();
+    let note = unjudged_note(merge_status);
+
+    if findings.is_empty() {
+        format!(
+            r#"<div class="card">
+                <h2>Merge laws</h2>
+                <div class="info-grid">
+                    <div class="info-label">Result</div><div class="info-value"><span class="fresh-pill fresh-ok">no violation found</span></div>
+                    <div class="info-label" title="How many cases the checker ran, fleet-wide, in its most recent tick — so a clean result here can be judged against how much looking actually happened.">Cases last tick</div><div class="info-value">{cases}</div>
+                </div>
+                <p class="empty" style="margin-top:0.75rem">No merge-law violation was found for this contract the last time it was checked.</p>
+                {note}
+            </div>"#,
+            cases = merge_status.cases_last_tick,
+            note = note,
+        )
+    } else {
+        let mut rows = String::new();
+        for f in &findings {
+            let (pill_class, label) = match f.severity {
+                Severity::Violation => ("fresh-stale", "Violation — cannot converge"),
+                Severity::Diagnostic => ("use-idle", "Diagnostic — legal but wasteful"),
+            };
+            rows.push_str(&format!(
+                r#"<tr><td>{property}</td><td><span class="fresh-pill {pill_class}">{label}</span></td><td class="right">{would_remove}</td></tr>"#,
+                property = html_escape(f.property),
+                would_remove = if f.would_remove { "yes" } else { "no" },
+            ));
+        }
+        format!(
+            r#"<div class="card">
+                <h2>Merge laws</h2>
+                <div class="table-wrap"><table><thead><tr><th>Property</th><th>Severity</th><th class="right">Would remove</th></tr></thead><tbody>{rows}</tbody></table></div>
+                <p class="empty" style="margin-top:0.75rem"><strong>Violation</strong> means the contract cannot converge: peers holding it disagree and retry indefinitely. <strong>Diagnostic</strong> is legal but wasteful — it never justifies removal on its own.</p>
+                {note}
+            </div>"#,
+            rows = rows,
+            note = note,
+        )
+    }
 }
 
 /// Governance transitions shown on the detail page.


### PR DESCRIPTION
## Problem

Everything the merge-law checker knows lives in the capture writer task and reaches the outside world only as `tracing` output. Those logs rotate hourly, and the lines aren't enumerated event kinds so they never reach the telemetry collector either. **The one place an operator would look shows nothing.**

That matters more than a missing view usually would, and Ian's framing is why: *users need visibility before deletion is automatic.* The RFC's gate for enabling removal requires that every prospective deletion "has been understood" — a statement about what a human has been able to inspect. If the only route to that is grepping a peer's logs before they rotate, the gate is argued from evidence most operators can't reach, and an operator whose contract is about to be deleted has no way to find out why, or to disagree, before it happens.

## Approach

A snapshot the shadow loop publishes after each tick, from the **same numbers the tick log reports**, so the dashboard and the log cannot disagree. Not a provider closure like `ring_stats` — the checker's state lives in a task, so there is nothing to read on demand; the task has to push.

Three deliberate choices:

- **`Option`, not a zeroed default.** "Not enabled on this node" and "nothing found" must not render alike. `mark_enabled` is set when capture starts, so the first interval reads as "on, nothing yet".
- **`contracts_without_verdict` is carried, not inferred.** An unjudgeable contract renders identically to a clean one; a panel showing only "0 violations" would be actively misleading. On the live capture peer **17% of hosted contracts could not be judged at all** and nothing said so.
- **Deduplicated on (contract, property), capped at 64.** Collapsing on contract alone would hide that a contract breaks more than one law; no cap would let a peer hosting many broken contracts grow this without bound.

## Rendering is deliberately separate

This publishes; nothing displays it yet. The per-contract page (#5387) landed today and is the natural home, but presentation is a design call on someone else's surface and there's active dashboard work in flight. Splitting it keeps this reviewable on its own terms.

## Testing

The fold logic lives on `MergeCheckStatus::record` rather than inside `publish`, so it's testable without the process-global.

The first version tested *through* the global and the tests interfered with each other — one test's findings appeared in another's assertions. That's the failure `.claude/rules/testing.md` describes, and per-process isolation would have hidden it rather than prevented it.

Refs #5397, #5320

[AI-assisted - Claude]