### PR TITLE
feat: make log directory byte budget configurable via FREENET_LOG_DIR_MAX_BYTES

### DIFF
--- a/crates/core/src/tracing/tracer.rs
+++ b/crates/core/src/tracing/tracer.rs
@@ -1561,6 +1561,102 @@ mod cleanup_tests {
         assert_eq!(parse_log_dir_max_bytes(Some("1")), LOG_DIR_MAX_BYTES);
     }
 
+    /// Bound `include_str!`-scraped source to one free function's body, so a
+    /// source-scrape pin can never silently widen to the whole file or match
+    /// itself. Copied from `bin/commands/auto_update.rs::fn_body` (see its
+    /// doc for the incident history motivating each check below) rather than
+    /// shared, since this file has no existing dependency on that module.
+    fn fn_body<'a>(src: &'a str, signature: &str) -> &'a str {
+        let at = src
+            .find(signature)
+            .unwrap_or_else(|| panic!("definition not found: {signature}"));
+        // Only valid for FREE functions at column 0 — a method's closing
+        // brace is indented, so the first `\n}\n` after it belongs to the
+        // enclosing `impl`, silently returning every sibling method too.
+        let tests_at = src
+            .find("\n#[cfg(test)]\nmod ")
+            .map(|i| i + 1)
+            .expect("test module not located — this guard cannot verify anything");
+        assert!(
+            at < tests_at,
+            "`{signature}` matched inside the test module — this pin is \
+             scraping its own source and would pass vacuously"
+        );
+        assert!(
+            at == 0 || src.as_bytes()[at - 1] == b'\n',
+            "fn_body only supports column-0 free functions; `{signature}` is \
+             indented (a method?), where the `\\n}}\\n` end-anchor would slice to \
+             the end of the enclosing impl instead"
+        );
+        let after = &src[at + signature.len()..];
+        let (body, _) = after
+            .split_once("\n}\n")
+            .unwrap_or_else(|| panic!("could not locate end of: {signature}"));
+        // Vacuity detector: a correctly-bounded function body can never
+        // contain the test-module attribute. If it does, the `\n}\n` search
+        // ran past the function and this pin is measuring the whole file.
+        assert!(
+            !body.contains("\n#[cfg(test)]\nmod "),
+            "scoped region for `{signature}` escaped into the test module — this \
+             pin would pass vacuously"
+        );
+        body
+    }
+
+    /// Pin that `cleanup_old_logs` actually wires the parsed
+    /// `FREENET_LOG_DIR_MAX_BYTES` override into `prune_log_files`, rather
+    /// than computing it and discarding it in favor of the hardcoded
+    /// `LOG_DIR_MAX_BYTES` constant.
+    ///
+    /// None of the `log_dir_max_bytes_*` tests above can catch this class of
+    /// regression: they call `parse_log_dir_max_bytes` directly and stay
+    /// green even if nothing in production ever calls it — a well-tested
+    /// function wired to nothing, the same shape
+    /// `init_tracer_wires_every_error_layer_through_build_error_filter`
+    /// (`error_filter_tests`, this file) already guards against for the
+    /// error-filter wiring. Verified against a live mutation of the call
+    /// site (`let max_bytes = LOG_DIR_MAX_BYTES;`), which this pin catches
+    /// and the runtime tests above do not — see the PR description for
+    /// issue #5021.
+    ///
+    /// Source-scrape rather than a runtime assertion because reaching this
+    /// call site behaviourally would mean mutating
+    /// `FREENET_LOG_DIR_MAX_BYTES` in the process environment from a test,
+    /// exactly the cross-test interference `.claude/rules/testing.md` and
+    /// `parse_log_dir_max_bytes`'s own doc warn against.
+    #[test]
+    fn cleanup_old_logs_wires_the_parsed_budget_into_prune_log_files() {
+        let body = fn_body(
+            include_str!("tracer.rs"),
+            "fn cleanup_old_logs(log_dir: &std::path::Path) {",
+        );
+
+        // Anchor on the call itself — the API surface that must be
+        // reached — not on the local variable it's assigned to, which a
+        // harmless rename should not be able to break this pin.
+        let calls = body
+            .matches("parse_log_dir_max_bytes(log_dir_max_bytes_env().as_deref())")
+            .count();
+        assert_eq!(
+            calls, 1,
+            "cleanup_old_logs must call parse_log_dir_max_bytes(log_dir_max_bytes_env()...) \
+             exactly once to resolve the byte budget; if the call was renamed or removed, \
+             update this pin deliberately"
+        );
+
+        // And the parsed value — not a hardcoded default sitting next to
+        // it — must be what reaches prune_log_files. LOG_DIR_MAX_BYTES is
+        // a stable named constant (itself pinned elsewhere in this file),
+        // not a local variable subject to casual renaming, so anchoring
+        // the negative check on it doesn't share that fragility.
+        assert!(
+            !body.contains("prune_log_files(files, cutoff, LOG_DIR_MAX_BYTES)"),
+            "prune_log_files must never be called with the hardcoded LOG_DIR_MAX_BYTES \
+             constant directly — that would silently disconnect \
+             FREENET_LOG_DIR_MAX_BYTES from the pruner"
+        );
+    }
+
     /// The size cap must engage exactly at the budget boundary.
     /// Clock-free: exercises the pure size math, so it asserts the
     /// boundary regardless of how large the budget is. `budget + 1` total

--- a/crates/core/src/tracing/tracer.rs
+++ b/crates/core/src/tracing/tracer.rs
@@ -49,7 +49,35 @@ use tracing_subscriber::{Layer, Registry};
 /// on the background prune loop spawned by `init_tracer` (issue #4699),
 /// so a long-uptime node under sustained runaway logging is bounded
 /// without needing a restart.
+///
+/// **This default is overridable at runtime via `FREENET_LOG_DIR_MAX_BYTES`**
+/// (issue #5021), because one compiled-in value has to serve both the
+/// gateway shape this default is sized for and a quiet background peer
+/// that may want to hand back disk, or widen the budget while chasing an
+/// intermittent fault, without rebuilding. See [`parse_log_dir_max_bytes`]
+/// for the fallback behaviour on a missing or unusable override, and
+/// [`MIN_LOG_DIR_MAX_BYTES`] for why an override cannot go arbitrarily low.
 const LOG_DIR_MAX_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB
+
+/// The smallest `FREENET_LOG_DIR_MAX_BYTES` override [`parse_log_dir_max_bytes`]
+/// will honour; anything below this falls back to [`LOG_DIR_MAX_BYTES`].
+///
+/// Exists for the same reason the compiled-in default cannot go arbitrarily
+/// low (see its doc): the size pass never deletes a file an appender has
+/// open, so a budget the two current-hour files (main + error) can fill on
+/// their own leaves *only* those files, discarding exactly the onset of
+/// whatever incident prompted the investigation (issue #5019, item 3).
+///
+/// Sized well above every observed hourly rate rather than just above it:
+/// the busiest measured gateway ran at ~20.95 MB/hour pre-#5015 and ~10.8
+/// MB/hour after (see `default_budget_holds_a_day_of_a_busy_gateways_logs`
+/// below for the measurement), combined across both families. 64 MiB is
+/// roughly 3x the worse of those two rates, so even a node logging far
+/// above anything measured so far keeps more than an hour of history
+/// before this floor would start discarding the incident onset — while
+/// still letting an operator shrink the 512 MiB default meaningfully for
+/// a quiet peer that never approaches it.
+const MIN_LOG_DIR_MAX_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
 /// Absolute age after which a rotated log file is deleted regardless of
 /// how little disk it occupies.
@@ -167,6 +195,61 @@ struct LogFile {
     family: LogFamily,
 }
 
+/// `FREENET_LOG_DIR_MAX_BYTES`'s raw value, or `None` if unset.
+///
+/// Split from [`parse_log_dir_max_bytes`] for the same reason as
+/// [`error_log_directives`]: keeps the parsing logic a pure function of
+/// its input, so it can be unit-tested without mutating process-global
+/// environment state (see the "Cross-test interference" entry in
+/// `.claude/rules/testing.md` — env vars are exactly that kind of state).
+fn log_dir_max_bytes_env() -> Option<String> {
+    std::env::var("FREENET_LOG_DIR_MAX_BYTES").ok()
+}
+
+/// Resolve the log directory's byte budget from `FREENET_LOG_DIR_MAX_BYTES`'s
+/// raw value, falling back to [`LOG_DIR_MAX_BYTES`] whenever the override
+/// isn't a usable one (issue #5021).
+///
+/// Degrade-safe by construction, never panics and never refuses to prune:
+/// - absent or empty → default, silently (nothing was configured)
+/// - unparseable → default, with a warning (something was configured wrong)
+/// - below [`MIN_LOG_DIR_MAX_BYTES`] (including `0`) → default, with a
+///   warning — see that constant's doc for why a tiny budget is as
+///   destructive as refusing to boot: a value of `0` would mean "delete
+///   everything the size pass may delete", and small-but-nonzero values are
+///   barely better.
+///
+/// A misconfigured value must never stop the node from starting or from
+/// pruning at all — a node that refuses to boot over a typo'd env var is
+/// worse than one that ignores it, which is why this warns and falls back
+/// rather than propagating an error.
+fn parse_log_dir_max_bytes(raw: Option<&str>) -> u64 {
+    match raw {
+        None => LOG_DIR_MAX_BYTES,
+        Some("") => LOG_DIR_MAX_BYTES,
+        Some(raw) => match raw.parse::<u64>() {
+            Ok(bytes) if bytes >= MIN_LOG_DIR_MAX_BYTES => bytes,
+            Ok(bytes) => {
+                eprintln!(
+                    "Warning: FREENET_LOG_DIR_MAX_BYTES={bytes} is below the minimum of \
+                     {MIN_LOG_DIR_MAX_BYTES} bytes; using the default of {LOG_DIR_MAX_BYTES} \
+                     bytes instead. A budget this small can be filled entirely by the current \
+                     hour's open log files, which are never pruned, discarding exactly the \
+                     incident history logging exists to keep."
+                );
+                LOG_DIR_MAX_BYTES
+            }
+            Err(_) => {
+                eprintln!(
+                    "Warning: FREENET_LOG_DIR_MAX_BYTES={raw:?} is not a valid byte count; \
+                     using the default of {LOG_DIR_MAX_BYTES} bytes instead."
+                );
+                LOG_DIR_MAX_BYTES
+            }
+        },
+    }
+}
+
 /// Prune the log directory. The single pruning authority for the two
 /// rolling appenders (see the `max_log_files` note in `init_tracer`).
 ///
@@ -177,6 +260,7 @@ fn cleanup_old_logs(log_dir: &std::path::Path) {
 
     let retention = Duration::from_secs(LOG_RETENTION_HOURS * 3600);
     let cutoff = SystemTime::now() - retention;
+    let max_bytes = parse_log_dir_max_bytes(log_dir_max_bytes_env().as_deref());
 
     let Ok(entries) = std::fs::read_dir(log_dir) else {
         return;
@@ -208,7 +292,7 @@ fn cleanup_old_logs(log_dir: &std::path::Path) {
         });
     }
 
-    prune_log_files(files, cutoff, LOG_DIR_MAX_BYTES);
+    prune_log_files(files, cutoff, max_bytes);
 }
 
 /// The indices, in a `files` sorted ascending by `(modified, path)`, of
@@ -1173,8 +1257,9 @@ mod error_filter_tests {
 #[cfg(test)]
 mod cleanup_tests {
     use super::{
-        LOG_DIR_MAX_BYTES, LogFamily, LogFile, cleanup_old_logs, live_file_indices,
-        periodic_log_prune, prune_log_files, rotating_log_family,
+        LOG_DIR_MAX_BYTES, LogFamily, LogFile, MIN_LOG_DIR_MAX_BYTES, cleanup_old_logs,
+        live_file_indices, parse_log_dir_max_bytes, periodic_log_prune, prune_log_files,
+        rotating_log_family,
     };
     use std::fs;
     use std::time::{Duration, SystemTime};
@@ -1409,6 +1494,71 @@ mod cleanup_tests {
              {GATEWAY_BYTES_PER_HOUR} B/h; an overnight incident must still \
              be on disk in the morning"
         );
+    }
+
+    /// No override configured → the compiled-in default, unchanged.
+    #[test]
+    fn log_dir_max_bytes_default_when_env_absent() {
+        assert_eq!(parse_log_dir_max_bytes(None), LOG_DIR_MAX_BYTES);
+    }
+
+    /// An explicitly-empty value is treated the same as absent, not as
+    /// garbage — some deploy tooling sets `VAR=` to mean "unset" rather
+    /// than omitting the variable.
+    #[test]
+    fn log_dir_max_bytes_default_when_env_empty() {
+        assert_eq!(parse_log_dir_max_bytes(Some("")), LOG_DIR_MAX_BYTES);
+    }
+
+    /// A valid override at or above the floor is honoured exactly,
+    /// whether it narrows the default (small background peer) or widens
+    /// it (chasing an intermittent fault on a busy node).
+    #[test]
+    fn log_dir_max_bytes_honours_a_valid_override() {
+        assert_eq!(
+            parse_log_dir_max_bytes(Some(&MIN_LOG_DIR_MAX_BYTES.to_string())),
+            MIN_LOG_DIR_MAX_BYTES,
+            "the floor itself must be accepted, not rejected as \"below\" it"
+        );
+        assert_eq!(
+            parse_log_dir_max_bytes(Some("1073741824")), // 1 GiB, above the default
+            1_073_741_824,
+        );
+    }
+
+    /// Unparseable garbage falls back to the default rather than
+    /// panicking or propagating an error — a typo in the env var must
+    /// not stop the node from booting or from pruning.
+    #[test]
+    fn log_dir_max_bytes_default_when_env_garbage() {
+        for garbage in ["not-a-number", "512MiB", "-1", "1.5", "0x200"] {
+            assert_eq!(
+                parse_log_dir_max_bytes(Some(garbage)),
+                LOG_DIR_MAX_BYTES,
+                "garbage value {garbage:?} must fall back to the default"
+            );
+        }
+    }
+
+    /// `0` is the sharpest form of the footgun `MIN_LOG_DIR_MAX_BYTES`
+    /// guards against — it would mean "delete everything the size pass
+    /// may delete" — and must fall back to the default, not be honoured
+    /// literally.
+    #[test]
+    fn log_dir_max_bytes_default_when_env_zero() {
+        assert_eq!(parse_log_dir_max_bytes(Some("0")), LOG_DIR_MAX_BYTES);
+    }
+
+    /// A small-but-nonzero value below the floor is just as destructive
+    /// as zero (issue #5019 item 3: the current-hour files alone can fill
+    /// it) and must also fall back to the default.
+    #[test]
+    fn log_dir_max_bytes_default_when_env_below_floor() {
+        assert_eq!(
+            parse_log_dir_max_bytes(Some(&(MIN_LOG_DIR_MAX_BYTES - 1).to_string())),
+            LOG_DIR_MAX_BYTES
+        );
+        assert_eq!(parse_log_dir_max_bytes(Some("1")), LOG_DIR_MAX_BYTES);
     }
 
     /// The size cap must engage exactly at the budget boundary.


### PR DESCRIPTION
## Problem

`LOG_DIR_MAX_BYTES` (`crates/core/src/tracing/tracer.rs`) was a compile-time `const`, so an operator could not tune log retention without rebuilding the binary. The 512 MiB default is sized for a busy gateway; a quiet background peer never approaches it but may still want to hand back disk, and someone chasing an intermittent fault may want to widen it temporarily.

## Approach

Adds `FREENET_LOG_DIR_MAX_BYTES`, read at prune time (startup plus the hourly background sweep), following the `FREENET_LOG_RATE_LIMIT` precedent already in the same file rather than inventing a new configuration mechanism.

The parsing is split into a pure `parse_log_dir_max_bytes(Option<&str>) -> u64` separate from the `std::env::var` lookup. That is deliberate: env vars are process-global and Rust runs tests as threads within one process, so a test that mutates the real variable interferes with every other test in the binary. Keeping the logic pure makes it directly testable with no global state touched.

**Format:** a bare integer byte count (e.g. `FREENET_LOG_DIR_MAX_BYTES=67108864`), matching the existing `FREENET_LOG_RATE_LIMIT` convention in this file. Suffixed forms like `32MB` or `64MiB` are not accepted — `parse::<u64>()` rejects them and falls back to the 512 MiB default (with a warning), which is the *opposite* of an operator's intent if they were trying to shrink the budget. This is consistent house style rather than a defect, but worth calling out explicitly for anyone reaching for this var.

**Degrade-safe by construction.** Absent, empty, unparseable, zero, or below-floor values all fall back to the compiled default — with a warning for the last three, so a misconfiguration is diagnosable rather than silent. A typo'd env var can never stop the node booting or pruning; a node that refuses to start over a bad env var is worse than one that ignores it.

**Why there is a floor.** `MIN_LOG_DIR_MAX_BYTES` (64 MiB) guards the footgun in #5019 item 3: the size pass never deletes a file an appender currently has open, so a budget the two current-hour files can fill on their own leaves *only* those files — discarding exactly the incident onset the logs exist to explain. 64 MiB is roughly 3x the busiest measured gateway rate, while still letting an operator meaningfully shrink the 512 MiB default on a quiet peer.

**Note on the background sweep:** it re-reads the env var every hour, but that does *not* let an operator retune a running node — a process's environment is fixed at exec time. The re-read is harmless (same value every time within one process lifetime); it exists only because `cleanup_old_logs` is a single function shared by the startup call and the periodic sweep, not as a live-reconfiguration mechanism.

## Testing

Six unit tests over the pure parser, covering each fallback path and the honoured-override case: absent, empty, valid override, garbage, zero, and below-floor. None mutates the process environment.

A seventh test, `cleanup_old_logs_wires_the_parsed_budget_into_prune_log_files`, pins that the parsed value actually reaches `prune_log_files` rather than the parser being correct in isolation while nothing calls it. This was a real gap caught in review: mutating the call site to `let max_bytes = LOG_DIR_MAX_BYTES;` (silently disconnecting the env var) left all six parser tests passing. The new pin is a source-scrape following this file's existing `init_tracer_wires_every_error_layer_through_build_error_filter` precedent, bounded to `cleanup_old_logs`'s function body via a ported `fn_body` helper so it can't self-match or silently widen to the whole file. Verified: reproduced that exact mutation and confirmed only the new pin goes red (34 passed, 1 failed); reverted and confirmed all 35 tests pass.

Closes #5021

[AI-assisted - Claude]
