### PR TITLE
feat(conformance): compare the delta path against the merge path

### DIFF
--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -127,7 +127,8 @@ pub use minimize::{MinimizeConfig, MinimizeReport, minimize};
 pub use oracle::{ConformanceOracle, OracleError, OracleErrorKind};
 pub use policy::{ConformanceAction, EnforcementMode, decide};
 pub use property::{
-    ConformanceProperty, Inconclusive, OutputDigest, PropertyOutcome, Severity, Violation,
+    ConformanceProperty, Inconclusive, OutputDigest, PremiseSource, PropertyOutcome, Severity,
+    Violation,
 };
 pub use runtime_oracle::{OracleBuildError, RuntimeOracle};
 pub use sampler::{Admission, ContractSampler, SamplerConfig, Stratum};

--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -118,7 +118,7 @@ mod tests;
 #[cfg(test)]
 mod wasm_tests;
 
-pub use bundle::ReplayBundle;
+pub use bundle::{ReplayBundle, Transition};
 pub use capture::{CaptureHandle, Observation};
 pub use evidence::{ConformanceEvidence, EVIDENCE_SCHEMA_VERSION, EvidenceId, EvidenceRejected};
 pub use focus::FocusSelector;

--- a/crates/core/src/conformance/bundle.rs
+++ b/crates/core/src/conformance/bundle.rs
@@ -244,10 +244,19 @@ impl ReplayBundle {
             .iter()
             .map(|s| Arc::from(s.as_slice()))
             .collect();
+        let mut steps: Vec<(Bytes, Bytes)> = Vec::with_capacity(self.transitions.len());
 
         for transition in &self.transitions {
             states.push(Arc::from(transition.base_state.as_slice()));
             states.push(Arc::from(transition.result_state.as_slice()));
+            // The ORDERED step, kept alongside the two loose states. Only this
+            // carries the fact that `result` was reached from `base`, which is what
+            // `TransitionPathAgreement` is a law about; the loose states alone
+            // cannot support the question.
+            steps.push((
+                Arc::from(transition.base_state.as_slice()),
+                Arc::from(transition.result_state.as_slice()),
+            ));
             if let Some(state) = &transition.incoming_state {
                 states.push(Arc::from(state.as_slice()));
             }
@@ -277,6 +286,7 @@ impl ReplayBundle {
             states,
             deltas,
             summaries,
+            transitions: steps,
             related: freenet_stdlib::prelude::RelatedContracts::from(related),
         }
         .deduplicated()

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -1930,9 +1930,28 @@ mod doc_attachment_pin {
 
 #[cfg(test)]
 mod contract_store_registration_pin {
-    /// Slice `get_runtime_stores`' body, from its signature to the next item. A
-    /// missing anchor panics rather than silently widening the region to the rest of
-    /// the file, which is how a source pin quietly stops testing anything.
+    /// Strip whole-line comments, so a comment naming the call cannot stand in for the
+    /// call.
+    ///
+    /// Both regions this module slices have a multi-line comment sitting directly on
+    /// top of the call being pinned, explaining the registration in prose. Neither
+    /// comment happens to spell the identifier today, which is the only reason these
+    /// pins work — one ordinary reword ("`set_contract_store` is a no-op when capture
+    /// is off") disarms them with nothing failing. That is not hypothetical: the pin
+    /// on `fdev`'s report was defeated by exactly such a comment, added by the same
+    /// commit, and `probe_wiring_pins::run_writer_code_only` in this file records the
+    /// same thing happening to the one-probe-at-a-time pin.
+    ///
+    /// Whole-line only: a real call's identifier cannot sit on a line whose
+    /// `trim_start()` begins with `//`, so this can produce a false FAILURE but never
+    /// a false pass.
+    fn code_only(body: &str) -> String {
+        body.lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Slice `get_runtime_stores`' body by counting braces to its own closing one.
     ///
     /// The first version of this ended the region at the next `pub(crate) fn` / `fn`
@@ -2003,7 +2022,7 @@ mod contract_store_registration_pin {
     /// the registration going away, because no unit test builds a `Ring`.
     #[test]
     fn the_ring_registers_its_hosted_contracts_for_conformance() {
-        let body = ring_new_body();
+        let body = code_only(ring_new_body());
         assert!(
             body.contains("set_hosted_contracts_source("),
             "the ring no longer tells conformance how to list hosted contracts, so \
@@ -2018,7 +2037,7 @@ mod contract_store_registration_pin {
     /// past teardown - and in the simulation harness, one per simulated peer.
     #[test]
     fn the_hosted_contracts_source_holds_only_a_weak_reference() {
-        let body = ring_new_body();
+        let body = code_only(ring_new_body());
         let start = body
             .find("set_hosted_contracts_source(")
             .expect("registration missing; the sibling pin covers that");
@@ -2032,7 +2051,7 @@ mod contract_store_registration_pin {
 
     #[test]
     fn the_executor_registers_the_contract_store_for_conformance() {
-        let body = get_runtime_stores_body();
+        let body = code_only(get_runtime_stores_body());
         assert!(
             body.contains("set_contract_store("),
             "the executor no longer registers its contract store with conformance, so \
@@ -3976,7 +3995,15 @@ mod tests {
         let end = after
             .find("struct TrackedContract")
             .expect("run_writer no longer precedes TrackedContract");
-        let body = &after[..end];
+        // Whole-line comments stripped, for the reason
+        // `contract_store_registration_pin::code_only` gives: the region is production
+        // code with prose in it, and a comment naming the call would satisfy this
+        // assertion just as well as the call does.
+        let body = after[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(
             body.contains("reload(&dir)"),
             "run_writer no longer reloads existing bundles on startup, so a node \

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -241,6 +241,28 @@ impl ConformanceEvidence {
                 got_deltas: self.deltas.len(),
             });
         }
+        // `summary` deliberately gets neither an arity nor a nullity constraint, and
+        // the reason is that the two hazards the exact-arity check closes do not both
+        // reach it.
+        //
+        // It is one `Option`, not a `Vec`, so "arbitrarily many trailing entries" has
+        // no analogue. Its bytes DO count in `input_bytes`, so unlike an empty
+        // trailing state — which weighs nothing and is therefore free — padding here
+        // is paid for against `MAX_EVIDENCE_INPUT_BYTES`. And it buys no execution:
+        // `DeltaDeterminism` is the only property that reads it, and a supplied
+        // summary REPLACES a `summarize_state` call the verifier would otherwise
+        // make, so it removes WASM work rather than adding it. Every other property
+        // ignores the field entirely.
+        //
+        // What does reach it is the deduplication half: `id()` hashes the summary,
+        // so toggling `Some`/`None` or varying its bytes yields a distinct id for the
+        // same underlying finding. That is a real residual, and it is left open
+        // because it costs the sender bandwidth per copy where the arity padding cost
+        // nothing — a rate, not a hole. Two things should change the answer: a second
+        // property starting to consume `summary`, or evidence acquiring a gossip
+        // receive path where dedup carries weight against a hostile sender. Either
+        // one makes "must be `None` unless the property consumes it" worth its own
+        // rejection variant.
         Ok(())
     }
 
@@ -295,6 +317,19 @@ impl ConformanceEvidence {
     /// was a `pub fn` returning the case unconditionally with a "call `check_bounds`
     /// first" doc comment, which is a convention rather than a gate, and conventions
     /// are what the untrusted front door cannot be built out of.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever [`Self::check_bounds`] rejects, and nothing else — the
+    /// rebuild itself cannot fail. So an [`EvidenceRejected`] here means the evidence
+    /// carries an unsupported [`EVIDENCE_SCHEMA_VERSION`], rests on provenance the
+    /// bytes cannot carry ([`EvidenceRejected::NotSelfVerifying`]), exceeds
+    /// [`MAX_EVIDENCE_INPUT_BYTES`] or [`MAX_EVIDENCE_RELATED`], or does not carry
+    /// exactly the state and delta counts its property requires.
+    ///
+    /// Note for callers upgrading past the signature change: this returned
+    /// `ConformanceCase` directly until the gate moved inside, so a caller that
+    /// previously ignored `check_bounds` now gets the refusal it was skipping.
     pub fn to_case(&self) -> Result<ConformanceCase, EvidenceRejected> {
         self.check_bounds()?;
         let related: HashMap<ContractInstanceId, Option<State<'static>>> = self

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -17,6 +17,12 @@
 //! it cannot re-establish a fact about how the sender OBSERVED them - and the sender
 //! is precisely the party this design refuses to trust. Such a property is marked
 //! [`PremiseSource::LocalProvenance`] and refused at the door.
+//!
+//! That check is not advisory. [`ConformanceEvidence::to_case`] - the only way to
+//! turn evidence into something runnable - performs it itself and returns a
+//! `Result`, so there is no path from a byte string to the WASM that skips it. A doc
+//! comment saying "call `check_bounds` first" would be the only thing standing
+//! between a future receive path and the runtime, and a doc comment is not a gate.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -175,14 +181,20 @@ impl ConformanceEvidence {
         // can be subverted. Every other property here is a universally quantified
         // identity over valid states, so re-execution re-establishes the whole
         // premise and a fabricated case can only surface a real defect sooner. A
-        // property that is a law only because the SENDER observed something — that
-        // `result` was reached from `base`, in `TransitionPathAgreement`'s case —
-        // hands the recipient an accusation it can confirm but cannot check, because
-        // the witness is not in the bytes and cannot be put there. A fabricated pair
-        // from a conforming grow-only contract is structurally indistinguishable
-        // from a genuine information-losing update, so every peer that received it
-        // would independently reach a removal-eligible verdict against a correct
-        // contract.
+        // property that is a law only because the SENDER observed something hands
+        // the recipient an accusation it can confirm but cannot check, because the
+        // witness is not in the bytes and cannot be put there.
+        //
+        // Two properties are in that position, for the same reason applied to
+        // different provenance. `TransitionPathAgreement` needs the witness that
+        // `result` was reached from `base`; a fabricated pair from a conforming
+        // grow-only contract is structurally indistinguishable from a genuine
+        // information-losing update. `DeltaPermutationInvariance` needs the witness
+        // that both deltas were observed against the SAME base; a causally-sequenced
+        // pair permutes to two different states on contracts that are perfectly
+        // sound, because production would never apply them in the other order.
+        // Either way, every peer receiving the fabrication would independently reach
+        // a removal-eligible verdict against a correct contract.
         //
         // Refused rather than deprioritised: a lower rank still lets it in, and the
         // whole point of the front door is that unsound input never reaches the
@@ -273,15 +285,25 @@ impl ConformanceEvidence {
         EvidenceId(*hasher.finalize().as_bytes())
     }
 
-    /// Rebuild the runnable case. Call [`Self::check_bounds`] first.
-    pub fn to_case(&self) -> ConformanceCase {
+    /// Rebuild the runnable case, refusing anything [`Self::check_bounds`] rejects.
+    ///
+    /// The check is folded in here rather than left to the caller on purpose. This is
+    /// the only way to turn an evidence object into something the WASM runtime will
+    /// execute, so making it the enforcement point means no caller — including a
+    /// future gossip receive path that does not exist yet — can reach the runtime
+    /// with unbounded, wrong-arity, or non-self-verifying input. The previous shape
+    /// was a `pub fn` returning the case unconditionally with a "call `check_bounds`
+    /// first" doc comment, which is a convention rather than a gate, and conventions
+    /// are what the untrusted front door cannot be built out of.
+    pub fn to_case(&self) -> Result<ConformanceCase, EvidenceRejected> {
+        self.check_bounds()?;
         let related: HashMap<ContractInstanceId, Option<State<'static>>> = self
             .related
             .iter()
             .map(|(id, state)| (*id, Some(State::from(state.clone()))))
             .collect();
         let related = RelatedContracts::from(related);
-        ConformanceCase {
+        Ok(ConformanceCase {
             property: self.property,
             states: self
                 .states
@@ -295,7 +317,7 @@ impl ConformanceEvidence {
                 .collect(),
             summary: self.summary.as_ref().map(|s| Arc::from(s.as_slice())),
             related,
-        }
+        })
     }
 }
 

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -9,6 +9,14 @@
 //! Consequently everything needed to re-run the check must be *in* the evidence,
 //! and the whole thing must stay small enough that verifying one is cheaper than
 //! being asked to.
+//!
+//! The sharper form of that first requirement is what [`ConformanceEvidence::check_bounds`]
+//! enforces first: a law whose PREMISE cannot be carried in the bytes is not
+//! shippable at all, however small it is. Re-execution re-establishes a universally
+//! quantified identity over valid states no matter where the states came from, but
+//! it cannot re-establish a fact about how the sender OBSERVED them - and the sender
+//! is precisely the party this design refuses to trust. Such a property is marked
+//! [`PremiseSource::LocalProvenance`] and refused at the door.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -16,7 +24,7 @@ use std::sync::Arc;
 use freenet_stdlib::prelude::{ContractInstanceId, RelatedContracts, State};
 use serde::{Deserialize, Serialize};
 
-use super::property::{ConformanceProperty, Violation};
+use super::property::{ConformanceProperty, PremiseSource, Violation};
 use super::verifier::ConformanceCase;
 
 /// Bump when the meaning of a field changes. A peer that does not understand a
@@ -81,6 +89,13 @@ pub enum EvidenceRejected {
     TooLarge { found: usize, limit: usize },
     #[error("evidence carries {found} related contracts, limit is {limit}")]
     TooManyRelated { found: usize, limit: usize },
+    /// The property is not self-verifying, so no amount of re-execution could
+    /// establish its premise. See [`PremiseSource`].
+    #[error(
+        "{property} rests on provenance the evidence bytes cannot carry, so it is \
+         local-only and never shippable as evidence"
+    )]
+    NotSelfVerifying { property: ConformanceProperty },
     #[error(
         "{property} needs {want} states and {want_deltas} deltas, evidence has {got} and {got_deltas}"
     )]
@@ -149,6 +164,37 @@ impl ConformanceEvidence {
             return Err(EvidenceRejected::UnsupportedSchema {
                 found: self.schema_version,
                 supported: EVIDENCE_SCHEMA_VERSION,
+            });
+        }
+        // Refuse a property whose premise the recipient could not re-establish even
+        // by running every byte of this evidence through its own copy of the
+        // contract.
+        //
+        // This is the front door's most important check, and it is not a size or a
+        // schema question: it is the one place the ship-inputs-not-verdicts design
+        // can be subverted. Every other property here is a universally quantified
+        // identity over valid states, so re-execution re-establishes the whole
+        // premise and a fabricated case can only surface a real defect sooner. A
+        // property that is a law only because the SENDER observed something — that
+        // `result` was reached from `base`, in `TransitionPathAgreement`'s case —
+        // hands the recipient an accusation it can confirm but cannot check, because
+        // the witness is not in the bytes and cannot be put there. A fabricated pair
+        // from a conforming grow-only contract is structurally indistinguishable
+        // from a genuine information-losing update, so every peer that received it
+        // would independently reach a removal-eligible verdict against a correct
+        // contract.
+        //
+        // Refused rather than deprioritised: a lower rank still lets it in, and the
+        // whole point of the front door is that unsound input never reaches the
+        // WASM. The property keeps its full value where provenance is observed
+        // directly (shadow mode, `fdev`); it simply never travels.
+        if !self.property.is_self_verifying() {
+            debug_assert_eq!(
+                self.property.premise_source(),
+                PremiseSource::LocalProvenance
+            );
+            return Err(EvidenceRejected::NotSelfVerifying {
+                property: self.property,
             });
         }
         let bytes = self.input_bytes();

--- a/crates/core/src/conformance/generator.rs
+++ b/crates/core/src/conformance/generator.rs
@@ -90,8 +90,16 @@ impl Corpus {
         self.delta_bases.get(i).and_then(Option::as_ref)
     }
 
+    /// Nothing here can produce a case.
+    ///
+    /// Transitions are counted as well as states. A corpus can legitimately carry
+    /// steps and no loose states (`fdev --transition` pushes both endpoints into
+    /// `states` today, but the sampler's own records and any future caller need
+    /// not), and a states-only test would short-circuit `generate_cases` before the
+    /// transition queue was ever built, so the one property that depends on
+    /// provenance would silently check nothing.
     pub fn is_empty(&self) -> bool {
-        self.states.is_empty()
+        self.states.is_empty() && self.transitions.is_empty()
     }
 }
 
@@ -100,13 +108,33 @@ fn dedup_with_bases(
     deltas: Vec<Bytes>,
     bases: Vec<Option<Bytes>>,
 ) -> (Vec<Bytes>, Vec<Option<Bytes>>) {
-    let mut seen = std::collections::HashSet::new();
-    let mut kept_deltas = Vec::with_capacity(deltas.len());
-    let mut kept_bases = Vec::with_capacity(deltas.len());
+    let mut seen: std::collections::HashMap<[u8; 32], usize> = std::collections::HashMap::new();
+    let mut kept_deltas: Vec<Bytes> = Vec::with_capacity(deltas.len());
+    let mut kept_bases: Vec<Option<Bytes>> = Vec::with_capacity(deltas.len());
     for (i, delta) in deltas.into_iter().enumerate() {
-        if seen.insert(*blake3::hash(&delta).as_bytes()) {
-            kept_bases.push(bases.get(i).cloned().flatten());
-            kept_deltas.push(delta);
+        let base = bases.get(i).cloned().flatten();
+        match seen.entry(*blake3::hash(&delta).as_bytes()) {
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(kept_deltas.len());
+                kept_bases.push(base);
+                kept_deltas.push(delta);
+            }
+            // First-seen order still decides which copy is KEPT, but a later copy
+            // that carries provenance upgrades the one already kept.
+            //
+            // Dropping to the first copy unconditionally is how a delta that appears
+            // both loose and on a transition — which is exactly what a bundle
+            // carrying both looks like — ends up unprovenanced, and an unprovenanced
+            // delta is never paired at all, so the permutation law silently checks
+            // nothing. Two identical delta byte strings observed against different
+            // bases already had an arbitrary one chosen; None to Some is strictly
+            // more information than that.
+            std::collections::hash_map::Entry::Occupied(slot) => {
+                let at = *slot.get();
+                if kept_bases[at].is_none() {
+                    kept_bases[at] = base;
+                }
+            }
         }
     }
     (kept_deltas, kept_bases)
@@ -132,6 +160,15 @@ pub struct GeneratorConfig {
     pub max_case_bytes: usize,
     /// Cap on states considered for pairing, since pairs grow quadratically.
     pub max_states_paired: usize,
+    /// Cap on recorded steps considered for `TransitionPathAgreement`.
+    ///
+    /// The transition branch does not pair anything, so it does not grow
+    /// quadratically - but it is linear in a corpus a busy contract fills without
+    /// limit, and every other arity branch is bounded. An unbounded queue here would
+    /// let one contract's step history crowd the interleave and decide which laws
+    /// the case budget reaches, which is exactly what the interleave exists to
+    /// prevent.
+    pub max_transitions: usize,
     pub seed: u64,
 }
 
@@ -142,6 +179,7 @@ impl Default for GeneratorConfig {
             properties: ConformanceProperty::ALL.to_vec(),
             max_case_bytes: 4 * 1024 * 1024,
             max_states_paired: 24,
+            max_transitions: 24,
             seed: 0,
         }
     }
@@ -230,8 +268,8 @@ fn cases_for(
     // that branch would emit `(A, B)` for every pair in the corpus and accuse every
     // conforming contract of last-write-wins.
     if property == ConformanceProperty::TransitionPathAgreement {
-        for (base, result) in &corpus.transitions {
-            push(build(vec![base.clone(), result.clone()]));
+        for (base, result) in sampled_transitions(corpus, config) {
+            push(build(vec![base, result]));
         }
         return cases;
     }
@@ -314,6 +352,22 @@ fn paired_states(corpus: &Corpus, config: &GeneratorConfig) -> Vec<Bytes> {
     let stride = n as f64 / config.max_states_paired as f64;
     (0..config.max_states_paired)
         .map(|i| corpus.states[((i as f64) * stride) as usize % n].clone())
+        .collect()
+}
+
+/// Deterministically choose which recorded steps to check.
+///
+/// Strided rather than truncated, for the same reason [`paired_states`] strides:
+/// observations arrive in time order, so the first N steps are all from the same few
+/// minutes and would test a contract only against its own recent past.
+fn sampled_transitions(corpus: &Corpus, config: &GeneratorConfig) -> Vec<(Bytes, Bytes)> {
+    let n = corpus.transitions.len();
+    if n <= config.max_transitions {
+        return corpus.transitions.clone();
+    }
+    let stride = n as f64 / config.max_transitions as f64;
+    (0..config.max_transitions)
+        .map(|i| corpus.transitions[((i as f64) * stride) as usize % n].clone())
         .collect()
 }
 

--- a/crates/core/src/conformance/generator.rs
+++ b/crates/core/src/conformance/generator.rs
@@ -13,6 +13,20 @@ use super::verifier::{Bytes, ConformanceCase};
 
 /// The material a generator works from: states and deltas actually observed, plus
 /// whatever related-contract state is needed to make them validate.
+///
+/// # The two provenance fields
+///
+/// `delta_bases` and `transitions` are the ONLY fields here that carry provenance —
+/// facts about how the bytes were observed rather than the bytes themselves. Evidence
+/// files carry bare `states`, `deltas` and `summaries` and nothing else, so provenance
+/// is precisely what a recipient re-executing a case cannot reconstruct. Hence the
+/// structural rule, stated in full on
+/// [`ConformanceProperty::premise_source`](super::property::ConformanceProperty::premise_source):
+///
+/// > **A property whose generator branch reads `delta_bases` or `transitions` must be
+/// > [`PremiseSource::LocalProvenance`](super::property::PremiseSource::LocalProvenance).**
+///
+/// Adding a third provenance field means extending that rule, not just this struct.
 #[derive(Debug, Default, Clone)]
 pub struct Corpus {
     pub states: Vec<Bytes>,

--- a/crates/core/src/conformance/generator.rs
+++ b/crates/core/src/conformance/generator.rs
@@ -32,6 +32,19 @@ pub struct Corpus {
     /// law is about.
     pub delta_bases: Vec<Option<Bytes>>,
     pub summaries: Vec<Bytes>,
+    /// Observed `(base, result)` steps: a peer held `base`, applied an update, and
+    /// ended up at `result`.
+    ///
+    /// This is PROVENANCE, and it is the whole reason
+    /// [`ConformanceProperty::TransitionPathAgreement`] is a law rather than an
+    /// accusation of last-write-wins. For an arbitrary pair of states, "merging B
+    /// into A yields B" is false for every conforming contract; it is only required
+    /// when the corpus witnesses that B was reached FROM A.
+    ///
+    /// So this must never be filled from states that merely appeared together. A
+    /// bundle's `transitions` and the sampler's own transition records are the only
+    /// sources; loose `--state` files carry no provenance and contribute none.
+    pub transitions: Vec<(Bytes, Bytes)>,
     pub related: RelatedContracts<'static>,
 }
 
@@ -60,6 +73,15 @@ impl Corpus {
         self.deltas = deltas;
         self.delta_bases = bases;
         self.summaries = dedup(self.summaries);
+        // A contract oscillating between two states offers the same step over and
+        // over; without this a thousand observations are one case repeated.
+        let mut seen = std::collections::HashSet::new();
+        self.transitions.retain(|(base, result)| {
+            seen.insert((
+                *blake3::hash(base).as_bytes(),
+                *blake3::hash(result).as_bytes(),
+            ))
+        });
         self
     }
 
@@ -196,6 +218,20 @@ fn cases_for(
             for summary in &corpus.summaries {
                 push(build(vec![state.clone()]).with_summary(summary.clone()));
             }
+        }
+        return cases;
+    }
+
+    // Transition cases come from recorded provenance, never from pairing states.
+    //
+    // Handled before the arity match for the same reason `DeltaDeterminism` is: the
+    // generic arity-2 branch pairs every state with every other, and this property
+    // is only a law for the ORDERED pair a transition witnesses. Falling through to
+    // that branch would emit `(A, B)` for every pair in the corpus and accuse every
+    // conforming contract of last-write-wins.
+    if property == ConformanceProperty::TransitionPathAgreement {
+        for (base, result) in &corpus.transitions {
+            push(build(vec![base.clone(), result.clone()]));
         }
         return cases;
     }

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -210,6 +210,72 @@ pub enum ConformanceProperty {
     /// false-positive profile (a capped collection trips it), and one law per
     /// property is the rule this module follows everywhere else.
     PathAgreement,
+    /// A state a peer actually REACHED must be reachable by the merge path too.
+    ///
+    /// The transition-shaped half of [`ConformanceProperty::PathAgreement`], and the
+    /// half that reaches the defect #5394 was written from. Where the corpus records
+    /// a transition `base -> result` — a peer that held `base`, applied an update,
+    /// and ended up at `result` — merging `result` back into `base` must reproduce
+    /// `result`:
+    ///
+    /// ```text
+    /// update_state(base, State(result))  ==  result
+    /// ```
+    ///
+    /// # Why this needs provenance, and why the pairwise form cannot substitute
+    ///
+    /// `PathAgreement` synthesizes its delta from the contract's own
+    /// `get_state_delta`, so it can only see a disagreement that the contract's own
+    /// delta ENCODING can express. Measured against the #5394 artifacts on
+    /// 2026-08-23, that contract returns the whole sender state for every
+    /// non-trivial pair in the corpus and then treats a whole-state `Delta` exactly
+    /// as a `State` — so both paths agree on every pair and the pairwise form is
+    /// silent on it. The disagreement lives on an APPLICATION-level delta, a client
+    /// `UPDATE` carrying one op, which `get_state_delta` never produces.
+    ///
+    /// A transition carries that op's effect as the `result` state, so no delta
+    /// encoding is needed to see it. What cannot be substituted is the ORDERING:
+    /// `merge(A, B) == B` is last-write-wins for an arbitrary pair and would accuse
+    /// every conforming contract. It is a law only because the corpus witnesses that
+    /// `result` came FROM `base`, which is what makes `base` the earlier state.
+    ///
+    /// # What a real capture must carry
+    ///
+    /// `ReplayBundle::transitions` (`base_state` + `result_state`), which the node's
+    /// capture path records for every merge — `Observation` owns both. Loose
+    /// `--state` files carry no provenance and produce no cases for this property at
+    /// all, which is not a clean run but an absence of evidence; `fdev --transition
+    /// BASE RESULT` is how a developer supplies it by hand.
+    ///
+    /// # Why this is `Severity::Violation`
+    ///
+    /// Two guards, and each one corresponds to a contract shape that would otherwise
+    /// be accused wrongly:
+    ///
+    /// 1. `result` is first driven to a fixpoint of its own merge, and the case is
+    ///    declined if it never settles. A canonicalizing contract legitimately
+    ///    rewrites a stored state on first merge (the PUT install path stores the
+    ///    client's raw bytes without running `update_state` at all), and a contract
+    ///    that never settles is [`ConformanceProperty::StateIdempotence`]'s defect,
+    ///    not this one.
+    /// 2. The comparison is against that settled form, so canonicalization alone can
+    ///    never produce a finding.
+    ///
+    /// What survives both is a merge that cannot reach a state one of its own peers
+    /// is already holding, which is non-convergence by definition: the peer at
+    /// `result` gossips it, every peer that merges it lands somewhere else, and the
+    /// two never agree.
+    ///
+    /// A bounded collection is the shape most likely to look like a false positive
+    /// here, and the distinction is measured rather than assumed. A cap that evicts
+    /// by the merge's OWN ordering (keep the largest N) is a genuine bounded
+    /// semilattice and passes: the entries `base` would re-add are exactly the ones
+    /// the cap drops again. A cap that evicts by something independent of that
+    /// ordering — arrival order, a hash, `CAPPED_SET` in the fixture contract — does
+    /// fire, and that contract is already removal-eligible under
+    /// [`ConformanceProperty::StateAssociativity`] for the same underlying reason.
+    /// Both are pinned by tests.
+    TransitionPathAgreement,
 }
 
 /// How seriously a failed property should be taken.
@@ -244,6 +310,7 @@ impl ConformanceProperty {
         ConformanceProperty::WholeStateSelfDelta,
         ConformanceProperty::ReconciliationCycle,
         ConformanceProperty::PathAgreement,
+        ConformanceProperty::TransitionPathAgreement,
     ];
 
     pub fn severity(self) -> Severity {
@@ -269,7 +336,8 @@ impl ConformanceProperty {
             | ConformanceProperty::DeltaDeterminism
             | ConformanceProperty::DeltaPermutationInvariance
             | ConformanceProperty::ReconciliationCycle
-            | ConformanceProperty::PathAgreement => Severity::Violation,
+            | ConformanceProperty::PathAgreement
+            | ConformanceProperty::TransitionPathAgreement => Severity::Violation,
         }
     }
 
@@ -287,7 +355,8 @@ impl ConformanceProperty {
             | ConformanceProperty::EmittedStateValidity
             | ConformanceProperty::UpdateDeterminism
             | ConformanceProperty::ReconciliationCycle
-            | ConformanceProperty::PathAgreement => 2,
+            | ConformanceProperty::PathAgreement
+            | ConformanceProperty::TransitionPathAgreement => 2,
             ConformanceProperty::StateAssociativity => 3,
         }
     }
@@ -307,7 +376,8 @@ impl ConformanceProperty {
             | ConformanceProperty::SelfDeltaEmpty
             | ConformanceProperty::WholeStateSelfDelta
             | ConformanceProperty::ReconciliationCycle
-            | ConformanceProperty::PathAgreement => 0,
+            | ConformanceProperty::PathAgreement
+            | ConformanceProperty::TransitionPathAgreement => 0,
         }
     }
 
@@ -326,6 +396,7 @@ impl ConformanceProperty {
             ConformanceProperty::WholeStateSelfDelta => "whole_state_self_delta",
             ConformanceProperty::ReconciliationCycle => "reconciliation_cycle",
             ConformanceProperty::PathAgreement => "path_agreement",
+            ConformanceProperty::TransitionPathAgreement => "transition_path_agreement",
         }
     }
 }
@@ -426,6 +497,13 @@ pub enum Inconclusive {
     /// path is not the path this update would take on the network, and checking it
     /// would be checking a call that never happens.
     NoDeltaPath,
+    /// An observed result state is not a fixpoint of its own merge.
+    ///
+    /// A contract whose state keeps changing every time it is re-merged cannot be
+    /// judged on whether some OTHER state absorbs into it, and the defect already
+    /// has a name: [`ConformanceProperty::StateIdempotence`]. Reporting it here
+    /// would accuse the right contract under the wrong law.
+    StateNotSettled,
     /// The check failed once and then did not fail the same way again.
     ///
     /// Something outside the inputs moved between the two runs — the host clock is
@@ -447,6 +525,9 @@ impl std::fmt::Display for Inconclusive {
             Inconclusive::MalformedCase(e) => write!(f, "malformed case: {e}"),
             Inconclusive::NoDeltaPath => {
                 f.write_str("no delta path exists for these inputs to compare against")
+            }
+            Inconclusive::StateNotSettled => {
+                f.write_str("an observed result state is not a fixpoint of its own merge")
             }
             Inconclusive::NotReproducible => {
                 f.write_str("the finding did not reproduce on a second run")

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -58,13 +58,27 @@ pub enum ConformanceProperty {
     /// case re-establishes the whole premise. There is no "how it was observed" fact
     /// left over.
     ///
+    /// **That unrestricted pairing is what the classification rests on, and nothing
+    /// pins it.** The plausible edit that breaks it is a refinement aimed at cutting
+    /// inconclusives — "only pair a delta with the state it was observed against",
+    /// which would raise the acceptance rate by dropping pairs the contract rejects.
+    /// Making the generator branch read `Corpus::delta_bases` turns this into a
+    /// provenance-dependent property, exactly like
+    /// [`ConformanceProperty::DeltaPermutationInvariance`], and it must move to
+    /// [`PremiseSource::LocalProvenance`] in the same change — see the structural
+    /// rule on [`ConformanceProperty::premise_source`]. Neither existing guard would
+    /// notice: the partition pin asserts the classification the code states rather
+    /// than deriving it from the generator, and
+    /// `no_shippable_removal_eligible_property_consumes_unvalidated_bytes` only
+    /// fires on a SEVERITY change, which such a refinement does not make.
+    ///
     /// What keeps the unvalidated bytes harmless is the [`Severity::Diagnostic`]
     /// tier, which `policy::decide` never maps to a removal: a fabricated delta buys
     /// an attacker a report and nothing else. That coupling is NOT incidental. This
     /// is the only property that both travels as evidence and consumes delta bytes,
     /// so promoting it to [`Severity::Violation`] — which the contested empirical
     /// question above may one day justify — must revisit this classification in the
-    /// same change. `no_shippable_removal_eligible_property_consumes_unvalidated_deltas`
+    /// same change. `no_shippable_removal_eligible_property_consumes_unvalidated_bytes`
     /// is the test that forces it to.
     DeltaIdempotence,
     /// Deltas applied in any order reach the same canonical state.
@@ -489,7 +503,7 @@ impl ConformanceProperty {
             // validates, there being no `require_valid` for a delta. Promoting it to
             // `Violation` without revisiting `premise_source` in the same change
             // would make attacker-chosen delta bytes removal-eligible. The test
-            // `no_shippable_removal_eligible_property_consumes_unvalidated_deltas`
+            // `no_shippable_removal_eligible_property_consumes_unvalidated_bytes`
             // fails if that happens.
             ConformanceProperty::DeltaIdempotence => Severity::Diagnostic,
             ConformanceProperty::StateIdempotence
@@ -513,6 +527,29 @@ impl ConformanceProperty {
     /// pinned by a test, so lumping a new provenance-dependent property in with the
     /// self-verifying ones fails CI rather than silently widening the untrusted
     /// path.
+    ///
+    /// # How to answer it for a new property
+    ///
+    /// The question is structural, not a judgement call. [`Corpus`] has exactly two
+    /// provenance fields — `delta_bases` and `transitions` — and provenance is the
+    /// only thing evidence bytes cannot carry. So:
+    ///
+    /// > **A property whose generator branch reads `Corpus::delta_bases` or
+    /// > `Corpus::transitions` MUST be [`PremiseSource::LocalProvenance`].**
+    ///
+    /// Everything else builds its cases from `states`, `deltas` and `summaries`,
+    /// which travel in the evidence file intact, so re-executing the case
+    /// re-establishes the whole premise.
+    ///
+    /// Follow the rule rather than the list. The arms below record which properties
+    /// happen to read those fields TODAY; a pin records a wrong answer exactly as
+    /// firmly as a right one, and it is the rule, not the list, that produces the
+    /// answer for the property that does not exist yet. The direction to watch is a
+    /// refinement that makes an existing `EvidenceBytes` property START reading one
+    /// of the two fields — see [`ConformanceProperty::DeltaIdempotence`], whose
+    /// classification depends on its generator branch NOT consulting `delta_bases`.
+    ///
+    /// [`Corpus`]: crate::conformance::generator::Corpus
     pub fn premise_source(self) -> PremiseSource {
         match self {
             // Each of these is an identity required of every conforming contract

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -249,8 +249,40 @@ pub enum ConformanceProperty {
     ///
     /// # Why this is `Severity::Violation`
     ///
-    /// Two guards, and each one corresponds to a contract shape that would otherwise
-    /// be accused wrongly:
+    /// The argument is algebraic, and the measurement below only corroborates it.
+    ///
+    /// Suppose the contract satisfies [`ConformanceProperty::StateCommutativity`],
+    /// [`ConformanceProperty::StateAssociativity`] and
+    /// [`ConformanceProperty::StateIdempotence`] — the three laws that are already
+    /// removal-eligible on their own. Then `merge` is a semilattice join, and it
+    /// induces a partial order on states:
+    ///
+    /// ```text
+    /// x <= y   iff   merge(x, y) == y
+    /// ```
+    ///
+    /// Under that order `merge(base, result)` *is* `base ⊔ result`, the least upper
+    /// bound. So this property's comparison
+    ///
+    /// ```text
+    /// merge(base, result) == result      i.e.      base ⊔ result == result
+    /// ```
+    ///
+    /// holds **iff** `base <= result` in the merge's own order. A firing therefore
+    /// says precisely: the update path moved the peer to a state that is not above
+    /// the state it started from, in the order its own merge defines. That is
+    /// non-convergence by construction — the peer at `result` gossips it, every peer
+    /// that merges it lands on the strictly larger `base ⊔ result`, and the two never
+    /// agree — and it needs no carve-out for bounded collections or any other
+    /// contract shape.
+    ///
+    /// If the contract does NOT satisfy those three laws, it is already
+    /// removal-eligible under whichever of them it breaks, so a firing here costs it
+    /// nothing it had not already lost. Either way there is no contract that this
+    /// property alone condemns while the settled algebra would have acquitted it.
+    ///
+    /// Two guards keep it from firing on a contract that is merely doing bookkeeping
+    /// rather than losing information:
     ///
     /// 1. `result` is first driven to a fixpoint of its own merge, and the case is
     ///    declined if it never settles. A canonicalizing contract legitimately
@@ -261,21 +293,93 @@ pub enum ConformanceProperty {
     /// 2. The comparison is against that settled form, so canonicalization alone can
     ///    never produce a finding.
     ///
-    /// What survives both is a merge that cannot reach a state one of its own peers
-    /// is already holding, which is non-convergence by definition: the peer at
-    /// `result` gossips it, every peer that merges it lands somewhere else, and the
-    /// two never agree.
+    /// ## Corroboration: the bounded-collection shapes, measured
     ///
-    /// A bounded collection is the shape most likely to look like a false positive
-    /// here, and the distinction is measured rather than assumed. A cap that evicts
-    /// by the merge's OWN ordering (keep the largest N) is a genuine bounded
-    /// semilattice and passes: the entries `base` would re-add are exactly the ones
-    /// the cap drops again. A cap that evicts by something independent of that
-    /// ordering — arrival order, a hash, `CAPPED_SET` in the fixture contract — does
-    /// fire, and that contract is already removal-eligible under
-    /// [`ConformanceProperty::StateAssociativity`] for the same underlying reason.
-    /// Both are pinned by tests.
+    /// A bounded collection is the shape most likely to look like a false positive,
+    /// and each variant was run rather than argued.
+    ///
+    /// - A cap that evicts by the merge's OWN ordering (keep the largest N) is a
+    ///   genuine bounded semilattice and passes: the entries `base` would re-add are
+    ///   exactly the ones the cap drops again.
+    /// - A cap that evicts by something independent of that ordering — arrival
+    ///   order, a hash, `CAPPED_SET` in the fixture contract — does fire, and that
+    ///   contract is already removal-eligible under
+    ///   [`ConformanceProperty::StateAssociativity`] for the same underlying reason.
+    /// - The **partially-ordered** cap is the case the first version of this
+    ///   property could not rule out: keep the at-most-N *maximal* elements under a
+    ///   causal partial order, breaking ties among mutually incomparable survivors
+    ///   by a total order. It looks like a legitimate bounded join, and the pairwise
+    ///   laws do not immediately dispose of it. Brute-forced over its full state
+    ///   space on 2026-08-23 (universe of five elements, `1` causally after `5`,
+    ///   N = 2, ties by keeping the largest: 15 valid states) it is commutative and
+    ///   idempotent with zero failures — and **not associative**, 532 failing
+    ///   triples, the smallest being
+    ///   `(({1} ⊔ {2}) ⊔ {3,5}) = {2,3}` against `({1} ⊔ ({2} ⊔ {3,5})) = {1,3}`.
+    ///   So it is already removal-eligible under `StateAssociativity` before this
+    ///   property is consulted, which closes the gap: the transition law condemns no
+    ///   contract the settled algebra acquits. It does also fire here — base
+    ///   `{2,5}`, an op reaching `{2,3}`, `merge(base, result) = {3,5}` — which is
+    ///   the consistency the algebra above predicts, not a second accusation.
+    ///
+    /// All of these are pinned by tests.
+    ///
+    /// # Local provenance only: this property is NOT self-verifying
+    ///
+    /// This is the one property in this module whose premise is not re-establishable
+    /// from the evidence bytes. See [`PremiseSource`], which is what enforces it.
+    ///
+    /// Every other law is a universally quantified identity over valid states, so a
+    /// receiving peer that re-executes the case against its own copy of the contract
+    /// re-establishes the whole premise: if `merge(A, B) != merge(B, A)` for states
+    /// the contract itself validates, that is true no matter where `A` and `B` came
+    /// from. This one is a law only because the corpus WITNESSES that `result` was
+    /// reached from `base`. That witness is not in the bytes and cannot be put
+    /// there: no signature or attestation would help, because the sending peer is
+    /// exactly the party not being trusted.
+    ///
+    /// So a fabricated pair from a perfectly conforming grow-only contract — any two
+    /// valid states with `base ⊄ result` — is structurally indistinguishable from a
+    /// genuine information-losing update, and every receiving peer would
+    /// independently confirm a removal-eligible violation against a correct
+    /// contract. `check_bounds` therefore REFUSES evidence carrying this property
+    /// outright rather than merely deprioritising it.
+    ///
+    /// The property keeps its full value where it runs today — shadow mode and
+    /// `fdev`, both of which observe provenance directly. Evidence gossip (#5377,
+    /// unbuilt) may revisit it if a verifiable form of provenance ever exists.
     TransitionPathAgreement,
+}
+
+/// Whether a property's premise can be re-established from the evidence bytes alone.
+///
+/// This is the attribute the whole evidence model rests on, stated once so a new
+/// property cannot inherit the hazard by omission. `evidence.rs` explains the rule:
+/// a receiving peer does not trust the sender, it re-executes the case against its
+/// own copy of the contract and reaches its own conclusion. That is only safe when
+/// re-execution re-establishes the *entire* premise of the law.
+///
+/// For a universally quantified identity over valid states it does. `merge(A, B) ==
+/// merge(B, A)` is required of every conforming contract for every pair of states it
+/// validates, so where `A` and `B` came from is irrelevant: a peer that re-runs the
+/// case has checked everything the law asserts. A fabricated pair can only make the
+/// recipient discover a real defect sooner.
+///
+/// A property whose premise includes a fact about how the inputs were OBSERVED is a
+/// different thing entirely, and shipping it would be unsafe in a way no amount of
+/// re-execution repairs: the witness is not in the bytes, so the recipient confirms
+/// an accusation it cannot check. [`ConformanceEvidence::check_bounds`] refuses such
+/// evidence outright rather than ranking it lower.
+///
+/// [`ConformanceEvidence::check_bounds`]: super::evidence::ConformanceEvidence::check_bounds
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PremiseSource {
+    /// Everything the law asserts is re-checkable from the evidence's own bytes.
+    /// Safe to ship: this is what the RFC's propagate-evidence-not-verdicts design
+    /// assumes of every property it carries.
+    EvidenceBytes,
+    /// The law additionally rests on provenance the observing peer had and the
+    /// bytes cannot carry. Usable locally, never shippable as evidence.
+    LocalProvenance,
 }
 
 /// How seriously a failed property should be taken.
@@ -339,6 +443,47 @@ impl ConformanceProperty {
             | ConformanceProperty::PathAgreement
             | ConformanceProperty::TransitionPathAgreement => Severity::Violation,
         }
+    }
+
+    /// Where this property's premise comes from - see [`PremiseSource`].
+    ///
+    /// Deliberately an exhaustive match with no wildcard arm: adding a property
+    /// without answering this question must not compile. The partition is also
+    /// pinned by a test, so lumping a new provenance-dependent property in with the
+    /// self-verifying ones fails CI rather than silently widening the untrusted
+    /// path.
+    pub fn premise_source(self) -> PremiseSource {
+        match self {
+            // Each of these is an identity required of every conforming contract
+            // over every pair (or triple, or state-and-delta) of inputs it
+            // validates. Re-executing the case re-establishes all of it.
+            ConformanceProperty::StateIdempotence
+            | ConformanceProperty::StateCommutativity
+            | ConformanceProperty::StateAssociativity
+            | ConformanceProperty::EmittedStateValidity
+            | ConformanceProperty::UpdateDeterminism
+            | ConformanceProperty::SummaryDeterminism
+            | ConformanceProperty::DeltaDeterminism
+            | ConformanceProperty::DeltaIdempotence
+            | ConformanceProperty::DeltaPermutationInvariance
+            | ConformanceProperty::SelfDeltaEmpty
+            | ConformanceProperty::WholeStateSelfDelta
+            | ConformanceProperty::ReconciliationCycle
+            | ConformanceProperty::PathAgreement => PremiseSource::EvidenceBytes,
+            // The one exception, and the reason this method exists. See the
+            // variant's own documentation: `merge(base, result) == result` is
+            // last-write-wins for an arbitrary pair and a law only because the
+            // corpus witnessed that `result` was reached FROM `base`. Nothing in the
+            // bytes carries that witness, so a fabricated pair from a conforming
+            // grow-only contract would have every recipient independently confirm a
+            // removal-eligible violation against a correct contract.
+            ConformanceProperty::TransitionPathAgreement => PremiseSource::LocalProvenance,
+        }
+    }
+
+    /// Shorthand for [`Self::premise_source`] being [`PremiseSource::EvidenceBytes`].
+    pub fn is_self_verifying(self) -> bool {
+        matches!(self.premise_source(), PremiseSource::EvidenceBytes)
     }
 
     /// How many distinct input states a case for this property must carry.

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -109,6 +109,107 @@ pub enum ConformanceProperty {
     /// - Any shadow finding from this property that turns out to converge in
     ///   production is a model bug, and should drop the severity immediately.
     ReconciliationCycle,
+    /// The delta path and the merge path must reach the same state.
+    ///
+    /// A contract has two write paths into the same logical state: `update_state`
+    /// handed a `Delta`, and `update_state` handed another peer's whole `State`.
+    /// Which one a peer takes is decided by the *protocol* — `gate_delta_size`
+    /// refuses an oversized delta and sends the whole state instead — not by the
+    /// application. So two peers given the same information by different routes must
+    /// end up with the same bytes, or they can never agree.
+    ///
+    /// Every other property here compares merge-to-merge or delta-to-delta.
+    /// `StateCommutativity`, `StateAssociativity`, `DeltaPermutationInvariance` and
+    /// `DeltaIdempotence` are all satisfiable by a contract whose two paths use
+    /// *different combinators*, because none of them ever puts one path beside the
+    /// other. The defect that motivated this (#5394) did exactly that: `insert`
+    /// (last write wins) when handed a delta, `entry().or_insert()` (first write
+    /// wins) when handed a state, on a map keyed by a client-chosen sequence number.
+    /// A retraction applied as a delta is silently resurrected when a replica
+    /// re-merges the same op as a state.
+    ///
+    /// # What is checked
+    ///
+    /// For a pair of observed states, in both orders:
+    ///
+    /// ```text
+    /// delta  = get_state_delta(other, summarize(base))   // what the sender ships
+    /// apply(base, delta)  ==  update_state(base, State(other))
+    /// ```
+    ///
+    /// # Why this is `Severity::Violation` and not a false-positive generator
+    ///
+    /// A plain inequality here would accuse a large and legitimate class of
+    /// contract: one whose summary is too coarse to express a particular divergence,
+    /// so its delta carries only *part* of what the other state holds. Such a
+    /// contract lands short of the merged state on this round and converges on the
+    /// next one, and this module already refuses to accuse it under
+    /// `ReconciliationCycle` for the same reason.
+    ///
+    /// So a disagreement is only reported when re-merging the whole state fails to
+    /// repair it:
+    ///
+    /// ```text
+    /// merge(apply(base, delta), other)  !=  merge(base, other)
+    /// ```
+    ///
+    /// For any contract whose merge is a genuine join, that condition is
+    /// unreachable: a delta derived from `other` can only move `base` somewhere
+    /// between `base` and `base ⊔ other`, and joining `other` back on top lands on
+    /// `base ⊔ other` either way. A partial delta therefore heals and is never
+    /// reported; a delta path that computed something the merge path cannot reach
+    /// does not heal and is. That is the same practical consequence as a
+    /// non-commutative merge — two peers with the same information, permanently
+    /// disagreeing — which is why the severity matches `StateCommutativity`.
+    ///
+    /// The guard errs toward silence in every direction, including when the merge
+    /// itself is unsound: a last-write-wins merge heals trivially, so this property
+    /// declines to pile a second accusation onto a defect `StateCommutativity`
+    /// already names. One law per property.
+    ///
+    /// # What this does NOT establish, and what would settle it
+    ///
+    /// Like `ReconciliationCycle`, and unlike the pure algebra above it, this rests
+    /// on a model of the protocol: that the sender computes its delta against the
+    /// recipient's summary, and that production would actually take the delta path.
+    /// The second is checked directly (`delta_would_be_refused`, production's own
+    /// gate); the first is the same assumption `reconciliation_cycle` makes. Unlike
+    /// `ReconciliationCycle` this is a single step with no schedule to get wrong,
+    /// which is the narrower assumption of the two.
+    ///
+    /// Shadow-mode counts are what should settle whether the severity is right:
+    /// contracts flagged by THIS property and by no other removal-eligible one. If
+    /// that number stays at zero the property earns nothing at this severity; if it
+    /// is the sole finding for real contracts, it is carrying signal the algebraic
+    /// checks miss.
+    ///
+    /// # Two measured limits, both of them misses rather than false accusations
+    ///
+    /// **The guard is direction-sensitive.** Re-merging repairs the difference for
+    /// one ordering of a pair and not the other — for the fixture in
+    /// `tests/test-contract-conformance` (mode 8) it silences exactly one of
+    /// `(A, B)` and `(B, A)`. Both directions are therefore checked for every pair.
+    /// A corpus holding only one state of such a pair still misses the defect.
+    ///
+    /// **A contract whose delta IS its state is invisible to this check.** The delta
+    /// is synthesized from the contract's own `get_state_delta`, so only a
+    /// disagreement that the contract's own delta encoding can express can be seen.
+    /// Measured against the #5394 artifacts on 2026-08-23: that contract's
+    /// `get_state_delta` returns the whole sender state for every non-trivial pair
+    /// in the corpus, and its `update_state` then treats a whole-state `Delta`
+    /// exactly as it treats a `State`, so both paths agree on every pair and this
+    /// property stays silent on the very defect it was written from. The
+    /// disagreement there lives on an APPLICATION-level delta — a client `UPDATE`
+    /// carrying one op — which `get_state_delta` never produces and which a
+    /// states-only corpus does not carry.
+    ///
+    /// Closing that needs a second, transition-shaped form of the same law, over the
+    /// captured deltas in `ReplayBundle::transitions`: for an observed
+    /// `base + delta -> result`, `merge(base, result)` must equal `result`. It is
+    /// deliberately NOT folded in here — it has a different arity and a different
+    /// false-positive profile (a capped collection trips it), and one law per
+    /// property is the rule this module follows everywhere else.
+    PathAgreement,
 }
 
 /// How seriously a failed property should be taken.
@@ -142,6 +243,7 @@ impl ConformanceProperty {
         ConformanceProperty::SelfDeltaEmpty,
         ConformanceProperty::WholeStateSelfDelta,
         ConformanceProperty::ReconciliationCycle,
+        ConformanceProperty::PathAgreement,
     ];
 
     pub fn severity(self) -> Severity {
@@ -166,7 +268,8 @@ impl ConformanceProperty {
             | ConformanceProperty::SummaryDeterminism
             | ConformanceProperty::DeltaDeterminism
             | ConformanceProperty::DeltaPermutationInvariance
-            | ConformanceProperty::ReconciliationCycle => Severity::Violation,
+            | ConformanceProperty::ReconciliationCycle
+            | ConformanceProperty::PathAgreement => Severity::Violation,
         }
     }
 
@@ -183,7 +286,8 @@ impl ConformanceProperty {
             ConformanceProperty::StateCommutativity
             | ConformanceProperty::EmittedStateValidity
             | ConformanceProperty::UpdateDeterminism
-            | ConformanceProperty::ReconciliationCycle => 2,
+            | ConformanceProperty::ReconciliationCycle
+            | ConformanceProperty::PathAgreement => 2,
             ConformanceProperty::StateAssociativity => 3,
         }
     }
@@ -202,7 +306,8 @@ impl ConformanceProperty {
             | ConformanceProperty::DeltaDeterminism
             | ConformanceProperty::SelfDeltaEmpty
             | ConformanceProperty::WholeStateSelfDelta
-            | ConformanceProperty::ReconciliationCycle => 0,
+            | ConformanceProperty::ReconciliationCycle
+            | ConformanceProperty::PathAgreement => 0,
         }
     }
 
@@ -220,6 +325,7 @@ impl ConformanceProperty {
             ConformanceProperty::SelfDeltaEmpty => "self_delta_empty",
             ConformanceProperty::WholeStateSelfDelta => "whole_state_self_delta",
             ConformanceProperty::ReconciliationCycle => "reconciliation_cycle",
+            ConformanceProperty::PathAgreement => "path_agreement",
         }
     }
 }
@@ -310,6 +416,16 @@ pub enum Inconclusive {
     RoundLimit,
     /// The case was malformed for the property (wrong arity, missing delta).
     MalformedCase(String),
+    /// There is no delta path for these inputs, so there is nothing to compare the
+    /// merge path against.
+    ///
+    /// Either the contract produced an empty delta — the protocol's "nothing to
+    /// send", which a summary too coarse to express the divergence produces
+    /// legitimately — or the delta was large enough that production's own size gate
+    /// would refuse it and send the whole state instead. In both cases the delta
+    /// path is not the path this update would take on the network, and checking it
+    /// would be checking a call that never happens.
+    NoDeltaPath,
     /// The check failed once and then did not fail the same way again.
     ///
     /// Something outside the inputs moved between the two runs — the host clock is
@@ -329,6 +445,9 @@ impl std::fmt::Display for Inconclusive {
             Inconclusive::ResourceLimit(e) => write!(f, "resource limit: {e}"),
             Inconclusive::RoundLimit => f.write_str("reconciliation round budget exhausted"),
             Inconclusive::MalformedCase(e) => write!(f, "malformed case: {e}"),
+            Inconclusive::NoDeltaPath => {
+                f.write_str("no delta path exists for these inputs to compare against")
+            }
             Inconclusive::NotReproducible => {
                 f.write_str("the finding did not reproduce on a second run")
             }

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -45,6 +45,27 @@ pub enum ConformanceProperty {
     /// it must be answered by running `fdev verify-merge` against deployed WASM
     /// before this property is ever allowed to influence anything on the network.
     /// Until then it is a reporting signal for contract authors.
+    ///
+    /// # Why this one stays [`PremiseSource::EvidenceBytes`], and what makes that safe
+    ///
+    /// It shares the unvalidated-delta-bytes weakness of
+    /// [`ConformanceProperty::DeltaPermutationInvariance`] — `verify_case` runs
+    /// whatever delta bytes it is handed straight into the contract, and there is no
+    /// `require_valid` analogue for a delta the way there is for a state — but not
+    /// that property's provenance dependency. The generator puts no restriction at
+    /// all on which delta it pairs with which state, so the law as checked is
+    /// universally quantified over (valid state, accepted delta) and re-executing the
+    /// case re-establishes the whole premise. There is no "how it was observed" fact
+    /// left over.
+    ///
+    /// What keeps the unvalidated bytes harmless is the [`Severity::Diagnostic`]
+    /// tier, which `policy::decide` never maps to a removal: a fabricated delta buys
+    /// an attacker a report and nothing else. That coupling is NOT incidental. This
+    /// is the only property that both travels as evidence and consumes delta bytes,
+    /// so promoting it to [`Severity::Violation`] — which the contested empirical
+    /// question above may one day justify — must revisit this classification in the
+    /// same change. `no_shippable_removal_eligible_property_consumes_unvalidated_deltas`
+    /// is the test that forces it to.
     DeltaIdempotence,
     /// Deltas applied in any order reach the same canonical state.
     ///
@@ -71,6 +92,33 @@ pub enum ConformanceProperty {
     /// [`ConformanceProperty::DeltaIdempotence`], which is contested and reports at
     /// a lower severity. Folding it in would accuse a counter-style contract under
     /// this property's name and severity regardless of that.
+    ///
+    /// # Local provenance only: this property is NOT self-verifying
+    ///
+    /// Everything the same-base paragraph above rests on is a fact about how the two
+    /// deltas were OBSERVED, and nothing carries it into the evidence bytes.
+    /// [`ConformanceEvidence`] holds bare `states` and `deltas` with no base
+    /// association, and `verify_case` applies whatever bytes it is handed in both
+    /// orders and compares. Delta bytes are in fact LESS constrained than states,
+    /// which at least go through `require_valid`.
+    ///
+    /// So a recipient that re-executes the case reproduces the comparison but not the
+    /// premise, and the gap is not academic. Take an add-wins OR-set whose delta
+    /// encodes tag adds and removes and which does not tombstone a tag it has never
+    /// seen — sound in production, because a delta is always
+    /// `get_state_delta(sender, recipient_summary)`. Hand it the causally-sequenced
+    /// pair `D1 = add A^t`, `D2 = remove t`: the two orders diverge, and every
+    /// recipient independently confirms a removal-eligible violation against a
+    /// correct contract. That contract's own same-base pairs are concurrent and
+    /// permute fine, so nothing observed locally ever fires.
+    ///
+    /// Marking it [`PremiseSource::LocalProvenance`] costs nothing today — no gossip
+    /// receive path exists — and keeps its full value where provenance is observed
+    /// directly, in shadow mode and `fdev`. The alternative, dropping the same-base
+    /// restriction so the law becomes genuinely universal, would not close the gap;
+    /// it would break the property, for the reason the paragraph above gives.
+    ///
+    /// [`ConformanceEvidence`]: super::evidence::ConformanceEvidence
     DeltaPermutationInvariance,
     /// A delta against an exact summary of the same state should be empty (#5072).
     SelfDeltaEmpty,
@@ -325,8 +373,11 @@ pub enum ConformanceProperty {
     ///
     /// # Local provenance only: this property is NOT self-verifying
     ///
-    /// This is the one property in this module whose premise is not re-establishable
-    /// from the evidence bytes. See [`PremiseSource`], which is what enforces it.
+    /// This is one of the two properties here whose premise is not re-establishable
+    /// from the evidence bytes; [`ConformanceProperty::DeltaPermutationInvariance`]
+    /// is the other, for the same reason applied to delta bases rather than to the
+    /// ordering of a pair of states. See [`PremiseSource`], which is what enforces
+    /// it.
     ///
     /// Every other law is a universally quantified identity over valid states, so a
     /// receiving peer that re-executes the case against its own copy of the contract
@@ -430,6 +481,16 @@ impl ConformanceProperty {
             // rather than a rule — and it is exactly the kind of gap that closes
             // itself the day someone enables enforcement for the settled properties
             // and this one rides along unnoticed.
+            //
+            // This tier is also load-bearing for the evidence gate, and NOT
+            // independently adjustable. After `DeltaPermutationInvariance` moved to
+            // `LocalProvenance`, this is the only property that both ships as
+            // evidence and consumes delta bytes — which `verify_case` never
+            // validates, there being no `require_valid` for a delta. Promoting it to
+            // `Violation` without revisiting `premise_source` in the same change
+            // would make attacker-chosen delta bytes removal-eligible. The test
+            // `no_shippable_removal_eligible_property_consumes_unvalidated_deltas`
+            // fails if that happens.
             ConformanceProperty::DeltaIdempotence => Severity::Diagnostic,
             ConformanceProperty::StateIdempotence
             | ConformanceProperty::StateCommutativity
@@ -465,19 +526,30 @@ impl ConformanceProperty {
             | ConformanceProperty::SummaryDeterminism
             | ConformanceProperty::DeltaDeterminism
             | ConformanceProperty::DeltaIdempotence
-            | ConformanceProperty::DeltaPermutationInvariance
             | ConformanceProperty::SelfDeltaEmpty
             | ConformanceProperty::WholeStateSelfDelta
             | ConformanceProperty::ReconciliationCycle
             | ConformanceProperty::PathAgreement => PremiseSource::EvidenceBytes,
-            // The one exception, and the reason this method exists. See the
-            // variant's own documentation: `merge(base, result) == result` is
-            // last-write-wins for an arbitrary pair and a law only because the
-            // corpus witnessed that `result` was reached FROM `base`. Nothing in the
-            // bytes carries that witness, so a fabricated pair from a conforming
-            // grow-only contract would have every recipient independently confirm a
-            // removal-eligible violation against a correct contract.
-            ConformanceProperty::TransitionPathAgreement => PremiseSource::LocalProvenance,
+            // The exceptions, and the reason this method exists. Both are laws only
+            // because of something the OBSERVER knew and the bytes cannot carry, so
+            // both hand a recipient an accusation it can confirm but cannot check.
+            //
+            // `TransitionPathAgreement`: `merge(base, result) == result` is
+            // last-write-wins for an arbitrary pair, and a law only because the
+            // corpus witnessed that `result` was reached FROM `base`. A fabricated
+            // pair from a conforming grow-only contract would have every recipient
+            // independently confirm a removal-eligible violation against a correct
+            // contract.
+            //
+            // `DeltaPermutationInvariance`: the generator pairs only deltas observed
+            // against the SAME base, because deltas observed against different bases
+            // can be causally sequenced and permuting those asks about a situation
+            // the protocol never produces. That restriction is the whole reason a
+            // finding means anything, and evidence records no base for a delta — so
+            // a causally-sequenced pair fabricated against a conforming contract is
+            // structurally indistinguishable from a genuine concurrent one.
+            ConformanceProperty::TransitionPathAgreement
+            | ConformanceProperty::DeltaPermutationInvariance => PremiseSource::LocalProvenance,
         }
     }
 

--- a/crates/core/src/conformance/sampler.rs
+++ b/crates/core/src/conformance/sampler.rs
@@ -454,9 +454,15 @@ impl ContractSampler {
             // Only deltas that have no step to travel on. Every other delta rides on
             // its `Transition`, which is the ONLY place a bundle can record what a
             // delta was applied to — `ReplayBundle::to_corpus` gives bundle-level
-            // deltas no base at all, by design. Emitting a delta in both places used
-            // to leave the replayed corpus holding the unprovenanced copy, so the
-            // export of a corpus covered less than the corpus itself.
+            // deltas no base at all, by design.
+            //
+            // This is a SIZE fix, not the correctness one: emitting a delta in both
+            // places serializes it twice into a bundle that is meant to stay small
+            // enough to pass around. Provenance survives either way, because
+            // `Corpus::deduplicated` upgrades a kept entry from no-base to a base
+            // rather than discarding it — which is where the guard belongs, since a
+            // bundle can arrive from anywhere and this export is only one source.
+            // Do not read the filter as the thing keeping `delta_bases` populated.
             deltas: corpus
                 .deltas
                 .iter()

--- a/crates/core/src/conformance/sampler.rs
+++ b/crates/core/src/conformance/sampler.rs
@@ -369,11 +369,20 @@ impl ContractSampler {
         // `DeltaPermutationInvariance`, which pairs only deltas observed against the
         // SAME base — deltas with no recorded base are not paired at all, on purpose,
         // because permuting causally sequenced deltas asks about a situation the
-        // protocol never produces. Leaving the bases behind therefore did not
-        // degrade that check on a live node, it disabled it: every delta arrived
-        // unprovenanced and no pair was ever built, while `ReplayBundle::to_corpus`
-        // — the offline path — filled them in and checked plenty. The two must
-        // agree, or shadow mode covers less than the replay of its own export.
+        // protocol never produces.
+        //
+        // Be precise about what filling this in fixes, because the obvious story is
+        // wrong. Leaving the bases behind did NOT disable the property on a live
+        // node: shadow mode never reads this function. It calls `to_bundle` and then
+        // `ReplayBundle::to_corpus`, which recovers each base from
+        // `transition.base_state`. Before this change `to_bundle` did not read
+        // `delta_bases` either, so the value was consumed by nothing at all and could
+        // not disable anything. What actually cost a live node its pairs was the
+        // duplicate-delta defect in `to_bundle` combined with first-seen-wins dedup.
+        //
+        // It is load-bearing NOW, which is why it stays: `to_bundle`'s filter below
+        // reads `delta_base(i)` to decide which deltas still need to travel loose, so
+        // an unpopulated `delta_bases` would serialize every delta twice.
         let mut deltas: Vec<Bytes> = Vec::new();
         let mut delta_bases: Vec<Option<Bytes>> = Vec::new();
         for record in &self.transitions {
@@ -397,11 +406,15 @@ impl ContractSampler {
 
         // Carry the ORDERED base -> result steps, not just the states either end.
         //
-        // Without this the node's own shadow-mode corpus produces no
-        // `TransitionPathAgreement` cases at all, and a property that only works on
-        // a hand-built `fdev --bundle` corpus is a check nothing on the network ever
-        // runs. `materialize` is the same resolver `to_bundle` uses, so the in-memory
-        // corpus and the exported bundle agree about what a transition is.
+        // Same correction as the `delta_bases` comment above, and for the same
+        // reason: shadow mode does not run cases off this `Corpus`, it exports a
+        // bundle and reads the steps back out of `ReplayBundle::to_corpus`. So this
+        // is not what keeps `TransitionPathAgreement` alive on a live node.
+        //
+        // It is here so the in-memory corpus and the exported bundle mean the same
+        // thing by "a transition" — `materialize` is the same resolver `to_bundle`
+        // uses — and so any in-memory consumer added later inherits the provenance
+        // instead of silently checking that property against nothing.
         let transitions: Vec<(Bytes, Bytes)> = self
             .transitions
             .iter()

--- a/crates/core/src/conformance/sampler.rs
+++ b/crates/core/src/conformance/sampler.rs
@@ -376,10 +376,30 @@ impl ContractSampler {
             .map(|s| Arc::from(s.as_slice()))
             .collect();
 
+        // Carry the ORDERED base -> result steps, not just the states either end.
+        //
+        // Without this the node's own shadow-mode corpus produces no
+        // `TransitionPathAgreement` cases at all, and a property that only works on
+        // a hand-built `fdev --bundle` corpus is a check nothing on the network ever
+        // runs. `materialize` is the same resolver `to_bundle` uses, so the in-memory
+        // corpus and the exported bundle agree about what a transition is.
+        let transitions: Vec<(Bytes, Bytes)> = self
+            .transitions
+            .iter()
+            .filter_map(|record| {
+                let materialized = self.materialize(record)?;
+                Some((
+                    Arc::from(materialized.base_state.as_slice()),
+                    Arc::from(materialized.result_state.as_slice()),
+                ))
+            })
+            .collect();
+
         Corpus {
             states,
             deltas,
             summaries,
+            transitions,
             ..Default::default()
         }
         .deduplicated()

--- a/crates/core/src/conformance/sampler.rs
+++ b/crates/core/src/conformance/sampler.rs
@@ -363,12 +363,31 @@ impl ContractSampler {
             .filter_map(|h| self.blobs.get(h))
             .map(|b| Arc::from(b.as_slice()))
             .collect();
-        let deltas: Vec<Bytes> = self
-            .transitions
-            .iter()
-            .filter_map(|t| t.delta.as_ref())
-            .map(|d| Arc::from(d.as_slice()))
-            .collect();
+        // Each delta travels WITH the state it was applied to.
+        //
+        // `delta_bases` is the only thing that pairs deltas for
+        // `DeltaPermutationInvariance`, which pairs only deltas observed against the
+        // SAME base — deltas with no recorded base are not paired at all, on purpose,
+        // because permuting causally sequenced deltas asks about a situation the
+        // protocol never produces. Leaving the bases behind therefore did not
+        // degrade that check on a live node, it disabled it: every delta arrived
+        // unprovenanced and no pair was ever built, while `ReplayBundle::to_corpus`
+        // — the offline path — filled them in and checked plenty. The two must
+        // agree, or shadow mode covers less than the replay of its own export.
+        let mut deltas: Vec<Bytes> = Vec::new();
+        let mut delta_bases: Vec<Option<Bytes>> = Vec::new();
+        for record in &self.transitions {
+            let Some(delta) = record.delta.as_ref() else {
+                continue;
+            };
+            deltas.push(Arc::from(delta.as_slice()));
+            // The same resolver the steps below use, so a delta and the step it came
+            // from cannot disagree about what the base was.
+            delta_bases.push(
+                self.materialize(record)
+                    .map(|m| Arc::from(m.base_state.as_slice())),
+            );
+        }
         let summaries: Vec<Bytes> = self
             .transitions
             .iter()
@@ -398,6 +417,7 @@ impl ContractSampler {
         Corpus {
             states,
             deltas,
+            delta_bases,
             summaries,
             transitions,
             ..Default::default()
@@ -431,7 +451,19 @@ impl ContractSampler {
             parameters,
             instance: None,
             states: corpus.states.iter().map(|s| s.to_vec()).collect(),
-            deltas: corpus.deltas.iter().map(|d| d.to_vec()).collect(),
+            // Only deltas that have no step to travel on. Every other delta rides on
+            // its `Transition`, which is the ONLY place a bundle can record what a
+            // delta was applied to — `ReplayBundle::to_corpus` gives bundle-level
+            // deltas no base at all, by design. Emitting a delta in both places used
+            // to leave the replayed corpus holding the unprovenanced copy, so the
+            // export of a corpus covered less than the corpus itself.
+            deltas: corpus
+                .deltas
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| corpus.delta_base(*i).is_none())
+                .map(|(_, d)| d.to_vec())
+                .collect(),
             summaries: corpus.summaries.iter().map(|s| s.to_vec()).collect(),
             transitions: self
                 .transitions

--- a/crates/core/src/conformance/sampler_tests.rs
+++ b/crates/core/src/conformance/sampler_tests.rs
@@ -84,6 +84,22 @@ fn the_in_memory_corpus_carries_transition_provenance() {
     );
     assert_eq!(replayed.delta_bases, corpus.delta_bases);
     assert_eq!(replayed.deltas, corpus.deltas);
+
+    // A delta rides on its step OR loose, never both. Serializing it twice does not
+    // cost provenance — `Corpus::deduplicated` upgrades the kept entry either way,
+    // which is pinned separately — but it does cost bytes in an artifact whose whole
+    // purpose is to stay small enough to pass around.
+    assert!(
+        bundle.deltas.is_empty(),
+        "a delta carried by a transition must not also be emitted loose: {:?}",
+        bundle.deltas
+    );
+    assert_eq!(
+        bundle.transitions[0].delta.as_deref(),
+        Some(&[9u8][..]),
+        "...and it must actually be on the transition, or the assertion above \
+         passes because the delta was dropped entirely"
+    );
 }
 
 // ------------------------------------------------------------------ deduplication

--- a/crates/core/src/conformance/sampler_tests.rs
+++ b/crates/core/src/conformance/sampler_tests.rs
@@ -30,6 +30,45 @@ fn state(tag: u8, len: usize) -> Vec<u8> {
     out
 }
 
+/// The node's own corpus must carry the ORDERED step, not just the two states.
+///
+/// `TransitionPathAgreement` is a law only because the corpus witnesses that one
+/// state was reached from the other; for an arbitrary pair, "merging B into A yields
+/// B" is last-write-wins and false for every conforming contract. So the generator
+/// builds no case for it at all without provenance.
+///
+/// This pins the in-memory path specifically. `to_bundle` already exported
+/// transitions, but `corpus()` — which is what shadow mode on a live node actually
+/// checks — pulled only `delta` and `summary` out of them and dropped the pairing.
+/// A property that ran on a hand-built `fdev --bundle` corpus and never once on the
+/// network would be the most expensive kind of miss: it reads as coverage.
+#[test]
+fn the_in_memory_corpus_carries_transition_provenance() {
+    let mut sampler = ContractSampler::new(config());
+    let base = state(1, 32);
+    let result = state(2, 48);
+    assert_eq!(
+        sampler.observe_transition(&base, None, Some(&[9]), None, &result),
+        Admission::Stored
+    );
+
+    let corpus = sampler.corpus();
+    assert_eq!(
+        corpus.transitions.len(),
+        1,
+        "the ordered base -> result step is what the transition law needs, and \
+         without it shadow mode checks that law on nothing"
+    );
+    assert_eq!(corpus.transitions[0].0.as_ref(), base.as_slice());
+    assert_eq!(corpus.transitions[0].1.as_ref(), result.as_slice());
+
+    // The exported bundle and the in-memory corpus must agree about what a
+    // transition is, or a finding on a live node would vanish on replay.
+    let bundle = sampler.to_bundle(None, Some([0u8; 32]), Vec::new());
+    assert_eq!(bundle.transitions.len(), 1);
+    assert_eq!(bundle.to_corpus().transitions, corpus.transitions);
+}
+
 // ------------------------------------------------------------------ deduplication
 
 #[test]

--- a/crates/core/src/conformance/sampler_tests.rs
+++ b/crates/core/src/conformance/sampler_tests.rs
@@ -5,6 +5,8 @@
 //! bytes once, byte budgets, large states, restart reconstruction, and focus
 //! rotation.
 
+use std::sync::Arc;
+
 use freenet_stdlib::prelude::ContractInstanceId;
 
 use super::focus::FocusSelector;
@@ -66,7 +68,22 @@ fn the_in_memory_corpus_carries_transition_provenance() {
     // transition is, or a finding on a live node would vanish on replay.
     let bundle = sampler.to_bundle(None, Some([0u8; 32]), Vec::new());
     assert_eq!(bundle.transitions.len(), 1);
-    assert_eq!(bundle.to_corpus().transitions, corpus.transitions);
+    let replayed = bundle.to_corpus();
+    assert_eq!(replayed.transitions, corpus.transitions);
+
+    // ...and about what a delta was applied TO. `delta_bases` is the second thing a
+    // transition carries, and the only thing that pairs deltas for
+    // `delta_permutation_invariance` — which pairs only deltas observed against the
+    // SAME base. Comparing transitions alone lets an export drop every base while
+    // this pin stays green, and a replay that quietly covers less than the run it
+    // replays is the worst shape an export can have.
+    assert_eq!(
+        corpus.delta_bases,
+        vec![Some(Arc::from(base.as_slice()))],
+        "the observed delta must be recorded against the state it was applied to"
+    );
+    assert_eq!(replayed.delta_bases, corpus.delta_bases);
+    assert_eq!(replayed.deltas, corpus.deltas);
 }
 
 // ------------------------------------------------------------------ deduplication

--- a/crates/core/src/conformance/sampler_tests.rs
+++ b/crates/core/src/conformance/sampler_tests.rs
@@ -40,10 +40,17 @@ fn state(tag: u8, len: usize) -> Vec<u8> {
 /// builds no case for it at all without provenance.
 ///
 /// This pins the in-memory path specifically. `to_bundle` already exported
-/// transitions, but `corpus()` — which is what shadow mode on a live node actually
-/// checks — pulled only `delta` and `summary` out of them and dropped the pairing.
-/// A property that ran on a hand-built `fdev --bundle` corpus and never once on the
-/// network would be the most expensive kind of miss: it reads as coverage.
+/// transitions, but `corpus()` pulled only `delta` and `summary` out of them and
+/// dropped the pairing.
+///
+/// Be precise about what that cost, because the obvious story is wrong: shadow mode
+/// does not run cases off `corpus()` at all. It calls `to_bundle` and then
+/// `ReplayBundle::to_corpus`, so the live path never depended on this. What the gap
+/// did mean is that the sampler's own view of its observations and the bundle it
+/// exports disagreed about what a transition is, which is how a later in-memory
+/// consumer would inherit a corpus that silently checks the provenance-dependent
+/// laws against nothing. The second half of this test — comparing the in-memory
+/// corpus against the replayed bundle — is the part that pins the agreement.
 #[test]
 fn the_in_memory_corpus_carries_transition_provenance() {
     let mut sampler = ContractSampler::new(config());
@@ -58,8 +65,8 @@ fn the_in_memory_corpus_carries_transition_provenance() {
     assert_eq!(
         corpus.transitions.len(),
         1,
-        "the ordered base -> result step is what the transition law needs, and \
-         without it shadow mode checks that law on nothing"
+        "the ordered base -> result step is what the transition law needs, and a \
+         corpus without it checks that law on nothing"
     );
     assert_eq!(corpus.transitions[0].0.as_ref(), base.as_slice());
     assert_eq!(corpus.transitions[0].1.as_ref(), result.as_slice());

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -241,6 +241,10 @@ fn conforming_contract_satisfies_every_state_law() {
     ));
     assert_holds(verify_case(
         &mut fake,
+        &case(ConformanceProperty::PathAgreement, &[a, b]),
+    ));
+    assert_holds(verify_case(
+        &mut fake,
         &case(ConformanceProperty::DeltaIdempotence, &[a]).with_deltas(vec![bytes(&[9])]),
     ));
     assert_holds(verify_case(
@@ -927,6 +931,288 @@ fn a_case_with_too_few_states_is_malformed_not_a_violation() {
 }
 
 // ------------------------------------------------------------------------ evidence
+
+// ------------------------------------------------------ #5394: disagreeing write paths
+
+/// A contract whose state is a map keyed by the high nibble of each byte, with a
+/// deliberate disagreement between its two write paths.
+///
+/// The merge path resolves a key collision by keeping the FIRST entry in ascending
+/// order (`entry(k).or_insert(v)`); the delta path keeps the LAST (`insert(k, v)`).
+/// Each rule on its own is a sound semilattice — min-per-key and max-per-key are
+/// both commutative, associative and idempotent — so every property that compares
+/// merge-to-merge or delta-to-delta holds. Only putting one path beside the other
+/// reveals the defect. This is the #5394 shape: `insert` on the direct-apply path,
+/// `entry().or_insert()` on the merge path, on a map keyed by a client-chosen
+/// sequence number.
+fn disagreeing_paths() -> Fake {
+    Fake::conforming()
+        .validating(|state| {
+            if is_canonical(state) && state.windows(2).all(|w| w[0] >> 4 != w[1] >> 4) {
+                Ok(ValidateResult::Valid)
+            } else {
+                Ok(ValidateResult::Invalid)
+            }
+        })
+        .merging(|a, b| Ok(collapse_by_key(&union(a, b), false)))
+        .applying(|a, d| Ok(collapse_by_key(&union(a, d), true)))
+}
+
+fn collapse_by_key(entries: &[u8], keep_last: bool) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    for entry in union(entries, &[]) {
+        match out.last().copied() {
+            Some(previous) if previous >> 4 == entry >> 4 => {
+                if keep_last {
+                    let last = out.len() - 1;
+                    out[last] = entry;
+                }
+            }
+            _ => out.push(entry),
+        }
+    }
+    out
+}
+
+/// The positive case: two states whose keys collide, so the two paths resolve the
+/// collision differently and the contract cannot converge.
+///
+/// `0x51` and `0x52` are two writes to key 5 carrying different values — the two
+/// retractions stamped with the same sequence number in the real defect.
+#[test]
+fn a_contract_whose_two_write_paths_disagree_is_caught() {
+    let mut fake = disagreeing_paths();
+    assert_violates(
+        verify_case(
+            &mut fake,
+            &case(
+                ConformanceProperty::PathAgreement,
+                &[&[0x10, 0x51], &[0x10, 0x52]],
+            ),
+        ),
+        ConformanceProperty::PathAgreement,
+    );
+}
+
+/// The matched negative the acceptance test in #5394 asks for, and the half that
+/// makes the positive above mean anything.
+///
+/// The SAME contract, with the SAME two write paths, on states whose keys do not
+/// collide. A property that flagged every contract with both a delta and a merge
+/// path would satisfy the test above while being worse than no property at all, and
+/// this is what distinguishes the two.
+#[test]
+fn the_same_disagreeing_contract_is_silent_when_no_key_collides() {
+    let mut fake = disagreeing_paths();
+    assert_holds(verify_case(
+        &mut fake,
+        &case(
+            ConformanceProperty::PathAgreement,
+            &[&[0x10, 0x51], &[0x10, 0x62]],
+        ),
+    ));
+}
+
+/// Every OTHER law holds for the disagreeing contract, which is the whole claim
+/// #5394 makes: a contract can satisfy the entire existing property set and still
+/// diverge, because none of those properties ever puts one write path beside the
+/// other.
+///
+/// Without this the new property could be riding on a defect the existing set
+/// already catches, and the gap it is supposed to close would be unproven.
+#[test]
+fn the_disagreeing_contract_satisfies_every_pre_existing_law() {
+    let (a, b, c): (&[u8], &[u8], &[u8]) = (&[0x10, 0x51], &[0x10, 0x52], &[0x23, 0x51]);
+    for (property, states, deltas) in [
+        (ConformanceProperty::StateIdempotence, vec![a], vec![]),
+        (ConformanceProperty::StateCommutativity, vec![a, b], vec![]),
+        (
+            ConformanceProperty::StateAssociativity,
+            vec![a, b, c],
+            vec![],
+        ),
+        (
+            ConformanceProperty::EmittedStateValidity,
+            vec![a, b],
+            vec![],
+        ),
+        (ConformanceProperty::UpdateDeterminism, vec![a, b], vec![]),
+        (ConformanceProperty::SummaryDeterminism, vec![a], vec![]),
+        (ConformanceProperty::DeltaDeterminism, vec![a], vec![]),
+        (ConformanceProperty::ReconciliationCycle, vec![a, b], vec![]),
+        (ConformanceProperty::SelfDeltaEmpty, vec![a], vec![]),
+        (
+            ConformanceProperty::DeltaIdempotence,
+            vec![a],
+            vec![bytes(&[0x52])],
+        ),
+        (
+            ConformanceProperty::DeltaPermutationInvariance,
+            vec![a],
+            vec![bytes(&[0x52]), bytes(&[0x63])],
+        ),
+    ] {
+        let mut fake = disagreeing_paths();
+        let built = ConformanceCase::new(property, states.iter().map(|s| bytes(s)).collect())
+            .with_deltas(deltas);
+        let outcome = verify_case(&mut fake, &built);
+        assert!(
+            !outcome.is_violation(),
+            "{property} fired on the disagreeing-paths contract, so it no longer \
+             demonstrates the #5394 gap (a contract that satisfies every existing \
+             law and still diverges): {outcome:?}"
+        );
+    }
+}
+
+/// A weak delta encoding is not a disagreement, and this is the guard that keeps the
+/// property off a large legitimate class.
+///
+/// The contract is a plain union semilattice whose delta carries only PART of what
+/// the other state holds — the shape of a coarse version clock or a compact digest,
+/// which `a_weak_delta_path_with_a_sound_merge_is_not_a_cycle` already refuses to
+/// accuse under `ReconciliationCycle`. Its delta path lands short of the merged
+/// state on this round and catches up on the next one.
+///
+/// Without the re-merge guard in `path_agreement` this test fails: the raw
+/// comparison `apply(base, delta) != merge(base, other)` is true here.
+#[test]
+fn a_delta_that_carries_only_part_of_the_other_state_is_not_a_disagreement() {
+    // Ships only the smallest missing byte, so the delta path always lags.
+    let mut fake = Fake::conforming()
+        .deltaing(|state, summary| Ok(difference(state, summary).into_iter().take(1).collect()));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::PathAgreement, &[&[1], &[2, 3, 4]]),
+    );
+    assert_holds(outcome);
+
+    // ...and the raw comparison really would have fired, so the assertion above is
+    // not passing because the two paths happened to agree.
+    let mut same = Fake::conforming()
+        .deltaing(|state, summary| Ok(difference(state, summary).into_iter().take(1).collect()));
+    let delta = same.get_state_delta(&[2, 3, 4], &[1]).expect("delta");
+    let delta_path = union(&[1], &delta);
+    let merge_path = union(&[1], &[2, 3, 4]);
+    assert_ne!(
+        delta_path, merge_path,
+        "this fixture no longer exercises the partial-delta case the guard exists \
+         for, so the assertion above passes for the wrong reason"
+    );
+}
+
+/// An empty delta is the protocol's "nothing to send", so there is no delta path to
+/// compare the merge path against and the honest answer is a refusal.
+#[test]
+fn a_contract_with_no_delta_path_is_inconclusive_rather_than_accused() {
+    let mut fake = Fake::conforming()
+        .summarizing(|_| Ok(vec![0]))
+        .deltaing(|_state, _summary| Ok(Vec::new()));
+
+    assert_inconclusive(
+        verify_case(
+            &mut fake,
+            &case(ConformanceProperty::PathAgreement, &[&[1, 2], &[3, 4]]),
+        ),
+        Inconclusive::NoDeltaPath,
+    );
+}
+
+/// A last-write-wins merge heals trivially under the guard, so this property
+/// declines to pile a second accusation onto a defect `StateCommutativity` already
+/// names. One law per property — the same rule `DeltaPermutationInvariance` follows
+/// with respect to `DeltaIdempotence`.
+#[test]
+fn a_broken_merge_is_left_to_the_property_that_names_it() {
+    let mut fake = Fake::conforming().merging(|_a, b| Ok(b.to_vec()));
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::PathAgreement, &[&[1, 2], &[2, 3]]),
+    );
+    assert!(
+        !outcome.is_violation(),
+        "path agreement must not re-accuse a contract whose merge is the defect: \
+         {outcome:?}"
+    );
+    assert_violates(
+        verify_case(
+            &mut fake,
+            &case(ConformanceProperty::StateCommutativity, &[&[1, 2], &[2, 3]]),
+        ),
+        ConformanceProperty::StateCommutativity,
+    );
+}
+
+/// A defect visible from only ONE of the two directions must still be found.
+///
+/// The pin for the second `path_agreement` call. The mode-8 fixture disagrees in
+/// both directions, so a test built on it passes whether or not the reverse
+/// direction is checked at all — which is a test that pins nothing. This contract's
+/// delta path adds a byte the merge path never produces, but only when the BASE
+/// already carries a marker, so exactly one of the two directions can see it.
+///
+/// The pair is listed with the marker state SECOND, which is the direction a
+/// single-direction check would miss.
+#[test]
+fn a_defect_visible_from_only_one_direction_is_still_found() {
+    const MARKER: u8 = 0xEE;
+    const EXTRA: u8 = 0xFF;
+    let make = || {
+        Fake::conforming().applying(|base, delta| {
+            let mut out = union(base, delta);
+            if base.contains(&MARKER) {
+                out = union(&out, &[EXTRA]);
+            }
+            Ok(out)
+        })
+    };
+
+    // Marker state second: the forward direction (base = the plain state) agrees,
+    // so only the reverse direction can find this.
+    assert_violates(
+        verify_case(
+            &mut make(),
+            &case(
+                ConformanceProperty::PathAgreement,
+                &[&[0x01, 0x02], &[0x01, MARKER]],
+            ),
+        ),
+        ConformanceProperty::PathAgreement,
+    );
+
+    // And the forward direction really does agree, so the assertion above is not
+    // passing because both directions happened to fire.
+    let mut fake = make();
+    let delta = fake
+        .get_state_delta(&[0x01, MARKER], &[0x01, 0x02])
+        .expect("delta");
+    assert_eq!(
+        union(&[0x01, 0x02], &delta),
+        union(&[0x01, 0x02], &[0x01, MARKER]),
+        "the forward direction must AGREE for this to pin the reverse one"
+    );
+}
+
+/// Which state the corpus happened to list first must not decide whether a defect is
+/// found. The generator emits each unordered pair once, so a one-directional check
+/// would make the finding depend on file order.
+#[test]
+fn a_disagreement_is_found_from_either_order_of_the_pair() {
+    for states in [
+        [&[0x10u8, 0x51u8][..], &[0x10, 0x52][..]],
+        [&[0x10, 0x52][..], &[0x10, 0x51][..]],
+    ] {
+        let mut fake = disagreeing_paths();
+        assert_violates(
+            verify_case(
+                &mut fake,
+                &case(ConformanceProperty::PathAgreement, &states),
+            ),
+            ConformanceProperty::PathAgreement,
+        );
+    }
+}
 
 fn instance(seed: u8) -> ContractInstanceId {
     ContractInstanceId::new([seed; 32])

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -1677,10 +1677,20 @@ fn the_transition_branch_is_bounded_and_strided() {
     };
     let cases = generate_cases(&corpus, &config);
     assert_eq!(cases.len(), 4, "the cap must bind");
-    // Strided over the whole history rather than the first four: the last step is
-    // reachable, which truncation could never manage.
+    // Strided over the whole history rather than the first four.
+    //
+    // Say what this actually pins: the four selected steps are spread across the
+    // range, not the first four. Index 39 is NOT selected — a stride of 10 from 0
+    // reaches 30 — so this is not a claim that the newest step is reachable. What it
+    // rules out is truncation, under which the bases would be `[0, 1, 2, 3]` and a
+    // contract would only ever be checked against its own oldest few minutes.
     let bases: Vec<u8> = cases.iter().map(|c| c.states[0][0]).collect();
     assert_eq!(bases, vec![0, 10, 20, 30]);
+    assert_ne!(
+        bases,
+        vec![0, 1, 2, 3],
+        "truncation is the thing this test exists to exclude, so name it"
+    );
 }
 
 /// The generator must build transition cases ONLY from recorded provenance.
@@ -1751,7 +1761,7 @@ fn evidence_round_trips_through_a_case() {
     let evidence = ConformanceEvidence::new(instance(7), vec![9, 9], &original, None);
     evidence.check_bounds().expect("bounds");
 
-    let rebuilt = evidence.to_case();
+    let rebuilt = evidence.to_case().expect("to_case");
     assert_eq!(rebuilt.property, original.property);
     assert_eq!(rebuilt.states, original.states);
 
@@ -1940,6 +1950,14 @@ fn evidence_for_a_self_verifying_property_is_accepted() {
 /// lumped in with the self-verifying ones fails here instead of silently widening
 /// the untrusted path — the exact hazard `TransitionPathAgreement` introduced.
 ///
+/// The list below has two entries rather than one because the first version of this
+/// pin recorded the wrong answer for a property that already existed:
+/// `DeltaPermutationInvariance` was classified `EvidenceBytes`, and the loop at the
+/// bottom of this test therefore asserted that a fabricated 1-state/2-delta case for
+/// it must be ACCEPTED. That is a caution about the shape of this pin, not just its
+/// contents — it records the answer given, and a wrong answer is pinned exactly as
+/// firmly as a right one. Read the property's own documentation before adding to it.
+///
 /// If you are here because you added a property: decide whether re-executing the
 /// case against a local copy of the contract re-establishes EVERYTHING the law
 /// asserts. If any part of it rests on how the inputs were observed, it is
@@ -1953,7 +1971,10 @@ fn every_property_declares_whether_it_is_self_verifying() {
         .collect();
     assert_eq!(
         local,
-        vec![ConformanceProperty::TransitionPathAgreement],
+        vec![
+            ConformanceProperty::DeltaPermutationInvariance,
+            ConformanceProperty::TransitionPathAgreement,
+        ],
         "the set of properties that cannot travel as evidence changed; if that is \
          deliberate, update this pin, and make sure `check_bounds` still refuses \
          every one of them"
@@ -1983,6 +2004,146 @@ fn every_property_declares_whether_it_is_self_verifying() {
              properties"
         );
     }
+}
+
+/// `DeltaPermutationInvariance` is refused as evidence, with its own test rather
+/// than only as a row in the pin above.
+///
+/// The pin above records the classification; this records WHY, so a future reader
+/// weighing "surely a delta pair is just bytes" has the counterexample in front of
+/// them. The generator pairs only deltas observed against the SAME base
+/// (`generator::delta_pairs`), because deltas observed against different bases can be
+/// causally sequenced. Evidence carries no base for a delta at all — `states` and
+/// `deltas` and nothing else — so a recipient re-running the case reproduces the
+/// comparison without the premise.
+///
+/// The concrete victim: an add-wins OR-set whose delta encodes tag adds and removes
+/// and which does not tombstone a tag it has never seen. Sound in production, because
+/// a delta is always `get_state_delta(sender, recipient_summary)`. Fed the
+/// causally-sequenced pair `D1 = add A^t`, `D2 = remove t`, the two orders diverge —
+/// and this property is `Severity::Violation`, which `policy::decide` maps to
+/// `ConformanceAction::Remove` in Enforce mode. Every recipient would independently
+/// confirm a removal against a correct contract.
+#[test]
+fn evidence_for_delta_permutation_invariance_is_refused() {
+    let built = ConformanceCase::new(
+        ConformanceProperty::DeltaPermutationInvariance,
+        vec![bytes(&[1])],
+    )
+    .with_deltas(vec![bytes(&[0x80]), bytes(&[0x81])]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &built, None);
+    assert!(
+        evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
+        "the fixture must be well within every OTHER bound, or this could pass for \
+         the wrong reason"
+    );
+    assert_eq!(
+        evidence.states.len(),
+        ConformanceProperty::DeltaPermutationInvariance.state_arity(),
+        "the fixture must satisfy the arity check, or this could pass for the wrong \
+         reason"
+    );
+    assert_eq!(
+        evidence.deltas.len(),
+        ConformanceProperty::DeltaPermutationInvariance.delta_arity(),
+        "the fixture must satisfy the arity check, or this could pass for the wrong \
+         reason"
+    );
+    assert_eq!(
+        evidence.check_bounds(),
+        Err(EvidenceRejected::NotSelfVerifying {
+            property: ConformanceProperty::DeltaPermutationInvariance,
+        })
+    );
+    assert_eq!(
+        evidence.to_case().err(),
+        Some(EvidenceRejected::NotSelfVerifying {
+            property: ConformanceProperty::DeltaPermutationInvariance,
+        }),
+        "and the gate must hold at the point where a case is built, not only where \
+         someone remembered to call `check_bounds`"
+    );
+}
+
+/// The hazard class, stated once so a new property cannot re-enter it.
+///
+/// `verify_case` validates every STATE in a case through `require_valid`, and never
+/// validates a delta — there is no `require_valid` analogue for delta bytes, because
+/// a contract exposes no "is this delta well-formed" entry point. So a property that
+/// (a) travels as evidence, (b) consumes delta bytes, and (c) is removal-eligible
+/// would let an attacker choose bytes that go straight into another peer's WASM and
+/// come back out as a removal verdict.
+///
+/// Two properties carry deltas. `DeltaPermutationInvariance` is `Violation` and is
+/// kept off the wire by `premise_source`. `DeltaIdempotence` ships, and is safe only
+/// because it is `Diagnostic`, which `policy::decide` never turns into a removal —
+/// so its severity is not independently adjustable, and its own documentation says
+/// so. This test is what makes that a rule rather than a note: promoting it without
+/// revisiting `premise_source` in the same change fails here.
+#[test]
+fn no_shippable_removal_eligible_property_consumes_unvalidated_deltas() {
+    let hazardous: Vec<ConformanceProperty> = ConformanceProperty::ALL
+        .iter()
+        .copied()
+        .filter(|p| {
+            p.delta_arity() > 0 && p.is_self_verifying() && p.severity() == Severity::Violation
+        })
+        .collect();
+    assert!(
+        hazardous.is_empty(),
+        "{hazardous:?}: a property that ships as evidence, runs attacker-chosen \
+         delta bytes through the WASM, and is removal-eligible is the combination \
+         the evidence gate exists to prevent. Either mark it \
+         `PremiseSource::LocalProvenance`, or drop it to `Severity::Diagnostic`, or \
+         give deltas a validity check first — do not simply update this test"
+    );
+
+    // The fixture must be able to fail: at least one property really does carry
+    // deltas, so the filter above is not vacuously empty.
+    assert!(
+        ConformanceProperty::ALL
+            .iter()
+            .any(|p| p.delta_arity() > 0 && p.is_self_verifying()),
+        "no property carries deltas as evidence any more, so the assertion above \
+         proves nothing; delete it or re-aim it"
+    );
+}
+
+/// `to_case` is the gate, not the doc comment above it.
+///
+/// It used to hand back a runnable case unconditionally, with a rustdoc line asking
+/// the caller to have run `check_bounds`. Every caller today does; the hazard is the
+/// caller that does not exist yet, because the receive path (#5377) is unbuilt. When
+/// it lands, a convention is what stands between an arbitrary byte string and the
+/// WASM runtime — so the check moved inside.
+#[test]
+fn to_case_refuses_what_check_bounds_refuses() {
+    let big = vec![0u8; MAX_EVIDENCE_INPUT_BYTES + 1];
+    let oversized = ConformanceCase::new(
+        ConformanceProperty::StateIdempotence,
+        vec![Arc::from(big.as_slice())],
+    );
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &oversized, None);
+    assert!(matches!(
+        evidence.to_case(),
+        Err(EvidenceRejected::TooLarge { .. })
+    ));
+
+    // Arity too, so this is not a test about size alone.
+    let wrong_arity = ConformanceCase::new(
+        ConformanceProperty::StateAssociativity,
+        vec![bytes(&[1]), bytes(&[2])],
+    );
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &wrong_arity, None);
+    assert!(matches!(
+        evidence.to_case(),
+        Err(EvidenceRejected::Arity { .. })
+    ));
+
+    // And the counterpart, so a `to_case` that refused everything would fail here.
+    let fine = case(ConformanceProperty::StateCommutativity, &[&[1], &[1, 2]]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &fine, None);
+    assert!(evidence.to_case().is_ok());
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -23,7 +23,9 @@ use super::evidence::{
 };
 use super::generator::{Corpus, GeneratorConfig, generate_cases};
 use super::oracle::{ConformanceOracle, OracleError};
-use super::property::{ConformanceProperty, Inconclusive, PropertyOutcome, Severity};
+use super::property::{
+    ConformanceProperty, Inconclusive, PremiseSource, PropertyOutcome, Severity,
+};
 use super::verifier::{Bytes, ConformanceCase, verify_case};
 
 // ---------------------------------------------------------------- fake contract
@@ -1064,12 +1066,20 @@ fn the_disagreeing_contract_satisfies_every_pre_existing_law() {
         let mut fake = disagreeing_paths();
         let built = ConformanceCase::new(property, states.iter().map(|s| bytes(s)).collect())
             .with_deltas(deltas);
-        let outcome = verify_case(&mut fake, &built);
-        assert!(
-            !outcome.is_violation(),
-            "{property} fired on the disagreeing-paths contract, so it no longer \
-             demonstrates the #5394 gap (a contract that satisfies every existing \
-             law and still diverges): {outcome:?}"
+        // `Holds`, not merely "not a violation".
+        //
+        // The claim the whole #5394 gap argument rests on is that every OTHER law
+        // HOLDS on this contract — a contract that satisfies the entire settled
+        // property set and still diverges. `!is_violation()` is also satisfied by
+        // `Inconclusive`, so a case that silently stopped being evaluated at all
+        // would keep this test green while the claim it exists to support quietly
+        // became unsupported.
+        assert_eq!(
+            verify_case(&mut fake, &built),
+            PropertyOutcome::Holds,
+            "{property} did not HOLD on the disagreeing-paths contract, so it no \
+             longer demonstrates the #5394 gap (a contract that satisfies every \
+             existing law and still diverges)"
         );
     }
 }
@@ -1367,6 +1377,104 @@ fn capped_collection_evicting_outside_the_merge_order_is_caught() {
     assert_holds(verify_case(&mut sound, &sound_case));
 }
 
+/// The PARTIALLY-ORDERED cap: keep the at-most-N maximal elements under a causal
+/// partial order, breaking ties among mutually incomparable survivors by a total
+/// order.
+///
+/// This is the bounded-collection shape the first version of this property could not
+/// rule out. Unlike "keep the largest N" it is not obviously a bounded semilattice,
+/// and unlike the content-indexed eviction in
+/// `capped_collection_evicting_outside_the_merge_order_is_caught` it does not look
+/// arbitrary — it is the shape a version-vector or causal-log application actually
+/// writes, and it survives the pairwise laws.
+///
+/// Brute-forced over its whole state space on 2026-08-23 (universe of five elements,
+/// `1` causally after `5`, N = 2, ties by keeping the largest: 15 valid states) it
+/// is commutative and idempotent with zero failures, and NOT associative — 532
+/// failing triples. So it is already removal-eligible under `StateAssociativity`
+/// before this property is consulted, which is what closes the gap: the transition
+/// law condemns no contract the settled algebra acquits. It fires here too, which is
+/// the consistency the semilattice argument in `TransitionPathAgreement`'s
+/// documentation predicts rather than a second, independent accusation.
+///
+/// Both halves are asserted. Asserting only the firing would leave the important
+/// half — that associativity already had it — as prose.
+#[test]
+fn a_partially_ordered_cap_is_already_caught_by_associativity() {
+    const N: usize = 2;
+    // `1` is causally after `5`, so a set holding both keeps only `1`.
+    fn dominates(after: u8, before: u8) -> bool {
+        after == 1 && before == 5
+    }
+    fn cap(a: &[u8], b: &[u8]) -> Result<Vec<u8>, OracleError> {
+        let all = union(a, b);
+        let mut out: Vec<u8> = all
+            .iter()
+            .copied()
+            .filter(|x| !all.iter().any(|y| dominates(*y, *x)))
+            .collect();
+        // Ties among incomparable survivors go to the total order.
+        while out.len() > N {
+            out.remove(0);
+        }
+        Ok(out)
+    }
+    let fake = || {
+        Fake::conforming()
+            .merging(cap)
+            .applying(cap)
+            .validating(|state| {
+                let canonical = cap(state, &[]).expect("cap is infallible");
+                if canonical == state {
+                    Ok(ValidateResult::Valid)
+                } else {
+                    Ok(ValidateResult::Invalid)
+                }
+            })
+    };
+
+    // The half that closes the gap: associativity already condemns it. The triple is
+    // the smallest of the 532 the brute force found.
+    assert_violates(
+        verify_case(
+            &mut fake(),
+            &case(
+                ConformanceProperty::StateAssociativity,
+                &[&[1], &[2], &[3, 5]],
+            ),
+        ),
+        ConformanceProperty::StateAssociativity,
+    );
+
+    // ...and the pairwise laws do NOT, which is why the shape looked plausible.
+    for pairwise in [
+        case(ConformanceProperty::StateCommutativity, &[&[1], &[3, 5]]),
+        case(ConformanceProperty::StateIdempotence, &[&[2, 5]]),
+    ] {
+        let property = pairwise.property;
+        assert_eq!(
+            verify_case(&mut fake(), &pairwise),
+            PropertyOutcome::Holds,
+            "{property} must hold, or this fixture is not the hard case it claims \
+             to be"
+        );
+    }
+
+    // The transition law fires too, on the step the brute force identified.
+    let mut oracle = fake();
+    let built = transition_case(&mut oracle, &[2, 5], &[1, 3]);
+    assert_eq!(
+        built.states[1].as_ref(),
+        &[2, 3],
+        "the op must actually reach the measured state, or the assertion below is \
+         about something else"
+    );
+    assert_violates(
+        verify_case(&mut oracle, &built),
+        ConformanceProperty::TransitionPathAgreement,
+    );
+}
+
 /// A contract that rewrites a stored state into canonical form on first merge must
 /// not be accused.
 ///
@@ -1399,6 +1507,46 @@ fn a_canonicalizing_contract_is_not_accused_by_the_transition_law() {
     assert_holds(verify_case(&mut fake, &built));
 }
 
+/// A merge that EMITS an invalid state is `EmittedStateValidity`'s defect, not this
+/// one.
+///
+/// Both sides of the comparison get the same validity precondition, for the reason
+/// every check in this module applies it: a state the contract itself rejects never
+/// reaches another peer, so reasoning about it is reasoning about a history that
+/// cannot happen. `path_agreement` validates both of its outputs already; without
+/// the matching check here the transition branch validated only the settled result
+/// and reported the emitted-invalid-state defect under its own name — accusing the
+/// right contract under the wrong law.
+#[test]
+fn a_merge_that_emits_an_invalid_state_is_not_reported_under_the_transition_law() {
+    // Merging anything into the base emits a state the contract rejects. The
+    // marker never appears in a state the delta path produces, so `result` and its
+    // fixpoint stay valid and only `merge(base, settled)` trips the check.
+    const MARKER: u8 = 0xFE;
+    let mut fake = Fake::conforming()
+        .merging(|a, b| {
+            let mut out = union(a, b);
+            if !out.is_empty() {
+                out.push(MARKER);
+            }
+            Ok(out)
+        })
+        .applying(|a, d| Ok(union(a, d)))
+        .validating(|state| {
+            if is_canonical(state) && !state.contains(&MARKER) {
+                Ok(ValidateResult::Valid)
+            } else {
+                Ok(ValidateResult::Invalid)
+            }
+        });
+
+    let built = case(
+        ConformanceProperty::TransitionPathAgreement,
+        &[&[1, 2], &[1, 2, 3]],
+    );
+    assert_inconclusive(verify_case(&mut fake, &built), Inconclusive::InputNotValid);
+}
+
 /// A result state that keeps rewriting itself cannot be judged here, and the defect
 /// already has a name. Reporting it under this law would accuse the right contract
 /// under the wrong one.
@@ -1423,6 +1571,68 @@ fn a_result_state_that_never_settles_is_inconclusive_not_a_violation() {
         ),
         Inconclusive::StateNotSettled,
     );
+}
+
+/// A corpus holding steps and no loose states is not empty.
+///
+/// `generate_cases` returns early on an empty corpus, so a states-only emptiness
+/// test short-circuits before the transition queue is ever built — and the one
+/// property that depends on provenance would silently check nothing while the run
+/// exited 0. The endpoints happen to be pushed into `states` by `fdev --transition`
+/// today, so this is a latent trap rather than a live one; it is exactly the kind
+/// that a future caller (the sampler's own records, a bundle carrying only steps)
+/// walks into.
+#[test]
+fn a_corpus_of_steps_alone_is_not_empty() {
+    let steps_only = Corpus {
+        transitions: vec![(bytes(&[1]), bytes(&[1, 2]))],
+        ..Default::default()
+    };
+    assert!(
+        !steps_only.is_empty(),
+        "a recorded step is material to check, so a corpus holding one is not empty"
+    );
+    let config = GeneratorConfig {
+        properties: vec![ConformanceProperty::TransitionPathAgreement],
+        ..Default::default()
+    };
+    assert_eq!(
+        generate_cases(&steps_only, &config).len(),
+        1,
+        "and the early return must not swallow it"
+    );
+
+    // The counterpart, so an `is_empty` that always returned false would fail here.
+    assert!(Corpus::default().is_empty());
+}
+
+/// The transition branch is bounded like every other arity branch.
+///
+/// It does not pair anything so it does not grow quadratically, but it is linear in
+/// a corpus a busy contract fills without limit, and an unbounded queue would let
+/// one contract's step history crowd the interleave and decide which laws the case
+/// budget reaches — the thing the interleave exists to prevent.
+///
+/// Strided, not truncated, for the same reason `paired_states` strides: steps arrive
+/// in time order, so the first N are all from the same few minutes.
+#[test]
+fn the_transition_branch_is_bounded_and_strided() {
+    let config = GeneratorConfig {
+        properties: vec![ConformanceProperty::TransitionPathAgreement],
+        max_transitions: 4,
+        max_cases: 1024,
+        ..Default::default()
+    };
+    let corpus = Corpus {
+        transitions: (0..40u8).map(|i| (bytes(&[i]), bytes(&[i, 200]))).collect(),
+        ..Corpus::from_states(vec![vec![1]])
+    };
+    let cases = generate_cases(&corpus, &config);
+    assert_eq!(cases.len(), 4, "the cap must bind");
+    // Strided over the whole history rather than the first four: the last step is
+    // reachable, which truncation could never manage.
+    let bases: Vec<u8> = cases.iter().map(|c| c.states[0][0]).collect();
+    assert_eq!(bases, vec![0, 10, 20, 30]);
 }
 
 /// The generator must build transition cases ONLY from recorded provenance.
@@ -1629,6 +1839,102 @@ fn evidence_at_the_related_contract_limit_is_accepted() {
         .map(|i| (instance(i as u8), vec![i as u8]))
         .collect();
     assert!(evidence.check_bounds().is_ok());
+}
+
+/// The fifth `check_bounds` branch, and the only one that is not about size or
+/// schema: a property whose premise the evidence bytes cannot carry is refused
+/// outright.
+///
+/// This is the branch that keeps the ship-inputs-not-verdicts design sound. Every
+/// other law is a universally quantified identity over valid states, so a recipient
+/// that re-executes the case re-establishes the whole premise and a fabricated case
+/// can only surface a real defect sooner. `TransitionPathAgreement` is a law only
+/// because the SENDER witnessed that `result` was reached from `base`, and that
+/// witness is not in the bytes — so a fabricated pair from a conforming grow-only
+/// contract would have every recipient independently confirm a removal-eligible
+/// violation against a correct contract.
+#[test]
+fn evidence_for_a_property_that_is_not_self_verifying_is_refused() {
+    let case = case(
+        ConformanceProperty::TransitionPathAgreement,
+        &[&[1], &[1, 2]],
+    );
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    assert!(
+        evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
+        "the fixture must be well within every OTHER bound, or this could pass for \
+         the wrong reason"
+    );
+    assert_eq!(
+        evidence.check_bounds(),
+        Err(EvidenceRejected::NotSelfVerifying {
+            property: ConformanceProperty::TransitionPathAgreement,
+        })
+    );
+}
+
+/// The counterpart: a self-verifying property with identical shape is accepted.
+///
+/// Without this, a `check_bounds` that rejected everything would satisfy the test
+/// above.
+#[test]
+fn evidence_for_a_self_verifying_property_is_accepted() {
+    let case = case(ConformanceProperty::StateCommutativity, &[&[1], &[1, 2]]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    assert_eq!(evidence.check_bounds(), Ok(()));
+}
+
+/// Every property must have a CONSIDERED answer to "can a recipient re-establish
+/// this premise from the bytes alone?".
+///
+/// An exhaustive match already makes a new property fail to compile without an
+/// answer. This pins which answer was given, so a new provenance-dependent property
+/// lumped in with the self-verifying ones fails here instead of silently widening
+/// the untrusted path — the exact hazard `TransitionPathAgreement` introduced.
+///
+/// If you are here because you added a property: decide whether re-executing the
+/// case against a local copy of the contract re-establishes EVERYTHING the law
+/// asserts. If any part of it rests on how the inputs were observed, it is
+/// `LocalProvenance` and belongs in the list below.
+#[test]
+fn every_property_declares_whether_it_is_self_verifying() {
+    let local: Vec<ConformanceProperty> = ConformanceProperty::ALL
+        .iter()
+        .copied()
+        .filter(|p| p.premise_source() == PremiseSource::LocalProvenance)
+        .collect();
+    assert_eq!(
+        local,
+        vec![ConformanceProperty::TransitionPathAgreement],
+        "the set of properties that cannot travel as evidence changed; if that is \
+         deliberate, update this pin, and make sure `check_bounds` still refuses \
+         every one of them"
+    );
+    assert_eq!(
+        ConformanceProperty::ALL.len(),
+        14,
+        "a property was added or removed; say explicitly whether it is \
+         self-verifying (see `ConformanceProperty::premise_source`) rather than \
+         letting it inherit an answer, then update this count"
+    );
+
+    // The classification is not decorative: the gate reads it.
+    for property in ConformanceProperty::ALL {
+        let states = (0..property.state_arity())
+            .map(|i| bytes(&[i as u8]))
+            .collect();
+        let deltas = (0..property.delta_arity())
+            .map(|i| bytes(&[0x80 | i as u8]))
+            .collect();
+        let built = ConformanceCase::new(*property, states).with_deltas(deltas);
+        let evidence = ConformanceEvidence::new(instance(1), vec![], &built, None);
+        assert_eq!(
+            evidence.check_bounds().is_ok(),
+            property.is_self_verifying(),
+            "{property}: check_bounds must accept exactly the self-verifying \
+             properties"
+        );
+    }
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -243,6 +243,15 @@ fn conforming_contract_satisfies_every_state_law() {
         &mut fake,
         &case(ConformanceProperty::PathAgreement, &[a, b]),
     ));
+    // A transition a conforming contract really could have taken: `a` merged with
+    // `b` is a state a peer at `a` reaches, and merging it back must be a no-op.
+    assert_holds(verify_case(
+        &mut fake,
+        &case(
+            ConformanceProperty::TransitionPathAgreement,
+            &[a, &[1, 2, 3]],
+        ),
+    ));
     assert_holds(verify_case(
         &mut fake,
         &case(ConformanceProperty::DeltaIdempotence, &[a]).with_deltas(vec![bytes(&[9])]),
@@ -1214,6 +1223,266 @@ fn a_disagreement_is_found_from_either_order_of_the_pair() {
     }
 }
 
+// -------------------------------------- #5394: the transition-shaped half of the law
+
+/// Build the `(base, result)` step a peer would have recorded, by running the
+/// contract's own delta path — so the test cannot accidentally assert against a
+/// result the contract would never have produced.
+fn transition_case(fake: &mut Fake, base: &[u8], delta: &[u8]) -> ConformanceCase {
+    let result = fake
+        .update_state(
+            base,
+            &[UpdateData::Delta(
+                freenet_stdlib::prelude::StateDelta::from(delta.to_vec()),
+            )],
+        )
+        .expect("apply")
+        .new_state
+        .expect("new state")
+        .into_bytes();
+    ConformanceCase::new(
+        ConformanceProperty::TransitionPathAgreement,
+        vec![bytes(base), bytes(&result)],
+    )
+}
+
+/// The positive case, and the one that reaches the defect #5394 was written from.
+///
+/// A peer at `[0x10, 0x51]` receives an op for key 5 carrying a different value and
+/// its delta path lands on `[0x10, 0x52]`. Merging that state back into the base it
+/// came from resurrects `0x51`, so no peer that receives it as a whole state can
+/// reach where the peer that applied the delta already is.
+#[test]
+fn a_reached_state_the_merge_path_cannot_reproduce_is_caught() {
+    let mut fake = disagreeing_paths();
+    let built = transition_case(&mut fake, &[0x10, 0x51], &[0x52]);
+    // The delta path really did move somewhere the base was not, so the case is not
+    // asserting against a no-op transition.
+    assert_ne!(
+        built.states[0], built.states[1],
+        "a transition that changed nothing proves nothing"
+    );
+    assert_violates(
+        verify_case(&mut fake, &built),
+        ConformanceProperty::TransitionPathAgreement,
+    );
+}
+
+/// The matched negative: the SAME contract, the SAME two write paths, an op whose
+/// key collides with nothing. A property that fired on every transition would pass
+/// the test above while being worse than the gap it closes.
+#[test]
+fn the_same_contract_is_silent_on_a_transition_whose_key_does_not_collide() {
+    let mut fake = disagreeing_paths();
+    let built = transition_case(&mut fake, &[0x10, 0x51], &[0x62]);
+    assert_ne!(
+        built.states[0], built.states[1],
+        "a transition that changed nothing proves nothing"
+    );
+    assert_holds(verify_case(&mut fake, &built));
+}
+
+/// A bounded collection that evicts by the merge's OWN ordering is a genuine
+/// bounded semilattice and must not be accused.
+///
+/// This is the false-positive risk that decides the severity. "Keep the newest N"
+/// is one of the most common shapes a real application writes, and the entries the
+/// base would re-add on a merge are exactly the ones the cap drops again — so the
+/// merge path reproduces what the delta path reached, and the law holds.
+///
+/// The contrast is `capped_collection_evicting_outside_the_merge_order_is_caught`
+/// below: the same cap, evicting by something independent of that ordering, does
+/// fire. Neither result is assumed; both are asserted.
+#[test]
+fn a_sound_bounded_collection_is_not_accused() {
+    const CAP: usize = 3;
+    let keep_largest = |a: &[u8], b: &[u8]| {
+        let mut out = union(a, b);
+        while out.len() > CAP {
+            out.remove(0);
+        }
+        Ok(out)
+    };
+    let mut fake = Fake::conforming()
+        .merging(keep_largest)
+        .applying(keep_largest);
+
+    let built = transition_case(&mut fake, &[1, 2], &[3, 4, 5]);
+    assert_eq!(
+        built.states[1].as_ref(),
+        &[3, 4, 5],
+        "the cap must actually have evicted something, or this tests nothing"
+    );
+    assert_holds(verify_case(&mut fake, &built));
+}
+
+/// The same cap, evicting by something INDEPENDENT of the merge's own ordering, is
+/// caught — and that is correct rather than a false positive: such a contract is
+/// already removal-eligible under `StateAssociativity`, for the same underlying
+/// reason (an entry dropped early destroys information a different merge order
+/// would have kept).
+///
+/// Asserted rather than left in prose, because it is the boundary the severity
+/// argument rests on: the property distinguishes the two caps, and does not simply
+/// flag every bounded collection.
+#[test]
+fn capped_collection_evicting_outside_the_merge_order_is_caught() {
+    const CAP: usize = 3;
+    let evict_by_content = |a: &[u8], b: &[u8]| {
+        let mut out = union(a, b);
+        while out.len() > CAP {
+            let sum: usize = out.iter().map(|byte| *byte as usize).sum();
+            out.remove(sum % out.len());
+        }
+        Ok(out)
+    };
+    let mut fake = Fake::conforming()
+        .merging(evict_by_content)
+        .applying(evict_by_content);
+
+    let built = transition_case(&mut fake, &[1, 2], &[3, 4, 5]);
+    assert_violates(
+        verify_case(&mut fake, &built),
+        ConformanceProperty::TransitionPathAgreement,
+    );
+
+    // ...and the SOUND cap above really is a different answer from this one, so the
+    // pair together shows the property discriminates rather than flagging all caps.
+    let mut sound = Fake::conforming()
+        .merging(|a: &[u8], b: &[u8]| {
+            let mut out = union(a, b);
+            while out.len() > CAP {
+                out.remove(0);
+            }
+            Ok(out)
+        })
+        .applying(|a: &[u8], b: &[u8]| {
+            let mut out = union(a, b);
+            while out.len() > CAP {
+                out.remove(0);
+            }
+            Ok(out)
+        });
+    let sound_case = transition_case(&mut sound, &[1, 2], &[3, 4, 5]);
+    assert_holds(verify_case(&mut sound, &sound_case));
+}
+
+/// A contract that rewrites a stored state into canonical form on first merge must
+/// not be accused.
+///
+/// The PUT install path stores the client's raw bytes without ever running
+/// `update_state`, so the state a peer holds — and therefore the `result` a
+/// transition records — may not be canonical yet. Comparing against those raw bytes
+/// would report that legitimate rewrite as a merge-law break, which is why `result`
+/// is driven to a fixpoint first.
+#[test]
+fn a_canonicalizing_contract_is_not_accused_by_the_transition_law() {
+    // Accepts a trailing marker byte but strips it on any merge, then stabilizes.
+    const MARKER: u8 = 0xFF;
+    let strip = |a: &[u8], b: &[u8]| {
+        let mut out = union(a, b);
+        out.retain(|byte| *byte != MARKER);
+        Ok(out)
+    };
+    let mut fake = Fake::conforming().merging(strip).applying(|a, d| {
+        // The delta path leaves the marker in place, so the recorded result is a
+        // non-canonical state exactly as a PUT-installed one would be.
+        Ok(union(a, d))
+    });
+
+    let built = transition_case(&mut fake, &[1, 2], &[MARKER]);
+    assert_eq!(
+        built.states[1].as_ref(),
+        &[1, 2, MARKER],
+        "the recorded result must be non-canonical, or the guard is untested"
+    );
+    assert_holds(verify_case(&mut fake, &built));
+}
+
+/// A result state that keeps rewriting itself cannot be judged here, and the defect
+/// already has a name. Reporting it under this law would accuse the right contract
+/// under the wrong one.
+#[test]
+fn a_result_state_that_never_settles_is_inconclusive_not_a_violation() {
+    let mut fake = Fake::conforming()
+        .validating(|_| Ok(ValidateResult::Valid))
+        .merging(|a, b| {
+            Ok(union(a, b)
+                .iter()
+                .map(|byte| byte.wrapping_add(1))
+                .collect())
+        });
+
+    assert_inconclusive(
+        verify_case(
+            &mut fake,
+            &case(
+                ConformanceProperty::TransitionPathAgreement,
+                &[&[1, 2], &[3, 4]],
+            ),
+        ),
+        Inconclusive::StateNotSettled,
+    );
+}
+
+/// The generator must build transition cases ONLY from recorded provenance.
+///
+/// This is the pin that keeps the property from becoming an accusation of
+/// last-write-wins against every conforming contract. "Merging B into A yields B" is
+/// false for a union semilattice on an arbitrary pair; it is a law only when the
+/// corpus witnesses that B was reached FROM A. If this property ever fell through to
+/// the generic arity-2 branch — which pairs every state with every other — the
+/// conforming baseline would start failing, and it would look like a real finding.
+#[test]
+fn transition_cases_come_only_from_recorded_provenance() {
+    let config = GeneratorConfig {
+        properties: vec![ConformanceProperty::TransitionPathAgreement],
+        ..Default::default()
+    };
+
+    // Negative: plenty of states, no provenance, so nothing to check.
+    let loose = Corpus::from_states(vec![vec![1], vec![2], vec![1, 2], vec![2, 3]]);
+    assert!(
+        generate_cases(&loose, &config).is_empty(),
+        "states that merely appeared together are not a transition; pairing them \
+         would accuse every conforming contract of last-write-wins"
+    );
+
+    // Positive: one recorded step yields exactly one case, in the recorded order.
+    let witnessed = Corpus {
+        transitions: vec![(bytes(&[1]), bytes(&[1, 2]))],
+        ..Corpus::from_states(vec![vec![1], vec![1, 2]])
+    };
+    let cases = generate_cases(&witnessed, &config);
+    assert_eq!(cases.len(), 1, "one recorded step is one case");
+    assert_eq!(cases[0].states[0].as_ref(), &[1], "base comes first");
+    assert_eq!(cases[0].states[1].as_ref(), &[1, 2], "result comes second");
+}
+
+/// A bundle must carry provenance across a round trip.
+///
+/// `to_corpus` flattens transitions into loose states, and before this it dropped
+/// the ORDERING while doing so — which would leave a replayed capture unable to
+/// check the one property that needs it, silently, and reading as a clean run.
+#[test]
+fn a_bundle_round_trip_preserves_transition_provenance() {
+    let mut bundle = super::bundle::ReplayBundle::new(b"code".to_vec(), Vec::new());
+    bundle.transitions.push(super::bundle::Transition {
+        base_state: vec![1],
+        result_state: vec![1, 2],
+        ..Default::default()
+    });
+
+    let decoded =
+        super::bundle::ReplayBundle::decode(&bundle.encode().expect("encode")).expect("decode");
+    let corpus = decoded.to_corpus();
+    assert_eq!(
+        corpus.transitions,
+        vec![(bytes(&[1]), bytes(&[1, 2]))],
+        "a replayed capture must still know which state came first"
+    );
+}
+
 fn instance(seed: u8) -> ContractInstanceId {
     ContractInstanceId::new([seed; 32])
 }
@@ -1461,7 +1730,11 @@ fn a_tight_case_budget_still_covers_every_law() {
     let base: Bytes = Arc::from([1u8].as_slice());
     let corpus = Corpus {
         deltas: vec![Arc::from([9u8].as_slice()), Arc::from([7u8].as_slice())],
-        delta_bases: vec![Some(base.clone()), Some(base)],
+        delta_bases: vec![Some(base.clone()), Some(base.clone())],
+        // `transition_path_agreement` is gated on recorded provenance and would
+        // otherwise contribute no cases at all — which would look like the budget
+        // dropping a law when in fact the corpus never offered one.
+        transitions: vec![(base, Arc::from([1u8, 9].as_slice()))],
         ..Corpus::from_states(states)
     };
     let config = GeneratorConfig {

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -2065,14 +2065,79 @@ fn evidence_for_delta_permutation_invariance_is_refused() {
     );
 }
 
+/// Does `verify_case` hand this property the SUPPLIED `ConformanceCase::summary`?
+///
+/// Summary bytes are unvalidated in exactly the way delta bytes are: `check_bounds`
+/// constrains their size and nothing else, and no `require_valid` analogue exists for
+/// a summary. So a property that reads a supplied summary is in the same hazard class
+/// as one that reads a delta, and
+/// [`no_shippable_removal_eligible_property_consumes_unvalidated_bytes`] must see it.
+///
+/// A local exhaustive match rather than a method on `ConformanceProperty`: this is a
+/// fact about `verify_case`'s branches, not part of the type's public contract, and
+/// matching exhaustively inside the crate still makes a new variant fail to compile.
+fn consumes_supplied_summary(property: ConformanceProperty) -> bool {
+    match property {
+        // `verifier.rs`'s `DeltaDeterminism` arm uses `case.summary` when present and
+        // falls back to `summarize_state` only when it is `None`.
+        ConformanceProperty::DeltaDeterminism => true,
+        ConformanceProperty::StateIdempotence
+        | ConformanceProperty::StateCommutativity
+        | ConformanceProperty::StateAssociativity
+        | ConformanceProperty::EmittedStateValidity
+        | ConformanceProperty::UpdateDeterminism
+        | ConformanceProperty::SummaryDeterminism
+        | ConformanceProperty::DeltaIdempotence
+        | ConformanceProperty::DeltaPermutationInvariance
+        | ConformanceProperty::SelfDeltaEmpty
+        | ConformanceProperty::WholeStateSelfDelta
+        | ConformanceProperty::ReconciliationCycle
+        | ConformanceProperty::PathAgreement
+        | ConformanceProperty::TransitionPathAgreement => false,
+    }
+}
+
+/// Can choosing the unvalidated bytes MANUFACTURE a verdict against a contract that
+/// is in fact conforming?
+///
+/// This is the question the hazard is actually about, and for one shape of law the
+/// answer is no by construction: a determinism law compares the contract against
+/// ITSELF on byte-identical inputs, so the verdict is "the same call returned
+/// different bytes twice". No choice of input makes a deterministic implementation
+/// nondeterministic, so a fabricated input buys an attacker nothing an honest one
+/// does not — it can only surface a real defect sooner.
+///
+/// That is NOT true of the comparison laws. `DeltaIdempotence` compares two
+/// DIFFERENT executions, and `DeltaPermutationInvariance` two different orders, so
+/// whether the comparison means anything depends on the bytes being ones the
+/// protocol could have produced. Those stay in the hazard class.
+fn verdict_survives_fabricated_bytes(property: ConformanceProperty) -> bool {
+    match property {
+        ConformanceProperty::UpdateDeterminism
+        | ConformanceProperty::SummaryDeterminism
+        | ConformanceProperty::DeltaDeterminism => true,
+        ConformanceProperty::StateIdempotence
+        | ConformanceProperty::StateCommutativity
+        | ConformanceProperty::StateAssociativity
+        | ConformanceProperty::EmittedStateValidity
+        | ConformanceProperty::DeltaIdempotence
+        | ConformanceProperty::DeltaPermutationInvariance
+        | ConformanceProperty::SelfDeltaEmpty
+        | ConformanceProperty::WholeStateSelfDelta
+        | ConformanceProperty::ReconciliationCycle
+        | ConformanceProperty::PathAgreement
+        | ConformanceProperty::TransitionPathAgreement => false,
+    }
+}
+
 /// The hazard class, stated once so a new property cannot re-enter it.
 ///
 /// `verify_case` validates every STATE in a case through `require_valid`, and never
-/// validates a delta — there is no `require_valid` analogue for delta bytes, because
-/// a contract exposes no "is this delta well-formed" entry point. So a property that
-/// (a) travels as evidence, (b) consumes delta bytes, and (c) is removal-eligible
-/// would let an attacker choose bytes that go straight into another peer's WASM and
-/// come back out as a removal verdict.
+/// validates a delta or a supplied summary — there is no `require_valid` analogue for
+/// either, because a contract exposes no "is this delta/summary well-formed" entry
+/// point. So a property that (a) travels as evidence, (b) consumes delta or supplied
+/// summary bytes, and (c) is removal-eligible would let an attacker choose bytes that
+/// go straight into another peer's WASM and come back out as a removal verdict.
 ///
 /// Two properties carry deltas. `DeltaPermutationInvariance` is `Violation` and is
 /// kept off the wire by `premise_source`. `DeltaIdempotence` ships, and is safe only
@@ -2080,32 +2145,69 @@ fn evidence_for_delta_permutation_invariance_is_refused() {
 /// so its severity is not independently adjustable, and its own documentation says
 /// so. This test is what makes that a rule rather than a note: promoting it without
 /// revisiting `premise_source` in the same change fails here.
+///
+/// One property consumes a supplied SUMMARY: `DeltaDeterminism`, which both ships and
+/// is `Violation`. It is in scope here — the earlier version of this test filtered on
+/// `delta_arity() > 0` and so could not see it at all, which left the guard narrower
+/// than the class its own docstring names. It is exempt by
+/// [`verdict_survives_fabricated_bytes`], and only by that: a fabricated summary
+/// cannot make a deterministic contract return two different answers to the same
+/// call, so it buys an attacker nothing. The exemption is a predicate rather than a
+/// name in a list precisely so a NEW summary-consuming property has to answer the
+/// question rather than inherit the answer.
 #[test]
-fn no_shippable_removal_eligible_property_consumes_unvalidated_deltas() {
+fn no_shippable_removal_eligible_property_consumes_unvalidated_bytes() {
+    let consumes_unvalidated =
+        |p: ConformanceProperty| p.delta_arity() > 0 || consumes_supplied_summary(p);
+
     let hazardous: Vec<ConformanceProperty> = ConformanceProperty::ALL
         .iter()
         .copied()
         .filter(|p| {
-            p.delta_arity() > 0 && p.is_self_verifying() && p.severity() == Severity::Violation
+            consumes_unvalidated(*p)
+                && p.is_self_verifying()
+                && p.severity() == Severity::Violation
+                && !verdict_survives_fabricated_bytes(*p)
         })
         .collect();
     assert!(
         hazardous.is_empty(),
         "{hazardous:?}: a property that ships as evidence, runs attacker-chosen \
-         delta bytes through the WASM, and is removal-eligible is the combination \
-         the evidence gate exists to prevent. Either mark it \
+         delta or summary bytes through the WASM, and is removal-eligible is the \
+         combination the evidence gate exists to prevent. Either mark it \
          `PremiseSource::LocalProvenance`, or drop it to `Severity::Diagnostic`, or \
-         give deltas a validity check first — do not simply update this test"
+         give those bytes a validity check first — do not simply update this test"
     );
 
     // The fixture must be able to fail: at least one property really does carry
-    // deltas, so the filter above is not vacuously empty.
+    // deltas, so the delta half of the filter is not vacuously empty.
     assert!(
         ConformanceProperty::ALL
             .iter()
             .any(|p| p.delta_arity() > 0 && p.is_self_verifying()),
         "no property carries deltas as evidence any more, so the assertion above \
          proves nothing; delete it or re-aim it"
+    );
+
+    // And the SUMMARY half must reach something, or widening the filter was
+    // decoration. Everything the widened filter catches before the determinism
+    // exemption is applied, so this fails both when the summary arm goes dead and
+    // when a SECOND property starts leaning on that exemption.
+    let carried_only_by_the_exemption: Vec<ConformanceProperty> = ConformanceProperty::ALL
+        .iter()
+        .copied()
+        .filter(|p| {
+            consumes_unvalidated(*p) && p.is_self_verifying() && p.severity() == Severity::Violation
+        })
+        .collect();
+    assert_eq!(
+        carried_only_by_the_exemption,
+        vec![ConformanceProperty::DeltaDeterminism],
+        "the set of shippable removal-eligible properties consuming unvalidated \
+         bytes has changed. `DeltaDeterminism` is here because a fabricated summary \
+         cannot manufacture a nondeterminism verdict; anything joining it needs that \
+         argument made for it in `verdict_survives_fabricated_bytes`, and anything \
+         leaving means the summary arm of the filter above now tests nothing"
     );
 }
 

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -1519,14 +1519,22 @@ fn a_canonicalizing_contract_is_not_accused_by_the_transition_law() {
 /// right contract under the wrong law.
 #[test]
 fn a_merge_that_emits_an_invalid_state_is_not_reported_under_the_transition_law() {
-    // Merging anything into the base emits a state the contract rejects. The
-    // marker never appears in a state the delta path produces, so `result` and its
-    // fixpoint stay valid and only `merge(base, settled)` trips the check.
+    // Merging two DIFFERENT states emits a state the contract rejects; merging a
+    // state with itself does not.
+    //
+    // That asymmetry is the whole fixture. The transition branch already validated
+    // `settled`, so a contract whose SELF-merge emits an invalid state trips that
+    // older check and would make this test pass whether or not the new one exists —
+    // which is exactly how the first version of this test was vacuous. Here `result`
+    // reaches its fixpoint immediately and validates, so `merge(base, settled)` is
+    // the only call that can produce an invalid state, and only the new check can
+    // see it. Verified by mutation: deleting `require_valid(&merged)` makes this
+    // report a `TransitionPathAgreement` violation instead.
     const MARKER: u8 = 0xFE;
     let mut fake = Fake::conforming()
         .merging(|a, b| {
             let mut out = union(a, b);
-            if !out.is_empty() {
+            if a != b {
                 out.push(MARKER);
             }
             Ok(out)
@@ -1571,6 +1579,46 @@ fn a_result_state_that_never_settles_is_inconclusive_not_a_violation() {
         ),
         Inconclusive::StateNotSettled,
     );
+}
+
+/// Deduplication must never trade a provenanced delta for an unprovenanced twin.
+///
+/// A delta can legitimately arrive twice: once loose and once attached to the step
+/// it was observed on. `ReplayBundle::to_corpus` builds exactly that shape, giving
+/// bundle-level deltas no base by design and the transition's copy the base it was
+/// applied to. First-seen-wins then keeps whichever the caller happened to push
+/// first, and an unprovenanced delta is never paired at all — so
+/// `delta_permutation_invariance` silently checks nothing while the corpus still
+/// reports the same delta count.
+///
+/// Both orders are asserted. Only checking the order that happens to be broken today
+/// would leave the invariant hostage to which list a future caller fills first.
+#[test]
+fn deduplicating_deltas_keeps_the_base_whichever_copy_arrives_first() {
+    let delta = bytes(&[9]);
+    let base = bytes(&[1, 2]);
+
+    for (label, bases) in [
+        ("unprovenanced copy first", vec![None, Some(base.clone())]),
+        ("provenanced copy first", vec![Some(base.clone()), None]),
+    ] {
+        let corpus = Corpus {
+            deltas: vec![delta.clone(), delta.clone()],
+            delta_bases: bases,
+            ..Corpus::from_states(vec![vec![1, 2]])
+        }
+        .deduplicated();
+        assert_eq!(
+            corpus.deltas.len(),
+            1,
+            "{label}: the duplicate must collapse"
+        );
+        assert_eq!(
+            corpus.delta_base(0),
+            Some(&base),
+            "{label}: the surviving delta must keep the state it was applied to"
+        );
+    }
 }
 
 /// A corpus holding steps and no loose states is not empty.

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -213,7 +213,8 @@ fn reproduced_identically(first: &Violation, second: &Violation) -> bool {
         | ConformanceProperty::SelfDeltaEmpty
         | ConformanceProperty::WholeStateSelfDelta
         | ConformanceProperty::ReconciliationCycle
-        | ConformanceProperty::PathAgreement => {
+        | ConformanceProperty::PathAgreement
+        | ConformanceProperty::TransitionPathAgreement => {
             first.left == second.left && first.right == second.right
         }
     }
@@ -514,6 +515,51 @@ fn run<O: ConformanceOracle + ?Sized>(
                 (Err(_), Ok(outcome)) => Ok(outcome),
                 (Err(reason), Err(_)) => Err(reason),
             }
+        }
+
+        ConformanceProperty::TransitionPathAgreement => {
+            // `states[0]` is the base a peer held, `states[1]` the result it
+            // actually reached. The generator only ever builds this case from a
+            // recorded transition, which is what makes the order meaningful: for an
+            // arbitrary pair, "merging B into A yields B" is last-write-wins.
+            let (base, result) = (&case.states[0], &case.states[1]);
+
+            // Drive `result` to a fixpoint of its own merge before comparing.
+            //
+            // A canonicalizing contract legitimately rewrites a stored state the
+            // first time it is merged — the PUT install path stores the client's raw
+            // bytes without ever running `update_state` — so the state a peer holds
+            // may not be canonical yet. Comparing against the raw bytes would report
+            // that rewrite as a merge-law break. `StateIdempotence` iterates for the
+            // same reason and to the same budget.
+            let mut settled = result.to_vec();
+            let mut reached_fixpoint = false;
+            for _ in 0..MAX_CANONICALIZATION_APPLIES {
+                let again = merge(oracle, &settled, &settled)?;
+                if again == settled {
+                    reached_fixpoint = true;
+                    break;
+                }
+                settled = again;
+            }
+            if !reached_fixpoint {
+                // A state that rewrites itself on every re-apply cannot be asked
+                // whether some OTHER state absorbs into it, and the defect already
+                // has a name. Accusing it here would name the wrong law.
+                return Err(Inconclusive::StateNotSettled);
+            }
+            require_valid(oracle, &settled, &case.related)?;
+
+            let merged = merge(oracle, base, &settled)?;
+            Ok(compare(
+                case.property,
+                &merged,
+                &settled,
+                "merging a state a peer actually REACHED back into the state it came \
+                 from did not reproduce it, so the merge path cannot reach what the \
+                 update path reached: every peer that receives this state merges it \
+                 into something else, and the two can never agree",
+            ))
         }
     }
 }

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -212,7 +212,8 @@ fn reproduced_identically(first: &Violation, second: &Violation) -> bool {
         | ConformanceProperty::DeltaPermutationInvariance
         | ConformanceProperty::SelfDeltaEmpty
         | ConformanceProperty::WholeStateSelfDelta
-        | ConformanceProperty::ReconciliationCycle => {
+        | ConformanceProperty::ReconciliationCycle
+        | ConformanceProperty::PathAgreement => {
             first.left == second.left && first.right == second.right
         }
     }
@@ -489,7 +490,114 @@ fn run<O: ConformanceOracle + ?Sized>(
         ConformanceProperty::ReconciliationCycle => {
             reconciliation_cycle(oracle, &case.states[0], &case.states[1], &case.related)
         }
+
+        ConformanceProperty::PathAgreement => {
+            // Both directions, because which state is "base" and which is "other" is
+            // an artifact of the order the corpus happened to be listed in, not of
+            // anything the contract does. The generator emits each unordered pair
+            // once (`i < j`), so checking one direction would make catching a defect
+            // depend on file order — the shape of a test that passes for the wrong
+            // reason.
+            let (a, b) = (&case.states[0], &case.states[1]);
+            let forward = path_agreement(oracle, a, b, &case.related);
+            if matches!(forward, Ok(PropertyOutcome::Violated(_))) {
+                return forward;
+            }
+            let reverse = path_agreement(oracle, b, a, &case.related);
+            if matches!(reverse, Ok(PropertyOutcome::Violated(_))) {
+                return reverse;
+            }
+            // Neither direction found anything. One usable verdict is a verdict;
+            // only refuse if neither direction could be evaluated at all.
+            match (forward, reverse) {
+                (Ok(outcome), _) => Ok(outcome),
+                (Err(_), Ok(outcome)) => Ok(outcome),
+                (Err(reason), Err(_)) => Err(reason),
+            }
+        }
     }
+}
+
+/// One direction of [`ConformanceProperty::PathAgreement`]: does `base` reach the
+/// same state whether it receives `other`'s information as a delta or whole?
+///
+/// The two calls mirror the two things production actually does with the same
+/// update. `get_state_delta(other, summarize(base))` is the delta the SENDER
+/// computes against the RECIPIENT's summary — the same orientation
+/// [`reconciliation_cycle`] uses, and getting it backwards would be checking a call
+/// the network never makes.
+fn path_agreement<O: ConformanceOracle + ?Sized>(
+    oracle: &mut O,
+    base: &Bytes,
+    other: &Bytes,
+    related: &RelatedContracts<'static>,
+) -> Result<PropertyOutcome, Inconclusive> {
+    let base_summary = oracle.summarize_state(base).map_err(inconclusive_from)?;
+    let delta = oracle
+        .get_state_delta(other, &base_summary)
+        .map_err(inconclusive_from)?;
+
+    // No delta path exists to compare against, in either of the two ways production
+    // can decline to take one.
+    //
+    // An empty delta is the protocol's "nothing to send", and a summary too coarse
+    // to express the divergence produces one legitimately — the same contract shape
+    // `reconciliation_cycle` models the full-state fallback for. An oversized delta
+    // is refused by production's own gate and replaced with a whole-state send, so
+    // the delta path is not the path this update would take. Checking either one
+    // would be checking a call that never happens.
+    if delta.is_empty() || delta_would_be_refused(&delta, other) {
+        return Err(Inconclusive::NoDeltaPath);
+    }
+
+    let delta_path = apply_delta_bytes(oracle, base, &delta)?;
+    let merge_path = merge(oracle, base, other)?;
+    if delta_path == merge_path {
+        return Ok(PropertyOutcome::Holds);
+    }
+
+    // Same validity precondition the inputs get, for the same reason: a state the
+    // contract rejects never reaches another peer, so reasoning about it is
+    // reasoning about a history that cannot happen.
+    require_valid(oracle, &delta_path, related)?;
+    require_valid(oracle, &merge_path, related)?;
+
+    // Distinguish "the delta carried less than the whole state" from "the two paths
+    // computed different things". This is the guard that keeps this property off a
+    // large and legitimate class of contract, and without it the check is a
+    // false-positive generator.
+    //
+    // A contract whose summary cannot express a particular divergence ships a delta
+    // carrying only PART of what `other` holds. Its delta path lands short of the
+    // merged state on this round and catches up on the next one — a weak delta
+    // encoding, not a broken merge, and this module already declines to accuse it
+    // under `ReconciliationCycle` for exactly this reason.
+    //
+    // Merging the whole state on top separates the two. For any merge that is a
+    // genuine join, a delta derived from `other` can only move `base` somewhere
+    // between `base` and `base ⊔ other`, so joining `other` back on top lands on
+    // `base ⊔ other` either way and a partial delta heals. A delta path that
+    // computed something the merge path cannot reach does not heal.
+    //
+    // The guard errs toward silence in every direction, which is the right direction
+    // for a removal-eligible property. That includes when the merge itself is
+    // unsound: a last-write-wins merge heals trivially, so this declines to pile a
+    // second accusation onto a defect `StateCommutativity` already names.
+    let healed = merge(oracle, &delta_path, other)?;
+    if healed == merge_path {
+        return Ok(PropertyOutcome::Holds);
+    }
+
+    Ok(compare(
+        ConformanceProperty::PathAgreement,
+        &delta_path,
+        &merge_path,
+        "the delta path and the merge path disagree: applying the delta the network \
+         would have sent reached a different state from merging the sender's whole \
+         state, and re-merging the whole state does not repair the difference, so a \
+         peer that received this update as a delta can never agree with one that \
+         received it as a state",
+    ))
 }
 
 /// Simulate two peers exchanging summaries and deltas until they agree.

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -551,14 +551,25 @@ fn run<O: ConformanceOracle + ?Sized>(
             require_valid(oracle, &settled, &case.related)?;
 
             let merged = merge(oracle, base, &settled)?;
+            // Both sides of the comparison get the same validity precondition, for
+            // the same reason `path_agreement` validates both of its outputs: a
+            // state the contract itself rejects never reaches another peer, so
+            // reasoning about it is reasoning about a history that cannot happen.
+            //
+            // Without this, a merge that EMITS an invalid state is reported under
+            // this property rather than under `EmittedStateValidity`, which is the
+            // law that actually names that defect. One law per property is the rule
+            // this module follows everywhere else.
+            require_valid(oracle, &merged, &case.related)?;
             Ok(compare(
                 case.property,
                 &merged,
                 &settled,
-                "merging a state a peer actually REACHED back into the state it came \
-                 from did not reproduce it, so the merge path cannot reach what the \
-                 update path reached: every peer that receives this state merges it \
-                 into something else, and the two can never agree",
+                "merging the settled form of a state a peer actually REACHED back \
+                 into the state it came from did not reproduce that settled form, so \
+                 the merge path cannot reach what the update path reached: every \
+                 peer that receives this state merges it into something else, and \
+                 the two can never agree",
             ))
         }
     }

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -213,11 +213,17 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
 
     // ------------------------------------------------- mode 5: capped collection
     //
-    // The only planted defect that the pairwise laws cannot see. Asserting the
+    // The only planted defect that the PAIRWISE state laws cannot see. Asserting the
     // associativity violation alone would not show that: a mode that also broke
     // commutativity would satisfy that assertion while proving nothing about the
     // three-state check. So assert the pairwise laws still HOLD here — that is
     // what makes this a test of associativity specifically.
+    //
+    // "Pairwise" is doing real work in that sentence: the transition law sees this
+    // mode too, from the same information loss, and that is asserted deliberately
+    // further down rather than being an exception this loop must dodge. The claim
+    // is that associativity is the law that NAMES the defect and no pairwise state
+    // law fires, not that nothing else in the module can see it.
     let mut capped = RuntimeOracle::standalone(wasm.clone(), vec![CAPPED_SET]).await?;
     let associativity_case = ConformanceCase::new(
         ConformanceProperty::StateAssociativity,
@@ -237,12 +243,13 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
             vec![bytes(&[1, 2]), bytes(&[3, 4])],
         ),
     ] {
-        let outcome = verify_case(&mut capped, &pairwise);
-        assert!(
-            !outcome.is_violation(),
-            "the capped-collection mode should break associativity ALONE, but {} \
-             also reported a violation: {outcome:?}",
-            pairwise.property
+        let property = pairwise.property;
+        assert_eq!(
+            verify_case(&mut capped, &pairwise),
+            PropertyOutcome::Holds,
+            "among the PAIRWISE state laws the capped-collection mode should break \
+             none — associativity is the one that names it — but {property} did not \
+             hold"
         );
     }
 
@@ -257,11 +264,30 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
     // removal-eligible either way; what matters is that it is a real divergence and
     // not an artifact of capping.
     //
+    // The cap applies to the mode's DELTA path as well as its merge path, which is
+    // what makes that true. Without it the recorded `result` would carry more than
+    // CAP entries — a state the merge path can never emit — and the assertion below
+    // would land on the right verdict for the wrong reason: it would be reporting
+    // the missing cap, not the eviction rule.
+    //
     // The contrasting SOUND cap (keep the largest N, evicting BY the merge order) is
     // pinned silent in `tests.rs::a_sound_bounded_collection_is_not_accused` — the
     // two together are what show the property discriminates rather than flagging
     // every bounded collection.
     let capped_transition = transition_case(&mut capped, &[1, 2], &[3, 4, 5])?;
+    // The recorded result must be a state the MERGE path could also have emitted.
+    //
+    // Without the cap on the delta path this is a five-entry state against a cap of
+    // three — something `merge_state` can never produce — and the violation below
+    // would be reporting the missing cap rather than the eviction rule. The
+    // assertion would land on the right verdict for the wrong reason, which is the
+    // failure shape this whole module is built to avoid.
+    assert!(
+        capped_transition.states[1].len() <= 3,
+        "the delta path must respect the cap, or this case is about a state the \
+         merge path can never reach: {:?}",
+        capped_transition.states[1]
+    );
     assert_violates(
         verify_case(&mut capped, &capped_transition),
         ConformanceProperty::TransitionPathAgreement,
@@ -398,14 +424,19 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
             1 => vec![bytes(&[0x52])],
             _ => vec![bytes(&[0x52]), bytes(&[0x63])],
         };
-        let outcome = verify_case(
-            &mut disagreeing,
-            &ConformanceCase::new(*property, states).with_deltas(deltas),
-        );
-        assert!(
-            !outcome.is_violation(),
-            "{property} fired on the disagreeing-paths mode, so it no longer \
-             isolates the one defect only path_agreement can see: {outcome:?}"
+        // `Holds`, not merely "not a violation": `Inconclusive` also satisfies
+        // `!is_violation()`, and the claim this loop supports is that every other
+        // law HOLDS on this mode. A case that stopped being evaluated at all would
+        // keep the loop green while the #5394 gap argument quietly lost its
+        // evidence.
+        assert_eq!(
+            verify_case(
+                &mut disagreeing,
+                &ConformanceCase::new(*property, states).with_deltas(deltas),
+            ),
+            PropertyOutcome::Holds,
+            "{property} did not HOLD on the disagreeing-paths mode, so it no longer \
+             isolates the one defect only path_agreement can see"
         );
     }
 

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -33,6 +33,38 @@ fn bytes(values: &[u8]) -> Bytes {
     Arc::from(values)
 }
 
+/// Build the `(base, result)` step a peer would have recorded, by driving the
+/// contract's own delta path through the real runtime.
+///
+/// Computed rather than hard-coded so the case cannot drift into asserting against
+/// a result this contract would never actually produce.
+fn transition_case(
+    oracle: &mut RuntimeOracle,
+    base: &[u8],
+    delta: &[u8],
+) -> Result<ConformanceCase, Box<dyn std::error::Error>> {
+    use super::oracle::ConformanceOracle;
+    let result = oracle
+        .update_state(
+            base,
+            &[freenet_stdlib::prelude::UpdateData::Delta(
+                freenet_stdlib::prelude::StateDelta::from(delta.to_vec()),
+            )],
+        )?
+        .new_state
+        .ok_or("contract produced no state")?
+        .into_bytes();
+    assert_ne!(
+        base,
+        result.as_slice(),
+        "a transition that changed nothing proves nothing"
+    );
+    Ok(ConformanceCase::new(
+        ConformanceProperty::TransitionPathAgreement,
+        vec![bytes(base), bytes(&result)],
+    ))
+}
+
 #[track_caller]
 fn assert_violates(outcome: PropertyOutcome, property: ConformanceProperty) {
     match outcome {
@@ -214,6 +246,27 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
         );
     }
 
+    // The transition law and a bounded collection.
+    //
+    // This is the false-positive boundary the `transition_path_agreement` severity
+    // rests on, so it is measured here against real WASM rather than argued. This
+    // cap evicts by an index derived from the set's own contents — independent of
+    // the merge's ordering — and merging the reached state back into its base
+    // genuinely does not reproduce it. That is the same information loss
+    // `StateAssociativity` already reports for this mode, so the contract is
+    // removal-eligible either way; what matters is that it is a real divergence and
+    // not an artifact of capping.
+    //
+    // The contrasting SOUND cap (keep the largest N, evicting BY the merge order) is
+    // pinned silent in `tests.rs::a_sound_bounded_collection_is_not_accused` — the
+    // two together are what show the property discriminates rather than flagging
+    // every bounded collection.
+    let capped_transition = transition_case(&mut capped, &[1, 2], &[3, 4, 5])?;
+    assert_violates(
+        verify_case(&mut capped, &capped_transition),
+        ConformanceProperty::TransitionPathAgreement,
+    );
+
     // ------------------------------------------------ mode 6: never settles
     //
     // Regression cover for the worst shape found on the live network: a contract
@@ -324,7 +377,12 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
     // mode would prove nothing about the gap #5394 describes, which is precisely a
     // contract that satisfies the entire existing property set and still diverges.
     for property in ConformanceProperty::ALL {
-        if *property == ConformanceProperty::PathAgreement {
+        // Both halves of the path-agreement family see this defect, which is the
+        // point of the mode; they are asserted positively above and below instead.
+        if matches!(
+            property,
+            ConformanceProperty::PathAgreement | ConformanceProperty::TransitionPathAgreement
+        ) {
             continue;
         }
         let states: Vec<Bytes> = match property.state_arity() {
@@ -350,6 +408,24 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
              isolates the one defect only path_agreement can see: {outcome:?}"
         );
     }
+
+    // The transition-shaped half of the same law, on the same mode. This is the form
+    // that reaches the #5394 artifacts, where the contract's own `get_state_delta`
+    // ships whole states and the pairwise form is therefore blind.
+    let disagreeing_transition = transition_case(&mut disagreeing, &[0x10, 0x51], &[0x52])?;
+    assert_violates(
+        verify_case(&mut disagreeing, &disagreeing_transition),
+        ConformanceProperty::TransitionPathAgreement,
+    );
+
+    // Its matched negative: the same contract, an op whose key collides with nothing.
+    let harmless_transition = transition_case(&mut disagreeing, &[0x10, 0x51], &[0x62])?;
+    assert_eq!(
+        verify_case(&mut disagreeing, &harmless_transition),
+        PropertyOutcome::Holds,
+        "a transition whose op collides with nothing must not be flagged, or the \
+         property is a blanket accusation against every contract with a delta path"
+    );
 
     // The matched negative #5394's acceptance test asks for: the SAME contract with
     // the SAME two write paths, on states whose keys do not collide. A property that

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -26,6 +26,7 @@ const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
 const NEVER_SETTLES: u8 = 6;
 const REQUIRES_RELATED: u8 = 7;
+const PATH_DISAGREEMENT: u8 = 8;
 const RELATED_ID: [u8; 32] = [7; 32];
 
 fn bytes(values: &[u8]) -> Bytes {
@@ -297,6 +298,74 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
         verify_case(&mut needs_related, &with_related),
         PropertyOutcome::Holds,
         "with the related state supplied the contract must become judgeable"
+    );
+
+    // ------------------------------------------- mode 8: disagreeing write paths
+    //
+    // The #5394 shape, and the one mode whose defect NO pre-existing property can
+    // see: the delta path takes the last write on a key collision, the merge path
+    // the first. Each rule is a sound semilattice on its own, so every law that
+    // compares merge-to-merge or delta-to-delta holds.
+    //
+    // `0x51` and `0x52` are two writes to key 5 with different values — two ops
+    // carrying the same client-chosen sequence number, which is exactly the
+    // collision the real defect resolved two different ways.
+    let mut disagreeing = RuntimeOracle::standalone(wasm.clone(), vec![PATH_DISAGREEMENT]).await?;
+    let colliding: Vec<Bytes> = vec![bytes(&[0x10, 0x51]), bytes(&[0x10, 0x52])];
+    assert_violates(
+        verify_case(
+            &mut disagreeing,
+            &ConformanceCase::new(ConformanceProperty::PathAgreement, colliding.clone()),
+        ),
+        ConformanceProperty::PathAgreement,
+    );
+
+    // Every OTHER property must stay silent on the same inputs. Without this the
+    // mode would prove nothing about the gap #5394 describes, which is precisely a
+    // contract that satisfies the entire existing property set and still diverges.
+    for property in ConformanceProperty::ALL {
+        if *property == ConformanceProperty::PathAgreement {
+            continue;
+        }
+        let states: Vec<Bytes> = match property.state_arity() {
+            3 => vec![
+                colliding[0].clone(),
+                colliding[1].clone(),
+                bytes(&[0x23, 0x51]),
+            ],
+            _ => colliding.clone(),
+        };
+        let deltas: Vec<Bytes> = match property.delta_arity() {
+            0 => Vec::new(),
+            1 => vec![bytes(&[0x52])],
+            _ => vec![bytes(&[0x52]), bytes(&[0x63])],
+        };
+        let outcome = verify_case(
+            &mut disagreeing,
+            &ConformanceCase::new(*property, states).with_deltas(deltas),
+        );
+        assert!(
+            !outcome.is_violation(),
+            "{property} fired on the disagreeing-paths mode, so it no longer \
+             isolates the one defect only path_agreement can see: {outcome:?}"
+        );
+    }
+
+    // The matched negative #5394's acceptance test asks for: the SAME contract with
+    // the SAME two write paths, on states whose keys do not collide. A property that
+    // flagged every contract with both a delta and a merge path would pass the
+    // assertion above while being worse than no property at all.
+    assert_eq!(
+        verify_case(
+            &mut disagreeing,
+            &ConformanceCase::new(
+                ConformanceProperty::PathAgreement,
+                vec![bytes(&[0x10, 0x51]), bytes(&[0x10, 0x62])],
+            ),
+        ),
+        PropertyOutcome::Holds,
+        "the two write paths only disagree on a key COLLISION; flagging a pair that \
+         has none makes this a blanket accusation rather than a finding"
     );
 
     // ---------------------------------- same code, different params, different instance

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -768,12 +768,17 @@ fn describe_oracle_build_error(err: OracleBuildError) -> anyhow::Error {
 /// "Distinct" is by [`ConformanceEvidence::id`] (a content hash of the
 /// inputs), so cases whose inputs coincide overwrite the same filename
 /// instead of piling up duplicate files for one finding.
-fn write_evidence(
+///
+/// Generic over the oracle purely so this function is testable: `minimize` and
+/// `verify_case` already are, and pinning this one to `RuntimeOracle` would have made
+/// "did minimisation run?" answerable only by scraping the source. A fake oracle that
+/// counts its calls answers it directly.
+fn write_evidence<O: ConformanceOracle + ?Sized>(
     dir: &PathBuf,
     instance: ContractInstanceId,
     parameters: &[u8],
     outcomes: &[(ConformanceCase, PropertyOutcome)],
-    oracle: &mut RuntimeOracle,
+    oracle: &mut O,
     state_candidates: &[Bytes],
     delta_candidates: &[Bytes],
 ) -> anyhow::Result<EvidenceSummary> {
@@ -1168,19 +1173,33 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
 /// one-token property. This asserts the property at the only place it can regress.
 #[cfg(test)]
 mod stdout_purity_pin {
-    /// Slice `load_inputs`' body by counting braces to its own closing one.
+    /// Slice a function's body by counting braces to its own closing one.
     ///
     /// Brace-counting rather than "up to the next `fn`": a region ended on a guessed
     /// anchor silently widens when the following item is not the shape assumed, and a
     /// widened region here would swallow the human-report code — which prints to stdout
     /// legitimately — and pass vacuously.
-    fn load_inputs_body() -> &'static str {
+    ///
+    /// Shared with `tests`, which pins other functions the same way, so that a second
+    /// source pin cannot hand-roll a `split_once` and inherit the self-satisfying
+    /// failure mode the project rules describe.
+    pub(super) fn fn_body(signature: &str) -> &'static str {
         let src = include_str!("conformance.rs");
         let start = src
-            .find("fn load_inputs(")
-            .expect("load_inputs not found in conformance.rs");
+            .find(signature)
+            .unwrap_or_else(|| panic!("{signature} not found in conformance.rs"));
+        // A signature that only matches inside a test module means the real function
+        // was renamed or removed: the region would then be some test's body, where the
+        // searched-for token is as likely to appear as not. Fail loudly instead.
+        if let Some(tests) = src.find("\n#[cfg(test)]") {
+            assert!(
+                start < tests,
+                "{signature} matched only inside a test module, so this pin would be \
+                 scoped to a test rather than to production code"
+            );
+        }
         let after = &src[start..];
-        let open = after.find('{').expect("load_inputs has no body");
+        let open = after.find('{').expect("signature has no body");
         let mut depth = 0usize;
         for (offset, ch) in after[open..].char_indices() {
             match ch {
@@ -1194,13 +1213,13 @@ mod stdout_purity_pin {
                 _ => {}
             }
         }
-        panic!("load_inputs' body is not brace-balanced");
+        panic!("{signature}'s body is not brace-balanced");
     }
 
     /// Strip whole-line comments, so a comment mentioning `println!` cannot satisfy or
     /// defeat the assertion. The comment above the `eprintln!` call names both.
     fn code_only() -> String {
-        load_inputs_body()
+        fn_body("fn load_inputs(")
             .lines()
             .filter(|line| !line.trim_start().starts_with("//"))
             .collect::<Vec<_>>()
@@ -1241,8 +1260,10 @@ mod stdout_purity_pin {
 
 #[cfg(test)]
 mod tests {
+    use super::stdout_purity_pin::fn_body;
     use super::*;
-    use freenet::conformance::Violation;
+    use freenet::conformance::{OracleError, Violation};
+    use freenet_stdlib::prelude::{RelatedContracts, UpdateModification, ValidateResult};
 
     /// A grow-only union contract, enough to exercise the reversed-pair heuristic
     /// without a WASM runtime.
@@ -1493,6 +1514,170 @@ mod tests {
              one pairing this corpus can support is gone from the replay"
         );
         assert_eq!(round_tripped.states, original.states);
+    }
+
+    /// An oracle that records every call, so a test can ask whether the WASM path
+    /// was entered at all.
+    ///
+    /// Deliberately trivial otherwise: nothing here is checking merge behaviour, only
+    /// whether `write_evidence` decided to spend WASM calls on a case it was going to
+    /// discard.
+    #[derive(Default)]
+    struct CountingOracle {
+        calls: std::cell::Cell<usize>,
+    }
+
+    impl freenet::conformance::ConformanceOracle for CountingOracle {
+        fn validate_state(
+            &mut self,
+            _state: &[u8],
+            _related: &RelatedContracts<'_>,
+        ) -> Result<ValidateResult, OracleError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(ValidateResult::Valid)
+        }
+
+        fn update_state(
+            &mut self,
+            state: &[u8],
+            _updates: &[UpdateData<'_>],
+        ) -> Result<UpdateModification<'static>, OracleError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(UpdateModification::valid(State::from(state.to_vec())))
+        }
+
+        fn summarize_state(&mut self, _state: &[u8]) -> Result<Vec<u8>, OracleError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(Vec::new())
+        }
+
+        fn get_state_delta(
+            &mut self,
+            _state: &[u8],
+            _summary: &[u8],
+        ) -> Result<Vec<u8>, OracleError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(Vec::new())
+        }
+    }
+
+    /// A finding that can never become evidence must be discarded BEFORE minimisation.
+    ///
+    /// Two things go wrong when the check sits after `minimize`, and they are not the
+    /// same defect. The cheap one is waste: minimisation is the expensive part of this
+    /// loop, and every byte of it is spent on a case that is then thrown away. The
+    /// one that misleads a reader is `input_bytes_before_shrinking`, documented as the
+    /// measure of "whether shrinking is earning its keep" — accumulating for a finding
+    /// shrinking could not have helped puts a number in the denominator the ratio is
+    /// not about. Measured on a real run before the fix: `files_written: 0` alongside
+    /// `input_bytes_before_shrinking: 32335`.
+    #[test]
+    fn a_local_only_finding_costs_no_minimisation_and_no_shrink_bytes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let out = dir.path().join("evidence");
+        let mut oracle = CountingOracle::default();
+
+        // `TransitionPathAgreement` is `Violation` (so it reaches the loop body) and
+        // `LocalProvenance` (so it can never be written).
+        let property = ConformanceProperty::TransitionPathAgreement;
+        assert!(
+            !property.is_self_verifying() && property.severity() == Severity::Violation,
+            "the fixture depends on this property being enforceable AND local-only"
+        );
+        let case = ConformanceCase::new(
+            property,
+            vec![Bytes::from(vec![7u8; 64]), Bytes::from(vec![8u8; 64])],
+        );
+        assert!(
+            case.input_bytes() > 0,
+            "the case must carry bytes, or the counter assertion below is vacuous"
+        );
+
+        let summary = write_evidence(
+            &out,
+            ContractInstanceId::new([3u8; 32]),
+            &[],
+            &[(case, PropertyOutcome::Violated(violation_of(property)))],
+            &mut oracle,
+            &[],
+            &[],
+        )
+        .expect("write evidence");
+
+        assert_eq!(summary.files_written, 0);
+        assert_eq!(summary.findings_local_only, 1);
+        assert_eq!(summary.findings_too_large, 0);
+        assert_eq!(
+            oracle.calls.get(),
+            0,
+            "minimisation and re-verification must not run for a finding that cannot \
+             travel; they are the expensive part of this loop"
+        );
+        assert_eq!(
+            (
+                summary.input_bytes_before_shrinking,
+                summary.input_bytes_after_shrinking
+            ),
+            (0, 0),
+            "and its bytes must not land in the shrink ratio, whose denominator is \
+             supposed to be work shrinking was asked to do"
+        );
+    }
+
+    /// The counterpart: a shippable finding DOES pay for minimisation and IS counted.
+    ///
+    /// Without this, moving the local-only check to the top of the loop body — or
+    /// deleting `minimize` outright — would satisfy the test above.
+    #[test]
+    fn a_shippable_finding_is_minimised_and_counted() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let out = dir.path().join("evidence");
+        let mut oracle = CountingOracle::default();
+
+        let property = ConformanceProperty::StateCommutativity;
+        assert!(property.is_self_verifying() && property.severity() == Severity::Violation);
+        let case = ConformanceCase::new(
+            property,
+            vec![Bytes::from(vec![7u8; 64]), Bytes::from(vec![8u8; 64])],
+        );
+
+        let summary = write_evidence(
+            &out,
+            ContractInstanceId::new([3u8; 32]),
+            &[],
+            &[(case, PropertyOutcome::Violated(violation_of(property)))],
+            &mut oracle,
+            &[],
+            &[],
+        )
+        .expect("write evidence");
+
+        assert_eq!(summary.files_written, 1);
+        assert_eq!(summary.findings_local_only, 0);
+        assert!(
+            oracle.calls.get() > 0,
+            "a shippable finding must actually go through minimisation"
+        );
+        assert_eq!(summary.input_bytes_before_shrinking, 128);
+    }
+
+    /// "wrote 0 evidence file(s)" must never stand alone.
+    ///
+    /// `findings_too_large`'s own doc comment says silently writing nothing would look
+    /// like there were none — and that is precisely what the DEFAULT (non-`--json`)
+    /// output did for both no-file reasons. The person who most needs the explanation
+    /// is the one who did not ask for JSON.
+    #[test]
+    fn the_human_report_says_why_no_evidence_was_written() {
+        let body = fn_body("fn print_human(");
+        for field in ["findings_local_only", "findings_too_large"] {
+            assert!(
+                body.contains(field),
+                "print_human never mentions {field}, so a run with such findings \
+                 prints 'wrote 0 evidence file(s)' and nothing else — which reads \
+                 exactly like a clean run"
+            );
+        }
     }
 
     /// Evidence is resolved by deriving each candidate's instance id, not by name.

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1020,12 +1020,30 @@ impl Report {
         }
     }
 
+    /// Print the human report to stdout.
+    ///
+    /// A thin wrapper over [`Report::write_human`] so the report's TEXT can be
+    /// rendered into a buffer and asserted on. The pin that used to guard the
+    /// no-evidence explanations scraped this function's source for two field
+    /// names, and `fn_body` returns raw source INCLUDING comments — so the
+    /// comment above those two blocks satisfied the pin on its own, and deleting
+    /// both `println!` blocks left the test green. Rendering to a sink lets the
+    /// test assert the lines actually appear.
+    ///
+    /// Write errors are dropped: a closed stdout (`| head`) is not a run failure,
+    /// and there is nowhere left to report it to anyway.
     fn print_human(&self) {
-        println!(
+        let _ = self.write_human(&mut std::io::stdout().lock());
+    }
+
+    fn write_human(&self, out: &mut impl std::io::Write) -> std::io::Result<()> {
+        writeln!(
+            out,
             "merge check: {} state(s), {} delta(s), {} summary/summaries in the corpus",
             self.corpus_states, self.corpus_deltas, self.corpus_summaries
-        );
-        println!(
+        )?;
+        writeln!(
+            out,
             "merge check: {} case(s) run \u{2014} {} held, {} violation(s) ({} enforceable, {} diagnostic-only), {} inconclusive",
             self.cases_run,
             self.holds,
@@ -1033,20 +1051,21 @@ impl Report {
             self.enforceable_violations,
             self.diagnostic_violations,
             self.inconclusive
-        );
+        )?;
 
         if !self.findings.is_empty() {
-            println!("\nfindings:");
+            writeln!(out, "\nfindings:")?;
             for (f, count) in group_findings(&self.findings) {
                 let cases = if count == 1 {
                     "1 case".to_string()
                 } else {
                     format!("{count} cases")
                 };
-                println!(
+                writeln!(
+                    out,
                     "  [{}] {} ({cases}): {}\n      example \u{2014} left: {}; right: {}",
                     f.severity, f.property, f.detail, f.left, f.right
-                );
+                )?;
             }
         }
 
@@ -1055,20 +1074,22 @@ impl Report {
         // and printing them as errors would train an author to "fix" working
         // code.
         if !self.inconclusive_reasons.is_empty() {
-            println!(
+            writeln!(
+                out,
                 "\ninconclusive ({} total \u{2014} NOT passes: these cases reached no verdict, so they say nothing about the contract):",
                 self.inconclusive
-            );
+            )?;
             for r in &self.inconclusive_reasons {
-                println!("  {}: {}", r.reason, r.occurrences);
+                writeln!(out, "  {}: {}", r.reason, r.occurrences)?;
             }
         }
 
         if let Some(evidence) = &self.evidence {
-            println!(
+            writeln!(
+                out,
                 "\nwrote {} evidence file(s) to {}",
                 evidence.files_written, evidence.directory
-            );
+            )?;
             // Never let that line stand alone when it says zero.
             //
             // `findings_local_only` and `findings_too_large` are the only two ways a
@@ -1079,32 +1100,37 @@ impl Report {
             // Only `--json` carried the reason, and the person who most needs it is
             // the one who did not ask for JSON.
             if evidence.findings_local_only > 0 {
-                println!(
+                writeln!(
+                    out,
                     "  {} finding(s) came from a property whose premise the evidence \
                      bytes cannot carry, so no evidence exists to write; they are \
                      listed above and are local-only by design",
                     evidence.findings_local_only
-                );
+                )?;
             }
             if evidence.findings_too_large > 0 {
-                println!(
+                writeln!(
+                    out,
                     "  {} finding(s) stayed over the evidence size limit even after \
                      shrinking; they are listed above and simply cannot be \
                      propagated",
                     evidence.findings_too_large
-                );
+                )?;
             }
         }
 
         if self.enforceable_violations == 0 {
-            println!("\nno enforceable violations found.");
+            writeln!(out, "\nno enforceable violations found.")?;
             if self.diagnostic_violations > 0 {
-                println!(
+                writeln!(
+                    out,
                     "({} diagnostic finding(s) above are efficiency notes, not merge-law breaks, and do not fail this command.)",
                     self.diagnostic_violations
-                );
+                )?;
             }
         }
+
+        Ok(())
     }
 }
 
@@ -1180,10 +1206,14 @@ mod stdout_purity_pin {
     /// widened region here would swallow the human-report code — which prints to stdout
     /// legitimately — and pass vacuously.
     ///
-    /// Shared with `tests`, which pins other functions the same way, so that a second
-    /// source pin cannot hand-roll a `split_once` and inherit the self-satisfying
-    /// failure mode the project rules describe.
-    pub(super) fn fn_body(signature: &str) -> &'static str {
+    /// Private on purpose, and reached only through [`code_only`]: the raw body it
+    /// returns INCLUDES comments, so a scrape built directly on it is satisfied by a
+    /// comment naming the token it searches for. That is not hypothetical — the pin
+    /// on the report's no-evidence explanations was written against `fn_body`, and a
+    /// comment added by the same commit kept it green after both `println!` blocks it
+    /// guarded were deleted. Every scrape in this file now goes through `code_only`,
+    /// so the footgun cannot be picked up by reaching for the obvious helper.
+    fn fn_body(signature: &str) -> &'static str {
         let src = include_str!("conformance.rs");
         let start = src
             .find(signature)
@@ -1216,10 +1246,15 @@ mod stdout_purity_pin {
         panic!("{signature}'s body is not brace-balanced");
     }
 
-    /// Strip whole-line comments, so a comment mentioning `println!` cannot satisfy or
-    /// defeat the assertion. The comment above the `eprintln!` call names both.
-    fn code_only() -> String {
-        fn_body("fn load_inputs(")
+    /// A function's body with whole-line comments stripped, so a comment mentioning
+    /// the searched-for token can neither satisfy nor defeat the assertion. The
+    /// comment above the `eprintln!` call names both macros; the comment above the
+    /// report's no-evidence blocks named both fields the old pin looked for.
+    ///
+    /// Takes the signature rather than hard-coding one, so that the comment-stripping
+    /// version is the ONLY way to scrape a body in this file.
+    fn code_only(signature: &str) -> String {
+        fn_body(signature)
             .lines()
             .filter(|line| !line.trim_start().starts_with("//"))
             .collect::<Vec<_>>()
@@ -1234,7 +1269,9 @@ mod stdout_purity_pin {
     /// code, which is the harmless direction; the same trap the other way is how a pin
     /// passes vacuously forever.
     fn stdout_macros_only() -> String {
-        code_only().replace("eprintln!", "").replace("eprint!", "")
+        code_only("fn load_inputs(")
+            .replace("eprintln!", "")
+            .replace("eprint!", "")
     }
 
     #[test]
@@ -1249,7 +1286,7 @@ mod stdout_purity_pin {
 
     #[test]
     fn the_bundle_note_still_reaches_the_reader() {
-        let body = code_only();
+        let body = code_only("fn load_inputs(");
         assert!(
             body.contains("eprintln!"),
             "the bundle note is no longer surfaced at all; a corpus whose related \
@@ -1260,10 +1297,24 @@ mod stdout_purity_pin {
 
 #[cfg(test)]
 mod tests {
-    use super::stdout_purity_pin::fn_body;
     use super::*;
     use freenet::conformance::{OracleError, Violation};
     use freenet_stdlib::prelude::{RelatedContracts, UpdateModification, ValidateResult};
+
+    /// Render the human report to a string.
+    ///
+    /// The report's text is what these tests assert on, rather than its source: a
+    /// source scrape of `print_human` is satisfied by a comment naming the same
+    /// tokens, which is exactly how the previous version of
+    /// `the_human_report_says_why_no_evidence_was_written` survived the deletion of
+    /// both blocks it existed to guard.
+    fn render_human(report: &Report) -> String {
+        let mut rendered = Vec::new();
+        report
+            .write_human(&mut rendered)
+            .expect("writing to a Vec cannot fail");
+        String::from_utf8(rendered).expect("the report is utf-8")
+    }
 
     /// A grow-only union contract, enough to exercise the reversed-pair heuristic
     /// without a WASM runtime.
@@ -1669,15 +1720,85 @@ mod tests {
     /// is the one who did not ask for JSON.
     #[test]
     fn the_human_report_says_why_no_evidence_was_written() {
-        let body = fn_body("fn print_human(");
-        for field in ["findings_local_only", "findings_too_large"] {
-            assert!(
-                body.contains(field),
-                "print_human never mentions {field}, so a run with such findings \
-                 prints 'wrote 0 evidence file(s)' and nothing else — which reads \
-                 exactly like a clean run"
-            );
-        }
+        let report = Report {
+            corpus_states: 1,
+            corpus_deltas: 1,
+            corpus_summaries: 0,
+            cases_run: 2,
+            holds: 0,
+            violations: 2,
+            enforceable_violations: 2,
+            diagnostic_violations: 0,
+            inconclusive: 0,
+            findings: Vec::new(),
+            inconclusive_reasons: Vec::new(),
+            evidence: Some(EvidenceSummary {
+                directory: "/tmp/evidence".to_string(),
+                files_written: 0,
+                findings_local_only: 1,
+                findings_too_large: 1,
+                input_bytes_before_shrinking: 0,
+                input_bytes_after_shrinking: 0,
+            }),
+        };
+
+        let rendered = render_human(&report);
+
+        assert!(
+            rendered.contains("wrote 0 evidence file(s)"),
+            "the fixture no longer produces the line this pin is about:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("the evidence bytes cannot carry"),
+            "a local-only finding drew no explanation, so the report says \
+             'wrote 0 evidence file(s)' and nothing else — which reads exactly \
+             like a clean run:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("stayed over the evidence size limit"),
+            "an over-size finding drew no explanation, so the report says \
+             'wrote 0 evidence file(s)' and nothing else — which reads exactly \
+             like a clean run:\n{rendered}"
+        );
+    }
+
+    /// The counterpart: a run with no unwritable findings must print NEITHER line.
+    ///
+    /// Without this, the pin above is satisfied by emitting both explanations
+    /// unconditionally, which would tell every clean run that findings it does not
+    /// have could not be written.
+    #[test]
+    fn the_no_evidence_explanations_are_conditional() {
+        let report = Report {
+            corpus_states: 1,
+            corpus_deltas: 1,
+            corpus_summaries: 0,
+            cases_run: 1,
+            holds: 1,
+            violations: 0,
+            enforceable_violations: 0,
+            diagnostic_violations: 0,
+            inconclusive: 0,
+            findings: Vec::new(),
+            inconclusive_reasons: Vec::new(),
+            evidence: Some(EvidenceSummary {
+                directory: "/tmp/evidence".to_string(),
+                files_written: 0,
+                findings_local_only: 0,
+                findings_too_large: 0,
+                input_bytes_before_shrinking: 0,
+                input_bytes_after_shrinking: 0,
+            }),
+        };
+
+        let rendered = render_human(&report);
+
+        assert!(
+            !rendered.contains("the evidence bytes cannot carry")
+                && !rendered.contains("stayed over the evidence size limit"),
+            "a run with zero unwritable findings explained away findings it does \
+             not have:\n{rendered}"
+        );
     }
 
     /// Evidence is resolved by deriving each candidate's instance id, not by name.

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -26,6 +26,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use freenet::conformance::ConformanceOracle;
 use freenet::conformance::generator::Corpus;
 use freenet::conformance::verifier::Bytes;
 use freenet::conformance::{
@@ -33,7 +34,7 @@ use freenet::conformance::{
     GeneratorConfig, Inconclusive, MinimizeConfig, OracleBuildError, PropertyOutcome, ReplayBundle,
     RuntimeOracle, Severity, Transition, generate_cases, minimize, verify_case,
 };
-use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId};
+use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId, State, UpdateData};
 use serde::Serialize;
 
 /// Run the contract conformance verifier (RFC #5320) against a contract's WASM.
@@ -68,6 +69,13 @@ pub struct ConformanceConfig {
     /// transition says the second was reached FROM the first, which is what makes
     /// "merging it back must reproduce it" a law rather than an accusation of
     /// last-write-wins against every conforming contract.
+    ///
+    /// ARGUMENT ORDER IS LOAD-BEARING AND CANNOT BE VERIFIED. BASE is the state
+    /// the peer HELD; RESULT is the state it REACHED. Supplied the other way
+    /// round, a perfectly conforming contract is reported as violating the law,
+    /// and nothing distinguishes that from a real finding — you are the witness
+    /// this property rests on. A likely-reversed pair is warned about, but the
+    /// check is a heuristic and cannot be conclusive.
     ///
     /// A capture bundle already carries these (`ReplayBundle::transitions`); this
     /// is how a developer supplies one by hand from two state files.
@@ -139,7 +147,12 @@ pub async fn conformance(config: ConformanceConfig) -> anyhow::Result<()> {
         return verify_evidence(&config, &path).await;
     }
     let properties = parse_properties(&config.properties)?;
-    let (wasm, parameters, corpus) = load_inputs(&config)?;
+    let LoadedInputs {
+        wasm,
+        parameters,
+        corpus,
+        hand_supplied_steps,
+    } = load_inputs(&config)?;
 
     if corpus.is_empty() {
         anyhow::bail!("no states to check: the corpus is empty");
@@ -179,6 +192,7 @@ pub async fn conformance(config: ConformanceConfig) -> anyhow::Result<()> {
         .await
         .map_err(describe_oracle_build_error)?;
     let instance = oracle.instance_id();
+    let _ = warn_on_reversed_transitions(&mut oracle, &hand_supplied_steps);
 
     let outcomes: Vec<(ConformanceCase, PropertyOutcome)> = cases
         .into_iter()
@@ -227,6 +241,57 @@ pub async fn conformance(config: ConformanceConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Warn when a hand-supplied `--transition BASE RESULT` pair looks reversed.
+///
+/// Argument order is load-bearing here and unverifiable. Every other malformed input
+/// to this command produces an error: an unreadable file, a WASM that will not load,
+/// a property name that does not exist. A REVERSED pair is the single exception,
+/// because it is structurally indistinguishable from a genuine finding - the whole
+/// reason `transition_path_agreement` is a law is that the corpus witnesses which
+/// state came first, and when a human types the two paths there is no witness but
+/// the order they typed them in.
+///
+/// The tell is that the law holds in the OTHER direction: if `merge(result, base)`
+/// reproduces `base`, then `base` sits above `result` in the merge's own order, so
+/// whatever was typed as `RESULT` is the earlier state. For a grow-only contract
+/// given the pair backwards this is exactly what happens, and the forward check then
+/// reports a violation against a perfectly conforming contract.
+///
+/// A warning rather than an error: a contract that genuinely disagrees in both
+/// directions is possible, and refusing to run would make a real finding
+/// unreportable. Stderr for the same reason `write_bundle` uses it - `--json` owns
+/// stdout.
+/// Returns how many pairs looked reversed, so a test can assert on the decision
+/// rather than on whether a line reached stderr.
+fn warn_on_reversed_transitions<O: ConformanceOracle + ?Sized>(
+    oracle: &mut O,
+    steps: &[(Bytes, Bytes)],
+) -> usize {
+    let mut suspicious = 0;
+    for (base, result) in steps {
+        let reversed =
+            oracle.update_state(result, &[UpdateData::State(State::from(base.to_vec()))]);
+        let Ok(modification) = reversed else {
+            continue;
+        };
+        let Some(state) = modification.new_state else {
+            continue;
+        };
+        if state.as_ref() == base.as_ref() {
+            suspicious += 1;
+            eprintln!(
+                "warning: for one --transition pair, merging BASE into RESULT \
+                 reproduces BASE, which is what a reversed pair looks like. \
+                 --transition takes the state the peer HELD first and the state it \
+                 REACHED second; supplied the other way round, a conforming \
+                 contract is reported as violating transition_path_agreement and \
+                 nothing can tell that apart from a real finding."
+            );
+        }
+    }
+    suspicious
+}
+
 /// Save the corpus under check as a replay bundle.
 ///
 /// Embeds the contract code, so the bundle names the contract it came from and
@@ -241,19 +306,48 @@ fn write_bundle(
 ) -> anyhow::Result<()> {
     let mut bundle = ReplayBundle::new(wasm.to_vec(), parameters.to_vec());
     bundle.states = corpus.states.iter().map(|s| s.to_vec()).collect();
-    bundle.deltas = corpus.deltas.iter().map(|d| d.to_vec()).collect();
     bundle.summaries = corpus.summaries.iter().map(|s| s.to_vec()).collect();
     // Carry the steps through, or `--bundle-out` would silently drop the one input
     // `transition_path_agreement` needs and the replayed bundle would report a clean
     // run where the original found something.
+    //
+    // Each step also reclaims the delta observed against its base. A `Transition` is
+    // the ONLY place a bundle can record what a delta was applied to:
+    // `ReplayBundle::to_corpus` fills `Corpus::delta_bases` from
+    // `transition.delta` + `transition.base_state`, and bundle-level `deltas` are
+    // explicitly given no base. Exporting the deltas loose therefore silently drops
+    // every pairing, and `delta_permutation_invariance` - which only pairs deltas
+    // observed against the SAME base - checks nothing on the re-exported bundle
+    // while the original run checked plenty. A replay that quietly covers less than
+    // the run it replays is the worst shape this command can have.
+    let (with_bases, loose): (Vec<usize>, Vec<usize>) =
+        (0..corpus.deltas.len()).partition(|i| corpus.delta_base(*i).is_some());
+    let mut unassigned = with_bases;
     bundle.transitions = corpus
         .transitions
         .iter()
-        .map(|(base, result)| Transition {
-            base_state: base.to_vec(),
-            result_state: result.to_vec(),
-            ..Default::default()
+        .map(|(base, result)| {
+            // Take one delta recorded against this exact base, at most one per step:
+            // that is the shape `to_corpus` produced them in, so re-pairing this way
+            // reconstructs the same `delta_bases` it built.
+            let taken = unassigned
+                .iter()
+                .position(|i| corpus.delta_base(*i).map(|b| b.as_ref()) == Some(base.as_ref()))
+                .map(|slot| unassigned.remove(slot));
+            Transition {
+                base_state: base.to_vec(),
+                result_state: result.to_vec(),
+                delta: taken.map(|i| corpus.deltas[i].to_vec()),
+                ..Default::default()
+            }
         })
+        .collect();
+    // Whatever no step claimed still travels, just without provenance - which is
+    // exactly what it had.
+    bundle.deltas = loose
+        .into_iter()
+        .chain(unassigned)
+        .map(|i| corpus.deltas[i].to_vec())
         .collect();
     bundle.note = Some(format!(
         "captured by fdev verify-merge {}",
@@ -506,7 +600,7 @@ fn find_code_in_store(store: &Path, bundle: &ReplayBundle) -> anyhow::Result<Vec
 
 /// Load the WASM, parameters and corpus, either from `--bundle` or from
 /// `--wasm` / `--params` / `--state`.
-fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, Corpus)> {
+fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<LoadedInputs> {
     if let Some(bundle_path) = &config.bundle {
         let bundle = ReplayBundle::read_from(bundle_path)
             .with_context(|| format!("reading bundle {}", bundle_path.display()))?;
@@ -549,7 +643,14 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
         }
 
         let corpus = bundle.to_corpus();
-        Ok((wasm, parameters, corpus))
+        // A bundle's steps carry real provenance from the capture path, so they are
+        // not hand-supplied and are not order-checked below.
+        Ok(LoadedInputs {
+            wasm,
+            parameters,
+            corpus,
+            hand_supplied_steps: Vec::new(),
+        })
     } else {
         let wasm_path = config
             .wasm
@@ -570,12 +671,16 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
             states.push(read_file(path)?);
         }
         // `num_args = 2` guarantees an even count, so the chunks are always whole
-        // pairs; the assert states that rather than leaving a lone path to be
-        // silently dropped if the arg definition is ever loosened.
-        assert!(
-            config.transitions.len() % 2 == 0,
-            "--transition takes two paths per occurrence"
-        );
+        // pairs; this states that rather than leaving a lone path to be silently
+        // dropped if the arg definition is ever loosened. An error rather than a
+        // panic: this is a CLI invariant, and a user who somehow reaches it deserves
+        // a message rather than a backtrace.
+        if config.transitions.len() % 2 != 0 {
+            anyhow::bail!(
+                "--transition takes two paths per occurrence, got {}",
+                config.transitions.len()
+            );
+        }
         let mut steps: Vec<(Bytes, Bytes)> = Vec::with_capacity(config.transitions.len() / 2);
         for pair in config.transitions.chunks(2) {
             let base = read_file(&pair[0])?;
@@ -588,12 +693,32 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
             steps.push((Bytes::from(base), Bytes::from(result)));
         }
         let corpus = Corpus {
-            transitions: steps,
+            transitions: steps.clone(),
             ..Corpus::from_states(states)
         }
         .deduplicated();
-        Ok((wasm, parameters, corpus))
+        Ok(LoadedInputs {
+            wasm,
+            parameters,
+            corpus,
+            hand_supplied_steps: steps,
+        })
     }
+}
+
+/// What a run was given: the contract, its parameters, the corpus, and separately
+/// the steps a human typed.
+///
+/// The last field exists only so [`warn_on_reversed_transitions`] can tell a
+/// hand-supplied pair from one a capture recorded. A bundle's steps are witnessed by
+/// the node that observed them; a `--transition BASE RESULT` pair is witnessed by
+/// nothing but argument order.
+#[derive(Debug)]
+struct LoadedInputs {
+    wasm: Vec<u8>,
+    parameters: Vec<u8>,
+    corpus: Corpus,
+    hand_supplied_steps: Vec<(Bytes, Bytes)>,
 }
 
 fn read_file(path: &PathBuf) -> anyhow::Result<Vec<u8>> {
@@ -634,6 +759,7 @@ fn write_evidence(
 
     let mut written = HashSet::new();
     let mut oversized = 0usize;
+    let mut local_only = 0usize;
     let mut shrunk_from = 0usize;
     let mut shrunk_to = 0usize;
     for (case, outcome) in outcomes {
@@ -657,6 +783,15 @@ fn write_evidence(
         let observed = verify_case(oracle, &minimized).violation().cloned();
         let evidence =
             ConformanceEvidence::new(instance, parameters.to_vec(), &minimized, observed);
+
+        // A property whose premise the bytes cannot carry is not evidence at all,
+        // and saying "could not be reduced to a shippable size" about one would be a
+        // false explanation of a permanent condition. It is not a failure either:
+        // the finding is real and this command reported it, it simply never travels.
+        if !minimized.property.is_self_verifying() {
+            local_only += 1;
+            continue;
+        }
 
         // Bounds-check with the same function a receiving peer uses, so this command
         // cannot report having written evidence that no peer would accept.
@@ -684,6 +819,7 @@ fn write_evidence(
     Ok(EvidenceSummary {
         directory: dir.display().to_string(),
         files_written: written.len(),
+        findings_local_only: local_only,
         findings_too_large: oversized,
         input_bytes_before_shrinking: shrunk_from,
         input_bytes_after_shrinking: shrunk_to,
@@ -694,6 +830,11 @@ fn write_evidence(
 struct EvidenceSummary {
     directory: String,
     files_written: usize,
+    /// Findings from a property that is not self-verifying, so no evidence can be
+    /// built for it at all. Reported rather than swallowed, and deliberately NOT
+    /// counted as "too large": the reason is permanent and has nothing to do with
+    /// size. See `ConformanceProperty::premise_source`.
+    findings_local_only: usize,
     /// Findings that stayed over the evidence size bound even after shrinking.
     /// Reported rather than swallowed: they are real findings that simply cannot be
     /// propagated, and silently writing nothing would look like there were none.
@@ -1024,6 +1165,186 @@ mod stdout_purity_pin {
 mod tests {
     use super::*;
     use freenet::conformance::Violation;
+
+    /// A grow-only union contract, enough to exercise the reversed-pair heuristic
+    /// without a WASM runtime.
+    struct GrowOnly;
+
+    impl ConformanceOracle for GrowOnly {
+        fn validate_state(
+            &mut self,
+            _state: &[u8],
+            _related: &freenet_stdlib::prelude::RelatedContracts<'_>,
+        ) -> Result<freenet_stdlib::prelude::ValidateResult, freenet::conformance::OracleError>
+        {
+            Ok(freenet_stdlib::prelude::ValidateResult::Valid)
+        }
+
+        fn update_state(
+            &mut self,
+            state: &[u8],
+            updates: &[UpdateData<'_>],
+        ) -> Result<
+            freenet_stdlib::prelude::UpdateModification<'static>,
+            freenet::conformance::OracleError,
+        > {
+            let mut out = state.to_vec();
+            for update in updates {
+                match update {
+                    UpdateData::State(incoming) => out.extend_from_slice(incoming.as_ref()),
+                    UpdateData::Delta(delta) => out.extend_from_slice(delta.as_ref()),
+                    _ => {}
+                }
+            }
+            out.sort_unstable();
+            out.dedup();
+            Ok(freenet_stdlib::prelude::UpdateModification::valid(
+                State::from(out),
+            ))
+        }
+
+        fn summarize_state(
+            &mut self,
+            state: &[u8],
+        ) -> Result<Vec<u8>, freenet::conformance::OracleError> {
+            Ok(state.to_vec())
+        }
+
+        fn get_state_delta(
+            &mut self,
+            state: &[u8],
+            summary: &[u8],
+        ) -> Result<Vec<u8>, freenet::conformance::OracleError> {
+            Ok(state
+                .iter()
+                .copied()
+                .filter(|b| !summary.contains(b))
+                .collect())
+        }
+    }
+
+    /// A reversed `--transition BASE RESULT` pair is the one malformed input this
+    /// command cannot turn into an error, so it must at least be warned about.
+    ///
+    /// Argument order is the entire provenance `transition_path_agreement` rests on
+    /// when a human supplies the pair. Given the two paths the wrong way round, a
+    /// perfectly conforming grow-only contract is reported as violating the law and
+    /// nothing distinguishes that from a real finding — the failure is silent and
+    /// confident, which is the worst combination.
+    #[test]
+    fn a_reversed_transition_pair_is_warned_about_and_a_correct_one_is_not() {
+        let earlier = Bytes::from(vec![1u8, 2]);
+        let later = Bytes::from(vec![1u8, 2, 3]);
+
+        assert_eq!(
+            warn_on_reversed_transitions(&mut GrowOnly, &[(earlier.clone(), later.clone())]),
+            0,
+            "a correctly ordered pair must not be warned about, or the warning is \
+             noise on every run and stops being read"
+        );
+        assert_eq!(
+            warn_on_reversed_transitions(&mut GrowOnly, &[(later, earlier)]),
+            1,
+            "merging BASE into RESULT reproducing BASE is what a reversed pair \
+             looks like, and it is the only tell there is"
+        );
+    }
+
+    /// The `--transition` arity invariant is an error, not a panic.
+    ///
+    /// `num_args = 2` makes it unreachable through clap today; the point is that
+    /// loosening the arg definition later must not turn a user's mistake into a
+    /// backtrace, and must not silently drop a lone path either.
+    #[test]
+    fn an_odd_number_of_transition_paths_is_an_error_not_a_panic() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let wasm = dir.path().join("c.wasm");
+        // Never loaded: the arity check is reached long before any runtime exists.
+        std::fs::write(&wasm, b"\0asm-stand-in").expect("write wasm");
+        let config = ConformanceConfig {
+            wasm: Some(wasm),
+            params: None,
+            states: Vec::new(),
+            transitions: vec![PathBuf::from("only-one.bin")],
+            bundle: None,
+            contract_store: None,
+            max_cases: None,
+            properties: Vec::new(),
+            json: false,
+            evidence_out: None,
+            evidence_in: None,
+            bundle_out: None,
+        };
+        let err = load_inputs(&config).expect_err("an odd count must be rejected");
+        assert!(
+            err.to_string().contains("--transition takes two paths"),
+            "the error must name the argument, got: {err}"
+        );
+    }
+
+    /// `--bundle-out` must re-export a corpus that replays to the SAME corpus.
+    ///
+    /// Not just the same states and steps: the same `delta_bases`. A `Transition` is
+    /// the only place a bundle can record what a delta was applied to, because
+    /// `ReplayBundle::to_corpus` deliberately gives bundle-level deltas no base at
+    /// all — pairing causally sequenced deltas asks about a situation the protocol
+    /// never produces. So re-exporting a transition without its `delta` drops every
+    /// pairing, and `delta_permutation_invariance` — which pairs only deltas
+    /// observed against the SAME base — checks nothing on the replayed bundle while
+    /// the original run checked plenty.
+    ///
+    /// That is the worst shape this command can have: the replay reports a clean run
+    /// and reads as a reproduction of the original.
+    #[test]
+    fn a_re_exported_bundle_keeps_what_each_delta_was_applied_to() {
+        let code = b"\0asm-stand-in".to_vec();
+        let base = vec![1u8, 2];
+        // Two deltas against the SAME base: the pairing this exists to preserve.
+        let bundle_in = ReplayBundle {
+            transitions: vec![
+                Transition {
+                    base_state: base.clone(),
+                    result_state: vec![1, 2, 3],
+                    delta: Some(vec![3]),
+                    ..Default::default()
+                },
+                Transition {
+                    base_state: base.clone(),
+                    result_state: vec![1, 2, 4],
+                    delta: Some(vec![4]),
+                    ..Default::default()
+                },
+            ],
+            ..ReplayBundle::new(code.clone(), Vec::new())
+        };
+
+        let original = bundle_in.to_corpus();
+        assert_eq!(
+            original.delta_bases,
+            vec![
+                Some(Bytes::from(base.clone())),
+                Some(Bytes::from(base.clone()))
+            ],
+            "the fixture must actually carry provenance, or the round trip below \
+             has nothing to lose"
+        );
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("out.bin");
+        write_bundle(&path, &code, &[], &original).expect("write bundle");
+        let round_tripped = ReplayBundle::read_from(&path)
+            .expect("read bundle")
+            .to_corpus();
+
+        assert_eq!(round_tripped.transitions, original.transitions);
+        assert_eq!(round_tripped.deltas, original.deltas);
+        assert_eq!(
+            round_tripped.delta_bases, original.delta_bases,
+            "a re-exported bundle must pair each delta with the state it was \
+             applied to, exactly as the corpus it was written from did"
+        );
+        assert_eq!(round_tripped.states, original.states);
+    }
 
     /// Evidence is resolved by deriving each candidate's instance id, not by name.
     ///

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -17,6 +17,9 @@
 //!
 //! # Replay a bundle captured from the network (or an earlier `fdev` run)
 //! fdev verify-merge --bundle observed.bin
+//!
+//! # Supply an observed step by hand: the state held, then the state reached
+//! fdev verify-merge --wasm contract.wasm --transition before.bin after.bin
 //! ```
 
 use std::collections::{HashMap, HashSet};
@@ -28,7 +31,7 @@ use freenet::conformance::verifier::Bytes;
 use freenet::conformance::{
     ConformanceCase, ConformanceEvidence, ConformanceProperty, EVIDENCE_SCHEMA_VERSION,
     GeneratorConfig, Inconclusive, MinimizeConfig, OracleBuildError, PropertyOutcome, ReplayBundle,
-    RuntimeOracle, Severity, generate_cases, minimize, verify_case,
+    RuntimeOracle, Severity, Transition, generate_cases, minimize, verify_case,
 };
 use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId};
 use serde::Serialize;
@@ -56,6 +59,20 @@ pub struct ConformanceConfig {
     /// Required unless `--bundle` is given.
     #[arg(long = "state")]
     pub(crate) states: Vec<PathBuf>,
+
+    /// An observed step: the state a peer held, and the state it reached after
+    /// applying an update. Takes two paths. Repeat for multiple steps.
+    ///
+    /// This is PROVENANCE, and `transition_path_agreement` cannot be checked
+    /// without it. Loose `--state` files say only that both states existed; a
+    /// transition says the second was reached FROM the first, which is what makes
+    /// "merging it back must reproduce it" a law rather than an accusation of
+    /// last-write-wins against every conforming contract.
+    ///
+    /// A capture bundle already carries these (`ReplayBundle::transitions`); this
+    /// is how a developer supplies one by hand from two state files.
+    #[arg(long = "transition", num_args = 2, value_names = ["BASE", "RESULT"])]
+    pub(crate) transitions: Vec<PathBuf>,
 
     /// Replay a corpus captured earlier (see `freenet::conformance::bundle`)
     /// instead of building one from `--state`.
@@ -146,8 +163,8 @@ pub async fn conformance(config: ConformanceConfig) -> anyhow::Result<()> {
             "no cases could be generated from this corpus: {} state(s), {} delta(s), \
              {} summary/summaries for the selected properties. Nothing was checked, \
              so this is not a pass — supply more states (commutativity and \
-             reconciliation need at least two), or captured deltas for the \
-             delta properties.",
+             reconciliation need at least two), captured deltas for the delta \
+             properties, or --transition BASE RESULT for transition_path_agreement.",
             corpus.states.len(),
             corpus.deltas.len(),
             corpus.summaries.len(),
@@ -226,6 +243,18 @@ fn write_bundle(
     bundle.states = corpus.states.iter().map(|s| s.to_vec()).collect();
     bundle.deltas = corpus.deltas.iter().map(|d| d.to_vec()).collect();
     bundle.summaries = corpus.summaries.iter().map(|s| s.to_vec()).collect();
+    // Carry the steps through, or `--bundle-out` would silently drop the one input
+    // `transition_path_agreement` needs and the replayed bundle would report a clean
+    // run where the original found something.
+    bundle.transitions = corpus
+        .transitions
+        .iter()
+        .map(|(base, result)| Transition {
+            base_state: base.to_vec(),
+            result_state: result.to_vec(),
+            ..Default::default()
+        })
+        .collect();
     bundle.note = Some(format!(
         "captured by fdev verify-merge {}",
         env!("CARGO_PKG_VERSION")
@@ -234,11 +263,13 @@ fn write_bundle(
         .write_to(path)
         .with_context(|| format!("writing bundle to {}", path.display()))?;
     eprintln!(
-        "wrote replay bundle to {} ({} state(s), {} delta(s), {} summary/summaries)",
+        "wrote replay bundle to {} ({} state(s), {} delta(s), {} summary/summaries, \
+         {} transition(s))",
         path.display(),
         bundle.states.len(),
         bundle.deltas.len(),
         bundle.summaries.len(),
+        bundle.transitions.len(),
     );
     Ok(())
 }
@@ -529,14 +560,38 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<(Vec<u8>, Vec<u8>, 
             Some(path) => read_file(path)?,
             None => Vec::new(),
         };
-        if config.states.is_empty() {
-            anyhow::bail!("at least one --state is required unless --bundle is given");
+        if config.states.is_empty() && config.transitions.is_empty() {
+            anyhow::bail!(
+                "at least one --state or --transition is required unless --bundle is given"
+            );
         }
         let mut states = Vec::with_capacity(config.states.len());
         for path in &config.states {
             states.push(read_file(path)?);
         }
-        let corpus = Corpus::from_states(states).deduplicated();
+        // `num_args = 2` guarantees an even count, so the chunks are always whole
+        // pairs; the assert states that rather than leaving a lone path to be
+        // silently dropped if the arg definition is ever loosened.
+        assert!(
+            config.transitions.len() % 2 == 0,
+            "--transition takes two paths per occurrence"
+        );
+        let mut steps: Vec<(Bytes, Bytes)> = Vec::with_capacity(config.transitions.len() / 2);
+        for pair in config.transitions.chunks(2) {
+            let base = read_file(&pair[0])?;
+            let result = read_file(&pair[1])?;
+            // Both endpoints are ordinary observed states too, so the other
+            // properties get to use them rather than the transition being a
+            // dead-end input.
+            states.push(base.clone());
+            states.push(result.clone());
+            steps.push((Bytes::from(base), Bytes::from(result)));
+        }
+        let corpus = Corpus {
+            transitions: steps,
+            ..Corpus::from_states(states)
+        }
+        .deduplicated();
         Ok((wasm, parameters, corpus))
     }
 }
@@ -870,6 +925,7 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
         Inconclusive::RoundLimit => "reconciliation round budget exhausted",
         Inconclusive::MalformedCase(_) => "malformed case",
         Inconclusive::NoDeltaPath => "no delta path to compare against",
+        Inconclusive::StateNotSettled => "observed result state never settles",
         Inconclusive::NotReproducible => "finding did not reproduce",
         _ => "other",
     }

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -869,6 +869,8 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
         Inconclusive::ResourceLimit(_) => "resource limit hit",
         Inconclusive::RoundLimit => "reconciliation round budget exhausted",
         Inconclusive::MalformedCase(_) => "malformed case",
+        Inconclusive::NoDeltaPath => "no delta path to compare against",
+        Inconclusive::NotReproducible => "finding did not reproduce",
         _ => "other",
     }
 }

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -921,7 +921,8 @@ fn write_unwritable_notes(
         writeln!(
             out,
             "note: {} {} finding(s) cannot be carried as evidence at all ({}); they \
-             are reported above and no evidence file is written for them",
+             appear in the report's findings list and no evidence file is written \
+             for them",
             note.cases,
             note.property,
             EvidenceRejected::NotSelfVerifying {

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -31,8 +31,9 @@ use freenet::conformance::generator::Corpus;
 use freenet::conformance::verifier::Bytes;
 use freenet::conformance::{
     ConformanceCase, ConformanceEvidence, ConformanceProperty, EVIDENCE_SCHEMA_VERSION,
-    GeneratorConfig, Inconclusive, MinimizeConfig, OracleBuildError, PropertyOutcome, ReplayBundle,
-    RuntimeOracle, Severity, Transition, generate_cases, minimize, verify_case,
+    EvidenceRejected, GeneratorConfig, Inconclusive, MinimizeConfig, OracleBuildError,
+    PropertyOutcome, ReplayBundle, RuntimeOracle, Severity, Transition, generate_cases, minimize,
+    verify_case,
 };
 use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId, State, UpdateData};
 use serde::Serialize;
@@ -323,27 +324,43 @@ fn write_bundle(
     let (with_bases, loose): (Vec<usize>, Vec<usize>) =
         (0..corpus.deltas.len()).partition(|i| corpus.delta_base(*i).is_some());
     let mut unassigned = with_bases;
-    bundle.transitions = corpus
-        .transitions
-        .iter()
-        .map(|(base, result)| {
-            // Take one delta recorded against this exact base, at most one per step:
-            // that is the shape `to_corpus` produced them in, so re-pairing this way
-            // reconstructs the same `delta_bases` it built.
-            let taken = unassigned
-                .iter()
-                .position(|i| corpus.delta_base(*i).map(|b| b.as_ref()) == Some(base.as_ref()))
-                .map(|slot| unassigned.remove(slot));
-            Transition {
-                base_state: base.to_vec(),
-                result_state: result.to_vec(),
-                delta: taken.map(|i| corpus.deltas[i].to_vec()),
-                ..Default::default()
-            }
-        })
-        .collect();
+    // Take one delta recorded against this exact base, removing it from the pool.
+    let take_for = |base: &Bytes, unassigned: &mut Vec<usize>| -> Option<usize> {
+        unassigned
+            .iter()
+            .position(|i| corpus.delta_base(*i).map(|b| b.as_ref()) == Some(base.as_ref()))
+            .map(|slot| unassigned.remove(slot))
+    };
+    let mut steps: Vec<Transition> = Vec::with_capacity(corpus.transitions.len());
+    for (base, result) in &corpus.transitions {
+        let step = |delta: Option<usize>| Transition {
+            base_state: base.to_vec(),
+            result_state: result.to_vec(),
+            delta: delta.map(|i| corpus.deltas[i].to_vec()),
+            ..Default::default()
+        };
+        steps.push(step(take_for(base, &mut unassigned)));
+        // A `Transition` holds at most ONE delta, and a base can legitimately own
+        // several. `Corpus::deduplicated` collapses steps by `(base, result)`, so a
+        // contract that took two different updates from the same state and landed on
+        // the same result arrives here as one step and two same-base deltas — the
+        // exact shape `delta_permutation_invariance` is FOR. Stopping at one delta
+        // per step therefore sent the second out loose, where `to_corpus` gives it no
+        // base and it is never paired: the re-exported bundle checks the property on
+        // nothing while the original run checked the pair.
+        //
+        // So repeat the step, once per further delta against the same base. The
+        // duplicate `(base, result)` pairs cost their two states in the encoding but
+        // collapse again in `to_corpus`'s own `deduplicated`, leaving one step and
+        // every delta still holding its base.
+        while let Some(extra) = take_for(base, &mut unassigned) {
+            steps.push(step(Some(extra)));
+        }
+    }
+    bundle.transitions = steps;
     // Whatever no step claimed still travels, just without provenance - which is
-    // exactly what it had.
+    // exactly what it had. `unassigned` can still hold deltas here: a corpus may
+    // record a base for a delta without holding any step that starts from it.
     bundle.deltas = loose
         .into_iter()
         .chain(unassigned)
@@ -448,7 +465,11 @@ async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::
     }
 
     // Bounds-check with the same function a receiving peer uses, so this command
-    // never accepts evidence the network itself would reject.
+    // never accepts evidence the network itself would reject, and do it BEFORE
+    // building the runtime — the point of the check is that nothing unbounded or
+    // unsound reaches the WASM. `to_case` re-runs it below; that is deliberate
+    // belt-and-braces, since `to_case` is the enforcement point and this call is the
+    // one that produces a good error message early.
     evidence
         .check_bounds()
         .map_err(|rejected| anyhow::anyhow!("evidence is not shippable: {rejected}"))?;
@@ -477,7 +498,9 @@ async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::
         );
     }
 
-    let case = evidence.to_case();
+    let case = evidence
+        .to_case()
+        .map_err(|rejected| anyhow::anyhow!("evidence is not shippable: {rejected}"))?;
     let outcome = verify_case(&mut oracle, &case);
 
     println!("evidence {}", evidence.id());
@@ -767,6 +790,30 @@ fn write_evidence(
             continue;
         }
 
+        // A property whose premise the bytes cannot carry is not evidence at all,
+        // and saying "could not be reduced to a shippable size" about one would be a
+        // false explanation of a permanent condition. It is not a failure either:
+        // the finding is real and this command reported it, it simply never travels.
+        //
+        // Checked BEFORE minimising, not after. Minimisation is the expensive part of
+        // this loop — repeated `verify_case` calls through the WASM runtime — and
+        // spending all of it on a case that is then discarded is pure waste. It also
+        // keeps the byte counters honest: they are documented as summed over the
+        // findings written, and accumulating for a finding shrinking could never help
+        // puts a number in the denominator that the ratio is not about.
+        if !case.property.is_self_verifying() {
+            local_only += 1;
+            eprintln!(
+                "note: a {} finding cannot be carried as evidence at all ({}); it is \
+                 reported above and no evidence file is written for it",
+                case.property,
+                EvidenceRejected::NotSelfVerifying {
+                    property: case.property
+                }
+            );
+            continue;
+        }
+
         // Shrink before serializing. A case generated from large states can carry
         // several MB, well over the evidence size bound, and evidence that every
         // recipient rejects is not evidence. Shrinking also makes the file a usable
@@ -783,15 +830,6 @@ fn write_evidence(
         let observed = verify_case(oracle, &minimized).violation().cloned();
         let evidence =
             ConformanceEvidence::new(instance, parameters.to_vec(), &minimized, observed);
-
-        // A property whose premise the bytes cannot carry is not evidence at all,
-        // and saying "could not be reduced to a shippable size" about one would be a
-        // false explanation of a permanent condition. It is not a failure either:
-        // the finding is real and this command reported it, it simply never travels.
-        if !minimized.property.is_self_verifying() {
-            local_only += 1;
-            continue;
-        }
 
         // Bounds-check with the same function a receiving peer uses, so this command
         // cannot report having written evidence that no peer would accept.
@@ -839,10 +877,25 @@ struct EvidenceSummary {
     /// Reported rather than swallowed: they are real findings that simply cannot be
     /// propagated, and silently writing nothing would look like there were none.
     findings_too_large: usize,
-    /// Total case input bytes before and after minimisation, summed over the
-    /// findings written. The ratio is the honest measure of whether shrinking is
-    /// earning its keep, and it is what decides whether a finding fits in evidence
-    /// at all.
+    /// Total case input bytes before and after minimisation, summed over every
+    /// finding minimisation was actually RUN on — which is not the same set as the
+    /// files written, and the difference is deliberate in both directions.
+    ///
+    /// A finding counted by `findings_too_large` is included: shrinking ran, and
+    /// failed to get it under the bound. Excluding it would drop exactly the cases
+    /// where shrinking did least and overstate the ratio.
+    ///
+    /// A finding counted by `findings_local_only` is excluded, because minimisation
+    /// never runs for one: the property cannot travel as evidence whatever its size,
+    /// so shrinking it could not have helped and its bytes are not a measure of
+    /// anything. That exclusion is structural — the check sits above the `minimize`
+    /// call — rather than a subtraction someone has to remember.
+    ///
+    /// Duplicates are included too: a second case with the same evidence id had
+    /// minimisation run on it before the id was known.
+    ///
+    /// So the ratio is the honest measure of whether shrinking is earning its keep on
+    /// the work it is actually asked to do.
     input_bytes_before_shrinking: usize,
     input_bytes_after_shrinking: usize,
 }
@@ -1011,6 +1064,31 @@ impl Report {
                 "\nwrote {} evidence file(s) to {}",
                 evidence.files_written, evidence.directory
             );
+            // Never let that line stand alone when it says zero.
+            //
+            // `findings_local_only` and `findings_too_large` are the only two ways a
+            // real finding produces no file, and the default human output printed
+            // neither — so "wrote 0 evidence file(s)" read exactly like a clean run,
+            // which is the failure mode `findings_too_large`'s own doc comment warns
+            // about ("silently writing nothing would look like there were none").
+            // Only `--json` carried the reason, and the person who most needs it is
+            // the one who did not ask for JSON.
+            if evidence.findings_local_only > 0 {
+                println!(
+                    "  {} finding(s) came from a property whose premise the evidence \
+                     bytes cannot carry, so no evidence exists to write; they are \
+                     listed above and are local-only by design",
+                    evidence.findings_local_only
+                );
+            }
+            if evidence.findings_too_large > 0 {
+                println!(
+                    "  {} finding(s) stayed over the evidence size limit even after \
+                     shrinking; they are listed above and simply cannot be \
+                     propagated",
+                    evidence.findings_too_large
+                );
+            }
         }
 
         if self.enforceable_violations == 0 {
@@ -1342,6 +1420,77 @@ mod tests {
             round_tripped.delta_bases, original.delta_bases,
             "a re-exported bundle must pair each delta with the state it was \
              applied to, exactly as the corpus it was written from did"
+        );
+        assert_eq!(round_tripped.states, original.states);
+    }
+
+    /// The same shape again, where the two steps COLLAPSE into one.
+    ///
+    /// The test above pairs two same-base deltas that arrive on two distinct steps,
+    /// so one delta per step is enough to carry them. `Corpus::deduplicated` keys
+    /// steps on `(base, result)`, so two updates taken from the same state that land
+    /// on the same result become ONE step holding two same-base deltas — and a
+    /// `Transition` holds at most one delta. Assigning one and chaining the rest onto
+    /// `bundle.deltas` sent the second out loose, where `to_corpus` gives it no base
+    /// and `delta_permutation_invariance` never pairs it.
+    ///
+    /// A same-base pair is exactly what that property is FOR, so the re-export
+    /// silently checked less than the run it replayed while reporting a clean bill of
+    /// health. The fix repeats the step once per further delta; the duplicate
+    /// `(base, result)` pairs collapse again on the way back in.
+    #[test]
+    fn a_re_exported_bundle_keeps_every_delta_of_a_collapsed_step() {
+        let code = b"\0asm-stand-in".to_vec();
+        let base = vec![1u8, 2];
+        let result = vec![1u8, 2, 3];
+        // Same base AND same result, two different deltas: one step after dedup.
+        let bundle_in = ReplayBundle {
+            transitions: vec![
+                Transition {
+                    base_state: base.clone(),
+                    result_state: result.clone(),
+                    delta: Some(vec![3]),
+                    ..Default::default()
+                },
+                Transition {
+                    base_state: base.clone(),
+                    result_state: result.clone(),
+                    delta: Some(vec![4]),
+                    ..Default::default()
+                },
+            ],
+            ..ReplayBundle::new(code.clone(), Vec::new())
+        };
+
+        let original = bundle_in.to_corpus();
+        assert_eq!(
+            original.transitions.len(),
+            1,
+            "the fixture must actually collapse to one step, or it is the test above"
+        );
+        assert_eq!(
+            original.delta_bases,
+            vec![
+                Some(Bytes::from(base.clone())),
+                Some(Bytes::from(base.clone()))
+            ],
+            "and both deltas must start out provenanced, or the round trip below has \
+             nothing to lose"
+        );
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("out.bin");
+        write_bundle(&path, &code, &[], &original).expect("write bundle");
+        let round_tripped = ReplayBundle::read_from(&path)
+            .expect("read bundle")
+            .to_corpus();
+
+        assert_eq!(round_tripped.transitions, original.transitions);
+        assert_eq!(round_tripped.deltas, original.deltas);
+        assert_eq!(
+            round_tripped.delta_bases, original.delta_bases,
+            "the second delta of a collapsed step must keep its base too, or the \
+             one pairing this corpus can support is gone from the replay"
         );
         assert_eq!(round_tripped.states, original.states);
     }

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -790,6 +790,12 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
     let mut local_only = 0usize;
     let mut shrunk_from = 0usize;
     let mut shrunk_to = 0usize;
+    // Grouped, not per-case. Both of these fire once per VIOLATED CASE, and a corpus
+    // routinely produces dozens of cases breaking the same law — `group_findings`
+    // exists for exactly that reason on the report side. Printing one identical line
+    // per case buries the report the note is telling the reader to go and look at.
+    let mut local_only_notes: Vec<UnwritableNote> = Vec::new();
+    let mut oversized_notes: Vec<UnwritableNote> = Vec::new();
     for (case, outcome) in outcomes {
         if !outcome.is_enforceable_violation() {
             continue;
@@ -808,14 +814,7 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
         // puts a number in the denominator that the ratio is not about.
         if !case.property.is_self_verifying() {
             local_only += 1;
-            eprintln!(
-                "note: a {} finding cannot be carried as evidence at all ({}); it is \
-                 reported above and no evidence file is written for it",
-                case.property,
-                EvidenceRejected::NotSelfVerifying {
-                    property: case.property
-                }
-            );
+            note_unwritable(&mut local_only_notes, case.property, None);
             continue;
         }
 
@@ -840,10 +839,10 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
         // cannot report having written evidence that no peer would accept.
         if let Err(rejected) = evidence.check_bounds() {
             oversized += 1;
-            eprintln!(
-                "warning: a {} finding could not be reduced to a shippable size ({rejected}); \
-                 no evidence file written for it",
-                minimized.property
+            note_unwritable(
+                &mut oversized_notes,
+                minimized.property,
+                Some(rejected.to_string()),
             );
             continue;
         }
@@ -859,6 +858,14 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
             .with_context(|| format!("writing evidence to {}", path.display()))?;
     }
 
+    // Stderr, never stdout: `--json` promises one JSON document on stdout and these
+    // notes would corrupt it. See the `stdout_purity_pin` module.
+    let _ = write_unwritable_notes(
+        &mut std::io::stderr().lock(),
+        &local_only_notes,
+        &oversized_notes,
+    );
+
     Ok(EvidenceSummary {
         directory: dir.display().to_string(),
         files_written: written.len(),
@@ -867,6 +874,72 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
         input_bytes_before_shrinking: shrunk_from,
         input_bytes_after_shrinking: shrunk_to,
     })
+}
+
+/// One "no evidence file was written" note, accumulated per property rather than
+/// emitted per case.
+struct UnwritableNote {
+    property: ConformanceProperty,
+    cases: usize,
+    /// A representative rejection, where the reason varies per case (the byte counts
+    /// in an over-size rejection do). The count is what the reader acts on; the
+    /// example is what tells them which knob it is about.
+    example: Option<String>,
+}
+
+/// Bump this property's note, keeping the FIRST example seen.
+///
+/// First rather than last so the line is stable across a re-run that produces the
+/// same findings in the same order — a note whose numbers move between identical runs
+/// reads as new information.
+fn note_unwritable(
+    notes: &mut Vec<UnwritableNote>,
+    property: ConformanceProperty,
+    example: Option<String>,
+) {
+    match notes.iter_mut().find(|n| n.property == property) {
+        Some(note) => note.cases += 1,
+        None => notes.push(UnwritableNote {
+            property,
+            cases: 1,
+            example,
+        }),
+    }
+}
+
+/// Emit the grouped notes, one line per property rather than one per case.
+///
+/// Split out from `write_evidence` so the grouping can be asserted: `write_evidence`
+/// needs a WASM oracle and a temp directory, and its notes go to stderr, which a test
+/// cannot capture.
+fn write_unwritable_notes(
+    out: &mut impl std::io::Write,
+    local_only: &[UnwritableNote],
+    oversized: &[UnwritableNote],
+) -> std::io::Result<()> {
+    for note in local_only {
+        writeln!(
+            out,
+            "note: {} {} finding(s) cannot be carried as evidence at all ({}); they \
+             are reported above and no evidence file is written for them",
+            note.cases,
+            note.property,
+            EvidenceRejected::NotSelfVerifying {
+                property: note.property
+            }
+        )?;
+    }
+    for note in oversized {
+        writeln!(
+            out,
+            "warning: {} {} finding(s) stayed over the evidence size limit even after \
+             shrinking, so no evidence file was written for them — example: {}",
+            note.cases,
+            note.property,
+            note.example.as_deref().unwrap_or("(no detail)")
+        )?;
+    }
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -1759,6 +1832,62 @@ mod tests {
             "an over-size finding drew no explanation, so the report says \
              'wrote 0 evidence file(s)' and nothing else — which reads exactly \
              like a clean run:\n{rendered}"
+        );
+    }
+
+    /// Twenty-four cases breaking one law are ONE note, not twenty-four.
+    ///
+    /// Both notes fired once per violated CASE, and a corpus routinely produces dozens
+    /// of cases of the same defect — `group_findings` exists for that reason on the
+    /// report side. The identical lines then bury the report the note points at.
+    #[test]
+    fn the_unwritable_notes_are_one_line_per_property_not_one_per_case() {
+        let mut local_only = Vec::new();
+        for _ in 0..24 {
+            note_unwritable(
+                &mut local_only,
+                ConformanceProperty::TransitionPathAgreement,
+                None,
+            );
+        }
+        note_unwritable(
+            &mut local_only,
+            ConformanceProperty::DeltaPermutationInvariance,
+            None,
+        );
+
+        let mut oversized = Vec::new();
+        for found in [900usize, 800, 700] {
+            note_unwritable(
+                &mut oversized,
+                ConformanceProperty::StateCommutativity,
+                Some(format!("{found} bytes over")),
+            );
+        }
+
+        let mut rendered = Vec::new();
+        write_unwritable_notes(&mut rendered, &local_only, &oversized)
+            .expect("writing to a Vec cannot fail");
+        let rendered = String::from_utf8(rendered).expect("notes are utf-8");
+
+        assert_eq!(
+            rendered.lines().count(),
+            3,
+            "28 unwritable findings across 3 properties should print 3 lines:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("24 transition_path_agreement finding(s)"),
+            "the note does not say how many cases it stands for:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("1 delta_permutation_invariance finding(s)"),
+            "a second property's findings were folded into the first's note:\n{rendered}"
+        );
+        // The FIRST example, so a re-run producing the same findings prints the same
+        // line rather than whichever case happened to land last.
+        assert!(
+            rendered.contains("example: 900 bytes over"),
+            "the over-size note lost its representative rejection:\n{rendered}"
         );
     }
 

--- a/crates/fdev/src/main.rs
+++ b/crates/fdev/src/main.rs
@@ -303,6 +303,7 @@ mod tests {
             wasm: None,
             params: None,
             states: Vec::new(),
+            transitions: Vec::new(),
             bundle: None,
             contract_store: None,
             max_cases: None,

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -40,6 +40,12 @@
 //!                                conforms. Proves the verifier declines rather than
 //!                                accuses when the state is missing, and reaches a
 //!                                real verdict once it is supplied.
+//!   8 PATH_DISAGREEMENT        — the two write paths use different combinators on a
+//!                                key collision: the delta path takes the last write,
+//!                                the merge path the first. Each path is a perfectly
+//!                                good semilattice ON ITS OWN, so every existing law
+//!                                holds and only `path_agreement` can see it. The
+//!                                #5394 shape.
 //!
 //! State is always a canonical byte set: sorted, strictly ascending, no
 //! duplicates. `validate_state` accepts exactly that canonical form.
@@ -61,6 +67,21 @@
 //! contract, and it is also the realistic shape of the bug: an author reaching
 //! for a timestamp to break ties in a summary.
 
+//! ## Why mode 8 needs a different state shape from the rest
+//!
+//! Every other mode's state is a plain byte SET, and a set has no way to express
+//! "two writes to the same slot" — which is the only situation in which a
+//! last-write-wins and a first-write-wins rule can disagree. So mode 8 reads each
+//! byte as a key/value pair (high nibble / low nibble) and its state is a MAP: at
+//! most one byte per key. That is the same shape as the real defect, a map keyed by
+//! a client-chosen sequence number, and the collision is two ops carrying the same
+//! sequence number with different payloads.
+//!
+//! The two rules are the two halves of the real bug written in Rust's own idiom:
+//! `entry(key).or_insert(value)` keeps whatever is already there (first write wins)
+//! and is what the merge path used; `insert(key, value)` overwrites it (last write
+//! wins) and is what the direct-apply path used.
+
 use freenet_stdlib::prelude::*;
 
 const CONFORMING: u8 = 0;
@@ -71,6 +92,7 @@ const NONDETERMINISTIC_SUMMARY: u8 = 4;
 const CAPPED_SET: u8 = 5;
 const NEVER_SETTLES: u8 = 6;
 const REQUIRES_RELATED: u8 = 7;
+const PATH_DISAGREEMENT: u8 = 8;
 
 /// The contract [`REQUIRES_RELATED`] insists on knowing about, as a fixed id so a
 /// test can supply its state without deriving anything.
@@ -87,6 +109,46 @@ fn mode(parameters: &Parameters<'static>) -> u8 {
 
 fn is_canonical(state: &[u8]) -> bool {
     state.windows(2).all(|w| w[0] < w[1])
+}
+
+/// The key half of a [`PATH_DISAGREEMENT`] entry. The low nibble is the value.
+fn key(entry: u8) -> u8 {
+    entry >> 4
+}
+
+/// A [`PATH_DISAGREEMENT`] state is a MAP: canonical, and at most one entry per key.
+///
+/// Without the second condition a state could carry two writes to the same key at
+/// once, which is not a state any of the paths below can produce and not the shape
+/// the real defect had.
+fn is_canonical_map(state: &[u8]) -> bool {
+    is_canonical(state) && state.windows(2).all(|w| key(w[0]) != key(w[1]))
+}
+
+/// Collapse key collisions in a byte set, keeping either the first or the last
+/// entry for each key as the set is walked in ascending order.
+///
+/// `keep_last == false` is `entry(key).or_insert(value)`: whatever is already
+/// there stays. `keep_last == true` is `insert(key, value)`: the newcomer wins.
+/// Both are deterministic and depend only on the union of the two inputs, which is
+/// what leaves every existing law intact — see the mode's comment in `merge_state`.
+fn collapse_by_key(entries: &[u8], keep_last: bool) -> Vec<u8> {
+    let mut sorted: Vec<u8> = entries.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let mut out: Vec<u8> = Vec::new();
+    for entry in sorted {
+        match out.last().copied() {
+            Some(previous) if key(previous) == key(entry) => {
+                if keep_last {
+                    let last = out.len() - 1;
+                    out[last] = entry;
+                }
+            }
+            _ => out.push(entry),
+        }
+    }
+    out
 }
 
 fn union(a: &[u8], b: &[u8]) -> Vec<u8> {
@@ -160,6 +222,21 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
             }
             out
         }
+        // First write wins on a key collision — `entry(key).or_insert(value)`.
+        //
+        // Resolving against the UNION rather than against "whichever argument the
+        // value came from" is what makes this mode isolate `path_agreement` alone,
+        // and it is not a softening of the real defect: the real merge folded the
+        // incoming ops into a map with `or_insert`, so the surviving op was decided
+        // by iteration order over the combined set, not by which peer supplied it.
+        //
+        // The consequence is that this merge is min-per-key, which is a genuine
+        // meet-semilattice: commutative, associative and idempotent. Every existing
+        // law therefore HOLDS here, which is the entire point of the mode — the gap
+        // #5394 describes is a contract that satisfies the whole property set and
+        // still diverges, and a fixture that also broke commutativity would prove
+        // nothing about the gap.
+        PATH_DISAGREEMENT => collapse_by_key(&union(current, incoming), false),
         // CONFORMING, NON_IDEMPOTENT_DELTA and NONDETERMINISTIC_SUMMARY all
         // merge full-state inputs conformingly: their defects are scoped to
         // delta application and summarization respectively, so isolating each
@@ -174,6 +251,14 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
 fn apply_delta(m: u8, current: &[u8], delta: &[u8]) -> Vec<u8> {
     match m {
         MUTUAL_REJECTION => current.to_vec(),
+        // Last write wins on a key collision — `insert(key, value)`.
+        //
+        // Max-per-key, which is just as sound a semilattice as the merge path's
+        // min-per-key: applying deltas is idempotent and order-independent, so
+        // `delta_idempotence` and `delta_permutation_invariance` both hold. The two
+        // paths are individually impeccable and disagree with each other, which no
+        // property that compares merge-to-merge or delta-to-delta can see.
+        PATH_DISAGREEMENT => collapse_by_key(&union(current, delta), true),
         NON_IDEMPOTENT_DELTA => {
             // Deliberately not deduplicated/sorted: re-delivering the same
             // delta appends it again instead of being a no-op the second time.
@@ -209,7 +294,13 @@ impl ContractInterface for Contract {
             }
         }
 
-        if is_canonical(state.as_ref()) {
+        // Mode 8's state is a map, not a set: see the module comment.
+        let valid = if mode(&parameters) == PATH_DISAGREEMENT {
+            is_canonical_map(state.as_ref())
+        } else {
+            is_canonical(state.as_ref())
+        };
+        if valid {
             Ok(ValidateResult::Valid)
         } else {
             Ok(ValidateResult::Invalid)

--- a/tests/test-contract-conformance/src/lib.rs
+++ b/tests/test-contract-conformance/src/lib.rs
@@ -23,9 +23,12 @@
 //!                                the state: real wall-clock time, the #4857 class.
 //!   5 CAPPED_SET               — merge caps the collection at N entries, evicting
 //!                                by something other than the merge's own ordering.
-//!                                Commutative and idempotent; only a three-state
-//!                                case reveals it. The one mode the pairwise laws
-//!                                cannot catch.
+//!                                Commutative and idempotent, so no PAIRWISE state
+//!                                law sees it and only a three-state case reveals
+//!                                it. The transition law sees it too, from the same
+//!                                information loss, and that is asserted rather than
+//!                                left implicit — but associativity is the law that
+//!                                names it, and the pairwise ones stay silent.
 //!   6 NEVER_SETTLES            — merge rewrites the state on every apply, so
 //!                                merge(A, A) never reaches a fixpoint. Idempotence
 //!                                and associativity break; commutativity still HOLDS
@@ -151,6 +154,23 @@ fn collapse_by_key(entries: &[u8], keep_last: bool) -> Vec<u8> {
     out
 }
 
+/// Union, then evict down to [`CAP`] entries by an index derived from the set's own
+/// contents - i.e. by something INDEPENDENT of the merge's own ordering.
+///
+/// Shared by both write paths on purpose. A cap applied on one path and not the
+/// other would make [`CAPPED_SET`] a second path-disagreement mode, which is
+/// [`PATH_DISAGREEMENT`]'s job; worse, it would let the delta path emit a state with
+/// more than `CAP` entries, which the merge path can never produce, so any finding
+/// against such a state would be a finding about a state the contract cannot reach.
+fn capped(a: &[u8], b: &[u8]) -> Vec<u8> {
+    let mut out = union(a, b);
+    while out.len() > CAP {
+        let sum: usize = out.iter().map(|byte| *byte as usize).sum();
+        out.remove(sum % out.len());
+    }
+    out
+}
+
 fn union(a: &[u8], b: &[u8]) -> Vec<u8> {
     let mut out: Vec<u8> = a.iter().chain(b.iter()).copied().collect();
     out.sort_unstable();
@@ -214,14 +234,7 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
         // The pairwise laws still hold: the result depends only on the union, so
         // it is commutative, and a state already at or under the cap merged with
         // itself is unchanged, so it is idempotent. Only the triple reveals it.
-        CAPPED_SET => {
-            let mut out = union(current, incoming);
-            while out.len() > CAP {
-                let sum: usize = out.iter().map(|b| *b as usize).sum();
-                out.remove(sum % out.len());
-            }
-            out
-        }
+        CAPPED_SET => capped(current, incoming),
         // First write wins on a key collision — `entry(key).or_insert(value)`.
         //
         // Resolving against the UNION rather than against "whichever argument the
@@ -251,6 +264,13 @@ fn merge_state(m: u8, current: &[u8], incoming: &[u8]) -> Vec<u8> {
 fn apply_delta(m: u8, current: &[u8], delta: &[u8]) -> Vec<u8> {
     match m {
         MUTUAL_REJECTION => current.to_vec(),
+        // The cap applies to BOTH write paths, or this mode's delta path emits a
+        // state with more than CAP entries - a state the merge path can never
+        // produce, and one `validate_state` would have to accept for the case to run
+        // at all. A transition recorded against such a state reaches the right
+        // verdict for the wrong reason: the finding would be about the missing cap,
+        // not about the eviction rule. See `capped`.
+        CAPPED_SET => capped(current, delta),
         // Last write wins on a key collision — `insert(key, value)`.
         //
         // Max-per-key, which is just as sound a semilattice as the merge path's


### PR DESCRIPTION
## Problem

The verifier had no property comparing a contract's **two write paths** against each other, and a real hand-found defect exercising exactly that gap went undetected.

Every existing property compares merge-to-merge or delta-to-delta — `StateCommutativity`, `StateAssociativity`, `DeltaPermutationInvariance`, `DeltaIdempotence`. **None compares merge-to-delta.** So a contract whose `update_state` uses one combinator when handed a delta and a different one when handed another peer's whole state satisfies the entire property set and still diverges in production.

In the case that exposed this, the direct-apply path used `insert` (last write wins) while the merge path used `entry().or_insert()` (first write wins), on a map keyed by a client-chosen sequence number. A peer that received two updates as deltas ends up with a different state from one that received them as a merged state, and a retraction can be silently resurrected when a replica re-merges.

## Approach

Two properties, deliberately separate — different arity, different false-positive profiles.

**`PathAgreement`** compares `apply(base, get_state_delta(other, summarize(base)))` against `update_state(base, State(other))`, both orders of every pair.

**`TransitionPathAgreement`** works from observed provenance: where the corpus holds a transition `base + delta -> result`, `merge(base, result)` must equal `result`. This is what #5394's body specifies, and it is the one that catches the motivating defect.

Both were measured against the real defect's corpora rather than assumed:

| Corpus | before | after |
|---|---|---|
| falsifier, **as a `--transition`**: ancestor → delta-path state | 0 enforceable, no properties | **1 enforceable, `transition_path_agreement`** |
| the same two files **as loose `--state`s** | 0 enforceable | 0 enforceable — *deliberate, see below* |
| **matched control** (`us-ctl-*`, same contract, non-colliding sequence numbers), as a transition | 0 enforceable | 0 enforceable |
| matched control, full state set + its transition | 0 enforceable | 0 enforceable |
| second contract (`gi-*`), states-only | 2 enforceable | unchanged |
| second contract, as transitions | n/a | 2 enforceable, **no `path_agreement`-family finding** |

Three things about reading that table:

**The loose-state row staying at 0 is the correct answer, not a residual miss.** Loose `--state` files carry no provenance, and pairing arbitrary states would make "merging B into A yields B" a demand on every conforming contract. `--transition BASE RESULT` is the new surface that supplies the witness, and it is what moves the number.

**The two controls answer different questions.** `us-ctl-*` is the *matched* control — same contract, non-colliding sequence numbers — and is the one that must stay at 0. `gi-*` is a second contract used only to check the new properties add no false positive; its 2 findings are pre-existing and identical to `main`.

**`fdev` exits non-zero on any row with an enforceable finding.** That is the intended behaviour of the tool, not a failure of the reproduction.

### Why `PathAgreement` alone was not enough, measured

`get_state_delta(other, summarize(base))` returns **exactly `other.len()` bytes** — the whole sender state — for every non-trivial pair, and `delta_path == merge_path` in all 12 directions. The contract has no distinct delta path reachable through its own API; the disagreement lives on an *application-level* delta (a client `UPDATE` carrying one op), which `get_state_delta` never emits. That is why the transition-shaped form is required, and why it needs provenance the loose-state corpus does not carry.

### A consistency fix, and a correction to an earlier claim in this description

`Sampler::corpus()` discarded the base→result pairing while `to_bundle` kept it. That inconsistency is real and is fixed, pinned by a test asserting the in-memory corpus and the exported bundle agree.

**An earlier revision of this description claimed the property "would never once have fired on the network" without that fix. That was wrong**, and review caught it: shadow mode builds its corpus via `bundle.to_corpus()`, and `to_bundle` populated `transitions` before this PR, so a live node would already have produced `TransitionPathAgreement` cases. `Sampler::corpus()` is `pub` and had exactly one in-tree caller, which did not read `transitions`. The fix stands on consistency; the "reads as covered but never runs" story does not apply here.

### Severity

`Violation` (removal-eligible), argued from the algebra rather than from measurement alone.

Given `StateCommutativity` + `StateAssociativity` + `StateIdempotence`, `merge` is a semilattice join over `x ≤ y ⟺ merge(x, y) = y`. So `merge(base, result) = base ⊔ result`, which equals `result` **iff** `base ≤ result`. A firing therefore means the update path moved to a state not above its own base in the merge's own order — non-convergence by construction, with no bounded-collection carve-out required. The corollary matters: a contract failing those three laws is *already* removal-eligible, so **no contract is condemned by this property alone that the settled algebra would acquit**.

Measurement corroborates rather than carries the argument. A bounded collection was the suspected false-positive risk, and the first test of it **passed vacuously** — a single-element overflow re-derives the same union and evicts the same victim. Brute-forcing all 49,278 `(base, delta)` pairs at cap 3 showed it fires on 9,265; a cap evicting *by the merge's own ordering* stays silent, one evicting by an index derived from contents fires.

**The partially-ordered-cap gap is now closed rather than caveated.** Review raised it, and rather than record the claim we re-derived it: an instantiation keeping the ≤N maximal elements under a causal partial order (universe of 5, ties by keeping the largest, 15 valid states) is commutative and idempotent with zero failures, but **not associative** — 532 failing triples, smallest `(({1}⊔{2})⊔{3,5}) = {2,3}` vs `({1}⊔({2}⊔{3,5})) = {1,3}`. It fires the transition law too, and lands in the already-removal-eligible bucket exactly as the algebra predicts. This is a test (`a_partially_ordered_cap_is_already_caught_by_associativity`), not prose.

Two guards keep it silent where it should be: `result` is driven to a fixpoint of its own merge first, so a canonicalizing contract cannot produce a finding (a state that never settles is `StateIdempotence`'s defect, reported as `Inconclusive::StateNotSettled`).

### `TransitionPathAgreement` is local-provenance-only, and the evidence boundary enforces it

Two properties are **not self-verifying**, and review caught that the subsystem's safety model depends on properties that are: a receiving peer does not trust a sender, it re-executes the case against its own contract copy. That works because every pre-existing property is a universally quantified identity over valid states — re-execution re-establishes the whole premise.

This one is a law only because the corpus **witnesses** that `result` came from `base`. That witness is not in the evidence bytes and cannot be. So a fabricated pair from a *conforming* grow-only contract (any two valid states with `base ⊄ result`) would make every receiving peer independently confirm a removal-eligible violation against a correct contract — and a forged pair is structurally indistinguishable from a genuine information-losing update.

`ConformanceProperty::premise_source()` now returns `EvidenceBytes` or `LocalProvenance`, and `check_bounds` refuses `LocalProvenance` evidence before any size or arity check, since it is a permanent property of the law rather than of these bytes. Three layers keep a future property from inheriting the hazard silently: the match is exhaustive with no wildcard, so a new variant does not compile until it answers; a partition pin asserts the exact local-only set and `ALL.len()`; and a wiring test asserts `check_bounds().is_ok() == is_self_verifying()` for every property, so the classification cannot become decorative.

`DeltaPermutationInvariance` turned out to carry the identical hazard and is reclassified alongside it. Its generator pairs only deltas observed against the same base — local provenance — and evidence carries no base for a delta, while the property is removal-eligible. A fabricated causally-sequenced pair (an add-wins OR-set fed `add A^t` then `remove t`) would have every recipient independently confirm a removal against a correct contract. **User-visible in `fdev`:** a `delta_permutation_invariance` finding no longer produces an evidence file under `--evidence-out`; it is counted as local-only.

An independent audit of all 14 properties confirms no third has this shape, and the argument is structural rather than a list: `Corpus` carries exactly two provenance fields (`delta_bases`, `transitions`), exactly two generator branches read them, and both are now local-only.

The property keeps its full value where it actually runs — shadow mode and `fdev`, both of which observe provenance directly. Evidence gossip (#5377, unbuilt) can revisit with verifiable provenance if that is ever wanted.

## Testing

New fixture mode 8 exercises the defect synthetically so CI does not depend on private artifacts: delta path keeps the last write on a key collision, merge path the first. Both rules are sound semilattices alone, so the WASM test asserts every *other* property stays silent on it.

Tests mutation-checked as they were written, with the caveat that review still found one guard that survived deletion of its subject and it was fixed — the check never reporting, each guard deleted, the generator pairing states instead of using provenance, and the bundle and sampler dropping provenance all go red. Every negative assertion carries a positive one beside it.

## Further defects found while fixing the above

All the same shape — a replay that silently checks *less* than the run it replays, while reporting a clean run:

1. **`to_bundle` emitted each transition's delta both loose and on its step**, and the old first-seen-wins dedup kept the unprovenanced copy — so a live node lost the base association `DeltaPermutationInvariance` needs to pair deltas at all.
2. **`Corpus::deduplicated` discarded provenance on a duplicate.** It now upgrades a kept entry from no-base to a base, pinned in both arrival orders since which list a caller fills first is not an invariant.
3. **`write_bundle` dropped the second delta of a collapsed step.** `Corpus::deduplicated` collapses transitions by `(base, result)`, so two transitions sharing both but carrying different deltas became one step and one orphaned delta — losing exactly the same-base pairing the property needs.
4. **`--evidence-out` counted shrink bytes for findings it never wrote**, so `input_bytes_before_shrinking` reported work done on findings that were discarded, and the ratio documented as "the honest measure of whether shrinking is earning its keep" included findings shrinking could never help.

*(An earlier revision of this list named `Sampler::corpus()` not populating `delta_bases` as the first defect, and said the offline bundle path was unaffected. Both were wrong, and review caught it: shadow mode reads `bundle.to_corpus()`, which populates the bases from `transition.base_state`; pre-fix the value `corpus()` produced had no non-test consumer, so it could not disable anything; and the offline path is the same `to_corpus` reading the same producer, so it lost the base identically. `corpus()` filling `delta_bases` is still correct and is now load-bearing, since `to_bundle`'s filter reads it. This is the same correction made above for `transitions`, which was not swept for its sibling the first time.)*

## Known limits

- No live-corpus measurement of how often a recorded transition is one where the paths diverge. `SamplerConfig::transitions` defaults to 8 per contract.
- The `gi-*` transitions are **reconstructed** (ancestor → each sibling), not captured from a live node — so that row is a false-positive check, not evidence that contract is free of such a defect.
- The `--transition` reversal warning is a heuristic and is honest about it. Validated out-of-sample: a reversed pair on the conforming contract produces a spurious violation **and** the warning fires; correctly ordered produces no warning; a reversed pair on the defective contract reports a violation with **no** warning, correctly, because that contract breaks the law in both directions so there is no tell.
- `--bundle` and `--transition` are silently mutually exclusive (pre-existing shape for `--state`).

Closes #5394. Refs #5320.

[AI-assisted - Claude]
