### PR TITLE
fix(fdev): stop `wasm-runtime` panicking in clap on every invocation

### DIFF
--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -315,6 +315,87 @@ mod tests {
 
     use super::Config;
 
+    /// Regression test for #5362: `fdev wasm-runtime` panicked inside clap on
+    /// every invocation, including `--help`.
+    ///
+    /// `ExecutorConfig`'s `ArgGroup` listed its members by their kebab-cased
+    /// *long flag* spellings (`"output-file"`, `"terminal-output"`) instead of
+    /// the arg ids clap derives from the field names (`output_file`,
+    /// `terminal_output`). Clap resolves a name in a group that matches no arg
+    /// as a nested group, finds no such group, and hits
+    /// `.expect(INTERNAL_ERROR_MSG)` in `Command::unroll_args_in_group`.
+    ///
+    /// `debug_assert` walks the whole command tree, so this guards every fdev
+    /// subcommand rather than just `wasm-runtime`: a malformed clap definition
+    /// anywhere in the CLI fails here instead of at a user's terminal.
+    #[test]
+    fn cli_definition_is_internally_consistent() {
+        use clap::CommandFactory as _;
+        Config::command().debug_assert();
+    }
+
+    /// `Config` deliberately has no `Debug`, so `Result::expect_err` is not
+    /// available on a parse result. Recover the error by hand instead.
+    fn expect_rejected(args: &[&str]) -> clap::Error {
+        match Config::try_parse_from(args) {
+            Ok(_) => panic!("expected `{}` to be rejected", args.join(" ")),
+            Err(err) => err,
+        }
+    }
+
+    /// Companion to `cli_definition_is_internally_consistent`. Clap's
+    /// `debug_assert` checks compile out when `debug_assertions` are off, so on
+    /// its own it would stop guarding a release build — and #5362 panicked in
+    /// `unroll_args_in_group`, which is a plain `expect` that runs in every
+    /// profile. Building the usage string for the required `ArgGroup` is what
+    /// reached it, so render `wasm-runtime --help` for real.
+    #[test]
+    fn wasm_runtime_help_does_not_panic() {
+        // clap reports --help as an error rather than a parsed config.
+        let err = expect_rejected(&["fdev", "wasm-runtime", "--help"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+        // Rendering is a second opportunity to walk the group.
+        assert!(err.render().to_string().contains("--terminal-output"));
+    }
+
+    /// While the group's members were misspelled the constraint it exists to
+    /// enforce was dead as well as fatal, so pin the behaviour rather than only
+    /// the absence of the panic: exactly one output sink, never zero or two.
+    #[test]
+    fn wasm_runtime_requires_exactly_one_output_sink() {
+        // Neither sink: the required group rejects it.
+        let err = expect_rejected(&["fdev", "wasm-runtime", "--input-file", "/tmp/in"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+
+        // Both sinks: the group is mutually exclusive.
+        let err = expect_rejected(&[
+            "fdev",
+            "wasm-runtime",
+            "--input-file",
+            "/tmp/in",
+            "--output-file",
+            "/tmp/out",
+            "--terminal-output",
+            "--deserialization-format",
+            "json",
+        ]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        // Exactly one sink: accepted.
+        assert!(
+            Config::try_parse_from([
+                "fdev",
+                "wasm-runtime",
+                "--input-file",
+                "/tmp/in",
+                "--output-file",
+                "/tmp/out",
+            ])
+            .is_ok(),
+            "--output-file alone should satisfy the output group"
+        );
+    }
+
     /// Regression test for #4088: `fdev publish --release` used to bail
     /// unconditionally with "Cannot publish contracts in the network yet".
     /// After the fix the `--release` flag no longer exists on `publish`;

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -381,7 +381,10 @@ mod tests {
         ]);
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
 
-        // Exactly one sink: accepted.
+        // Exactly one sink: accepted. `--deserialization-format` is passed so
+        // this case stays valid whichever way #5416 is resolved — today only
+        // `terminal_output` carries `requires = "fmt"`, and this test should
+        // not quietly pin that asymmetry while testing the output group.
         assert!(
             Config::try_parse_from([
                 "fdev",
@@ -390,9 +393,11 @@ mod tests {
                 "/tmp/in",
                 "--output-file",
                 "/tmp/out",
+                "--deserialization-format",
+                "json",
             ])
             .is_ok(),
-            "--output-file alone should satisfy the output group"
+            "one output sink should satisfy the output group"
         );
     }
 

--- a/crates/fdev/src/wasm_runtime.rs
+++ b/crates/fdev/src/wasm_runtime.rs
@@ -51,10 +51,14 @@ pub enum DeserializationFmt {
 #[derive(clap::Parser, Clone)]
 #[clap(name = "Freenet Local Development Node Environment")]
 #[clap(author = "The Freenet Project Inc.")]
+// The group members are clap *arg ids*, which the derive takes verbatim from the
+// Rust field names. They are not the kebab-cased `--long` spellings: naming those
+// here made clap treat them as nested groups, fail to find any, and panic out of
+// `Command::unroll_args_in_group` on every invocation including `--help` (#5362).
 #[clap(group(
     ArgGroup::new("output")
         .required(true)
-        .args(&["output-file", "terminal-output"])
+        .args(["output_file", "terminal_output"])
 ))]
 pub struct ExecutorConfig {
     /// Cleanups all state which was created locally during execution


### PR DESCRIPTION
## Problem

`fdev wasm-runtime` panicked inside clap on every invocation, including `--help`, so the subcommand was 100% unusable — not degraded. It advertises itself as "an interactive runtime for WASM for testing contracts and delegates development", which is the first tool a contract author reaches for to drive a contract's entry points without standing up a node.

`ExecutorConfig`'s `ArgGroup` named its members by their kebab-cased `--long` flag spellings:

```rust
ArgGroup::new("output")
    .required(true)
    .args(&["output-file", "terminal-output"])
```

The clap derive takes an argument's **id** verbatim from the Rust field name and only kebab-cases the `--long` flag text, so the real ids are `output_file` and `terminal_output`. Clap resolves a name in a group that matches no argument as a *nested group*; finding no such group, it reaches `.expect(INTERNAL_ERROR_MSG)` in `Command::unroll_args_in_group` (`command.rs:5066`, exactly the frame in the report).

Worth being precise about one thing, because it changes what a regression test has to look like: **this is not a debug assertion.** `unroll_args_in_group` is ordinary code that runs in every profile, which is why a released `fdev 0.3.273` panicked rather than only a dev build. Building the usage string for a *required* group is what reaches that path, hence even `--help` dying. (Debug builds happen to trip clap's nicer `debug_asserts.rs` message first, but the release path is the one users hit.)

The bug has been present since `1cf32f7c0` (2023-11-15, "Add util for starting
randomized network test"), found with
`git log -S'"output-file", "terminal-output"' -- crates/fdev/src/wasm_runtime.rs`.

*(Corrected after review: this originally cited `02a5ae714` / #2581, which I had
repeated from the issue's triage comment without checking. That commit is dated
2026-01-05 and never touched these lines.)*

## Approach

Point the group at the actual arg ids. A guard comment records why the kebab-cased spellings are wrong there, since the two spellings look interchangeable at the call site and this is the second thing a reader would try.

The mutual exclusion the group exists to enforce was dead as well as fatal — nothing was constraining the output sink at all. It now works, and the usage line reads:

```
Usage: fdev wasm-runtime [OPTIONS] --input-file <INPUT_FILE> <--output-file <OUTPUT_FILE>|--terminal-output> [MODE]
```

I swept the rest of the repo for the same class of defect (`ArgGroup`, `group =`, `requires =`, `conflicts_with`) across `fdev` and `crates/core`. Every other site already uses snake_case ids correctly; this was the only instance.

## Testing

**Why CI missed it:** nothing anywhere built the fdev command tree in a test. Existing clap tests all parse *specific* argument lists against subcommands that happen to be well-formed, so a malformed subcommand definition was invisible.

The primary regression test closes that gap rather than just this bug — `Config::command().debug_assert()` on the **top-level** parser, which walks the entire command tree. Any future malformed clap definition in *any* fdev subcommand now fails in CI instead of at a user's terminal.

Because those checks compile out without `debug_assertions`, that test alone would stop guarding release builds — the profile exactly where #5362 bit. So two more:

- `wasm_runtime_help_does_not_panic` — renders `wasm-runtime --help` for real and asserts clap returns `DisplayHelp`, exercising the profile-independent `unroll_args_in_group` path.
- `wasm_runtime_requires_exactly_one_output_sink` — pins the behaviour the group is *for*: zero sinks → `MissingRequiredArgument`, both → `ArgumentConflict`, exactly one → accepted. Without this the fix could regress into "no panic, no constraint either", which is the state the bug actually left the CLI in.

Verified red first: all three fail on the unfixed tree with `Argument group 'output' contains non-existent argument 'output-file'`, and pass after. Also verified end-to-end against a built **release** binary (the profile from the report), where `--help` renders and a missing sink produces a clean clap error rather than a panic.

`cargo fmt` and `cargo clippy -p fdev --all-targets` are clean.

Closes #5362

[AI-assisted - Claude]
