### PR TITLE
test(fdev): make the wasm-runtime help assertion actually load-bearing

### DIFF
--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -328,6 +328,14 @@ mod tests {
     /// `debug_assert` walks the whole command tree, so this guards every fdev
     /// subcommand rather than just `wasm-runtime`: a malformed clap definition
     /// anywhere in the CLI fails here instead of at a user's terminal.
+    ///
+    /// Note what this test depends on: the checks inside `debug_assert` are
+    /// `#[cfg(debug_assertions)]`-gated, but `debug_assert` itself is not, so
+    /// with assertions off it becomes a silently-passing no-op rather than a
+    /// build error. It is live today because CI runs `cargo nextest` in the test
+    /// profile and the workspace sets no `[profile.test] debug-assertions`
+    /// override. If that ever changes, this test stops checking anything and
+    /// `wasm_runtime_help_does_not_panic` below becomes the only guard.
     #[test]
     fn cli_definition_is_internally_consistent() {
         use clap::CommandFactory as _;
@@ -351,11 +359,23 @@ mod tests {
     /// reached it, so render `wasm-runtime --help` for real.
     #[test]
     fn wasm_runtime_help_does_not_panic() {
-        // clap reports --help as an error rather than a parsed config.
+        // clap reports --help as an error rather than a parsed config. Reaching
+        // this line at all is the load-bearing half: the group walk happens
+        // inside `try_parse_from`, so a regression panics before we get here.
         let err = expect_rejected(&["fdev", "wasm-runtime", "--help"]);
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
-        // Rendering is a second opportunity to walk the group.
-        assert!(err.render().to_string().contains("--terminal-output"));
+
+        // `render()` does NOT re-walk the group — for `DisplayHelp` the text is
+        // already built during parse and stored as `Message::Formatted`, which
+        // `render()` hands back verbatim. So assert something the flag list
+        // alone cannot satisfy: that the usage line still presents the two sinks
+        // as one required either/or group. A bare `--terminal-output` substring
+        // would match the per-flag "Options:" listing even with the group gone.
+        let rendered = err.render().to_string();
+        assert!(
+            rendered.contains("<--output-file <OUTPUT_FILE>|--terminal-output>"),
+            "usage line should show the output group; got:\n{rendered}"
+        );
     }
 
     /// While the group's members were misspelled the constraint it exists to


### PR DESCRIPTION
## Problem

Follow-up to #5415 (already merged). Its reviewers landed after the merge and caught a wrong claim in one of that PR's own comments — worth correcting, because it made one assertion weaker than it read.

The comment said `err.render()` was *"a second opportunity to walk the group"*. It is not. For a `DisplayHelp` error clap builds the help text **during parse** and stores it as `Message::Formatted`; `Error::render` then returns it verbatim:

```rust
// clap_builder-4.6.5/src/error/mod.rs:882-891
fn formatted(&self, styles: &Styles) -> Cow<'_, StyledStr> {
    match self {
        Message::Raw(s) => { /* ... */ }
        Message::Formatted(s) => Cow::Borrowed(s),   // <- no re-walk
    }
}
```

So the group is unrolled exactly once, inside `try_parse_from`, on the way to producing the error. Reaching the assertion at all is what proves the walk survived.

That left the assertion itself close to vacuous: `contains("--terminal-output")` matches the per-flag `Options:` listing, which renders whether or not the `ArgGroup` exists. **Verified, not assumed** — deleting the group entirely and re-running, the old assertion still passed, with `--terminal-output` sitting plainly in the help output.

## Approach

Assert on the usage line's either/or syntax instead:

```
<--output-file <OUTPUT_FILE>|--terminal-output>
```

which only renders when the required group is live. Re-ran the same delete-the-group mutation: the new assertion **fails**, so it now has something to catch. Comment corrected to describe what actually happens.

Also documented what `cli_definition_is_internally_consistent` rests on, since it is the kind of dependency that rots silently: the checks inside `debug_assert` are `#[cfg(debug_assertions)]`-gated but `debug_assert` itself is not, so with assertions off it degrades into a **silently-passing no-op** rather than a build error. It is a live guard today — CI runs `cargo nextest` in the test profile and the workspace sets no `[profile.test] debug-assertions` override — but a future profile change would remove the coverage without any signal. Now stated in the doc comment.

## Testing

No behaviour change; this is tests and comments only.

- `cargo test -p fdev --bin fdev config::tests::` — 13 passed.
- Mutation check both ways: with the `ArgGroup` deleted, the old assertion passed and the new one fails.
- `cargo fmt` and `cargo clippy -p fdev --all-targets` clean.

Refs #5362, follows #5415.

[AI-assisted - Claude]
