### PR TITLE
feat(ci): sign Windows release binaries with Authenticode via Azure Artifact Signing

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -259,11 +259,24 @@ jobs:
       # the attach-to-release job after downloading them -- cover the SIGNED
       # bytes. Do not move these steps.
       #
-      # Gated to release tags and manual dispatch, mirroring build-macos-dmg,
-      # so routine main-push builds don't burn signing quota (Basic tier:
-      # 5,000 signatures/month).
+      # Gated to release tags and manual dispatch so routine main-push builds
+      # don't burn signing quota (Basic tier: 5,000 signatures/month).
+      #
+      # NOTE the gating SCOPE differs from build-macos-dmg: that job puts the
+      # same `if:` expression at JOB level, so it does not run at all on a main
+      # push. Here the condition is per-STEP, because build-x86_64-windows must
+      # still run on main pushes to produce artifacts -- which means the job,
+      # and therefore its `environment: release` declaration, is entered on
+      # every main push. That is currently harmless (the environment has no
+      # protection rules and no branch policy), but adding required reviewers
+      # to it would pause every Build and Cross-Compile run. See
+      # docs/RELEASING.md.
       - name: Azure login (OIDC)
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        # Bounded so a hung Azure endpoint surfaces in minutes instead of
+        # consuming the job's 60-minute budget, which during a release reads
+        # as "the build is stuck" rather than "Azure is down".
+        timeout-minutes: 10
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -272,6 +285,11 @@ jobs:
 
       - name: Sign Windows binaries (Azure Artifact Signing)
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        # Same reasoning as the login step above; this one also reaches the
+        # RFC3161 timestamp server, which is a second external dependency that
+        # can hang. Observed real duration is a few seconds per file plus
+        # tooling download, so 15 minutes is generous.
+        timeout-minutes: 15
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: https://eus.codesigning.azure.net/

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -208,6 +208,19 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
 
+    # Gates the OIDC token behind the `release` environment; the federated
+    # credential in Entra is pinned to exactly this subject
+    # (repo:freenet/freenet-core:environment:release), so a job that does not
+    # declare it cannot obtain an Azure token and signing fails closed.
+    # A fork PR or an unrelated workflow cannot borrow the signing identity.
+    environment: release
+
+    # Required for OIDC federation to Azure. `contents: read` must be restated
+    # because naming any permission drops the rest to none.
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@v7
 
@@ -231,6 +244,66 @@ jobs:
         run: |
           target/release/freenet.exe --version
           target/release/freenet.exe service --help
+
+      # --- Authenticode signing (Azure Artifact Signing) -------------------
+      # freenet.exe IS the Windows installer, uninstaller, tray, service
+      # wrapper and updater -- they are all the same self-contained binary
+      # (crates/core/src/bin/commands/setup_wizard/, service/, tray.rs), so
+      # signing it covers every one of those roles. fdev.exe is downloaded
+      # from the GitHub release by `installer::run_install`, so it must be
+      # signed as a release artifact too or the installer drops an unsigned
+      # binary next to a signed one.
+      #
+      # Signing runs AFTER the smoke test and BEFORE both upload-artifact
+      # steps, so the artifacts -- and therefore SHA256SUMS.txt, generated in
+      # the attach-to-release job after downloading them -- cover the SIGNED
+      # bytes. Do not move these steps.
+      #
+      # Gated to release tags and manual dispatch, mirroring build-macos-dmg,
+      # so routine main-push builds don't burn signing quota (Basic tier:
+      # 5,000 signatures/month).
+      - name: Azure login (OIDC)
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows binaries (Azure Artifact Signing)
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: freenetsigning
+          certificate-profile-name: freenet-public-trust
+          # files-folder + filter picks up anything else that lands in
+          # target\release and needs signing, without maintaining a list.
+          # recurse stays false so it does not descend into build/ and deps/
+          # and burn signature quota on intermediate artifacts.
+          files-folder: ${{ github.workspace }}\target\release
+          files-folder-filter: exe,dll
+          files-folder-recurse: false
+          file-digest: SHA256
+          # Not optional: Artifact Signing certificates are short-lived
+          # (~3 days). Without a countersigned timestamp, every release binary
+          # stops validating almost immediately.
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      # The gate. Runs on a real Windows machine and fails the build rather
+      # than shipping something unsigned -- this is what stands in for the
+      # Windows box the project doesn't have.
+      - name: Verify signatures
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          foreach ($f in @('target\release\freenet.exe','target\release\fdev.exe')) {
+            $sig = Get-AuthenticodeSignature $f
+            Write-Host "$f => $($sig.Status) / $($sig.SignerCertificate.Subject)"
+            if ($sig.Status -ne 'Valid') { throw "Unsigned or invalid: $f" }
+            if (-not $sig.TimeStamperCertificate) { throw "Missing timestamp: $f" }
+          }
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v7

--- a/crates/core/tests/windows_signing_order.rs
+++ b/crates/core/tests/windows_signing_order.rs
@@ -138,6 +138,70 @@ fn check_signing_precedes_upload(yml: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Every binary the Windows job UPLOADS must also be named in the
+/// `Get-AuthenticodeSignature` verification loop.
+///
+/// Without this, dropping one entry from that loop ships an unsigned binary
+/// while the gate still passes. `fdev.exe` is the live risk: the setup wizard
+/// downloads it from the release at install time, so an unsigned `fdev.exe`
+/// lands next to a signed `freenet.exe` — the exact "unsigned binary beside a
+/// signed one" case the signing work exists to prevent.
+fn check_every_uploaded_binary_is_verified(yml: &str) -> Result<(), String> {
+    let range = job_range(yml, "build-x86_64-windows")?;
+    let lines: Vec<&str> = yml.lines().collect();
+
+    // Basenames of everything the job uploads, e.g. `freenet.exe`.
+    let uploaded: Vec<String> = (range.0..range.1)
+        .filter(|i| {
+            let t = lines[*i].trim();
+            t.starts_with("path:") && !t.starts_with('#')
+        })
+        .filter_map(|i| {
+            lines[i]
+                .trim()
+                .trim_start_matches("path:")
+                .trim()
+                .rsplit(['/', '\\'])
+                .next()
+                .map(str::to_string)
+        })
+        .collect();
+
+    if uploaded.is_empty() {
+        return Err(
+            "no `path:` upload targets found in build-x86_64-windows — this guard can no longer \
+             tell which binaries ship, so it cannot confirm they are all verified."
+                .to_string(),
+        );
+    }
+
+    // The single `foreach` line listing the paths the verification loop walks.
+    let verify_list = (range.0..range.1)
+        .map(|i| lines[i])
+        .find(|l| l.contains("foreach") && l.contains("release"))
+        .ok_or_else(|| {
+            "could not find the `foreach` line of the Verify signatures step. If the verification \
+             was restructured, update this guard so it still proves every uploaded binary is \
+             checked."
+                .to_string()
+        })?;
+
+    for bin in &uploaded {
+        if !verify_list.contains(bin.as_str()) {
+            return Err(format!(
+                "build-x86_64-windows uploads `{bin}` but the Verify signatures loop does not \
+                 check it:\n  {}\n\
+                 That binary would ship unsigned while the gate still passed. `fdev.exe` in \
+                 particular is downloaded by the installer at install time, so it lands next to \
+                 a signed freenet.exe.",
+                verify_list.trim()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// The checksum manifest must be produced from the artifacts the signing job
 /// uploaded: `attach-to-release` must depend on the Windows job, download both
 /// Windows artifacts, stage them, and only THEN run `sha256sum`.
@@ -206,6 +270,14 @@ fn windows_signing_precedes_artifact_upload() {
 fn windows_checksums_cover_the_signed_artifacts() {
     let yml = cross_compile_yml();
     if let Err(e) = check_checksums_cover_signed_artifacts(&yml) {
+        panic!("{e}");
+    }
+}
+
+#[test]
+fn every_uploaded_windows_binary_is_signature_verified() {
+    let yml = cross_compile_yml();
+    if let Err(e) = check_every_uploaded_binary_is_verified(&yml) {
         panic!("{e}");
     }
 }
@@ -282,18 +354,22 @@ fn synthetic_workflow(sign_first: bool, checksums_last: bool) -> String {
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
       - name: Verify signatures
         run: |
-          $sig = Get-AuthenticodeSignature $f
-          if (-not $sig.TimeStamperCertificate) { throw \"x\" }
+          foreach ($f in @('target\\release\\freenet.exe','target\\release\\fdev.exe')) {
+            $sig = Get-AuthenticodeSignature $f
+            if (-not $sig.TimeStamperCertificate) { throw \"x\" }
+          }
 ";
     let upload_block = "\
       - name: Upload freenet binary
         uses: actions/upload-artifact@v7
         with:
           name: binaries-x86_64-windows-freenet
+          path: target/release/freenet.exe
       - name: Upload fdev binary
         uses: actions/upload-artifact@v7
         with:
           name: binaries-x86_64-windows-fdev
+          path: target/release/fdev.exe
 ";
     let windows_steps = if sign_first {
         format!("{sign_block}{upload_block}")
@@ -382,6 +458,36 @@ fn guard_rejects_a_dropped_windows_dependency() {
     let err = check_checksums_cover_signed_artifacts(&bad)
         .expect_err("dropping the windows dependency MUST be rejected");
     assert!(err.contains("build-x86_64-windows"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_accepts_a_workflow_that_verifies_every_upload() {
+    let good = synthetic_workflow(true, true);
+    check_every_uploaded_binary_is_verified(&good)
+        .expect("a workflow verifying both uploaded binaries must pass");
+}
+
+#[test]
+fn guard_rejects_an_unverified_uploaded_binary() {
+    // Drop fdev.exe from the verification loop but keep uploading it.
+    let bad = synthetic_workflow(true, true).replace(
+        "@('target\\release\\freenet.exe','target\\release\\fdev.exe')",
+        "@('target\\release\\freenet.exe')",
+    );
+    let err = check_every_uploaded_binary_is_verified(&bad).expect_err(
+        "an uploaded-but-unverified binary MUST be rejected — this is the fdev.exe case",
+    );
+    assert!(
+        err.contains("fdev.exe"),
+        "unexpected rejection reason: {err}"
+    );
+}
+
+#[test]
+fn guard_rejects_a_removed_verification_loop() {
+    let bad = synthetic_workflow(true, true).replace("foreach", "noop");
+    check_every_uploaded_binary_is_verified(&bad)
+        .expect_err("a removed verification loop MUST fail closed");
 }
 
 #[test]

--- a/crates/core/tests/windows_signing_order.rs
+++ b/crates/core/tests/windows_signing_order.rs
@@ -1,0 +1,392 @@
+//! Recurrence guard for the Windows Authenticode signing / checksum ordering in
+//! `.github/workflows/cross-compile.yml`.
+//!
+//! # Why this guard exists
+//!
+//! Windows release binaries are Authenticode-signed in `build-x86_64-windows`,
+//! and `SHA256SUMS.txt` is generated later in `attach-to-release` from the
+//! artifacts that job uploads. The auto-updater
+//! (`crates/core/src/bin/commands/update.rs`) authenticates `SHA256SUMS.txt`
+//! against a baked-in ed25519 key and then checks each downloaded asset's
+//! SHA-256 against that manifest.
+//!
+//! That chain is only consistent while **signing precedes upload**, because
+//! signing CHANGES THE BYTES of the `.exe` (the Authenticode signature is
+//! appended to the PE certificate table). Move signing after the
+//! `upload-artifact` steps — or generate the checksums from anything other than
+//! the artifacts the signing job produced — and the manifest describes UNSIGNED
+//! bytes while the release ships SIGNED ones. Every Windows auto-update then
+//! fails checksum verification.
+//!
+//! # Why a source-scrape guard rather than a CI job
+//!
+//! The auto-update canary (Gate A / Gate B) covers **Linux musl x86_64 only** —
+//! see freenet/freenet-core#5341. Windows auto-update has no end-to-end gate at
+//! all. So the reordering described above is a silent, total, platform-wide
+//! break that **nothing else in CI would catch**, sitting one refactor away.
+//! This test is the backstop for that specific hole.
+//!
+//! # Note for whoever edits the workflow next
+//!
+//! If you are here because this test failed, do not "fix" it by relaxing the
+//! assertion. Put the signing steps back before the uploads. The ordering is
+//! load-bearing for auto-update on a platform with no other coverage.
+//!
+//! The checks below are pure functions over the workflow text so that the
+//! guard's own ability to FAIL is itself pinned: the synthetic-mutation tests
+//! at the bottom feed deliberately-broken workflows in and assert each check
+//! rejects them. A guard that cannot go red is not a guard.
+
+use std::path::PathBuf;
+
+fn cross_compile_yml() -> String {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace layout: crates/core/../../ should resolve")
+        .to_path_buf();
+    let path = workspace_root.join(".github/workflows/cross-compile.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path:?}: {e}"))
+}
+
+/// Line range `[start, end)` of a top-level job block (jobs sit at indent 2).
+fn job_range(yml: &str, job: &str) -> Result<(usize, usize), String> {
+    let lines: Vec<&str> = yml.lines().collect();
+    let header = format!("  {job}:");
+    let start = lines
+        .iter()
+        .position(|l| *l == header)
+        .ok_or_else(|| format!("job `{job}` not found in cross-compile.yml (looked for the exact line `{header}`). If the job was renamed, update this guard so it keeps protecting the Windows signing order."))?;
+
+    // The next line at indent 2 that opens another job block ends this one.
+    let end = lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find(|(_, l)| {
+            l.starts_with("  ")
+                && !l.starts_with("   ")
+                && l.trim_end().ends_with(':')
+                && !l.trim_start().starts_with('#')
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(lines.len());
+
+    Ok((start, end))
+}
+
+/// Index of the single line in `range` containing `needle`, requiring exactly
+/// `expected` occurrences. Fails closed: a vanished or duplicated anchor is an
+/// error, never a silent pass.
+fn sole_index(
+    yml: &str,
+    range: (usize, usize),
+    needle: &str,
+    expected: usize,
+) -> Result<Vec<usize>, String> {
+    let lines: Vec<&str> = yml.lines().collect();
+    let hits: Vec<usize> = (range.0..range.1)
+        .filter(|i| lines[*i].contains(needle) && !lines[*i].trim_start().starts_with('#'))
+        .collect();
+    if hits.len() != expected {
+        return Err(format!(
+            "expected {expected} non-comment occurrence(s) of `{needle}` in the job block, found {}. \
+             The anchor this guard relies on moved or disappeared — update the guard rather than \
+             deleting it, or the Windows signing/checksum ordering becomes unprotected.",
+            hits.len()
+        ));
+    }
+    Ok(hits)
+}
+
+/// Signing and its verification must both precede EVERY `upload-artifact` in
+/// the Windows build job, so the uploaded artifacts carry the signature.
+fn check_signing_precedes_upload(yml: &str) -> Result<(), String> {
+    let range = job_range(yml, "build-x86_64-windows")?;
+
+    // Anchor on the API surface (the action ref and the PowerShell cmdlet),
+    // not on step `name:` strings, which are prose and get reworded.
+    let sign = sole_index(yml, range, "azure/artifact-signing-action", 1)?[0];
+    let verify = sole_index(yml, range, "Get-AuthenticodeSignature", 1)?[0];
+    let uploads = sole_index(yml, range, "actions/upload-artifact", 2)?;
+
+    for upload in &uploads {
+        if sign > *upload {
+            return Err(format!(
+                "cross-compile.yml signs the Windows binaries (line {}) AFTER an \
+                 upload-artifact step (line {}).\n\
+                 Signing appends bytes to the PE, so the uploaded artifact would be UNSIGNED \
+                 while SHA256SUMS.txt (generated later from these artifacts) would describe \
+                 those unsigned bytes. Windows auto-update has no canary (#5341), so nothing \
+                 else in CI catches this. Move signing back above the uploads.",
+                sign + 1,
+                upload + 1
+            ));
+        }
+        if verify > *upload {
+            return Err(format!(
+                "cross-compile.yml verifies the Windows signatures (line {}) AFTER an \
+                 upload-artifact step (line {}).\n\
+                 The Get-AuthenticodeSignature gate must run BEFORE upload, or an unsigned \
+                 or untimestamped binary can still reach the release.",
+                verify + 1,
+                upload + 1
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// The checksum manifest must be produced from the artifacts the signing job
+/// uploaded: `attach-to-release` must depend on the Windows job, download both
+/// Windows artifacts, stage them, and only THEN run `sha256sum`.
+fn check_checksums_cover_signed_artifacts(yml: &str) -> Result<(), String> {
+    let range = job_range(yml, "attach-to-release")?;
+
+    let needs = sole_index(yml, range, "needs:", 1)?[0];
+    let needs_line = yml.lines().nth(needs).unwrap_or_default();
+    if !needs_line.contains("build-x86_64-windows") {
+        return Err(format!(
+            "`attach-to-release` no longer declares `needs: [... build-x86_64-windows ...]`:\n  {}\n\
+             Without that dependency the release can be assembled without the signed Windows \
+             binaries, and the signing gate stops gating anything.",
+            needs_line.trim()
+        ));
+    }
+
+    // Both Windows artifacts must be downloaded before assets are staged.
+    let dl_freenet = sole_index(yml, range, "binaries-x86_64-windows-freenet", 1)?[0];
+    let dl_fdev = sole_index(yml, range, "binaries-x86_64-windows-fdev", 1)?[0];
+
+    // Staging (the zip/cp of the signed exe) and then checksum generation.
+    let stage = sole_index(yml, range, "freenet-x86_64-pc-windows-msvc.zip", 1)?[0];
+    let checksums = sole_index(yml, range, "sha256sum", 1)?[0];
+
+    for (label, idx) in [("freenet", dl_freenet), ("fdev", dl_fdev)] {
+        if idx > stage {
+            return Err(format!(
+                "`attach-to-release` stages the Windows release assets (line {}) BEFORE \
+                 downloading the {label} artifact (line {}). The staged asset would not be \
+                 the signed binary produced by build-x86_64-windows.",
+                stage + 1,
+                idx + 1
+            ));
+        }
+    }
+
+    if checksums < stage {
+        return Err(format!(
+            "`attach-to-release` generates SHA256 checksums (line {}) BEFORE staging the \
+             signed Windows assets (line {}).\n\
+             SHA256SUMS.txt would then describe bytes other than the ones shipped, and every \
+             Windows auto-update would fail checksum verification against a manifest that is \
+             itself correctly ed25519-signed — a failure with no canary to catch it (#5341).",
+            checksums + 1,
+            stage + 1
+        ));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The real workflow
+// ---------------------------------------------------------------------------
+
+#[test]
+fn windows_signing_precedes_artifact_upload() {
+    let yml = cross_compile_yml();
+    if let Err(e) = check_signing_precedes_upload(&yml) {
+        panic!("{e}");
+    }
+}
+
+#[test]
+fn windows_checksums_cover_the_signed_artifacts() {
+    let yml = cross_compile_yml();
+    if let Err(e) = check_checksums_cover_signed_artifacts(&yml) {
+        panic!("{e}");
+    }
+}
+
+/// Signing must stay gated to release tags and manual dispatch, and the gate
+/// must be the SAME on all three steps. A login that runs without the signing
+/// step (or a verify that runs without signing) is a misconfiguration that
+/// shows up as a confusing auth error rather than as "signing is off".
+#[test]
+fn signing_steps_share_one_gating_condition() {
+    let yml = cross_compile_yml();
+    let range = job_range(&yml, "build-x86_64-windows").expect("windows job");
+    let lines: Vec<&str> = yml.lines().collect();
+
+    let gate =
+        "if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'";
+    let gated = (range.0..range.1)
+        .filter(|i| lines[*i].trim() == gate)
+        .count();
+
+    assert_eq!(
+        gated, 3,
+        "expected exactly 3 signing-related steps in build-x86_64-windows gated on \
+         `{gate}` (azure/login, the signing action, and the Get-AuthenticodeSignature \
+         verification), found {gated}. If the gate changed, make sure all three steps still \
+         share it: a partially-gated set either burns signing quota on every main push or \
+         fails a release with an auth error that looks like an Azure outage."
+    );
+}
+
+/// The timestamp is not optional: Artifact Signing certificates are short-lived
+/// (~3 days), so an untimestamped signature stops validating almost at once.
+#[test]
+fn signing_requests_an_rfc3161_timestamp() {
+    let yml = cross_compile_yml();
+    let range = job_range(&yml, "build-x86_64-windows").expect("windows job");
+    let lines: Vec<&str> = yml.lines().collect();
+
+    let has_timestamp = (range.0..range.1)
+        .any(|i| lines[i].contains("timestamp-rfc3161") && !lines[i].trim_start().starts_with('#'));
+    assert!(
+        has_timestamp,
+        "the Windows signing step no longer passes `timestamp-rfc3161`. Artifact Signing \
+         certificates live ~3 days; without a countersigned timestamp every released binary \
+         stops validating shortly after the cert rotates, retroactively breaking already- \
+         shipped releases."
+    );
+
+    let verifies_timestamp =
+        (range.0..range.1).any(|i| lines[i].contains("TimeStamperCertificate"));
+    assert!(
+        verifies_timestamp,
+        "the Verify signatures step no longer asserts `TimeStamperCertificate`. Without that \
+         assertion a silently-untimestamped signature passes the gate and ships."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mutation tests: prove the guards above can actually go RED.
+//
+// A guard nobody has watched fail is indistinguishable from a guard that
+// cannot fail. These feed deliberately-broken workflows to the same pure
+// functions the real-file tests use.
+// ---------------------------------------------------------------------------
+
+/// Minimal but structurally faithful stand-in for the real workflow.
+fn synthetic_workflow(sign_first: bool, checksums_last: bool) -> String {
+    let sign_block = "\
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+      - name: Sign
+        uses: azure/artifact-signing-action@v2
+        with:
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+      - name: Verify signatures
+        run: |
+          $sig = Get-AuthenticodeSignature $f
+          if (-not $sig.TimeStamperCertificate) { throw \"x\" }
+";
+    let upload_block = "\
+      - name: Upload freenet binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: binaries-x86_64-windows-freenet
+      - name: Upload fdev binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: binaries-x86_64-windows-fdev
+";
+    let windows_steps = if sign_first {
+        format!("{sign_block}{upload_block}")
+    } else {
+        format!("{upload_block}{sign_block}")
+    };
+
+    let dl_block = "\
+      - name: Download windows freenet
+        uses: actions/download-artifact@v8
+        with:
+          name: binaries-x86_64-windows-freenet
+      - name: Download windows fdev
+        uses: actions/download-artifact@v8
+        with:
+          name: binaries-x86_64-windows-fdev
+";
+    let stage_block = "\
+      - name: Prepare release assets
+        run: |
+          zip freenet-x86_64-pc-windows-msvc.zip freenet.exe
+";
+    let sums_block = "\
+      - name: Generate SHA256 checksums
+        run: |
+          sha256sum *.zip > SHA256SUMS.txt
+";
+    let attach_steps = if checksums_last {
+        format!("{dl_block}{stage_block}{sums_block}")
+    } else {
+        format!("{dl_block}{sums_block}{stage_block}")
+    };
+
+    format!(
+        "jobs:\n  build-x86_64-windows:\n    runs-on: windows-latest\n    steps:\n{windows_steps}\
+         \n  attach-to-release:\n    needs: [build-x86_64-windows]\n    steps:\n{attach_steps}"
+    )
+}
+
+#[test]
+fn guard_accepts_a_correctly_ordered_workflow() {
+    let good = synthetic_workflow(true, true);
+    check_signing_precedes_upload(&good).expect("correct ordering must pass");
+    check_checksums_cover_signed_artifacts(&good).expect("correct ordering must pass");
+}
+
+#[test]
+fn guard_rejects_signing_moved_after_upload() {
+    let bad = synthetic_workflow(false, true);
+    let err = check_signing_precedes_upload(&bad)
+        .expect_err("signing after upload MUST be rejected — otherwise this guard is decorative");
+    assert!(
+        err.contains("AFTER an upload-artifact step"),
+        "unexpected rejection reason: {err}"
+    );
+}
+
+#[test]
+fn guard_rejects_checksums_generated_before_staging() {
+    let bad = synthetic_workflow(true, false);
+    let err = check_checksums_cover_signed_artifacts(&bad)
+        .expect_err("checksums before staging MUST be rejected");
+    assert!(
+        err.contains("BEFORE staging"),
+        "unexpected rejection reason: {err}"
+    );
+}
+
+#[test]
+fn guard_rejects_a_deleted_signing_step() {
+    let bad = synthetic_workflow(true, true).replace("azure/artifact-signing-action@v2", "noop");
+    check_signing_precedes_upload(&bad)
+        .expect_err("a deleted signing step MUST be rejected, not silently pass");
+}
+
+#[test]
+fn guard_rejects_a_deleted_verification_step() {
+    let bad = synthetic_workflow(true, true).replace("Get-AuthenticodeSignature", "echo");
+    check_signing_precedes_upload(&bad)
+        .expect_err("a deleted verification step MUST be rejected, not silently pass");
+}
+
+#[test]
+fn guard_rejects_a_dropped_windows_dependency() {
+    let bad = synthetic_workflow(true, true).replace("needs: [build-x86_64-windows]", "needs: [x]");
+    let err = check_checksums_cover_signed_artifacts(&bad)
+        .expect_err("dropping the windows dependency MUST be rejected");
+    assert!(err.contains("build-x86_64-windows"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_rejects_a_renamed_job() {
+    let bad = synthetic_workflow(true, true).replace("  build-x86_64-windows:", "  build-win:");
+    check_signing_precedes_upload(&bad)
+        .expect_err("a renamed job MUST fail closed rather than silently skipping the check");
+}

--- a/crates/core/tests/windows_signing_order.rs
+++ b/crates/core/tests/windows_signing_order.rs
@@ -138,6 +138,62 @@ fn check_signing_precedes_upload(yml: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// The Windows job must keep declaring `environment: release` and
+/// `permissions: id-token: write` (plus `contents: read`).
+///
+/// These are the authentication contract, not decoration. The Entra federated
+/// credential is pinned to the subject
+/// `repo:freenet/freenet-core:environment:release`, so a job that does not
+/// declare the environment cannot mint an Azure token at all. And because
+/// naming ANY permission drops the rest to none, `contents: read` has to be
+/// restated or `actions/checkout` loses repository access.
+///
+/// Dropping either would not fail here — it would fail on the next TAG push,
+/// as an opaque Azure auth error, at exactly the moment a release is being
+/// cut. Windows auto-update has no canary (#5341) and signing is fail-closed,
+/// so that error arrives as a stuck draft release rather than as anything
+/// diagnosable. Pin it where the mistake is made instead.
+fn check_oidc_wiring_intact(yml: &str) -> Result<(), String> {
+    let range = job_range(yml, "build-x86_64-windows")?;
+    let lines: Vec<&str> = yml.lines().collect();
+
+    let has = |needle: &str| {
+        (range.0..range.1)
+            .any(|i| lines[i].trim() == needle && !lines[i].trim_start().starts_with('#'))
+    };
+
+    if !has("environment: release") {
+        return Err(
+            "build-x86_64-windows no longer declares `environment: release`.\n\
+             The Entra federated credential is pinned to the subject \
+             `repo:freenet/freenet-core:environment:release`, so without this line the job \
+             cannot obtain an Azure token and signing fails — as an opaque auth error on the \
+             next tag push, blocking the release as a draft. This is not a simplification."
+                .to_string(),
+        );
+    }
+
+    if !has("id-token: write") {
+        return Err(
+            "build-x86_64-windows no longer requests `id-token: write`.\n\
+             OIDC federation to Azure cannot work without it; azure/login will fail to mint a \
+             token and Windows signing will fail on the next tag push."
+                .to_string(),
+        );
+    }
+
+    if !has("contents: read") {
+        return Err(
+            "build-x86_64-windows names permissions but no longer restates `contents: read`.\n\
+             Naming ANY permission drops the rest to none, so actions/checkout loses repository \
+             access and the job fails before it ever reaches the signing steps."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 /// Every binary the Windows job UPLOADS must also be named in the
 /// `Get-AuthenticodeSignature` verification loop.
 ///
@@ -275,6 +331,14 @@ fn windows_checksums_cover_the_signed_artifacts() {
 }
 
 #[test]
+fn windows_job_keeps_its_oidc_wiring() {
+    let yml = cross_compile_yml();
+    if let Err(e) = check_oidc_wiring_intact(&yml) {
+        panic!("{e}");
+    }
+}
+
+#[test]
 fn every_uploaded_windows_binary_is_signature_verified() {
     let yml = cross_compile_yml();
     if let Err(e) = check_every_uploaded_binary_is_verified(&yml) {
@@ -404,7 +468,7 @@ fn synthetic_workflow(sign_first: bool, checksums_last: bool) -> String {
     };
 
     format!(
-        "jobs:\n  build-x86_64-windows:\n    runs-on: windows-latest\n    steps:\n{windows_steps}\
+        "jobs:\n  build-x86_64-windows:\n    runs-on: windows-latest\n    environment: release\n    permissions:\n      id-token: write\n      contents: read\n    steps:\n{windows_steps}\
          \n  attach-to-release:\n    needs: [build-x86_64-windows]\n    steps:\n{attach_steps}"
     )
 }
@@ -488,6 +552,37 @@ fn guard_rejects_a_removed_verification_loop() {
     let bad = synthetic_workflow(true, true).replace("foreach", "noop");
     check_every_uploaded_binary_is_verified(&bad)
         .expect_err("a removed verification loop MUST fail closed");
+}
+
+#[test]
+fn guard_accepts_intact_oidc_wiring() {
+    let good = synthetic_workflow(true, true);
+    check_oidc_wiring_intact(&good).expect("intact OIDC wiring must pass");
+}
+
+#[test]
+fn guard_rejects_a_dropped_release_environment() {
+    let bad = synthetic_workflow(true, true).replace("    environment: release\n", "");
+    let err = check_oidc_wiring_intact(&bad)
+        .expect_err("dropping `environment: release` MUST be rejected — it breaks Azure auth");
+    assert!(err.contains("environment: release"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_rejects_a_dropped_id_token_permission() {
+    let bad = synthetic_workflow(true, true).replace("      id-token: write\n", "");
+    let err = check_oidc_wiring_intact(&bad)
+        .expect_err("dropping `id-token: write` MUST be rejected — OIDC cannot work without it");
+    assert!(err.contains("id-token: write"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_rejects_a_dropped_contents_read_permission() {
+    let bad = synthetic_workflow(true, true).replace("      contents: read\n", "");
+    let err = check_oidc_wiring_intact(&bad).expect_err(
+        "dropping `contents: read` MUST be rejected — naming any permission zeroes the rest",
+    );
+    assert!(err.contains("contents: read"), "unexpected: {err}");
 }
 
 #[test]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,8 +39,9 @@ Within ~30–60 minutes you should see:
 2. An auto-created bump PR titled `build: release X.Y.Z` that merges itself.
 3. A `vX.Y.Z` git tag pushed and a **draft** GitHub release created, which
    triggers `Build and Cross-Compile`.
-4. Cross-compile builds Linux musl + macOS (Intel + arm64) + Windows + signed
-   DMG and attaches all 14 artifacts to the draft release.
+4. Cross-compile builds Linux musl + macOS (Intel + arm64) + Windows
+   (Authenticode-signed) + signed DMG and attaches all 14 artifacts to the
+   draft release.
 5. Still inside that job, in this order: **Gate A** (the blocking auto-update
    pre-flight, see "Release gates" below) → `freenet` and `fdev` published to
    crates.io → undraft.
@@ -66,12 +67,74 @@ a `::warning::` annotation telling you what to fix.
 | `MATRIX_ACCESS_TOKEN` | release-announce.yml | Matrix job warns + skips. |
 | `RELEASE_AGENT_HMAC_NOVA` | gateway-update.yml, release-announce.yml | nova update + River announce fail (HTTP 401). |
 | `RELEASE_AGENT_HMAC_VEGA` | gateway-update.yml | vega update fails (HTTP 401). |
+| `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` | cross-compile.yml `build-x86_64-windows` (Authenticode signing) | **Does NOT degrade gracefully — this one fails the release.** See "Windows code signing" below. |
 | `FREENET_RELEASE_SIGNING_KEY` | cross-compile.yml (`Sign SHA256SUMS.txt`) | Releases are UNSIGNED (no `SHA256SUMS.txt.sig` attached). Clients accept unsigned releases during the transition window (`REQUIRE_RELEASE_SIGNATURE = false`), but once that flag is flipped to `true` in a future release, unsigned releases are REFUSED by the auto-updater. PEM-encoded ed25519 private key whose public half is baked into the updater (`update.rs` `FREENET_RELEASE_PUBKEY`). |
 
 To validate `FREENET_RELEASE_SIGNING_KEY` without cutting a release, run the
 `Build and Cross-Compile` workflow via `workflow_dispatch`: its
 `verify-signing-key` job derives the public key from the secret, asserts it
 matches the key baked into the binary, and does a sign/verify round-trip.
+
+### Windows code signing (Authenticode)
+
+`freenet.exe` and `fdev.exe` are Authenticode-signed in
+`build-x86_64-windows` via [Azure Artifact
+Signing](https://learn.microsoft.com/azure/artifact-signing/), on release tags
+and on manual `workflow_dispatch` only (routine main-push builds are not
+signed, and can never become a release because `attach-to-release` is
+tag-gated). Signing sits between the smoke test and the `upload-artifact`
+steps, so `SHA256SUMS.txt` — generated later in `attach-to-release` from the
+downloaded artifacts — covers the signed bytes.
+
+Signing `freenet.exe` covers the installer, uninstaller, tray, service wrapper
+and updater at once: on Windows they are all the same self-contained binary.
+`fdev.exe` is signed because `installer::run_install` downloads it from the
+GitHub release at install time.
+
+Expected signer subject:
+
+```
+CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
+```
+
+**Unlike every other secret in the table above, this path is fail-closed.** The
+`Verify signatures` step runs `Get-AuthenticodeSignature` on the runner and
+throws if a binary is unsigned, invalid, or missing its RFC3161 timestamp. A
+broken Azure configuration therefore fails `build-x86_64-windows`, and because
+`attach-to-release` needs that job, the release stops as a draft rather than
+shipping unsigned binaries. That is deliberate — but it means Azure-side
+breakage is a release-blocking failure, not a warning.
+
+Authentication is OIDC federation (`azure/login@v3`), so there is no client
+secret and no exportable key: the Artifact Signing key lives in Microsoft's
+HSM and never leaves it. The three `AZURE_*` values are identifiers, stored as
+secrets only by convention. The federated credential in Entra is pinned to the
+subject `repo:freenet/freenet-core:environment:release`, which is why the job
+declares `environment: release` and `permissions: id-token: write`. **Those
+three lines are load-bearing for authentication — do not "simplify" them.**
+
+Note that adding required reviewers to the `release` environment would pause
+*every* `Build and Cross-Compile` run, including main-push builds, since the
+Windows job is not itself gated to tags.
+
+The RFC3161 timestamp is not optional: Artifact Signing certificates are
+short-lived (~3 days), so without a countersigned timestamp every release
+binary would stop validating almost immediately.
+
+To verify a published asset from Linux/macOS (no Windows machine needed):
+
+```bash
+osslsigncode verify -in freenet.exe
+```
+
+Expect `Signature verification: ok`, the signer subject above, and a
+`Timestamp` block. A complaint about an untrusted root usually just means the
+Microsoft Identity Verification Root CA 2020 is absent from the local trust
+store; the signer, digest and timestamp lines are the useful signal.
+
+SmartScreen reputation is per-publisher and accrues over downloads, so expect
+the download warning to soften rather than vanish on the first signed release.
+Observing that requires a Windows machine and does not gate anything.
 
 `RELEASE_PAT` is a personal access token with `repo` (Contents, Pull
 requests, Metadata) and `workflow` scopes. See AGENTS.md → "Release Workflow

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,22 +121,17 @@ The RFC3161 timestamp is not optional: Artifact Signing certificates are
 short-lived (~3 days), so without a countersigned timestamp every release
 binary would stop validating almost immediately.
 
-To verify a published asset from Linux/macOS (no Windows machine needed),
-fetch the Microsoft root first and verify against it. **A bare
-`osslsigncode verify -in freenet.exe` reports `Signature verification: failed`
-on a correctly-signed binary** — the Microsoft Identity Verification Root CA
-2020 is not in a typical Linux trust store, so the chain cannot be built. That
-failure is a local trust-store artifact, not a problem with the signature, and
-it is confusing enough to be worth avoiding:
+To verify a published asset from Linux or macOS (no Windows machine needed).
+Fetch the Microsoft root and verify against it — that root alone is enough, so
+this works the same on both platforms:
 
 ```bash
-# apt install osslsigncode   |   brew install osslsigncode
+# Linux: apt install osslsigncode    macOS: brew install osslsigncode
 curl -o msroot.crt \
   "https://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt"
 openssl x509 -inform DER -in msroot.crt -out msroot.pem
-cat /etc/ssl/certs/ca-certificates.crt msroot.pem > combined.pem
 
-osslsigncode verify -in freenet.exe -CAfile combined.pem -TSA-CAfile combined.pem
+osslsigncode verify -in freenet.exe -CAfile msroot.pem -TSA-CAfile msroot.pem
 ```
 
 Expect, on a good binary:
@@ -150,13 +145,27 @@ Number of verified signatures: 1
 Succeeded
 ```
 
-and the signer subject above. Note `-TSA-CAfile` is needed as well as
-`-CAfile`; without it the timestamp chain fails separately.
+plus the signer subject above.
 
-Do NOT pass `-CAfile msroot.pem` alone. The signature bundle embeds the root,
-and OpenSSL then rejects the chain with `self-signed certificate in
-certificate chain` even though the binary is fine. Concatenate the root onto
-the system bundle as above.
+**Pass `-TSA-CAfile` as well as `-CAfile`, and do not skip it.** With `-CAfile`
+alone the command still prints `Succeeded` and exits 0 — but the timestamp
+chain was NOT verified, and the only sign of that is a
+`Timestamp Server Signature verification: failed` line further up the output.
+Given the three-day signing certificate below, the countersignature is the part
+that matters most, so a check that silently skips it is close to no check at
+all. Measured behaviour against a real signed artifact:
+
+| Invocation | Signature | Timestamp | Prints |
+|---|---|---|---|
+| no CA arguments | failed | failed | `Failed` (exit 1) |
+| `-CAfile msroot.pem` | ok | **failed** | `Succeeded` (exit 0) |
+| `-CAfile msroot.pem -TSA-CAfile msroot.pem` | ok | ok | `Succeeded` (exit 0) |
+
+The bare form fails because the Microsoft Identity Verification Root CA 2020 is
+not in a typical Linux or macOS trust store, so no chain can be built. That is
+a local trust-store artifact, not a problem with the signature — but it means
+**a bare `osslsigncode verify` reports `failed` on a perfectly good binary**,
+which is exactly the wrong impression to give someone checking a release.
 
 **The signing certificate is valid for about 3 days** (a real example:
 `notBefore Aug 24 15:22:28 2026`, `notAfter Aug 27 15:22:28 2026`). That is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -121,16 +121,48 @@ The RFC3161 timestamp is not optional: Artifact Signing certificates are
 short-lived (~3 days), so without a countersigned timestamp every release
 binary would stop validating almost immediately.
 
-To verify a published asset from Linux/macOS (no Windows machine needed):
+To verify a published asset from Linux/macOS (no Windows machine needed),
+fetch the Microsoft root first and verify against it. **A bare
+`osslsigncode verify -in freenet.exe` reports `Signature verification: failed`
+on a correctly-signed binary** — the Microsoft Identity Verification Root CA
+2020 is not in a typical Linux trust store, so the chain cannot be built. That
+failure is a local trust-store artifact, not a problem with the signature, and
+it is confusing enough to be worth avoiding:
 
 ```bash
-osslsigncode verify -in freenet.exe
+# apt install osslsigncode   |   brew install osslsigncode
+curl -o msroot.crt \
+  "https://www.microsoft.com/pkiops/certs/microsoft%20identity%20verification%20root%20certificate%20authority%202020.crt"
+openssl x509 -inform DER -in msroot.crt -out msroot.pem
+cat /etc/ssl/certs/ca-certificates.crt msroot.pem > combined.pem
+
+osslsigncode verify -in freenet.exe -CAfile combined.pem -TSA-CAfile combined.pem
 ```
 
-Expect `Signature verification: ok`, the signer subject above, and a
-`Timestamp` block. A complaint about an untrusted root usually just means the
-Microsoft Identity Verification Root CA 2020 is absent from the local trust
-store; the signer, digest and timestamp lines are the useful signal.
+Expect, on a good binary:
+
+```
+Current message digest    : <hash>
+Calculated message digest : <hash>      # must MATCH — this is the integrity check
+Signature verification: ok
+Timestamp Server Signature verification: ok
+Number of verified signatures: 1
+Succeeded
+```
+
+and the signer subject above. Note `-TSA-CAfile` is needed as well as
+`-CAfile`; without it the timestamp chain fails separately.
+
+Do NOT pass `-CAfile msroot.pem` alone. The signature bundle embeds the root,
+and OpenSSL then rejects the chain with `self-signed certificate in
+certificate chain` even though the binary is fine. Concatenate the root onto
+the system bundle as above.
+
+**The signing certificate is valid for about 3 days** (a real example:
+`notBefore Aug 24 15:22:28 2026`, `notAfter Aug 27 15:22:28 2026`). That is
+normal for Artifact Signing and is exactly why the RFC3161 countersignature is
+mandatory — the timestamp is what keeps already-shipped binaries validating
+after the certificate expires.
 
 SmartScreen reputation is per-publisher and accrues over downloads, so expect
 the download warning to soften rather than vanish on the first signed release.

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -185,6 +185,34 @@ gh run list --repo freenet/freenet-core --workflow=cross-compile.yml \
 gh workflow run cross-compile.yml --repo freenet/freenet-core --ref v0.1.X
 ```
 
+**Each dispatch re-signs the Windows binaries.** `build-x86_64-windows`
+Authenticode-signs `freenet.exe` and `fdev.exe` on every tag build and every
+manual dispatch, against an Azure Artifact Signing quota of 5,000 signatures
+per month (Basic tier) — 2 per run. That is a large budget and ordinary
+recovery will not dent it, but a dispatch loop is not free, which is one more
+reason to check for a running job before firing another.
+
+**If this job fails at signing, the failure is Azure-side and cannot be fixed
+from the repo.** Unlike every other release secret, Windows signing is
+fail-closed: the `Verify signatures` step throws if either binary is unsigned,
+invalid, or missing its RFC3161 timestamp, and `attach-to-release` needs this
+job, so the release stops as a draft rather than shipping unsigned binaries.
+Read the `Verify signatures` step output first — it prints each binary's status
+and signer subject. Expect:
+
+```
+CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
+```
+
+Common causes, in the order worth checking: the `release` environment or the
+`AZURE_*` secrets were changed (the Entra federated credential is pinned to the
+subject `repo:freenet/freenet-core:environment:release`, so removing
+`environment: release` from the job breaks authentication); the certificate
+profile was rotated or disabled in Azure; or a genuine Artifact Signing
+outage. There is no repo-side workaround — do NOT strip the signing steps to
+force a release through, because that ships unsigned binaries to users whose
+Windows auto-update has no canary to catch the regression (#5341).
+
 ### Step 4: Binaries Attached but Crates Not Published
 
 **Symptoms:**

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -192,6 +192,15 @@ per month (Basic tier) — 2 per run. That is a large budget and ordinary
 recovery will not dent it, but a dispatch loop is not free, which is one more
 reason to check for a running job before firing another.
 
+**What a signing failure looks like from the outside: a draft release with NO
+Windows assets at all.** The `Verify signatures` step runs BEFORE the two
+`upload-artifact` steps, so when it throws they are *skipped* — the unsigned
+binaries never become artifacts, and there is nothing for `attach-to-release`
+to attach. Do not go debugging artifact upload; an empty Windows slot is the
+expected shape of a signing failure. Go straight to the `Verify signatures`
+step output. (Verified by deliberately failing the gate: `Verify signatures =>
+failure`, `Upload freenet binary => skipped`, `Upload fdev binary => skipped`.)
+
 **If this job fails at signing, the failure is Azure-side and cannot be fixed
 from the repo.** Unlike every other release secret, Windows signing is
 fail-closed: the `Verify signatures` step throws if either binary is unsigned,


### PR DESCRIPTION
## Problem

Windows users downloading `freenet.exe` get an "unknown publisher" SmartScreen dialog. On Windows `freenet.exe` is not just a daemon — the same self-contained binary is the GUI setup wizard, the service installer, the supervisor + tray, the updater and the uninstaller (`setup_wizard/installer.rs`, `service/windows.rs`, `service/wrapper.rs`, `tray.rs`). So the warning sits on the install path, not on a side binary.

`fdev.exe` matters too: `installer::run_install` downloads it from the GitHub release at install time, so leaving it unsigned drops an unsigned binary next to a signed one.

## Approach

Sign both binaries in `build-x86_64-windows` with Azure Artifact Signing (`azure/artifact-signing-action@v2`), authenticating by OIDC federation (`azure/login@v3`) — no client secret, and no exportable key: the signing key lives in Microsoft's HSM and never leaves it.

Signing `freenet.exe` covers the installer, uninstaller, tray, wrapper and updater at once, because they are the same file. The copy the installer writes to `%LOCALAPPDATA%` inherits the signature (byte-for-byte `std::fs::copy`), and the updater replaces the binary with another signed release build.

Three things are load-bearing and should not be "simplified":

- **Step placement.** Signing runs after the smoke test and before both `upload-artifact` steps, so the artifacts — and therefore `SHA256SUMS.txt`, generated later in `attach-to-release` from those artifacts — cover the signed bytes. The ed25519 detached signature over `SHA256SUMS.txt` is unrelated to Authenticode and is untouched.
- **`environment: release` + `permissions: id-token: write`.** The Entra federated credential is pinned to the subject `repo:freenet/freenet-core:environment:release`, so a job that does not declare the environment cannot obtain a token and signing fails closed. Removing either turns into an auth failure that looks like an Azure problem.
- **`timestamp-rfc3161`.** Artifact Signing certificates are short-lived (~3 days), so without a countersigned timestamp every release binary would stop validating almost immediately.

Signing is gated to release tags and `workflow_dispatch`, mirroring `build-macos-dmg`, so routine main-push builds don't burn signing quota (Basic tier: 5,000 signatures/month). `attach-to-release` is tag-gated, so an unsigned main-push build can never become a release.

## Auto-update safety

Freenet auto-updates on every platform, including the currently-unsigned Windows installs that will take this release, so the update path is the main risk surface here. Reviewers should check this specifically. The intended argument is that signing changes only the *bytes of the artifact*, and:

- `SHA256SUMS.txt` is generated in `attach-to-release` **after** downloading the signed artifacts, so the checksums the updater verifies describe the signed bytes.
- The updater downloads a release asset and replaces the binary; it does not rewrite or patch the binary, so the Authenticode signature survives the replacement.
- An unsigned → signed transition is a plain version upgrade from the updater's point of view.

If any of that is wrong, this PR should not merge as-is.

## Testing

There is no Windows machine in this project's loop, so the gate runs on the runner: the `Verify signatures` step calls `Get-AuthenticodeSignature` on both binaries and throws unless each is `Valid` and carries an RFC3161 timestamp. That fails the build rather than shipping something unsigned.

Note this makes the Windows job **fail-closed**, unlike every other release secret, which degrades gracefully with a `::warning::`. A broken Azure config blocks the release as a draft instead of publishing unsigned binaries. `docs/RELEASING.md` documents that explicitly.

Verified before opening this PR:

- `azure/login@v3` and `azure/artifact-signing-action@v2` both exist as tags.
- Every input name matches the action's own `action.yml`.
- The patch matches the action README's canonical OIDC example.
- `exclude-azure-cli-credential` defaults to `false`, so `DefaultAzureCredential` picks up the `azure/login` session.
- `actionlint` passes clean on the whole workflow.
- The `release` environment exists with **no** protection rules and **no** deployment branch policy, so this does not stall main-push builds or dispatch from a feature branch.
- All three `AZURE_*` repo secrets exist under exactly the referenced names.

Independent verification of a signed artifact from Linux/macOS is via `osslsigncode verify`, documented in `docs/RELEASING.md`.

## First run should be a dispatch, not a tag

The `if:` conditions allow `workflow_dispatch` precisely so a first signed build can be produced without a release going out to users. If signing is misconfigured, that is where it surfaces harmlessly.

## Note on secret exposure

The signing steps live in `build-x86_64-windows`, which holds no other credentials. They do not share a job or step with `APPLE_DEVELOPER_ID_P12_BASE64`, `APPLE_ASC_API_KEY_P8_BASE64`, `CARGO_REGISTRY_TOKEN`, `RELEASE_PAT` or `FREENET_RELEASE_SIGNING_KEY`. The three `AZURE_*` values are identifiers rather than credentials; authentication is OIDC, so nothing long-lived and stealable is stored in GitHub.

[AI-assisted - Claude]

https://claude.ai/code/session_01LxKUxTkoykH3pokzEa1Lab
