### PR TITLE
fix: read fdev's version from the tag when rolling a release back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,16 @@ jobs:
       - name: Self-test Rule Lint shell-assertion counter
         run: bash scripts/rule_lint_shell_assertion_counter_test.sh
 
+      # Behavioural cover for the ROLLBACK tool, the thing reached for when a
+      # release has already gone wrong. It derived fdev's version from
+      # freenet's by arithmetic (`0.$((minor + 2)).$patch`, so fdev 0.4.129 for
+      # freenet 0.2.129 — a version that has never existed, fdev's patch number
+      # being independent of freenet's), then swallowed the resulting failure
+      # and printed "Rollback complete!" over it. Both halves are properties of
+      # what the script DOES, so it is run end to end against stubs.
+      - name: Self-test release rollback
+        run: bash scripts/release_rollback_test.sh
+
       # install.sh now sets up a supervised service by default (issue #4073) so
       # new nodes auto-update. The system-vs-user + lingering decision is the
       # load-bearing new logic; these smoke tests pin it without needing real
@@ -311,7 +321,7 @@ jobs:
       # clean when they landed but were not actually in this list, so nothing
       # held them to it. `-x` because the two test scripts `source` the canary.
       - name: Lint install/uninstall scripts (shellcheck)
-        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/rule_lint_shell_assertion_counter_test.sh scripts/release.sh scripts/pr-backlog-sweep.sh scripts/pr-backlog-sweep_test.sh
+        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/rule_lint_shell_assertion_counter_test.sh scripts/release.sh scripts/pr-backlog-sweep.sh scripts/pr-backlog-sweep_test.sh scripts/release-rollback.sh scripts/release_rollback_test.sh
       # The PR-backlog sweep reports stalled PRs (see
       # .github/workflows/pr-backlog-sweep.yml). Its self-test drives the ABORT
       # paths -- failed query, empty listing the REST probe contradicts,

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -560,20 +560,39 @@ If you need to rollback a release:
 ```bash
 ./scripts/release-rollback.sh --version 0.1.X
 
-# To also yank from crates.io (cannot be undone!)
+# To also yank from crates.io
 ./scripts/release-rollback.sh --version 0.1.X --yank-crates
 ```
 
-`--yank-crates` yanks BOTH crates, and the fdev version is read from
-`crates/fdev/Cargo.toml` **at the release tag** — fdev's version is independent
-of freenet's (0.3.x against 0.2.x), and the working tree has usually bumped it
-again by the time anyone is rolling a release back. **Origin's tag wins** over a
-local tag of the same name: `release.sh` skips tag creation when a local tag
-already exists, so an aborted run can leave a stale one behind, while the tag
-that shipped is the one CI pushed. A disagreement between the two is printed.
+A yank is reversible — `cargo yank --undo --version X.Y.Z <crate>` puts the
+version back — but while it stands it breaks dependency resolution for everyone
+building against it, and yanking the WRONG version does that to a good release.
+So the script is deliberately strict about where the fdev version comes from.
 
-If the tag is gone both locally and on origin — or the manifest at it cannot be
-parsed — the script stops **before deleting anything** and asks for the version:
+`--yank-crates` yanks BOTH crates, and the fdev version is read from
+`crates/fdev/Cargo.toml` **at the release tag on ORIGIN** — fdev's version is
+independent of freenet's (0.3.x against 0.2.x), and the working tree has usually
+bumped it again by the time anyone is rolling a release back.
+
+**Only origin's tag, or your own `--fdev-version`, is good enough to yank on.**
+A local tag of the same name is read as a HINT and never acted on:
+`release.sh` skips tag creation when a local tag already exists, so an aborted
+run leaves a stale one pointing at a different release, and adjacent fdev patch
+versions all exist on crates.io — so a near-miss succeeds and takes a good
+release's fdev down. When origin's tag and a local one disagree, origin wins and
+the disagreement is printed. When origin cannot be read at all, the script stops
+and asks, quoting the local tag's number only as something to check.
+
+For the same reason `origin` must actually BE `freenet/freenet-core`. Steps 2
+and 3 delete from whatever origin points at (and from a hardcoded
+`--repo freenet/freenet-core`), but `cargo yank` always reaches the real
+crates.io — so with origin on a fork, its tag could name a version that belongs
+to a live release. The script refuses to use a non-freenet origin as a version
+source and says so.
+
+If the tag is gone both locally and on origin — or it is readable only locally,
+or the manifest at it cannot be parsed — the script stops **before deleting
+anything** and asks for the version:
 
 ```bash
 ./scripts/release-rollback.sh --version 0.1.X --yank-crates --fdev-version 0.Y.Z
@@ -582,7 +601,11 @@ parsed — the script stops **before deleting anything** and asks for the versio
 That is also why a run **without** `--yank-crates` prints the fdev version in
 its follow-up suggestion: the run has just deleted the tag (and the release
 page) the number would have been read from, so the second invocation needs it
-passed in.
+passed in. It prints a ready-to-paste command only when the number came from
+origin or from you — never a local-tag reading, which pasted would become an
+"explicit" `--fdev-version` and silence the very check that questioned it. When
+there is no such number it names the lookup and an `X.Y.Z` placeholder instead
+of a bare `--yank-crates` re-run, which would only stop with the same error.
 
 The script exits **non-zero** if any step fails, and says which. A yank is
 attempted only for a version crates.io reports as published (200); a 404 is

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -567,20 +567,36 @@ If you need to rollback a release:
 `--yank-crates` yanks BOTH crates, and the fdev version is read from
 `crates/fdev/Cargo.toml` **at the release tag** — fdev's version is independent
 of freenet's (0.3.x against 0.2.x), and the working tree has usually bumped it
-again by the time anyone is rolling a release back. If the tag is already gone
-both locally and on origin, the script stops before it deletes anything and
-asks for the version explicitly:
+again by the time anyone is rolling a release back. **Origin's tag wins** over a
+local tag of the same name: `release.sh` skips tag creation when a local tag
+already exists, so an aborted run can leave a stale one behind, while the tag
+that shipped is the one CI pushed. A disagreement between the two is printed.
+
+If the tag is gone both locally and on origin — or the manifest at it cannot be
+parsed — the script stops **before deleting anything** and asks for the version:
 
 ```bash
 ./scripts/release-rollback.sh --version 0.1.X --yank-crates --fdev-version 0.Y.Z
 ```
+
+That is also why a run **without** `--yank-crates` prints the fdev version in
+its follow-up suggestion: the run has just deleted the tag (and the release
+page) the number would have been read from, so the second invocation needs it
+passed in.
 
 The script exits **non-zero** if any step fails, and says which. A yank is
 attempted only for a version crates.io reports as published (200); a 404 is
 reported as "not published, skipping" and is not a failure, while any other
 status is UNKNOWN and IS a failure — the 403-without-a-User-Agent trap
 described in the Quick Reference, which a two-state check reads as "not
-published" for every version ever released.
+published" for every version ever released. There is deliberately no override
+for that: if crates.io is rate-limiting or down and the yank has to happen now,
+run it by hand once you have confirmed the version's state (`cargo yank
+--version X.Y.Z freenet`, `cargo yank --version 0.Y.Z fdev`).
+
+`--dry-run` resolves and prints the fdev version and asks crates.io whether both
+versions are actually published, without yanking or deleting anything. Worth
+running first.
 
 ## Verification Checklist
 

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -564,6 +564,24 @@ If you need to rollback a release:
 ./scripts/release-rollback.sh --version 0.1.X --yank-crates
 ```
 
+`--yank-crates` yanks BOTH crates, and the fdev version is read from
+`crates/fdev/Cargo.toml` **at the release tag** — fdev's version is independent
+of freenet's (0.3.x against 0.2.x), and the working tree has usually bumped it
+again by the time anyone is rolling a release back. If the tag is already gone
+both locally and on origin, the script stops before it deletes anything and
+asks for the version explicitly:
+
+```bash
+./scripts/release-rollback.sh --version 0.1.X --yank-crates --fdev-version 0.Y.Z
+```
+
+The script exits **non-zero** if any step fails, and says which. A yank is
+attempted only for a version crates.io reports as published (200); a 404 is
+reported as "not published, skipping" and is not a failure, while any other
+status is UNKNOWN and IS a failure — the 403-without-a-User-Agent trap
+described in the Quick Reference, which a two-state check reads as "not
+published" for every version ever released.
+
 ## Verification Checklist
 
 After recovery, verify:

--- a/scripts/release-rollback.sh
+++ b/scripts/release-rollback.sh
@@ -217,12 +217,50 @@ RESOLVED_FDEV_SOURCE=""
 # at a fork, a tag naming a different fdev would take a good release's crate off
 # the real registry while every other step operated on the fork. Origin is a
 # version source only when it is the project's own repository.
-origin_is_freenet_core() {
-    local url
-    url="$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null)" || return 1
+#
+# The string half is split out so it can be table-tested. It has to be: an
+# end-to-end case whose origin is the real `git@github.com:freenet/freenet-core`
+# would have step 2 `ls-remote` and `push --delete` against the REAL repository,
+# so the only branch production ever takes (the colon form -- the sandbox's
+# origin is a filesystem path, which is the slash form) is untestable any other
+# way. Verified by deletion: dropping the colon branch left the whole suite
+# green before `url_is_freenet_core` existed.
+#
+# The match is a SUFFIX, deliberately: the test fixture's origin is a bare repo
+# at `<sandbox>/github.com/freenet/freenet-core.git`, which is what lets the
+# suite exercise this matcher instead of a test-only backdoor in a destructive
+# script. Do not anchor it to the start of the string without also rebuilding
+# that fixture. It IS anchored on the delimiter -- the character before
+# `github.com` must be `/` or `@` -- so a lookalike host like
+# `evilgithub.com/freenet/freenet-core` does not match. That is tidiness, not a
+# security boundary: anyone who can rewrite your git config can do worse.
+url_is_freenet_core() {
+    local url="$1"
+    # Trailing slash first, so a URL ending `.git/` still loses its `.git`.
+    url="${url%/}"
     url="${url%.git}"
     url="${url%/}"
-    [[ "$url" == *"github.com/freenet/freenet-core" || "$url" == *"github.com:freenet/freenet-core" ]]
+    # The leading "/" gives a bare `github.com:freenet/freenet-core` (a valid
+    # scp-like URL with no user) the delimiter the pattern requires.
+    local delimited="/$url"
+    [[ "$delimited" == *[/@]"github.com/freenet/freenet-core" \
+        || "$delimited" == *[/@]"github.com:freenet/freenet-core" ]]
+}
+
+origin_is_freenet_core() {
+    local url
+    # `git remote get-url` EXPANDS `url.<base>.insteadOf`, so an operator using
+    # a host alias (`fnalias:core` rewritten to the real repository) is not
+    # refused on the genuine repo. Measured on git 2.43.0, since the obvious
+    # reading is the opposite and this was queried in review: with
+    # `url.git@github.com:freenet/freenet-core.git.insteadOf = fnalias:core`,
+    # `remote get-url origin` returns the REWRITTEN url, identical to
+    # `ls-remote --get-url`. Do NOT "fix" this to `git config --get
+    # remote.origin.url`, which returns the raw configured string and would
+    # refuse the genuine repository mid-incident.
+    url="$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null)" || return 1
+    [[ -n "$url" ]] || return 1
+    url_is_freenet_core "$url"
 }
 
 # Why origin did not supply a version: "unusable" (refused -- not freenet-core)
@@ -294,9 +332,19 @@ if [[ -n "$FDEV_VERSION" ]]; then
         # because adjacent fdev patch versions all exist on crates.io and a
         # near-miss yanks a GOOD release.
         if [[ "$RESOLVED_FDEV_SOURCE" == "local" ]]; then
+            # Same fork as the hard stop below. Saying "origin could not be
+            # read" over the top of the "origin is not freenet/freenet-core"
+            # warning printed three lines earlier gives an operator two
+            # contradictory explanations directly above a yank confirmation.
             echo "⚠️  --fdev-version $FDEV_VERSION does not match the LOCAL $TAG, which names"
-            echo "    fdev $RESOLVED_FDEV. Origin could not be read, so the local tag may itself"
-            echo "    be the stale one. Yanking $FDEV_VERSION as instructed."
+            echo "    fdev $RESOLVED_FDEV."
+            if [[ "$ORIGIN_SOURCE_PROBLEM" == "unusable" ]]; then
+                echo "    Origin is not freenet/freenet-core, so it could not confirm either"
+                echo "    number, and the local tag may itself be the stale one."
+            else
+                echo "    Origin could not be read, so the local tag may itself be the stale one."
+            fi
+            echo "    Yanking $FDEV_VERSION as instructed."
         else
             echo "⚠️  --fdev-version $FDEV_VERSION does not match $TAG, which names fdev $RESOLVED_FDEV."
             echo "    Yanking $FDEV_VERSION as instructed."

--- a/scripts/release-rollback.sh
+++ b/scripts/release-rollback.sh
@@ -43,12 +43,17 @@ record_failure() {
 # `pipefail`, under which a producer piped into a short-circuiting reader dies
 # of SIGPIPE and takes the pipeline's status with it (see
 # .claude/rules/bug-prevention-patterns.md).
-indent_output() {
+indent_note() {
     [[ -n "$1" ]] || return 0
     local line
     while IFS= read -r line; do
-        echo "      $line" >&2
+        echo "      $line"
     done <<<"$1"
+}
+
+# The same, on stderr, for a step's error text.
+indent_output() {
+    indent_note "$1" >&2
 }
 
 show_help() {
@@ -64,16 +69,22 @@ show_help() {
     echo "Options:"
     echo "  --version X.Y.Z      Version to rollback (required)"
     echo "  --yank-crates        Yank crates from crates.io (optional, use with caution)"
-    echo "  --fdev-version X.Y.Z fdev version to yank. Only needed when the release tag"
-    echo "                       is no longer available locally or on origin; otherwise"
-    echo "                       it is read from crates/fdev/Cargo.toml at the tag."
+    echo "  --fdev-version X.Y.Z fdev version to yank. Normally read from"
+    echo "                       crates/fdev/Cargo.toml at ORIGIN's release tag. Needed"
+    echo "                       whenever origin cannot supply it: the tag is gone from"
+    echo "                       origin, origin is unreachable, or origin is not"
+    echo "                       freenet/freenet-core. A LOCAL tag is only ever a hint --"
+    echo "                       an aborted release leaves stale ones, and a near-miss"
+    echo "                       yanks a good release's fdev."
     echo "  --dry-run            Show what would be done without executing"
     echo "  --help               Show this help"
     echo
     echo "Example: $0 --version 0.1.32"
     echo
     echo "⚠️  WARNING: This is a destructive operation!"
-    echo "    Use with caution. Yanking from crates.io cannot be undone."
+    echo "    Use with caution. A yank is reversible (\`cargo yank --undo --version"
+    echo "    X.Y.Z <crate>\`), but while it stands it breaks dependency resolution"
+    echo "    for everyone building against that version."
 }
 
 require_value() {
@@ -183,15 +194,55 @@ fdev_version_from_ref() {
 # ORIGIN'S tag wins over a local tag of the same name. The local one can be
 # stale -- release.sh skips tag creation when a tag of that name already exists,
 # so an aborted run leaves one behind, while the tag that actually shipped is
-# the one CI pushed. Reading a stale local tag would name a different release's
-# fdev, and a yank cannot be undone. `git fetch <remote> refs/tags/<tag>` writes
-# FETCH_HEAD only; it does not create or move the local tag.
+# the one CI pushed. Reading a stale local tag names a DIFFERENT release's fdev,
+# and yanking a good release's crate breaks every build that resolves it until
+# somebody notices and undoes it. `git fetch <remote> refs/tags/<tag>` writes
+# FETCH_HEAD only; it does not create or move the local tag -- but only with
+# --no-tags, because `remote.origin.tagOpt = --tags` otherwise turns even this
+# single-ref fetch into a full tag download (demonstrated: a DRY RUN created a
+# local v9.9.9).
+#
+# The resolution's PROVENANCE is recorded alongside the number, because the two
+# sources are not interchangeable. Origin's tag (or the operator's own
+# --fdev-version) is evidence; a local tag is a hint that may be stale, and this
+# number is handed to an irreversible-in-practice `cargo yank`.
+RESOLVED_FDEV=""
+RESOLVED_FDEV_SOURCE=""
+
+# Is `origin` really freenet/freenet-core?
+#
+# Steps 2 and 3 delete from whatever origin happens to be, and from a HARDCODED
+# --repo freenet/freenet-core -- but the version this resolves is passed to
+# `cargo yank`, which always reaches the REAL crates.io. So with origin pointed
+# at a fork, a tag naming a different fdev would take a good release's crate off
+# the real registry while every other step operated on the fork. Origin is a
+# version source only when it is the project's own repository.
+origin_is_freenet_core() {
+    local url
+    url="$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null)" || return 1
+    url="${url%.git}"
+    url="${url%/}"
+    [[ "$url" == *"github.com/freenet/freenet-core" || "$url" == *"github.com:freenet/freenet-core" ]]
+}
+
+# Why origin did not supply a version: "unusable" (refused -- not freenet-core)
+# or "unreadable" (fetch failed / no such tag). The distinction matters in the
+# message, because "could not read origin" sends an operator to check the
+# network when the actual answer is that their remote points somewhere else.
+ORIGIN_SOURCE_PROBLEM=""
+
 resolve_fdev_version() {
     local from_origin="" from_local=""
 
-    if git -C "$PROJECT_ROOT" fetch --quiet origin "refs/tags/$TAG" 2>/dev/null; then
+    if ! origin_is_freenet_core; then
+        ORIGIN_SOURCE_PROBLEM="unusable"
+        echo "warning: origin is not freenet/freenet-core, so its tags are not used as a" >&2
+        echo "         source for the fdev version to yank (a yank always reaches the" >&2
+        echo "         real crates.io, whatever origin points at)." >&2
+    elif git -C "$PROJECT_ROOT" fetch --quiet --no-tags origin "refs/tags/$TAG" 2>/dev/null; then
         from_origin="$(fdev_version_from_ref FETCH_HEAD)" || from_origin=""
     fi
+    [[ -n "$from_origin" || -n "$ORIGIN_SOURCE_PROBLEM" ]] || ORIGIN_SOURCE_PROBLEM="unreadable"
     from_local="$(fdev_version_from_ref "refs/tags/$TAG")" || from_local=""
 
     if [[ -n "$from_origin" ]]; then
@@ -199,14 +250,21 @@ resolve_fdev_version() {
             echo "warning: local $TAG names fdev $from_local, origin's names $from_origin." >&2
             echo "         Using origin's -- that is the tag the release was cut from." >&2
         fi
-        echo "$from_origin"
+        RESOLVED_FDEV="$from_origin"
+        RESOLVED_FDEV_SOURCE="origin"
         return 0
     fi
 
     if [[ -n "$from_local" ]]; then
-        echo "warning: could not read $TAG from origin; using the LOCAL tag, which may" >&2
-        echo "         be stale. Pass --fdev-version to be certain." >&2
-        echo "$from_local"
+        if [[ "$ORIGIN_SOURCE_PROBLEM" == "unusable" ]]; then
+            echo "warning: origin cannot be used as a version source (above). The LOCAL $TAG" >&2
+        else
+            echo "warning: could not read $TAG from origin. The LOCAL $TAG" >&2
+        fi
+        echo "         names fdev $from_local, but a local tag can be stale, so that is a" >&2
+        echo "         HINT only -- not a version this script will yank on." >&2
+        RESOLVED_FDEV="$from_local"
+        RESOLVED_FDEV_SOURCE="local"
         return 0
     fi
 
@@ -217,23 +275,38 @@ resolve_fdev_version() {
 # release this reads from, so a version that cannot be established afterwards
 # cannot be established at all. Done even without --yank-crates, so the hints at
 # the end of a tag-only rollback can carry the number the next run will need.
-RESOLVED_FDEV=""
-if RESOLVED_FDEV="$(resolve_fdev_version)"; then
-    [[ "$RESOLVED_FDEV" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || RESOLVED_FDEV=""
-else
+resolve_fdev_version || true
+if [[ ! "$RESOLVED_FDEV" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     RESOLVED_FDEV=""
+    RESOLVED_FDEV_SOURCE=""
 fi
 
-if [[ -n "$FDEV_VERSION" && -n "$RESOLVED_FDEV" && "$FDEV_VERSION" != "$RESOLVED_FDEV" ]]; then
-    # Not fatal -- an operator may deliberately be yanking a version the tag does
-    # not name -- but said loudly, above the confirmation prompt, because
-    # adjacent fdev patch versions all exist on crates.io and a near-miss yanks
-    # a GOOD release.
-    echo "⚠️  --fdev-version $FDEV_VERSION does not match $TAG, which names fdev $RESOLVED_FDEV."
-    echo "    Yanking $FDEV_VERSION as instructed."
-    echo
+# Where the number that reaches `cargo yank` actually came from: "operator",
+# "origin", "local", or empty. Everything downstream that either ACTS on the
+# number or hands it back to the operator for a re-run consults this, so a
+# local-tag guess can never be laundered into something that reads as fact.
+FDEV_VERSION_SOURCE=""
+if [[ -n "$FDEV_VERSION" ]]; then
+    FDEV_VERSION_SOURCE="operator"
+    if [[ -n "$RESOLVED_FDEV" && "$FDEV_VERSION" != "$RESOLVED_FDEV" ]]; then
+        # Not fatal -- an operator may deliberately be yanking a version the tag
+        # does not name -- but said loudly, above the confirmation prompt,
+        # because adjacent fdev patch versions all exist on crates.io and a
+        # near-miss yanks a GOOD release.
+        if [[ "$RESOLVED_FDEV_SOURCE" == "local" ]]; then
+            echo "⚠️  --fdev-version $FDEV_VERSION does not match the LOCAL $TAG, which names"
+            echo "    fdev $RESOLVED_FDEV. Origin could not be read, so the local tag may itself"
+            echo "    be the stale one. Yanking $FDEV_VERSION as instructed."
+        else
+            echo "⚠️  --fdev-version $FDEV_VERSION does not match $TAG, which names fdev $RESOLVED_FDEV."
+            echo "    Yanking $FDEV_VERSION as instructed."
+        fi
+        echo
+    fi
+else
+    FDEV_VERSION="$RESOLVED_FDEV"
+    FDEV_VERSION_SOURCE="$RESOLVED_FDEV_SOURCE"
 fi
-[[ -n "$FDEV_VERSION" ]] || FDEV_VERSION="$RESOLVED_FDEV"
 
 if [[ "$YANK_CRATES" == "true" && -z "$FDEV_VERSION" ]]; then
     echo "Error: cannot determine which fdev version shipped with $TAG."
@@ -248,6 +321,36 @@ if [[ "$YANK_CRATES" == "true" && -z "$FDEV_VERSION" ]]; then
     exit 1
 fi
 
+# A LOCAL tag is never enough to yank on.
+#
+# Both preconditions are routine and they compose: release.sh skips tag creation
+# when a local tag of that name exists, so an aborted run leaves a stale one
+# behind, and an origin that cannot be reached mid-incident is ordinary. With
+# only the local tag readable the script would otherwise print a stale number as
+# fact and yank a GOOD release's fdev -- adjacent fdev patch versions all exist
+# on crates.io, so the yank succeeds. Stop and make the operator name it.
+if [[ "$YANK_CRATES" == "true" && "$FDEV_VERSION_SOURCE" == "local" ]]; then
+    echo "Error: cannot determine which fdev version shipped with $TAG."
+    echo
+    if [[ "$ORIGIN_SOURCE_PROBLEM" == "unusable" ]]; then
+        echo "  Origin is not freenet/freenet-core, so it is not a version source, and"
+        echo "  the only thing left is the LOCAL $TAG, which names fdev $FDEV_VERSION."
+    else
+        echo "  Origin could not be read, so the only source left is the LOCAL $TAG,"
+        echo "  which names fdev $FDEV_VERSION."
+    fi
+    echo "  That is a hint, not evidence:"
+    echo "  release.sh skips tag creation when a local tag already exists, so an"
+    echo "  aborted run leaves one pointing at a different release -- and yanking"
+    echo "  on it takes a GOOD release's fdev off crates.io."
+    echo
+    echo "  Fix origin and re-run, or confirm the version by hand"
+    echo "  (https://crates.io/crates/fdev/versions, and the release announcement"
+    echo "  for freenet $VERSION) and pass it explicitly:"
+    echo "    $0 --version $VERSION --yank-crates --fdev-version X.Y.Z"
+    exit 1
+fi
+
 echo "Freenet Release Rollback"
 echo "========================"
 echo "Version:     $VERSION"
@@ -257,7 +360,13 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 if [[ "$YANK_CRATES" == "true" ]]; then
     echo "Yank crates: YES"
-    echo "fdev:        $FDEV_VERSION"
+    # Never a bare number: the whole point of the gate above is that where this
+    # came from decides whether it may be acted on.
+    case "$FDEV_VERSION_SOURCE" in
+        origin)   echo "fdev:        $FDEV_VERSION (read from origin's $TAG)" ;;
+        operator) echo "fdev:        $FDEV_VERSION (given on the command line)" ;;
+        *)        echo "fdev:        $FDEV_VERSION" ;;
+    esac
 fi
 echo
 
@@ -265,7 +374,10 @@ echo
 if [[ "$DRY_RUN" == "false" ]]; then
     echo "⚠️  WARNING: This will rollback release $VERSION"
     if [[ "$YANK_CRATES" == "true" ]]; then
-        echo "⚠️  This includes YANKING crates from crates.io (cannot be undone)"
+        echo "⚠️  This includes YANKING crates from crates.io."
+        echo "    A yank is reversible (\`cargo yank --undo --version X.Y.Z <crate>\`), but"
+        echo "    until it is undone it breaks dependency resolution for anyone building"
+        echo "    against that version."
     fi
     echo
     # An `if`, because a bare `read` that hits EOF (a non-interactive caller, or
@@ -291,7 +403,12 @@ if git -C "$PROJECT_ROOT" rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "[DRY RUN]"
     elif step_output="$(git -C "$PROJECT_ROOT" tag -d "$TAG" 2>&1)"; then
+        # `git tag -d` prints "Deleted tag 'vX.Y.Z' (was <sha>)". That SHA is the
+        # only record of where the tag pointed, and the next two steps delete the
+        # tag from origin and delete the release page -- so print it on SUCCESS,
+        # not only when something goes wrong.
         echo "✓"
+        indent_note "$step_output"
     else
         echo "✗ (failed)"
         indent_output "$step_output"
@@ -467,11 +584,22 @@ if [[ $FAILURE_COUNT -gt 0 ]]; then
     echo
     echo "The release is only partially rolled back. Fix the cause and re-run, or"
     echo "finish the failed steps by hand (see scripts/RELEASE_RECOVERY.md)."
-    if [[ -n "$FDEV_VERSION" ]]; then
+    # Only a version that came from origin or from the operator is echoed back
+    # as something to re-run with. A local-tag reading is a hint, and printing it
+    # inside a ready-to-paste command turns it into an instruction -- which on
+    # the second run also silences the mismatch warning, because the operator is
+    # now "explicitly" passing the very guess this script produced.
+    if [[ -n "$FDEV_VERSION" && "$FDEV_VERSION_SOURCE" != "local" ]]; then
         echo
         echo "A re-run may no longer be able to read the fdev version from $TAG,"
         echo "so pass it explicitly:"
         echo "  $0 --version $VERSION --yank-crates --fdev-version $FDEV_VERSION"
+    elif [[ "$FDEV_VERSION_SOURCE" == "local" ]]; then
+        echo
+        echo "The local $TAG names fdev $FDEV_VERSION, but origin did not confirm it,"
+        echo "so that is a hint and not a version to yank on. Confirm which fdev shipped"
+        echo "with freenet $VERSION (https://crates.io/crates/fdev/versions, and the"
+        echo "release announcement) before re-running with --yank-crates."
     fi
     exit 1
 fi
@@ -482,11 +610,21 @@ echo "Next steps:"
 echo "  • Verify the tag and release are gone: gh release list --repo freenet/freenet-core"
 echo "  • Check crates.io: https://crates.io/crates/freenet"
 if [[ "$YANK_CRATES" == "false" ]]; then
-    if [[ -n "$FDEV_VERSION" ]]; then
+    if [[ -n "$FDEV_VERSION" && "$FDEV_VERSION_SOURCE" != "local" ]]; then
         # --fdev-version is included because THIS run deleted the tag the number
         # is read from; without it the suggested command stops with an error.
         echo "  • To yank crates, run: $0 --version $VERSION --yank-crates --fdev-version $FDEV_VERSION"
     else
-        echo "  • To yank crates, run: $0 --version $VERSION --yank-crates"
+        # No version this run is willing to stand behind -- either nothing
+        # resolved, or only a local tag did. A bare --yank-crates re-run would
+        # hard-error (the tag it reads from was just deleted), so do not suggest
+        # one: name the lookup and the placeholder instead.
+        if [[ "$FDEV_VERSION_SOURCE" == "local" ]]; then
+            echo "  • The local $TAG named fdev $FDEV_VERSION, but origin did not confirm it,"
+            echo "    so treat that as a hint only."
+        fi
+        echo "  • To yank crates, look up the fdev version that shipped with freenet $VERSION"
+        echo "    (https://crates.io/crates/fdev/versions, or the release announcement) and run:"
+        echo "      $0 --version $VERSION --yank-crates --fdev-version X.Y.Z"
     fi
 fi

--- a/scripts/release-rollback.sh
+++ b/scripts/release-rollback.sh
@@ -13,8 +13,36 @@ if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)
 fi
 
 VERSION=""
+FDEV_VERSION=""
 DRY_RUN=false
 YANK_CRATES=false
+
+# Step failures are accumulated here and decide the exit status.
+#
+# Every step reports its own outcome and keeps going, because a rollback that
+# stops at the first problem leaves the release half-torn-down. What must NOT
+# happen is the script printing "Rollback complete" over the top of a step that
+# failed -- this is recovery tooling, and a rollback that silently did nothing
+# is exactly the moment an operator cannot afford to be told it worked.
+FAILURE_COUNT=0
+FAILED_STEPS=()
+record_failure() {
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+    FAILED_STEPS+=("$1")
+}
+
+# Indent a captured command's output so a multi-line error stays readable under
+# the step it belongs to. A here-string, never a pipe: this script sets
+# `pipefail`, under which a producer piped into a short-circuiting reader dies
+# of SIGPIPE and takes the pipeline's status with it (see
+# .claude/rules/bug-prevention-patterns.md).
+indent_output() {
+    [[ -n "$1" ]] || return 0
+    local line
+    while IFS= read -r line; do
+        echo "      $line" >&2
+    done <<<"$1"
+}
 
 show_help() {
     echo "Freenet Release Rollback Script"
@@ -27,10 +55,13 @@ show_help() {
     echo "  • Optionally yank crates from crates.io (--yank-crates)"
     echo
     echo "Options:"
-    echo "  --version X.Y.Z  Version to rollback (required)"
-    echo "  --yank-crates    Yank crates from crates.io (optional, use with caution)"
-    echo "  --dry-run        Show what would be done without executing"
-    echo "  --help           Show this help"
+    echo "  --version X.Y.Z      Version to rollback (required)"
+    echo "  --yank-crates        Yank crates from crates.io (optional, use with caution)"
+    echo "  --fdev-version X.Y.Z fdev version to yank. Only needed when the release tag"
+    echo "                       is no longer available locally or on origin; otherwise"
+    echo "                       it is read from crates/fdev/Cargo.toml at the tag."
+    echo "  --dry-run            Show what would be done without executing"
+    echo "  --help               Show this help"
     echo
     echo "Example: $0 --version 0.1.32"
     echo
@@ -43,6 +74,10 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --version)
             VERSION="$2"
+            shift 2
+            ;;
+        --fdev-version)
+            FDEV_VERSION="$2"
             shift 2
             ;;
         --yank-crates)
@@ -77,7 +112,66 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
+if [[ -n "$FDEV_VERSION" && ! "$FDEV_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: --fdev-version must be in format X.Y.Z (e.g., 0.3.293)"
+    exit 1
+fi
+
 TAG="v$VERSION"
+
+# Which fdev version shipped WITH freenet vX.Y.Z?
+#
+# fdev's version is independent of freenet's: release.yml bumps fdev's OWN
+# patch number in crates/fdev/Cargo.toml on each release, so the two have
+# drifted far apart (freenet 0.2.131 shipped alongside fdev 0.3.293). Any
+# arithmetic relationship between them is a coincidence of the first few
+# releases -- which is what this used to rely on, computing
+# `0.$((minor + 2)).$patch` and asking crates.io to yank fdev 0.4.129 for
+# freenet 0.2.129. No such version has ever existed, so the yank never yanked
+# anything.
+#
+# Read the number rather than computing it, and read it from the RELEASE TAG
+# rather than from the working tree: by the time anyone is rolling a release
+# back, main has usually bumped fdev again, so the working tree names the
+# version that shipped with a DIFFERENT release. A yank cannot be undone, so
+# the source has to be the tree the release was actually cut from.
+resolve_fdev_version() {
+    local toml=""
+    if toml="$(git -C "$PROJECT_ROOT" show "$TAG:crates/fdev/Cargo.toml" 2>/dev/null)"; then
+        :
+    elif git -C "$PROJECT_ROOT" fetch --quiet origin "refs/tags/$TAG" 2>/dev/null &&
+        toml="$(git -C "$PROJECT_ROOT" show FETCH_HEAD:crates/fdev/Cargo.toml 2>/dev/null)"; then
+        # The tag is gone locally but still on origin -- a re-run after a
+        # partially completed rollback. FETCH_HEAD is read-only; this does not
+        # recreate the local tag.
+        :
+    else
+        return 1
+    fi
+
+    # The [package] version is the first `version = "..."` at the start of a
+    # line; dependency versions all appear later and are indented or inline.
+    local parsed
+    parsed="$(awk -F'"' '/^version = "/ { print $2; exit }' <<<"$toml")"
+    [[ "$parsed" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+    echo "$parsed"
+}
+
+# Resolve BEFORE anything destructive runs: steps 1 and 2 delete the very tag
+# this reads from, and discovering the version is unavailable after the tag is
+# gone would leave the operator with nothing to look it up from.
+if [[ "$YANK_CRATES" == "true" && -z "$FDEV_VERSION" ]]; then
+    if ! FDEV_VERSION="$(resolve_fdev_version)"; then
+        echo "Error: cannot determine which fdev version shipped with $TAG."
+        echo
+        echo "  crates/fdev/Cargo.toml could not be read at $TAG (the tag is"
+        echo "  missing locally and on origin, or the manifest is unreadable)."
+        echo
+        echo "  Look the version up on the release page or crates.io, then pass it:"
+        echo "    $0 --version $VERSION --yank-crates --fdev-version X.Y.Z"
+        exit 1
+    fi
+fi
 
 echo "Freenet Release Rollback"
 echo "========================"
@@ -88,6 +182,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 if [[ "$YANK_CRATES" == "true" ]]; then
     echo "Yank crates: YES"
+    echo "fdev:        $FDEV_VERSION"
 fi
 echo
 
@@ -106,29 +201,47 @@ if [[ "$DRY_RUN" == "false" ]]; then
 fi
 
 # Delete local git tag
+#
+# `refs/tags/$TAG` rather than a bare `$TAG`, so a branch or a file of the same
+# name cannot be mistaken for the tag.
 echo -n "[1/4] Deleting local git tag... "
-if git rev-parse "$TAG" >/dev/null 2>&1; then
+if git -C "$PROJECT_ROOT" rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "[DRY RUN]"
-    else
-        git tag -d "$TAG"
+    elif step_output="$(git -C "$PROJECT_ROOT" tag -d "$TAG" 2>&1)"; then
         echo "✓"
+    else
+        echo "✗ (failed)"
+        indent_output "$step_output"
+        record_failure "delete local tag $TAG"
     fi
 else
     echo "not found, skipping"
 fi
 
 # Delete remote git tag
+#
+# Ask origin for the ONE ref, and keep the three answers apart -- present,
+# absent, and "could not ask". The previous form piped `ls-remote --tags` into
+# `grep -q`: under `pipefail` the short-circuiting grep kills git with SIGPIPE
+# once it matches, so on a repo with enough tags a PRESENT tag reads as absent
+# and the deletion is silently skipped. A failed lookup read as "absent" would
+# do the same thing for a different reason.
 echo -n "[2/4] Deleting remote git tag... "
-if git ls-remote --tags origin | grep -q "refs/tags/$TAG"; then
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "[DRY RUN]"
-    else
-        git push origin --delete "$TAG" 2>&1 | grep -v "^remote:" || true
-        echo "✓"
-    fi
-else
+if ! step_output="$(git -C "$PROJECT_ROOT" ls-remote --tags origin "refs/tags/$TAG" 2>&1)"; then
+    echo "✗ (could not query origin)"
+    indent_output "$step_output"
+    record_failure "delete remote tag $TAG (could not query origin)"
+elif [[ -z "$step_output" ]]; then
     echo "not found, skipping"
+elif [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY RUN]"
+elif step_output="$(git -C "$PROJECT_ROOT" push origin --delete "$TAG" 2>&1)"; then
+    echo "✓"
+else
+    echo "✗ (failed)"
+    indent_output "$step_output"
+    record_failure "delete remote tag $TAG"
 fi
 
 # Delete GitHub release
@@ -136,49 +249,108 @@ echo -n "[3/4] Deleting GitHub release... "
 if gh release view "$TAG" --repo freenet/freenet-core >/dev/null 2>&1; then
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "[DRY RUN]"
-    else
-        gh release delete "$TAG" --repo freenet/freenet-core --yes
+    elif step_output="$(gh release delete "$TAG" --repo freenet/freenet-core --yes 2>&1)"; then
         echo "✓"
+    else
+        echo "✗ (failed)"
+        indent_output "$step_output"
+        record_failure "delete GitHub release $TAG"
     fi
 else
     echo "not found, skipping"
 fi
 
+# Is <crate> <version> on crates.io?
+#   0 = published, 1 = genuinely absent, 2 = UNKNOWN (do not act on it)
+#
+# The same tri-state probe scripts/RELEASE_RECOVERY.md documents for the manual
+# path. The `-A` is load-bearing: crates.io answers 403 to a request carrying no
+# descriptive User-Agent, and a two-state form reads that 403 as "not published"
+# for every version ever released. Telling 404 apart from every other status is
+# also what stops an outage or a rate-limit from reading as "nothing to yank".
+crate_version_state() {
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' -A 'freenet-release-driver' \
+        --max-time 30 --retry 3 --retry-all-errors \
+        "https://crates.io/api/v1/crates/$1/$2" 2>/dev/null)" || return 2
+    case "$code" in
+        200) return 0 ;;
+        404) return 1 ;;
+        *)
+            echo "crates.io answered HTTP $code for $1 $2 -- UNKNOWN, not 'absent'" >&2
+            return 2
+            ;;
+    esac
+}
+
+# Yank one crate version, keeping the three outcomes that matter distinct:
+# yanked (or already yanked) is fine, genuinely never published is fine, and
+# anything else is a failure that has to reach the exit status.
+yank_crate() {
+    local crate="$1" version="$2"
+
+    echo -n "  Yanking $crate v$version... "
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[DRY RUN]"
+        return 0
+    fi
+
+    local state=0
+    crate_version_state "$crate" "$version" || state=$?
+    case "$state" in
+        1)
+            echo "not published, skipping"
+            return 0
+            ;;
+        2)
+            echo "✗ (crates.io status unknown -- NOT yanked)"
+            record_failure "yank $crate v$version (could not determine publish state)"
+            return 0
+            ;;
+    esac
+
+    # Judge by cargo's EXIT STATUS. The previous form grepped cargo's output for
+    # "successfully yanked", a string cargo no longer prints, so even a yank that
+    # worked was reported as "✗ (failed or not published)" -- and since nothing
+    # consumed that verdict, the script printed "Rollback complete!" underneath
+    # it either way.
+    local output
+    if output="$(cargo yank --version "$version" "$crate" 2>&1)"; then
+        echo "✓"
+    elif grep -qi "already yanked" <<<"$output"; then
+        echo "✓ (already yanked)"
+    else
+        echo "✗ (yank failed)"
+        indent_output "$output"
+        record_failure "yank $crate v$version"
+    fi
+}
+
 # Yank crates from crates.io
 if [[ "$YANK_CRATES" == "true" ]]; then
     echo "[4/4] Yanking crates from crates.io..."
-
-    # Calculate fdev version
-    IFS='.' read -r major minor patch <<< "$VERSION"
-    minor_plus_2=$((minor + 2))
-    FDEV_VERSION="0.${minor_plus_2}.${patch}"
-
-    echo -n "  Yanking freenet v$VERSION... "
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "[DRY RUN]"
-    else
-        if cargo yank --vers "$VERSION" freenet 2>&1 | grep -q "successfully yanked\|already yanked"; then
-            echo "✓"
-        else
-            echo "✗ (failed or not published)"
-        fi
-    fi
-
-    echo -n "  Yanking fdev v$FDEV_VERSION... "
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "[DRY RUN]"
-    else
-        if cargo yank --vers "$FDEV_VERSION" fdev 2>&1 | grep -q "successfully yanked\|already yanked"; then
-            echo "✓"
-        else
-            echo "✗ (failed or not published)"
-        fi
-    fi
+    yank_crate freenet "$VERSION"
+    yank_crate fdev "$FDEV_VERSION"
 else
     echo "[4/4] Skipping crate yanking (use --yank-crates to enable)"
 fi
 
 echo
+# Counted separately from the array: `${#FAILED_STEPS[@]}` on an EMPTY array is
+# an unbound-variable error under `set -u` on bash 3.2, which is what a mac
+# operator's /bin/bash is -- and a rollback that dies on its own summary line
+# is a poor way to find that out.
+if [[ $FAILURE_COUNT -gt 0 ]]; then
+    echo "❌ Rollback INCOMPLETE -- $FAILURE_COUNT step(s) failed:"
+    for step in "${FAILED_STEPS[@]}"; do
+        echo "  • $step"
+    done
+    echo
+    echo "The release is only partially rolled back. Fix the cause and re-run, or"
+    echo "finish the failed steps by hand (see scripts/RELEASE_RECOVERY.md)."
+    exit 1
+fi
+
 echo "✅ Rollback complete!"
 echo
 echo "Next steps:"

--- a/scripts/release-rollback.sh
+++ b/scripts/release-rollback.sh
@@ -17,6 +17,13 @@ FDEV_VERSION=""
 DRY_RUN=false
 YANK_CRATES=false
 
+# Somewhere to capture a command's stderr WITHOUT merging it into the value the
+# script then tests. Merging the two is its own bug: `x="$(cmd 2>&1)"` followed
+# by `[[ -z "$x" ]]` reads any transport banner ("Warning: Permanently added
+# 'github.com' ... to the list of known hosts") as a result.
+STDERR_FILE="$(mktemp)"
+trap 'rm -f "$STDERR_FILE"' EXIT
+
 # Step failures are accumulated here and decide the exit status.
 #
 # Every step reports its own outcome and keeps going, because a rollback that
@@ -69,14 +76,23 @@ show_help() {
     echo "    Use with caution. Yanking from crates.io cannot be undone."
 }
 
+require_value() {
+    if [[ $2 -lt 2 ]]; then
+        echo "Error: $1 requires a value"
+        exit 1
+    fi
+}
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --version)
+            require_value --version $#
             VERSION="$2"
             shift 2
             ;;
         --fdev-version)
+            require_value --fdev-version $#
             FDEV_VERSION="$2"
             shift 2
             ;;
@@ -119,58 +135,117 @@ fi
 
 TAG="v$VERSION"
 
-# Which fdev version shipped WITH freenet vX.Y.Z?
+# The [package] version out of a Cargo.toml on stdin.
 #
-# fdev's version is independent of freenet's: release.yml bumps fdev's OWN
-# patch number in crates/fdev/Cargo.toml on each release, so the two have
-# drifted far apart (freenet 0.2.131 shipped alongside fdev 0.3.293). Any
-# arithmetic relationship between them is a coincidence of the first few
-# releases -- which is what this used to rely on, computing
-# `0.$((minor + 2)).$patch` and asking crates.io to yank fdev 0.4.129 for
-# freenet 0.2.129. No such version has ever existed, so the yank never yanked
-# anything.
-#
-# Read the number rather than computing it, and read it from the RELEASE TAG
-# rather than from the working tree: by the time anyone is rolling a release
-# back, main has usually bumped fdev again, so the working tree names the
-# version that shipped with a DIFFERENT release. A yank cannot be undone, so
-# the source has to be the tree the release was actually cut from.
-resolve_fdev_version() {
-    local toml=""
-    if toml="$(git -C "$PROJECT_ROOT" show "$TAG:crates/fdev/Cargo.toml" 2>/dev/null)"; then
-        :
-    elif git -C "$PROJECT_ROOT" fetch --quiet origin "refs/tags/$TAG" 2>/dev/null &&
-        toml="$(git -C "$PROJECT_ROOT" show FETCH_HEAD:crates/fdev/Cargo.toml 2>/dev/null)"; then
-        # The tag is gone locally but still on origin -- a re-run after a
-        # partially completed rollback. FETCH_HEAD is read-only; this does not
-        # recreate the local tag.
-        :
-    else
-        return 1
-    fi
+# Anchored to the [package] section rather than taking the first line-anchored
+# `version = `: a dependency version has the same SHAPE, so a shape check alone
+# would not notice if the two ever swapped places, and this value feeds an
+# irreversible yank. It reads the same field .github/workflows/release.yml's
+# validate step reads when it bumps fdev; if that ever moves to
+# `version.workspace = true`, this returns nothing and the script stops and asks
+# for --fdev-version rather than guessing.
+package_version() {
+    awk '
+        /^\[/ { in_pkg = ($0 ~ /^\[package\][[:space:]]*$/); next }
+        in_pkg && /^version[[:space:]]*=/ {
+            sub(/^version[[:space:]]*=[[:space:]]*"/, "")
+            sub(/".*$/, "")
+            print
+            exit
+        }
+    '
+}
 
-    # The [package] version is the first `version = "..."` at the start of a
-    # line; dependency versions all appear later and are indented or inline.
+fdev_version_from_ref() {
+    local toml
+    toml="$(git -C "$PROJECT_ROOT" show "$1:crates/fdev/Cargo.toml" 2>/dev/null)" || return 1
     local parsed
-    parsed="$(awk -F'"' '/^version = "/ { print $2; exit }' <<<"$toml")"
+    parsed="$(package_version <<<"$toml")"
     [[ "$parsed" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
     echo "$parsed"
 }
 
-# Resolve BEFORE anything destructive runs: steps 1 and 2 delete the very tag
-# this reads from, and discovering the version is unavailable after the tag is
-# gone would leave the operator with nothing to look it up from.
-if [[ "$YANK_CRATES" == "true" && -z "$FDEV_VERSION" ]]; then
-    if ! FDEV_VERSION="$(resolve_fdev_version)"; then
-        echo "Error: cannot determine which fdev version shipped with $TAG."
-        echo
-        echo "  crates/fdev/Cargo.toml could not be read at $TAG (the tag is"
-        echo "  missing locally and on origin, or the manifest is unreadable)."
-        echo
-        echo "  Look the version up on the release page or crates.io, then pass it:"
-        echo "    $0 --version $VERSION --yank-crates --fdev-version X.Y.Z"
-        exit 1
+# Which fdev version shipped WITH freenet vX.Y.Z?
+#
+# fdev's version is independent of freenet's: release.yml bumps fdev's OWN patch
+# number in crates/fdev/Cargo.toml on each release, so the two have drifted far
+# apart (freenet 0.2.131 shipped alongside fdev 0.3.293). Any arithmetic
+# relationship between them is a coincidence of the first few releases -- which
+# is what this used to rely on, computing `0.$((minor + 2)).$patch` and asking
+# crates.io to yank fdev 0.4.129 for freenet 0.2.129. No such version has ever
+# existed, so the yank never yanked anything.
+#
+# Read the number rather than computing it, and read it from the RELEASE TAG
+# rather than from the working tree: by the time anyone is rolling a release
+# back, main has usually bumped fdev again, so the working tree names the
+# version that shipped with a DIFFERENT release.
+#
+# ORIGIN'S tag wins over a local tag of the same name. The local one can be
+# stale -- release.sh skips tag creation when a tag of that name already exists,
+# so an aborted run leaves one behind, while the tag that actually shipped is
+# the one CI pushed. Reading a stale local tag would name a different release's
+# fdev, and a yank cannot be undone. `git fetch <remote> refs/tags/<tag>` writes
+# FETCH_HEAD only; it does not create or move the local tag.
+resolve_fdev_version() {
+    local from_origin="" from_local=""
+
+    if git -C "$PROJECT_ROOT" fetch --quiet origin "refs/tags/$TAG" 2>/dev/null; then
+        from_origin="$(fdev_version_from_ref FETCH_HEAD)" || from_origin=""
     fi
+    from_local="$(fdev_version_from_ref "refs/tags/$TAG")" || from_local=""
+
+    if [[ -n "$from_origin" ]]; then
+        if [[ -n "$from_local" && "$from_local" != "$from_origin" ]]; then
+            echo "warning: local $TAG names fdev $from_local, origin's names $from_origin." >&2
+            echo "         Using origin's -- that is the tag the release was cut from." >&2
+        fi
+        echo "$from_origin"
+        return 0
+    fi
+
+    if [[ -n "$from_local" ]]; then
+        echo "warning: could not read $TAG from origin; using the LOCAL tag, which may" >&2
+        echo "         be stale. Pass --fdev-version to be certain." >&2
+        echo "$from_local"
+        return 0
+    fi
+
+    return 1
+}
+
+# Resolve BEFORE anything destructive runs: steps 1 to 3 delete the tag and the
+# release this reads from, so a version that cannot be established afterwards
+# cannot be established at all. Done even without --yank-crates, so the hints at
+# the end of a tag-only rollback can carry the number the next run will need.
+RESOLVED_FDEV=""
+if RESOLVED_FDEV="$(resolve_fdev_version)"; then
+    [[ "$RESOLVED_FDEV" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || RESOLVED_FDEV=""
+else
+    RESOLVED_FDEV=""
+fi
+
+if [[ -n "$FDEV_VERSION" && -n "$RESOLVED_FDEV" && "$FDEV_VERSION" != "$RESOLVED_FDEV" ]]; then
+    # Not fatal -- an operator may deliberately be yanking a version the tag does
+    # not name -- but said loudly, above the confirmation prompt, because
+    # adjacent fdev patch versions all exist on crates.io and a near-miss yanks
+    # a GOOD release.
+    echo "⚠️  --fdev-version $FDEV_VERSION does not match $TAG, which names fdev $RESOLVED_FDEV."
+    echo "    Yanking $FDEV_VERSION as instructed."
+    echo
+fi
+[[ -n "$FDEV_VERSION" ]] || FDEV_VERSION="$RESOLVED_FDEV"
+
+if [[ "$YANK_CRATES" == "true" && -z "$FDEV_VERSION" ]]; then
+    echo "Error: cannot determine which fdev version shipped with $TAG."
+    echo
+    echo "  crates/fdev/Cargo.toml could not be read at $TAG (the tag is missing"
+    echo "  locally and on origin, or the manifest could not be parsed)."
+    echo
+    echo "  crates.io lists every published fdev version at"
+    echo "  https://crates.io/crates/fdev/versions, and the one that shipped with"
+    echo "  freenet $VERSION is named in that release's announcement. Then:"
+    echo "    $0 --version $VERSION --yank-crates --fdev-version X.Y.Z"
+    exit 1
 fi
 
 echo "Freenet Release Rollback"
@@ -193,7 +268,14 @@ if [[ "$DRY_RUN" == "false" ]]; then
         echo "⚠️  This includes YANKING crates from crates.io (cannot be undone)"
     fi
     echo
-    read -p "Are you sure you want to continue? (yes/no): " -r
+    # An `if`, because a bare `read` that hits EOF (a non-interactive caller, or
+    # `</dev/null`) is a non-zero command under `set -e`: the script would die
+    # before printing anything about why.
+    if ! read -p "Are you sure you want to continue? (yes/no): " -r; then
+        echo
+        echo "Aborted (no answer given)."
+        exit 1
+    fi
     if [[ ! $REPLY =~ ^yes$ ]]; then
         echo "Aborted."
         exit 1
@@ -224,19 +306,20 @@ fi
 # Ask origin for the ONE ref, and keep the three answers apart -- present,
 # absent, and "could not ask". The previous form piped `ls-remote --tags` into
 # `grep -q`: under `pipefail` the short-circuiting grep kills git with SIGPIPE
-# once it matches, so on a repo with enough tags a PRESENT tag reads as absent
-# and the deletion is silently skipped. A failed lookup read as "absent" would
-# do the same thing for a different reason.
+# once it matches, so a PRESENT tag reads as absent and the deletion is silently
+# skipped. Measured on this repo (34 KB of `ls-remote --tags` output): 10 of 10
+# lookups of tags that DO exist returned 141. A failed lookup read as "absent"
+# would skip the deletion just as quietly, for a different reason.
 echo -n "[2/4] Deleting remote git tag... "
-if ! step_output="$(git -C "$PROJECT_ROOT" ls-remote --tags origin "refs/tags/$TAG" 2>&1)"; then
+if ! remote_refs="$(git -C "$PROJECT_ROOT" ls-remote --tags origin "refs/tags/$TAG" 2>"$STDERR_FILE")"; then
     echo "✗ (could not query origin)"
-    indent_output "$step_output"
+    indent_output "$(cat "$STDERR_FILE")"
     record_failure "delete remote tag $TAG (could not query origin)"
-elif [[ -z "$step_output" ]]; then
+elif [[ -z "$remote_refs" ]]; then
     echo "not found, skipping"
 elif [[ "$DRY_RUN" == "true" ]]; then
     echo "[DRY RUN]"
-elif step_output="$(git -C "$PROJECT_ROOT" push origin --delete "$TAG" 2>&1)"; then
+elif step_output="$(git -C "$PROJECT_ROOT" push origin --delete "refs/tags/$TAG" 2>&1)"; then
     echo "✓"
 else
     echo "✗ (failed)"
@@ -245,8 +328,15 @@ else
 fi
 
 # Delete GitHub release
+#
+# Three answers here too, for the same reason as step 2: `gh release view` exits
+# non-zero for a release that does not exist AND for gh being absent, the token
+# having expired, a rate limit, or an outage. Reading all of those as "not
+# found, skipping" leaves the release and its binaries live while the script
+# reports a completed rollback. "release not found" is gh's own wording for the
+# genuinely-absent case.
 echo -n "[3/4] Deleting GitHub release... "
-if gh release view "$TAG" --repo freenet/freenet-core >/dev/null 2>&1; then
+if gh release view "$TAG" --repo freenet/freenet-core --json id >/dev/null 2>"$STDERR_FILE"; then
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "[DRY RUN]"
     elif step_output="$(gh release delete "$TAG" --repo freenet/freenet-core --yes 2>&1)"; then
@@ -256,8 +346,12 @@ if gh release view "$TAG" --repo freenet/freenet-core >/dev/null 2>&1; then
         indent_output "$step_output"
         record_failure "delete GitHub release $TAG"
     fi
-else
+elif grep -qi "release not found" "$STDERR_FILE"; then
     echo "not found, skipping"
+else
+    echo "✗ (could not query GitHub)"
+    indent_output "$(cat "$STDERR_FILE")"
+    record_failure "delete GitHub release $TAG (could not query GitHub)"
 fi
 
 # Is <crate> <version> on crates.io?
@@ -268,11 +362,22 @@ fi
 # descriptive User-Agent, and a two-state form reads that 403 as "not published"
 # for every version ever released. Telling 404 apart from every other status is
 # also what stops an outage or a rate-limit from reading as "nothing to yank".
+#
+# Deliberately a fourth copy rather than a shared helper: release.sh's
+# equivalent (crate_version_on_crates_io) is two-state ON PURPOSE, with a long
+# comment explaining why its fail-closed direction makes that gap safe there,
+# and unifying them means rewriting that function's behavioural fixtures. That
+# is a change of its own; this one keeps to the tri-state form the docs already
+# specify.
 crate_version_state() {
-    local code
+    local code rc=0
     code="$(curl -sS -o /dev/null -w '%{http_code}' -A 'freenet-release-driver' \
         --max-time 30 --retry 3 --retry-all-errors \
-        "https://crates.io/api/v1/crates/$1/$2" 2>/dev/null)" || return 2
+        "https://crates.io/api/v1/crates/$1/$2" 2>/dev/null)" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "curl could not reach crates.io for $1 $2 (exit $rc) -- UNKNOWN, not 'absent'" >&2
+        return 2
+    fi
     case "$code" in
         200) return 0 ;;
         404) return 1 ;;
@@ -286,14 +391,14 @@ crate_version_state() {
 # Yank one crate version, keeping the three outcomes that matter distinct:
 # yanked (or already yanked) is fine, genuinely never published is fine, and
 # anything else is a failure that has to reach the exit status.
+#
+# The crates.io probe runs under --dry-run as well. It is a read-only GET, and a
+# dry run whose whole job is previewing an irreversible step should be able to
+# say whether the version it resolved is actually there.
 yank_crate() {
     local crate="$1" version="$2"
 
     echo -n "  Yanking $crate v$version... "
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "[DRY RUN]"
-        return 0
-    fi
 
     local state=0
     crate_version_state "$crate" "$version" || state=$?
@@ -308,6 +413,11 @@ yank_crate() {
             return 0
             ;;
     esac
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[DRY RUN] (published, would be yanked)"
+        return 0
+    fi
 
     # Judge by cargo's EXIT STATUS. The previous form grepped cargo's output for
     # "successfully yanked", a string cargo no longer prints, so even a yank that
@@ -324,6 +434,11 @@ yank_crate() {
         indent_output "$output"
         record_failure "yank $crate v$version"
     fi
+
+    # Explicit, not incidental: this function must never end on a non-zero
+    # status, or `set -e` would abort the rollback between the two yanks and the
+    # failure summary would never print.
+    return 0
 }
 
 # Yank crates from crates.io
@@ -338,16 +453,26 @@ fi
 echo
 # Counted separately from the array: `${#FAILED_STEPS[@]}` on an EMPTY array is
 # an unbound-variable error under `set -u` on bash 3.2, which is what a mac
-# operator's /bin/bash is -- and a rollback that dies on its own summary line
-# is a poor way to find that out.
+# operator's /bin/bash is -- and a rollback that dies on its own summary line is
+# a poor way to find that out.
 if [[ $FAILURE_COUNT -gt 0 ]]; then
-    echo "❌ Rollback INCOMPLETE -- $FAILURE_COUNT step(s) failed:"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "❌ Dry run INCOMPLETE -- $FAILURE_COUNT step(s) could not be checked:"
+    else
+        echo "❌ Rollback INCOMPLETE -- $FAILURE_COUNT step(s) failed:"
+    fi
     for step in "${FAILED_STEPS[@]}"; do
         echo "  • $step"
     done
     echo
     echo "The release is only partially rolled back. Fix the cause and re-run, or"
     echo "finish the failed steps by hand (see scripts/RELEASE_RECOVERY.md)."
+    if [[ -n "$FDEV_VERSION" ]]; then
+        echo
+        echo "A re-run may no longer be able to read the fdev version from $TAG,"
+        echo "so pass it explicitly:"
+        echo "  $0 --version $VERSION --yank-crates --fdev-version $FDEV_VERSION"
+    fi
     exit 1
 fi
 
@@ -357,5 +482,11 @@ echo "Next steps:"
 echo "  • Verify the tag and release are gone: gh release list --repo freenet/freenet-core"
 echo "  • Check crates.io: https://crates.io/crates/freenet"
 if [[ "$YANK_CRATES" == "false" ]]; then
-    echo "  • To yank crates, run: $0 --version $VERSION --yank-crates"
+    if [[ -n "$FDEV_VERSION" ]]; then
+        # --fdev-version is included because THIS run deleted the tag the number
+        # is read from; without it the suggested command stops with an error.
+        echo "  • To yank crates, run: $0 --version $VERSION --yank-crates --fdev-version $FDEV_VERSION"
+    else
+        echo "  • To yank crates, run: $0 --version $VERSION --yank-crates"
+    fi
 fi

--- a/scripts/release_rollback_test.sh
+++ b/scripts/release_rollback_test.sh
@@ -607,7 +607,13 @@ test_explicit_fdev_version_overrides_the_tag() {
 # here, given the number used to be wrong) and probe crates.io, without yanking.
 test_dry_run_shows_the_fdev_version_without_yanking() {
     make_sandbox
-    run_rollback --version "$FREENET_VERSION" --yank-crates --dry-run
+    # GH_RELEASE_EXISTS=1 is load-bearing. Without it the `gh` stub answers
+    # "release not found" and step 3 takes its absent-release arm, so the
+    # DRY_RUN branch inside step 3 is never reached and replacing that guard
+    # with `if false` leaves the whole suite green. Deleting a release and its
+    # assets is the least reversible thing this script does -- a yank comes back
+    # with `cargo yank --undo`; release binaries do not.
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates --dry-run
 
     if [[ $RC -eq 0 ]] && printed "Yanking fdev v$TAG_FDEV"; then
         pass "a dry run names the fdev version it would yank"
@@ -625,6 +631,12 @@ test_dry_run_shows_the_fdev_version_without_yanking() {
         fail "a dry run invoked cargo yank" "$(dump)"
     else
         pass "a dry run does not invoke cargo yank"
+    fi
+
+    if logged "gh release delete"; then
+        fail "a dry run deleted the GitHub release" "$(dump)"
+    else
+        pass "a dry run does not delete the GitHub release"
     fi
 
     if local_tag_exists && origin_tag_exists; then
@@ -957,6 +969,127 @@ test_fork_origin_is_not_a_version_source() {
     else
         fail "the rollback yanked with origin pointed at a fork" "$(dump)"
     fi
+
+    # With --fdev-version supplied the run is NOT stopped -- it proceeds to a
+    # yank -- so the mismatch warning is the last thing an operator reads before
+    # confirming. It must not say "origin could not be read" three lines under a
+    # warning saying origin is not freenet/freenet-core: two contradictory
+    # explanations at exactly the wrong moment.
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" \
+        --yank-crates --fdev-version 0.3.777
+
+    if printed "Origin is not freenet/freenet-core, so it could not confirm"; then
+        pass "the mismatch warning gives the fork the same explanation the hard stop does"
+    else
+        fail "the mismatch warning did not account for origin being a fork" "$(dump)"
+    fi
+
+    if printed "Origin could not be read"; then
+        fail "the mismatch warning claims origin was unreadable when it was refused" "$(dump)"
+    else
+        pass "the mismatch warning does not contradict the refusal printed above it"
+    fi
+}
+
+# 21. `url.<base>.insteadOf` and host aliases. An operator whose git config
+# rewrites `fnalias:core` to the real repository IS on freenet/freenet-core, and
+# refusing them would hard-stop a `--yank-crates` run mid-incident.
+#
+# `git remote get-url` expands the rewrite, so the script is already correct
+# here -- but the obvious-looking "simplification", `git config --get
+# remote.origin.url`, returns the raw configured string and does not. That is
+# the mutation this case is written against, and it is the realistic edit: the
+# raw-config form is shorter and reads as equivalent.
+test_origin_rewritten_by_insteadof_is_still_freenet_core() {
+    make_sandbox
+    git -C "$REPO" config "url.$ORIGIN.insteadOf" "fnalias:core"
+    git -C "$REPO" remote set-url origin "fnalias:core"
+
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if printed "origin is not freenet/freenet-core"; then
+        fail "an insteadOf-rewritten origin was refused as though it were a fork" "$(dump)"
+    else
+        pass "an insteadOf-rewritten origin is recognised as freenet/freenet-core"
+    fi
+
+    if logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "the rewritten origin still supplies the fdev version"
+    else
+        fail "the fdev version was not resolved through a rewritten origin" "$(dump)"
+    fi
+}
+
+# 20. The origin matcher's URL forms -- including the ONLY branch production
+# takes.
+#
+# `origin_is_freenet_core` accepts both `github.com/freenet/freenet-core` and
+# `github.com:freenet/freenet-core`. The real repository's origin is
+# `git@github.com:freenet/freenet-core.git`, the COLON form; every sandbox in
+# this file uses a filesystem path, which is the SLASH form. So the branch that
+# matters in production was exercised by nothing -- deleting it outright left
+# all 62 assertions green -- and a later tidy-up of the matcher would hard-stop
+# every real `--yank-crates` run, during an incident.
+#
+# This cannot be covered end to end: a sandbox whose origin is the real URL
+# would have step 2 `ls-remote` and `push --delete` against freenet/freenet-core
+# itself. So extract the pure string half and drive it directly. The extraction
+# fails LOUDLY if the function is renamed or the colon branch disappears, rather
+# than silently testing nothing.
+test_origin_url_matcher_covers_the_real_repositorys_url_forms() {
+    local body
+    body="$(awk '/^url_is_freenet_core\(\) \{$/,/^\}$/' "$ROLLBACK_SH")"
+
+    if [[ -z "$body" ]]; then
+        fail "could not extract url_is_freenet_core() from $ROLLBACK_SH (renamed?)"
+        return
+    fi
+    if [[ "$body" != *"github.com:freenet/freenet-core"* ]]; then
+        fail "the extracted matcher has no colon (scp-like) branch -- the one production uses"
+        return
+    fi
+    eval "$body"
+
+    # The colon form first: it is the real repository's own origin.
+    local accept=(
+        "git@github.com:freenet/freenet-core.git"
+        "git@github.com:freenet/freenet-core"
+        "github.com:freenet/freenet-core.git"
+        "ssh://git@github.com/freenet/freenet-core.git"
+        "https://github.com/freenet/freenet-core.git"
+        "https://github.com/freenet/freenet-core"
+        "https://github.com/freenet/freenet-core/"
+        "https://github.com/freenet/freenet-core.git/"
+        # The shape this suite's own fixture relies on. Asserted so a future
+        # tightening of the matcher fails here instead of silently voiding
+        # every origin-resolution case in the file.
+        "/tmp/sandbox/github.com/freenet/freenet-core.git"
+    )
+    local reject=(
+        "git@github.com:somebody/freenet-core.git"
+        "https://github.com/somebody/freenet-core.git"
+        "https://github.com/freenet/freenet-core-fork.git"
+        "https://github.com/freenet/river.git"
+        "https://gitlab.com/freenet/freenet-core.git"
+        # A lookalike host: the match is a suffix, but it is anchored on the
+        # delimiter before "github.com", so this is not accepted.
+        "https://evilgithub.com/freenet/freenet-core.git"
+        # What `ls-remote --get-url` prints when there is no `origin` at all.
+        "origin"
+        ""
+    )
+
+    local url bad=0
+    for url in "${accept[@]}"; do
+        url_is_freenet_core "$url" || { fail "matcher REJECTED the real repo URL form: '$url'"; bad=1; }
+    done
+    for url in "${reject[@]}"; do
+        if url_is_freenet_core "$url"; then
+            fail "matcher ACCEPTED a URL that is not freenet/freenet-core: '$url'"
+            bad=1
+        fi
+    done
+    [[ $bad -ne 0 ]] || pass "the origin matcher accepts every real freenet-core URL form and rejects the rest"
 }
 
 test_fdev_version_comes_from_the_release_tag
@@ -981,6 +1114,8 @@ test_no_stdin_aborts_before_anything_destructive
 test_missing_tag_everywhere_demands_an_explicit_fdev_version
 test_local_tag_alone_never_decides_the_yank
 test_fork_origin_is_not_a_version_source
+test_origin_url_matcher_covers_the_real_repositorys_url_forms
+test_origin_rewritten_by_insteadof_is_still_freenet_core
 
 echo
 if [[ $FAILURES -eq 0 ]]; then

--- a/scripts/release_rollback_test.sh
+++ b/scripts/release_rollback_test.sh
@@ -67,6 +67,9 @@ TAG_FDEV="0.3.291"
 MAIN_FDEV="0.3.300"
 STALE_FDEV="0.3.100"
 ARITHMETIC_FDEV="0.4.129"
+# What a FORK's tag of the same name claims, for the case where `origin` is not
+# freenet/freenet-core. The yank always reaches the real crates.io regardless.
+FORK_FDEV="0.3.999"
 
 SANDBOX_ROOT="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX_ROOT"' EXIT
@@ -88,18 +91,29 @@ make_sandbox() {
     SANDBOX="$(mktemp -d -p "$SANDBOX_ROOT")"
     BIN="$SANDBOX/bin"
     REPO="$SANDBOX/repo"
-    ORIGIN="$SANDBOX/origin.git"
+    # The script refuses to take the fdev version from an origin that is not
+    # freenet/freenet-core (the yank reaches the real crates.io whatever origin
+    # is). Give the sandbox's bare repo a path the real matcher accepts, rather
+    # than adding a test-only backdoor to a destructive script.
+    ORIGIN="$SANDBOX/github.com/freenet/freenet-core.git"
     STUB_LOG="$SANDBOX/stub.log"
     OUT="$SANDBOX/out.txt"
     REPLY_INPUT="yes"
     mkdir -p "$BIN"
     : > "$STUB_LOG"
 
+    mkdir -p "$(dirname "$ORIGIN")"
     git init --quiet --bare "$ORIGIN"
     git init --quiet -b main "$REPO"
     git -C "$REPO" config user.email "test@example.invalid"
     git -C "$REPO" config user.name "Rollback Test"
     git -C "$REPO" remote add origin "$ORIGIN"
+    # The hostile-but-legal config the resolution fetch has to survive: with
+    # `tagOpt = --tags` a fetch of ONE ref also downloads every tag, so a
+    # resolution -- including one inside a DRY RUN -- creates local tags as a
+    # side effect. Set on every sandbox so the --no-tags guard is exercised by
+    # the whole suite rather than by one case that remembers to opt in.
+    git -C "$REPO" config remote.origin.tagOpt --tags
 
     mkdir -p "$REPO/scripts" "$REPO/crates/fdev"
     cp "$ROLLBACK_SH" "$REPO/scripts/release-rollback.sh"
@@ -127,6 +141,21 @@ make_sandbox() {
     fi
 
     write_stubs
+}
+
+# What an aborted release attempt leaves behind: a LOCAL tag pointing at a
+# commit naming STALE_FDEV, while origin's tag of the same name still points at
+# the commit that actually shipped (TAG_FDEV). release.sh skips tag creation
+# when a local tag of that name exists, which is how the two diverge.
+make_local_tag_stale() {
+    local shipped_sha
+    shipped_sha="$(git -C "$REPO" rev-parse "refs/tags/v$FREENET_VERSION")"
+    write_fdev_manifest "$STALE_FDEV"
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "aborted release attempt"
+    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+    git -C "$REPO" tag -a "v$FREENET_VERSION" -m "stale local tag"
+    git -C "$REPO" push --quiet --force origin "$shipped_sha:refs/tags/v$FREENET_VERSION"
 }
 
 write_fdev_manifest() {
@@ -233,16 +262,26 @@ assert_stubs_intercept() {
 # core.hooksPath would neutralise the pre-receive hook case below), and no
 # registry or GitHub credentials, so a stub that somehow failed to intercept
 # cannot authenticate against production either.
+_invoke_rollback() {
+    cd "$REPO" || exit 99
+    PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" \
+        GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 \
+        CARGO_HOME="$SANDBOX/cargo-home" CARGO_REGISTRY_TOKEN='' \
+        GH_TOKEN='' GITHUB_TOKEN='' GH_CONFIG_DIR="$SANDBOX/gh-config" \
+        bash scripts/release-rollback.sh "$@"
+}
+
 run_rollback() {
     assert_stubs_intercept
-    (
-        cd "$REPO" || exit 99
-        PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" \
-            GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 \
-            CARGO_HOME="$SANDBOX/cargo-home" CARGO_REGISTRY_TOKEN='' \
-            GH_TOKEN='' GITHUB_TOKEN='' GH_CONFIG_DIR="$SANDBOX/gh-config" \
-            bash scripts/release-rollback.sh "$@" <<<"$REPLY_INPUT"
-    ) > "$OUT" 2>&1
+    ( _invoke_rollback "$@" <<<"$REPLY_INPUT" ) > "$OUT" 2>&1
+    RC=$?
+}
+
+# As run_rollback, but with stdin at EOF -- what cron, CI, a systemd unit or a
+# `< /dev/null` invocation actually look like to the confirmation prompt.
+run_rollback_no_stdin() {
+    assert_stubs_intercept
+    ( _invoke_rollback "$@" </dev/null ) > "$OUT" 2>&1
     RC=$?
 }
 
@@ -301,6 +340,16 @@ test_fdev_version_comes_from_the_release_tag() {
         pass "the local and origin tags are actually deleted"
     else
         fail "a tag survived the rollback (local: $(local_tag_exists && echo yes || echo no), origin: $(origin_tag_exists && echo yes || echo no))" "$(dump)"
+    fi
+
+    # `git tag -d` prints "Deleted tag 'vX' (was <sha>)" -- the only record of
+    # where the tag pointed, printed immediately before the script deletes that
+    # tag from origin and deletes the release page. Capturing it and showing it
+    # only on FAILURE loses it on the path that actually destroys things.
+    if printed "Deleted tag 'v$FREENET_VERSION' (was "; then
+        pass "the deleted tag's SHA is reported on success, not only on failure"
+    else
+        fail "the deleted tag's SHA was swallowed on the successful path" "$(dump)"
     fi
 
     if logged "gh release delete v$FREENET_VERSION"; then
@@ -590,18 +639,30 @@ test_dry_run_shows_the_fdev_version_without_yanking() {
 test_fdev_version_resolves_from_origin_when_the_local_tag_is_gone() {
     make_sandbox
     git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+
+    # A DRY RUN first, and that is the whole point of the ordering: a dry run
+    # deletes nothing, so a local tag created by the RESOLUTION FETCH is still
+    # there to be seen. After a real run step 1 deletes the tag either way, so
+    # the same check there would pass whether or not the fetch created it.
+    #
+    # This is the --no-tags guard. The sandbox sets `tagOpt = --tags`, under
+    # which `git fetch origin refs/tags/<tag>` also downloads every other tag --
+    # so a dry run, whose contract is to touch nothing, silently creates local
+    # tags.
+    run_rollback --version "$FREENET_VERSION" --yank-crates --dry-run
+
+    if local_tag_exists; then
+        fail "a DRY RUN's resolution fetch created a local tag" "$(dump)"
+    else
+        pass "the resolution fetch creates no local tag, not even under --dry-run"
+    fi
+
     run_rollback --version "$FREENET_VERSION" --yank-crates
 
     if logged "cargo yank --version $TAG_FDEV fdev"; then
         pass "the fdev version is read from origin when the local tag is gone"
     else
         fail "resolution failed with the tag still on origin" "$(dump)"
-    fi
-
-    if local_tag_exists; then
-        fail "the resolution fetch recreated the local tag" "$(dump)"
-    else
-        pass "the resolution fetch does not recreate the local tag"
     fi
 }
 
@@ -610,19 +671,7 @@ test_fdev_version_resolves_from_origin_when_the_local_tag_is_gone() {
 # behind pointing somewhere else. Origin's tag is what shipped.
 test_stale_local_tag_does_not_win_over_origin() {
     make_sandbox
-
-    # Rewrite history under the tag's name: the local tag keeps pointing at a
-    # commit naming STALE_FDEV while origin's tag of the same name names
-    # TAG_FDEV.
-    local shipped_sha
-    shipped_sha="$(git -C "$REPO" rev-parse "refs/tags/v$FREENET_VERSION")"
-    write_fdev_manifest "$STALE_FDEV"
-    git -C "$REPO" add crates >/dev/null
-    git -C "$REPO" commit --quiet -m "aborted release attempt"
-    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
-    git -C "$REPO" tag -a "v$FREENET_VERSION" -m "stale local tag"
-    git -C "$REPO" push --quiet --force origin "$shipped_sha:refs/tags/v$FREENET_VERSION"
-
+    make_local_tag_stale
     run_rollback --version "$FREENET_VERSION" --yank-crates
 
     if logged "cargo yank --version $TAG_FDEV fdev"; then
@@ -735,6 +784,181 @@ EOF
     fi
 }
 
+# 16. The confirmation prompt is the last thing standing between an UNATTENDED
+# caller -- cron, CI, a systemd unit, anything with stdin closed -- and an
+# irreversible-in-practice yank. At EOF `read` must abort, never fall through
+# with an empty or defaulted REPLY.
+#
+# Found by mutation: making EOF set REPLY=yes left all 45 other assertions in
+# this file green. Case 13 pipes "no", which such a mutant also rejects, so
+# nothing else here separates "declined" from "never asked".
+test_no_stdin_aborts_before_anything_destructive() {
+    make_sandbox
+    GH_RELEASE_EXISTS=1 run_rollback_no_stdin --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]]; then
+        pass "a run with no stdin exits non-zero rather than auto-confirming"
+    else
+        fail "a run with no stdin exited 0 -- the prompt was not a gate" "$(dump)"
+    fi
+
+    if printed "Aborted (no answer given)"; then
+        pass "the abort says the prompt was never answered"
+    else
+        fail "an EOF on the prompt was not reported as an unanswered prompt" "$(dump)"
+    fi
+
+    if logged "cargo yank" || logged "gh release delete" || ! local_tag_exists || ! origin_tag_exists; then
+        fail "something destructive ran with nobody there to confirm it" "$(dump)"
+    else
+        pass "no tag, release or crate was touched with stdin at EOF"
+    fi
+}
+
+# 17. The re-run this script's own summary steers the operator into: it has just
+# deleted the tag locally AND on origin, so a second run has nothing left to read
+# the fdev version from. The --no-tag fixture is that state.
+test_missing_tag_everywhere_demands_an_explicit_fdev_version() {
+    make_sandbox --no-tag
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]] && printed "cannot determine which fdev version"; then
+        pass "with no tag locally or on origin, the rollback stops instead of guessing"
+    else
+        fail "a missing tag on both sides did not stop the rollback" "$(dump)"
+    fi
+
+    if logged "cargo yank"; then
+        fail "cargo yank ran with no tag to read the fdev version from" "$(dump)"
+    else
+        pass "nothing is yanked when there is no tag to resolve from"
+    fi
+
+    # ... and the documented escape hatch has to carry that re-run through.
+    make_sandbox --no-tag
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates --fdev-version "$TAG_FDEV"
+
+    if [[ $RC -eq 0 ]] && logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "--fdev-version carries the tagless re-run through"
+    else
+        fail "--fdev-version did not rescue a re-run with no tag anywhere" "$(dump)"
+    fi
+
+    # And a SUCCESSFUL tag-only rollback in the same state must not suggest a
+    # command that cannot run. It used to print "run: ... --yank-crates" and
+    # exit 0 -- but that command hard-errors, because the tag it would read the
+    # fdev version from is exactly what this run just deleted.
+    make_sandbox --no-tag
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION"
+
+    if [[ $RC -ne 0 ]]; then
+        fail "the tag-only rollback did not succeed, so the follow-up hint was never reached" "$(dump)"
+    elif printed "--yank-crates --fdev-version X.Y.Z"; then
+        pass "the follow-up hint names the version lookup, not a command that would fail"
+    else
+        fail "the follow-up hint omits --fdev-version, so the suggested re-run hard-errors" "$(dump)"
+    fi
+
+    # ... and specifically not the BARE ready-to-run form, which is what exits
+    # 0 here and then stops with an error on the re-run.
+    if printed "To yank crates, run: "; then
+        fail "the follow-up hint still offers a ready-to-run command it has no version for" "$(dump)"
+    else
+        pass "no ready-to-run re-run command is offered with no version to put in it"
+    fi
+}
+
+# 18. THE COMPOSED FAILURE: a stale LOCAL tag plus an origin that cannot be
+# reached. Both halves are routine -- release.sh skips tag creation when a local
+# tag exists, so an aborted run leaves one behind, and a dead origin mid-incident
+# is ordinary -- and together they used to yank whatever the local tag named.
+test_local_tag_alone_never_decides_the_yank() {
+    make_sandbox
+    make_local_tag_stale
+    mv "$ORIGIN" "$SANDBOX/origin-gone.git"
+
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]] && printed "cannot determine which fdev version"; then
+        pass "a local-tag-only resolution is a hard stop, not a yank"
+    else
+        fail "the rollback proceeded on a local tag alone" "$(dump)"
+    fi
+
+    if logged "cargo yank"; then
+        fail "cargo yank ran on a version read from a possibly-stale local tag" "$(dump)"
+    else
+        pass "nothing is yanked from a local-tag reading"
+    fi
+
+    if printed "--fdev-version X.Y.Z"; then
+        pass "the stop names the escape hatch"
+    else
+        fail "the stop does not tell the operator how to supply the version" "$(dump)"
+    fi
+
+    # The banner used to reprint the local reading as though it were the fact of
+    # the matter ("fdev: 0.3.100"), one line above the confirmation prompt.
+    if printed "fdev:        $STALE_FDEV"; then
+        fail "the banner presented a local-tag guess as the fdev version" "$(dump)"
+    else
+        pass "the banner never states a local-tag guess as fact"
+    fi
+
+    # And the tag-only rollback must not hand that guess back inside a
+    # ready-to-paste command: pasted, it becomes an "explicit" --fdev-version,
+    # which on the next run also silences the mismatch warning.
+    make_sandbox
+    make_local_tag_stale
+    mv "$ORIGIN" "$SANDBOX/origin-gone.git"
+    run_rollback --version "$FREENET_VERSION"
+
+    if printed "--fdev-version $STALE_FDEV"; then
+        fail "the summary handed back a local-tag guess as a command to run" "$(dump)"
+    else
+        pass "no local-tag guess is laundered into the follow-up command"
+    fi
+}
+
+# 19. `origin` decides which tag is read, but `cargo yank` always reaches the
+# REAL crates.io and step 3 deletes from a hardcoded --repo freenet/freenet-core.
+# With origin pointed at a fork, a tag of the same name naming a different fdev
+# would therefore take a GOOD release's crate off the real registry.
+test_fork_origin_is_not_a_version_source() {
+    make_sandbox
+
+    local fork="$SANDBOX/github.com/somebody/freenet-core.git"
+    mkdir -p "$(dirname "$fork")"
+    git init --quiet --bare "$fork"
+    write_fdev_manifest "$FORK_FDEV"
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "fork's release"
+    git -C "$REPO" tag -a "fork-tag" -m "fork" >/dev/null
+    git -C "$REPO" push --quiet "$fork" "refs/tags/fork-tag:refs/tags/v$FREENET_VERSION"
+    git -C "$REPO" tag -d "fork-tag" >/dev/null
+    git -C "$REPO" remote set-url origin "$fork"
+
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if printed "origin is not freenet/freenet-core"; then
+        pass "a non-freenet origin is called out rather than trusted"
+    else
+        fail "origin being a fork passed without comment" "$(dump)"
+    fi
+
+    if logged "$FORK_FDEV"; then
+        fail "a fork's tag chose the version yanked from the real crates.io" "$(dump)"
+    else
+        pass "a fork's tag is never the source of the version to yank"
+    fi
+
+    if [[ $RC -ne 0 ]] && ! logged "cargo yank"; then
+        pass "the run stops instead of yanking on a fork's say-so"
+    else
+        fail "the rollback yanked with origin pointed at a fork" "$(dump)"
+    fi
+}
+
 test_fdev_version_comes_from_the_release_tag
 test_failed_yank_is_not_reported_as_success
 test_absent_crate_version_is_not_a_failure
@@ -753,6 +977,10 @@ test_stale_local_tag_does_not_win_over_origin
 test_declining_the_prompt_does_nothing
 test_parses_the_repositorys_real_fdev_manifest
 test_workspace_inherited_version_is_refused_not_misparsed
+test_no_stdin_aborts_before_anything_destructive
+test_missing_tag_everywhere_demands_an_explicit_fdev_version
+test_local_tag_alone_never_decides_the_yank
+test_fork_origin_is_not_a_version_source
 
 echo
 if [[ $FAILURES -eq 0 ]]; then

--- a/scripts/release_rollback_test.sh
+++ b/scripts/release_rollback_test.sh
@@ -23,6 +23,13 @@
 # run end to end against a throwaway git repo with `cargo`, `curl` and `gh`
 # stubbed on PATH -- the release_driver_test.sh idiom.
 #
+# SAFETY. This suite runs a tool that deletes tags and yanks crates, with a
+# REAL released version number, and the script hardcodes --repo
+# freenet/freenet-core. Every run therefore goes through `assert_stubs_intercept`
+# first, and the subshell clears the credentials a real `cargo`/`gh` would need.
+# Without that, one failed `chmod +x` in the setup would point the whole suite
+# at production.
+#
 # Run manually: bash scripts/release_rollback_test.sh
 # Wired into CI (the Fmt job in .github/workflows/ci.yml).
 
@@ -30,6 +37,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLBACK_SH="$SCRIPT_DIR/release-rollback.sh"
+REAL_FDEV_MANIFEST="$SCRIPT_DIR/../crates/fdev/Cargo.toml"
 
 FAILURES=0
 fail() {
@@ -45,10 +53,11 @@ if [[ ! -f "$ROLLBACK_SH" ]]; then
     exit 1
 fi
 
-# The version numbers are deliberately far apart, and all three are distinct:
+# The version numbers are deliberately far apart, and all distinct:
 #
 #   TAG_FDEV     what shipped with the release being rolled back  (the answer)
 #   MAIN_FDEV    what the working tree says NOW, main having moved on
+#   STALE_FDEV   what a leftover LOCAL tag of the same name says
 #   0.4.129      what the old `minor + 2` arithmetic produces
 #
 # A test whose expected value is reachable by more than one route cannot say
@@ -56,20 +65,25 @@ fi
 FREENET_VERSION="0.2.129"
 TAG_FDEV="0.3.291"
 MAIN_FDEV="0.3.300"
+STALE_FDEV="0.3.100"
 ARITHMETIC_FDEV="0.4.129"
 
 SANDBOX_ROOT="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX_ROOT"' EXIT
 
-# make_sandbox [--no-tag]
+# make_sandbox [--no-tag | --no-manifest]
 #
 # Builds a self-contained git repo holding a COPY of the script under test (so
 # the script's own `git rev-parse --show-toplevel` resolves to the sandbox, not
 # to freenet-core), an origin it can push to, a release tag whose tree names
 # TAG_FDEV, and a later commit on main naming MAIN_FDEV.
+#
+#   --no-tag       no release tag anywhere (local or origin)
+#   --no-manifest  the tag EXISTS, on both sides, but has no fdev manifest --
+#                  so resolution fails with the tag still present, which is what
+#                  makes the "stops before deleting anything" case non-vacuous
 make_sandbox() {
-    local with_tag=true
-    [[ "${1:-}" == "--no-tag" ]] && with_tag=false
+    local mode="${1:-normal}"
 
     SANDBOX="$(mktemp -d -p "$SANDBOX_ROOT")"
     BIN="$SANDBOX/bin"
@@ -77,6 +91,7 @@ make_sandbox() {
     ORIGIN="$SANDBOX/origin.git"
     STUB_LOG="$SANDBOX/stub.log"
     OUT="$SANDBOX/out.txt"
+    REPLY_INPUT="yes"
     mkdir -p "$BIN"
     : > "$STUB_LOG"
 
@@ -89,10 +104,14 @@ make_sandbox() {
     mkdir -p "$REPO/scripts" "$REPO/crates/fdev"
     cp "$ROLLBACK_SH" "$REPO/scripts/release-rollback.sh"
 
-    write_fdev_manifest "$TAG_FDEV"
+    if [[ "$mode" == "--no-manifest" ]]; then
+        echo "placeholder" > "$REPO/crates/fdev/README.md"
+    else
+        write_fdev_manifest "$TAG_FDEV"
+    fi
     git -C "$REPO" add scripts crates >/dev/null
     git -C "$REPO" commit --quiet -m "build: release $FREENET_VERSION"
-    if [[ "$with_tag" == "true" ]]; then
+    if [[ "$mode" != "--no-tag" ]]; then
         git -C "$REPO" tag -a "v$FREENET_VERSION" -m "Release v$FREENET_VERSION"
     fi
 
@@ -103,7 +122,7 @@ make_sandbox() {
     git -C "$REPO" commit --quiet -m "build: bump fdev"
 
     git -C "$REPO" push --quiet origin main
-    if [[ "$with_tag" == "true" ]]; then
+    if [[ "$mode" != "--no-tag" ]]; then
         git -C "$REPO" push --quiet origin "refs/tags/v$FREENET_VERSION"
     fi
 
@@ -160,11 +179,22 @@ esac
 exit 0
 EOF
 
+    # "release not found" is gh's real wording for an absent release; an auth or
+    # transport error says something else entirely, which is the distinction the
+    # script now depends on.
     cat > "$BIN/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "gh $*" >> "$STUB_LOG"
 if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
-    if [[ "${GH_RELEASE_EXISTS:-0}" == "1" ]]; then exit 0; fi
+    if [[ "${GH_VIEW_ERROR:-0}" == "1" ]]; then
+        echo "HTTP 401: Bad credentials (https://api.github.com/repos/freenet/freenet-core/releases/tags/x)" >&2
+        exit 1
+    fi
+    if [[ "${GH_RELEASE_EXISTS:-0}" == "1" ]]; then
+        echo '{"id":"RE_stub"}'
+        exit 0
+    fi
+    echo "release not found" >&2
     exit 1
 fi
 if [[ "${1:-}" == "release" && "${2:-}" == "delete" ]]; then
@@ -180,13 +210,38 @@ EOF
     chmod +x "$BIN/cargo" "$BIN/curl" "$BIN/gh"
 }
 
-# run_rollback <args...> -- answers the confirmation prompt, captures combined
-# output in $OUT and the exit status in $RC.
+# The suite drives a destructive tool with a REAL released version number. If a
+# stub were missing (a failed chmod, a typo'd path) the script would reach the
+# real `cargo yank` and the real `gh release delete` -- on a machine that is
+# authenticated for both. Refuse to run at all in that case.
+assert_stubs_intercept() {
+    local tool resolved
+    for tool in cargo curl gh; do
+        resolved="$(PATH="$BIN:$PATH" command -v "$tool" 2>/dev/null)"
+        if [[ "$resolved" != "$BIN/$tool" ]]; then
+            echo "FATAL - $tool would resolve to '${resolved:-nothing}', not the stub at $BIN/$tool." >&2
+            echo "        Refusing to run a destructive script against the real registry." >&2
+            exit 99
+        fi
+    done
+}
+
+# run_rollback <args...> -- answers the confirmation prompt with $REPLY_INPUT,
+# captures combined output in $OUT and the exit status in $RC.
+#
+# The environment is scrubbed on purpose: no ambient git config (a global
+# core.hooksPath would neutralise the pre-receive hook case below), and no
+# registry or GitHub credentials, so a stub that somehow failed to intercept
+# cannot authenticate against production either.
 run_rollback() {
+    assert_stubs_intercept
     (
         cd "$REPO" || exit 99
         PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" \
-            bash scripts/release-rollback.sh "$@" <<<"yes"
+            GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 \
+            CARGO_HOME="$SANDBOX/cargo-home" CARGO_REGISTRY_TOKEN='' \
+            GH_TOKEN='' GITHUB_TOKEN='' GH_CONFIG_DIR="$SANDBOX/gh-config" \
+            bash scripts/release-rollback.sh "$@" <<<"$REPLY_INPUT"
     ) > "$OUT" 2>&1
     RC=$?
 }
@@ -196,6 +251,8 @@ run_rollback() {
 # reads as absent (see .claude/rules/bug-prevention-patterns.md).
 logged() { [[ "$(cat "$STUB_LOG")" == *"$1"* ]]; }
 printed() { [[ "$(cat "$OUT")" == *"$1"* ]]; }
+local_tag_exists() { git -C "$REPO" rev-parse -q --verify "refs/tags/v$FREENET_VERSION" >/dev/null 2>&1; }
+origin_tag_exists() { git -C "$ORIGIN" rev-parse -q --verify "refs/tags/v$FREENET_VERSION" >/dev/null 2>&1; }
 
 dump() {
     echo "--- exit status: $RC"
@@ -212,7 +269,7 @@ dump() {
 # different release's fdev).
 test_fdev_version_comes_from_the_release_tag() {
     make_sandbox
-    run_rollback --version "$FREENET_VERSION" --yank-crates
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
 
     if logged "cargo yank --version $TAG_FDEV fdev"; then
         pass "fdev yank targets the version recorded at the release tag ($TAG_FDEV)"
@@ -236,6 +293,20 @@ test_fdev_version_comes_from_the_release_tag() {
         pass "freenet yank targets the released version"
     else
         fail "freenet was not yanked at $FREENET_VERSION" "$(dump)"
+    fi
+
+    # The rollback must actually roll back. Without these, making step 1 or 3 a
+    # no-op leaves the whole suite green.
+    if ! local_tag_exists && ! origin_tag_exists; then
+        pass "the local and origin tags are actually deleted"
+    else
+        fail "a tag survived the rollback (local: $(local_tag_exists && echo yes || echo no), origin: $(origin_tag_exists && echo yes || echo no))" "$(dump)"
+    fi
+
+    if logged "gh release delete v$FREENET_VERSION"; then
+        pass "the GitHub release is actually deleted"
+    else
+        fail "the GitHub release was never deleted" "$(dump)"
     fi
 
     if [[ $RC -eq 0 ]] && printed "Rollback complete"; then
@@ -267,6 +338,18 @@ test_failed_yank_is_not_reported_as_success() {
         pass "the failure summary names the step that failed"
     else
         fail "the failure summary does not name the failed yank" "$(dump)"
+    fi
+
+    if printed "api errored with status 500"; then
+        pass "the failing command's own output reaches the operator"
+    else
+        fail "the underlying error text was swallowed" "$(dump)"
+    fi
+
+    if printed "--fdev-version $TAG_FDEV"; then
+        pass "the failure summary carries the fdev version a re-run will need"
+    else
+        fail "the failure summary omits the fdev version, which the re-run cannot re-derive" "$(dump)"
     fi
 }
 
@@ -348,19 +431,19 @@ test_failed_remote_tag_deletion_is_reported() {
     make_sandbox
     # A pre-receive hook that declines, rather than `receive.denyDeletes`:
     # verified that denyDeletes does NOT reject this push on a local-path
-    # remote, which would have made the case vacuous. The second assertion
+    # remote, which would have made the case vacuous. The tag-survival assertion
     # below re-checks that the refusal really happened.
     printf '#!/bin/sh\nexit 1\n' > "$ORIGIN/hooks/pre-receive"
     chmod +x "$ORIGIN/hooks/pre-receive"
     run_rollback --version "$FREENET_VERSION"
 
-    if [[ $RC -ne 0 ]] && printed "delete remote tag v$FREENET_VERSION"; then
+    if [[ $RC -ne 0 ]] && printed "delete remote tag v$FREENET_VERSION" && ! printed "could not query origin"; then
         pass "a refused remote tag deletion reaches the exit status"
     else
         fail "a refused remote tag deletion was reported as success" "$(dump)"
     fi
 
-    if git -C "$ORIGIN" rev-parse "refs/tags/v$FREENET_VERSION" >/dev/null 2>&1; then
+    if origin_tag_exists; then
         pass "the sandbox really did refuse the deletion (the case is not vacuous)"
     else
         fail "the remote tag was deleted, so this case proved nothing" "$(dump)"
@@ -382,11 +465,48 @@ test_unqueryable_origin_is_not_read_as_no_remote_tag() {
     fi
 }
 
+# 7c. Step 3 had the same two-state shape: `gh release view` exits non-zero both
+# for "no such release" and for gh being broken/unauthenticated, and reading the
+# second as the first leaves the release live under a "complete" rollback.
+test_gh_query_error_is_not_read_as_no_release() {
+    make_sandbox
+    GH_VIEW_ERROR=1 run_rollback --version "$FREENET_VERSION"
+
+    if [[ $RC -ne 0 ]] && printed "could not query GitHub"; then
+        pass "a GitHub lookup error is a failure, not 'no such release'"
+    else
+        fail "a GitHub lookup error was reported as 'not found, skipping'" "$(dump)"
+    fi
+
+    if printed "Bad credentials"; then
+        pass "gh's own error text reaches the operator"
+    else
+        fail "gh's error text was swallowed" "$(dump)"
+    fi
+}
+
+# 7d. And the deletion itself failing must reach the exit status, like every
+# other step.
+test_failed_github_release_deletion_is_reported() {
+    make_sandbox
+    GH_RELEASE_EXISTS=1 GH_DELETE_FAIL=1 run_rollback --version "$FREENET_VERSION"
+
+    if [[ $RC -ne 0 ]] && printed "delete GitHub release v$FREENET_VERSION"; then
+        pass "a failed GitHub release deletion reaches the exit status"
+    else
+        fail "a failed GitHub release deletion was reported as success" "$(dump)"
+    fi
+}
+
 # 8. If the version cannot be established, stop BEFORE the destructive steps --
-# steps 1 and 2 delete the tag the version is read from, so failing afterwards
-# would leave the operator with nothing to look it up from.
+# steps 1 to 3 delete the tag and release the version is read from, so failing
+# afterwards would leave the operator with nothing to look it up from.
+#
+# The tag EXISTS here (on both sides) and resolution fails for a different
+# reason, so the case can actually observe the ordering: with the resolve moved
+# below the tag deletions, the two survival assertions go red.
 test_unresolvable_fdev_version_stops_before_deleting_anything() {
-    make_sandbox --no-tag
+    make_sandbox --no-manifest
     GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
 
     if [[ $RC -ne 0 ]] && printed "cannot determine which fdev version"; then
@@ -395,10 +515,16 @@ test_unresolvable_fdev_version_stops_before_deleting_anything() {
         fail "an unresolvable fdev version did not stop the rollback" "$(dump)"
     fi
 
-    if logged "gh release delete"; then
-        fail "destructive steps ran before the fdev version was resolved" "$(dump)"
+    if local_tag_exists && origin_tag_exists; then
+        pass "both tags survive: nothing destructive ran before resolution"
     else
-        pass "nothing destructive runs before the fdev version is resolved"
+        fail "a tag was deleted before the fdev version was resolved" "$(dump)"
+    fi
+
+    if logged "gh release delete"; then
+        fail "the GitHub release was deleted before the fdev version was resolved" "$(dump)"
+    else
+        pass "the GitHub release survives too"
     fi
 
     if printed "--fdev-version"; then
@@ -418,24 +544,194 @@ test_explicit_fdev_version_overrides_the_tag() {
     else
         fail "--fdev-version was ignored" "$(dump)"
     fi
+
+    # ... but silently yanking a version the tag contradicts is how a near-miss
+    # takes out a GOOD release: adjacent fdev patches all exist on crates.io.
+    if printed "does not match" && printed "$TAG_FDEV"; then
+        pass "an override that contradicts the tag is called out before the prompt"
+    else
+        fail "an override contradicting the tag passed without comment" "$(dump)"
+    fi
 }
 
 # 10. A dry run must resolve and SHOW the version (that is most of its value
-# here, given the number used to be wrong) without touching crates.io.
+# here, given the number used to be wrong) and probe crates.io, without yanking.
 test_dry_run_shows_the_fdev_version_without_yanking() {
     make_sandbox
     run_rollback --version "$FREENET_VERSION" --yank-crates --dry-run
 
-    if [[ $RC -eq 0 ]] && printed "$TAG_FDEV"; then
-        pass "a dry run prints the fdev version it would yank"
+    if [[ $RC -eq 0 ]] && printed "Yanking fdev v$TAG_FDEV"; then
+        pass "a dry run names the fdev version it would yank"
     else
         fail "a dry run did not show the fdev version" "$(dump)"
+    fi
+
+    if logged "crates.io/api/v1/crates/fdev/$TAG_FDEV"; then
+        pass "a dry run checks crates.io, so it can preview the irreversible step"
+    else
+        fail "a dry run does not verify the version is even published" "$(dump)"
     fi
 
     if logged "cargo yank"; then
         fail "a dry run invoked cargo yank" "$(dump)"
     else
         pass "a dry run does not invoke cargo yank"
+    fi
+
+    if local_tag_exists && origin_tag_exists; then
+        pass "a dry run deletes nothing"
+    else
+        fail "a dry run deleted a tag" "$(dump)"
+    fi
+}
+
+# 11. The re-run path this script's own failure summary points at: the local tag
+# is already gone, and only origin still has it.
+test_fdev_version_resolves_from_origin_when_the_local_tag_is_gone() {
+    make_sandbox
+    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "the fdev version is read from origin when the local tag is gone"
+    else
+        fail "resolution failed with the tag still on origin" "$(dump)"
+    fi
+
+    if local_tag_exists; then
+        fail "the resolution fetch recreated the local tag" "$(dump)"
+    else
+        pass "the resolution fetch does not recreate the local tag"
+    fi
+}
+
+# 12. A STALE local tag is the dangerous version of case 11: release.sh skips
+# tag creation when a local tag of that name exists, so an aborted run leaves one
+# behind pointing somewhere else. Origin's tag is what shipped.
+test_stale_local_tag_does_not_win_over_origin() {
+    make_sandbox
+
+    # Rewrite history under the tag's name: the local tag keeps pointing at a
+    # commit naming STALE_FDEV while origin's tag of the same name names
+    # TAG_FDEV.
+    local shipped_sha
+    shipped_sha="$(git -C "$REPO" rev-parse "refs/tags/v$FREENET_VERSION")"
+    write_fdev_manifest "$STALE_FDEV"
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "aborted release attempt"
+    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+    git -C "$REPO" tag -a "v$FREENET_VERSION" -m "stale local tag"
+    git -C "$REPO" push --quiet --force origin "$shipped_sha:refs/tags/v$FREENET_VERSION"
+
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "origin's tag decides the fdev version, not a stale local tag"
+    else
+        fail "a stale local tag chose the fdev version to yank" "$(dump)"
+    fi
+
+    if logged "$STALE_FDEV"; then
+        fail "the stale local tag's fdev version ($STALE_FDEV) was yanked" "$(dump)"
+    else
+        pass "the stale local tag's version ($STALE_FDEV) is never used"
+    fi
+
+    if printed "warning: local v$FREENET_VERSION names fdev $STALE_FDEV"; then
+        pass "the disagreement between local and origin is reported, not hidden"
+    else
+        fail "the local/origin disagreement passed silently" "$(dump)"
+    fi
+}
+
+# 13. Answering anything but "yes" must stop before every destructive action.
+test_declining_the_prompt_does_nothing() {
+    make_sandbox
+    REPLY_INPUT="no"
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]] && printed "Aborted"; then
+        pass "declining the confirmation aborts with a non-zero status"
+    else
+        fail "declining the confirmation did not abort" "$(dump)"
+    fi
+
+    if logged "cargo yank" || logged "gh release delete" || ! local_tag_exists || ! origin_tag_exists; then
+        fail "something destructive ran after the operator declined" "$(dump)"
+    else
+        pass "nothing was deleted or yanked after declining"
+    fi
+}
+
+# 14. The fixture manifest is hand-written, so on its own it cannot notice the
+# real one moving out from under the parser (`version.workspace = true`, a
+# layout change). Parse the REPO'S OWN crates/fdev/Cargo.toml and require the
+# answer to match what that file declares.
+test_parses_the_repositorys_real_fdev_manifest() {
+    if [[ ! -f "$REAL_FDEV_MANIFEST" ]]; then
+        fail "the repo's crates/fdev/Cargo.toml is missing at $REAL_FDEV_MANIFEST"
+        return
+    fi
+
+    local expected
+    expected="$(awk -F'"' '/^version = "/ { print $2; exit }' "$REAL_FDEV_MANIFEST")"
+
+    make_sandbox
+    cp "$REAL_FDEV_MANIFEST" "$REPO/crates/fdev/Cargo.toml"
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "real manifest"
+    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+    git -C "$REPO" tag -a "v$FREENET_VERSION" -m "real manifest"
+    git -C "$REPO" push --quiet --force origin "refs/tags/v$FREENET_VERSION"
+
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ -n "$expected" ]] && logged "cargo yank --version $expected fdev"; then
+        pass "the parser reads the repo's real fdev manifest ($expected)"
+    else
+        fail "the parser could not read the repo's real crates/fdev/Cargo.toml (expected '$expected')" "$(dump)"
+    fi
+}
+
+# 15. The parse is anchored to [package] rather than taking the first
+# line-anchored `version = `, and this is the shape that makes the difference: a
+# manifest that inherits its own version from the workspace, with a dependency
+# table whose version IS line-anchored. Unanchored, the parser returns the
+# DEPENDENCY's version -- freenet's -- and yanks it as though it were fdev's.
+# Anchored, nothing parses and the script stops and asks.
+#
+# Found by mutation: dropping the [package] anchor left the whole suite green
+# until this case existed.
+test_workspace_inherited_version_is_refused_not_misparsed() {
+    make_sandbox
+    cat > "$REPO/crates/fdev/Cargo.toml" <<EOF
+[package]
+name = "fdev"
+version.workspace = true
+edition = "2024"
+
+[dependencies.freenet]
+path = "../core"
+version = "0.2.129"
+EOF
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "workspace-inherited version"
+    git -C "$REPO" tag -d "v$FREENET_VERSION" >/dev/null
+    git -C "$REPO" tag -a "v$FREENET_VERSION" -m "workspace-inherited version"
+    git -C "$REPO" push --quiet --force origin "refs/tags/v$FREENET_VERSION"
+
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]] && printed "cannot determine which fdev version"; then
+        pass "a manifest with no literal [package] version stops the rollback"
+    else
+        fail "a workspace-inherited fdev version did not stop the rollback" "$(dump)"
+    fi
+
+    if logged "cargo yank --version 0.2.129 fdev"; then
+        fail "a DEPENDENCY's version was parsed as fdev's and yanked" "$(dump)"
+    else
+        pass "no dependency version is mistaken for the [package] version"
     fi
 }
 
@@ -447,9 +743,16 @@ test_crates_io_probe_sends_a_descriptive_user_agent
 test_already_yanked_is_success
 test_failed_remote_tag_deletion_is_reported
 test_unqueryable_origin_is_not_read_as_no_remote_tag
+test_gh_query_error_is_not_read_as_no_release
+test_failed_github_release_deletion_is_reported
 test_unresolvable_fdev_version_stops_before_deleting_anything
 test_explicit_fdev_version_overrides_the_tag
 test_dry_run_shows_the_fdev_version_without_yanking
+test_fdev_version_resolves_from_origin_when_the_local_tag_is_gone
+test_stale_local_tag_does_not_win_over_origin
+test_declining_the_prompt_does_nothing
+test_parses_the_repositorys_real_fdev_manifest
+test_workspace_inherited_version_is_refused_not_misparsed
 
 echo
 if [[ $FAILURES -eq 0 ]]; then

--- a/scripts/release_rollback_test.sh
+++ b/scripts/release_rollback_test.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+# Behavioural tests for scripts/release-rollback.sh -- the release ROLLBACK
+# tool, i.e. the thing an operator reaches for when a release has already gone
+# wrong.
+#
+# WHY THESE ARE BEHAVIOURAL AND NOT SOURCE PINS. Both bugs they cover are
+# properties of what the script DOES, and both were invisible from the outside:
+#
+#   * The fdev version to yank was COMPUTED from the freenet version as
+#     `0.$((minor + 2)).$patch`. fdev's version is independent of freenet's --
+#     release.yml bumps fdev's own patch in crates/fdev/Cargo.toml -- so the two
+#     drifted apart long ago: for freenet 0.2.129 the formula asks crates.io to
+#     yank fdev 0.4.129, a version that has never existed.
+#
+#   * That failure was then SWALLOWED. The yank's verdict was printed
+#     ("✗ (failed or not published)") and consumed by nothing, so the script
+#     went on to print "✅ Rollback complete!" and exit 0. `--yank-crates` has
+#     therefore never yanked an fdev version, and always reported success.
+#
+# A source pin ("does the script mention crates/fdev/Cargo.toml?") would be
+# satisfied by a mention. The property is "which version does it actually pass
+# to `cargo yank`, and does a failure reach the exit status", so the script is
+# run end to end against a throwaway git repo with `cargo`, `curl` and `gh`
+# stubbed on PATH -- the release_driver_test.sh idiom.
+#
+# Run manually: bash scripts/release_rollback_test.sh
+# Wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROLLBACK_SH="$SCRIPT_DIR/release-rollback.sh"
+
+FAILURES=0
+fail() {
+    echo "FAIL - $1" >&2
+    shift
+    for line in "$@"; do echo "       $line" >&2; done
+    FAILURES=$((FAILURES + 1))
+}
+pass() { echo "ok   - $1"; }
+
+if [[ ! -f "$ROLLBACK_SH" ]]; then
+    echo "FAIL - $ROLLBACK_SH not found" >&2
+    exit 1
+fi
+
+# The version numbers are deliberately far apart, and all three are distinct:
+#
+#   TAG_FDEV     what shipped with the release being rolled back  (the answer)
+#   MAIN_FDEV    what the working tree says NOW, main having moved on
+#   0.4.129      what the old `minor + 2` arithmetic produces
+#
+# A test whose expected value is reachable by more than one route cannot say
+# which route produced it.
+FREENET_VERSION="0.2.129"
+TAG_FDEV="0.3.291"
+MAIN_FDEV="0.3.300"
+ARITHMETIC_FDEV="0.4.129"
+
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+
+# make_sandbox [--no-tag]
+#
+# Builds a self-contained git repo holding a COPY of the script under test (so
+# the script's own `git rev-parse --show-toplevel` resolves to the sandbox, not
+# to freenet-core), an origin it can push to, a release tag whose tree names
+# TAG_FDEV, and a later commit on main naming MAIN_FDEV.
+make_sandbox() {
+    local with_tag=true
+    [[ "${1:-}" == "--no-tag" ]] && with_tag=false
+
+    SANDBOX="$(mktemp -d -p "$SANDBOX_ROOT")"
+    BIN="$SANDBOX/bin"
+    REPO="$SANDBOX/repo"
+    ORIGIN="$SANDBOX/origin.git"
+    STUB_LOG="$SANDBOX/stub.log"
+    OUT="$SANDBOX/out.txt"
+    mkdir -p "$BIN"
+    : > "$STUB_LOG"
+
+    git init --quiet --bare "$ORIGIN"
+    git init --quiet -b main "$REPO"
+    git -C "$REPO" config user.email "test@example.invalid"
+    git -C "$REPO" config user.name "Rollback Test"
+    git -C "$REPO" remote add origin "$ORIGIN"
+
+    mkdir -p "$REPO/scripts" "$REPO/crates/fdev"
+    cp "$ROLLBACK_SH" "$REPO/scripts/release-rollback.sh"
+
+    write_fdev_manifest "$TAG_FDEV"
+    git -C "$REPO" add scripts crates >/dev/null
+    git -C "$REPO" commit --quiet -m "build: release $FREENET_VERSION"
+    if [[ "$with_tag" == "true" ]]; then
+        git -C "$REPO" tag -a "v$FREENET_VERSION" -m "Release v$FREENET_VERSION"
+    fi
+
+    # main moves on: fdev is bumped again by the NEXT release's prep, so the
+    # working tree no longer names the version that shipped with the tag.
+    write_fdev_manifest "$MAIN_FDEV"
+    git -C "$REPO" add crates >/dev/null
+    git -C "$REPO" commit --quiet -m "build: bump fdev"
+
+    git -C "$REPO" push --quiet origin main
+    if [[ "$with_tag" == "true" ]]; then
+        git -C "$REPO" push --quiet origin "refs/tags/v$FREENET_VERSION"
+    fi
+
+    write_stubs
+}
+
+write_fdev_manifest() {
+    cat > "$REPO/crates/fdev/Cargo.toml" <<EOF
+[package]
+name = "fdev"
+version = "$1"
+edition = "2024"
+
+[dependencies]
+freenet = { path = "../core", version = "0.2.129" }
+serde = { version = "9.9.9" }
+EOF
+}
+
+# cargo / curl / gh stubs. Each logs its argv so the assertions can ask what the
+# script actually invoked, and each takes its behaviour from the environment.
+write_stubs() {
+    cat > "$BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo $*" >> "$STUB_LOG"
+case "${CARGO_YANK_BEHAVIOUR:-ok}" in
+    fail)
+        echo "error: api errored with status 500 Internal Server Error" >&2
+        exit 1
+        ;;
+    already)
+        echo "error: failed to yank crate: crate version is already yanked" >&2
+        exit 1
+        ;;
+    *)
+        echo "        Yank ok"
+        exit 0
+        ;;
+esac
+EOF
+
+    # Mirrors crates.io's REST shape: the last argument is the URL, and the
+    # crate name is its second-to-last path segment.
+    cat > "$BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "curl $*" >> "$STUB_LOG"
+url="${*: -1}"
+crate="$(basename "$(dirname "$url")")"
+case "$crate" in
+    freenet) printf '%s' "${CRATES_IO_CODE_FREENET:-200}" ;;
+    fdev)    printf '%s' "${CRATES_IO_CODE_FDEV:-200}" ;;
+    *)       printf '000' ;;
+esac
+exit 0
+EOF
+
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+    if [[ "${GH_RELEASE_EXISTS:-0}" == "1" ]]; then exit 0; fi
+    exit 1
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "delete" ]]; then
+    if [[ "${GH_DELETE_FAIL:-0}" == "1" ]]; then
+        echo "gh: release delete failed" >&2
+        exit 1
+    fi
+    exit 0
+fi
+exit 0
+EOF
+
+    chmod +x "$BIN/cargo" "$BIN/curl" "$BIN/gh"
+}
+
+# run_rollback <args...> -- answers the confirmation prompt, captures combined
+# output in $OUT and the exit status in $RC.
+run_rollback() {
+    (
+        cd "$REPO" || exit 99
+        PATH="$BIN:$PATH" STUB_LOG="$STUB_LOG" \
+            bash scripts/release-rollback.sh "$@" <<<"yes"
+    ) > "$OUT" 2>&1
+    RC=$?
+}
+
+# Bash-glob matching, never `printf | grep -q`: under `pipefail` a
+# short-circuiting grep kills the producer with SIGPIPE and a PRESENT string
+# reads as absent (see .claude/rules/bug-prevention-patterns.md).
+logged() { [[ "$(cat "$STUB_LOG")" == *"$1"* ]]; }
+printed() { [[ "$(cat "$OUT")" == *"$1"* ]]; }
+
+dump() {
+    echo "--- exit status: $RC"
+    echo "--- output:"
+    sed 's/^/       | /' "$OUT"
+    echo "--- stub invocations:"
+    sed 's/^/       | /' "$STUB_LOG"
+}
+
+# 1. THE BUG: which fdev version does the script actually ask cargo to yank?
+#
+# Three-way: it must be the tag's version, and must be NEITHER the arithmetic
+# answer (the bug) NOR the working tree's (the plausible half-fix that yanks a
+# different release's fdev).
+test_fdev_version_comes_from_the_release_tag() {
+    make_sandbox
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "fdev yank targets the version recorded at the release tag ($TAG_FDEV)"
+    else
+        fail "fdev yank did not target the tag's fdev version ($TAG_FDEV)" "$(dump)"
+    fi
+
+    if logged "$ARITHMETIC_FDEV"; then
+        fail "fdev version was computed from the freenet version ($ARITHMETIC_FDEV)" "$(dump)"
+    else
+        pass "no trace of the 'minor + 2' arithmetic ($ARITHMETIC_FDEV)"
+    fi
+
+    if logged "$MAIN_FDEV"; then
+        fail "fdev version came from the working tree ($MAIN_FDEV), not the tag" "$(dump)"
+    else
+        pass "the working tree's later fdev version ($MAIN_FDEV) is not used"
+    fi
+
+    if logged "cargo yank --version $FREENET_VERSION freenet"; then
+        pass "freenet yank targets the released version"
+    else
+        fail "freenet was not yanked at $FREENET_VERSION" "$(dump)"
+    fi
+
+    if [[ $RC -eq 0 ]] && printed "Rollback complete"; then
+        pass "a fully successful rollback still exits 0"
+    else
+        fail "successful rollback did not report success" "$(dump)"
+    fi
+}
+
+# 2. THE OTHER HALF OF THE BUG: a failed yank must not be papered over with
+# "✅ Rollback complete!" and exit 0.
+test_failed_yank_is_not_reported_as_success() {
+    make_sandbox
+    CARGO_YANK_BEHAVIOUR=fail run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]]; then
+        pass "a failed yank makes the script exit non-zero"
+    else
+        fail "a failed yank exited 0" "$(dump)"
+    fi
+
+    if printed "Rollback INCOMPLETE" && ! printed "Rollback complete"; then
+        pass "a failed yank reports INCOMPLETE, not complete"
+    else
+        fail "a failed yank still printed a success summary" "$(dump)"
+    fi
+
+    if printed "yank fdev v$TAG_FDEV"; then
+        pass "the failure summary names the step that failed"
+    else
+        fail "the failure summary does not name the failed yank" "$(dump)"
+    fi
+}
+
+# 3. "Genuinely not published" is a normal outcome, not a failure. A rollback
+# often runs for a release that never got as far as crates.io.
+test_absent_crate_version_is_not_a_failure() {
+    make_sandbox
+    CRATES_IO_CODE_FREENET=404 CRATES_IO_CODE_FDEV=404 \
+        run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -eq 0 ]] && printed "not published, skipping"; then
+        pass "a 404 from crates.io is reported as 'not published', not as an error"
+    else
+        fail "an unpublished version was treated as a failure" "$(dump)"
+    fi
+
+    if logged "cargo yank"; then
+        fail "cargo yank was invoked for a version crates.io says is absent" "$(dump)"
+    else
+        pass "no yank is attempted for a version that was never published"
+    fi
+}
+
+# 4. The 403 trap RELEASE_RECOVERY.md documents: crates.io answers 403 to a
+# request with no descriptive User-Agent. Reading that as "not published" is how
+# a rollback silently skips a version that IS live.
+test_unknown_crates_io_status_is_not_read_as_absent() {
+    make_sandbox
+    CRATES_IO_CODE_FDEV=403 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]]; then
+        pass "an undetermined crates.io status fails the rollback"
+    else
+        fail "HTTP 403 was swallowed and the rollback reported success" "$(dump)"
+    fi
+
+    if printed "UNKNOWN"; then
+        pass "the 403 is reported as UNKNOWN rather than as 'not published'"
+    else
+        fail "a 403 was not distinguished from a 404" "$(dump)"
+    fi
+
+    if logged "cargo yank --version $TAG_FDEV fdev"; then
+        fail "yanked fdev despite not knowing whether it is published" "$(dump)"
+    else
+        pass "no yank is attempted while the publish state is unknown"
+    fi
+}
+
+# 5. The User-Agent is the reason case 4 is a hypothetical rather than the
+# normal case: drop it and crates.io answers 403 to EVERY probe.
+test_crates_io_probe_sends_a_descriptive_user_agent() {
+    make_sandbox
+    run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if logged "-A freenet-release-driver"; then
+        pass "the crates.io probe identifies itself (403-avoidance)"
+    else
+        fail "the crates.io probe carries no descriptive User-Agent" "$(dump)"
+    fi
+}
+
+# 6. Yanking something already yanked is the expected state on a re-run; it must
+# not be re-reported as a failure.
+test_already_yanked_is_success() {
+    make_sandbox
+    CARGO_YANK_BEHAVIOUR=already run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -eq 0 ]] && printed "already yanked"; then
+        pass "an already-yanked version is a success, so a re-run is safe"
+    else
+        fail "re-running the rollback reported the already-yanked crate as failed" "$(dump)"
+    fi
+}
+
+# 7. Same silent-success shape one step earlier: the remote tag deletion used to
+# end in `|| true` and print ✓ regardless.
+test_failed_remote_tag_deletion_is_reported() {
+    make_sandbox
+    # A pre-receive hook that declines, rather than `receive.denyDeletes`:
+    # verified that denyDeletes does NOT reject this push on a local-path
+    # remote, which would have made the case vacuous. The second assertion
+    # below re-checks that the refusal really happened.
+    printf '#!/bin/sh\nexit 1\n' > "$ORIGIN/hooks/pre-receive"
+    chmod +x "$ORIGIN/hooks/pre-receive"
+    run_rollback --version "$FREENET_VERSION"
+
+    if [[ $RC -ne 0 ]] && printed "delete remote tag v$FREENET_VERSION"; then
+        pass "a refused remote tag deletion reaches the exit status"
+    else
+        fail "a refused remote tag deletion was reported as success" "$(dump)"
+    fi
+
+    if git -C "$ORIGIN" rev-parse "refs/tags/v$FREENET_VERSION" >/dev/null 2>&1; then
+        pass "the sandbox really did refuse the deletion (the case is not vacuous)"
+    else
+        fail "the remote tag was deleted, so this case proved nothing" "$(dump)"
+    fi
+}
+
+# 7b. The other way a remote tag deletion goes quietly missing: the lookup that
+# decides whether there IS a remote tag fails, and "could not ask" is read as
+# "not there". Same silent-skip outcome, no failure anywhere.
+test_unqueryable_origin_is_not_read_as_no_remote_tag() {
+    make_sandbox
+    mv "$ORIGIN" "$SANDBOX/origin-gone.git"
+    run_rollback --version "$FREENET_VERSION"
+
+    if [[ $RC -ne 0 ]] && printed "could not query origin"; then
+        pass "an unreachable origin is a failure, not 'no remote tag'"
+    else
+        fail "an unreachable origin was reported as 'not found, skipping'" "$(dump)"
+    fi
+}
+
+# 8. If the version cannot be established, stop BEFORE the destructive steps --
+# steps 1 and 2 delete the tag the version is read from, so failing afterwards
+# would leave the operator with nothing to look it up from.
+test_unresolvable_fdev_version_stops_before_deleting_anything() {
+    make_sandbox --no-tag
+    GH_RELEASE_EXISTS=1 run_rollback --version "$FREENET_VERSION" --yank-crates
+
+    if [[ $RC -ne 0 ]] && printed "cannot determine which fdev version"; then
+        pass "an unresolvable fdev version is a hard error"
+    else
+        fail "an unresolvable fdev version did not stop the rollback" "$(dump)"
+    fi
+
+    if logged "gh release delete"; then
+        fail "destructive steps ran before the fdev version was resolved" "$(dump)"
+    else
+        pass "nothing destructive runs before the fdev version is resolved"
+    fi
+
+    if printed "--fdev-version"; then
+        pass "the error tells the operator how to supply the version by hand"
+    else
+        fail "the error does not mention the --fdev-version escape hatch" "$(dump)"
+    fi
+}
+
+# 9. That escape hatch has to work, since it is the documented answer to case 8.
+test_explicit_fdev_version_overrides_the_tag() {
+    make_sandbox
+    run_rollback --version "$FREENET_VERSION" --yank-crates --fdev-version 0.3.777
+
+    if logged "cargo yank --version 0.3.777 fdev" && ! logged "cargo yank --version $TAG_FDEV fdev"; then
+        pass "--fdev-version overrides the value read from the tag"
+    else
+        fail "--fdev-version was ignored" "$(dump)"
+    fi
+}
+
+# 10. A dry run must resolve and SHOW the version (that is most of its value
+# here, given the number used to be wrong) without touching crates.io.
+test_dry_run_shows_the_fdev_version_without_yanking() {
+    make_sandbox
+    run_rollback --version "$FREENET_VERSION" --yank-crates --dry-run
+
+    if [[ $RC -eq 0 ]] && printed "$TAG_FDEV"; then
+        pass "a dry run prints the fdev version it would yank"
+    else
+        fail "a dry run did not show the fdev version" "$(dump)"
+    fi
+
+    if logged "cargo yank"; then
+        fail "a dry run invoked cargo yank" "$(dump)"
+    else
+        pass "a dry run does not invoke cargo yank"
+    fi
+}
+
+test_fdev_version_comes_from_the_release_tag
+test_failed_yank_is_not_reported_as_success
+test_absent_crate_version_is_not_a_failure
+test_unknown_crates_io_status_is_not_read_as_absent
+test_crates_io_probe_sends_a_descriptive_user_agent
+test_already_yanked_is_success
+test_failed_remote_tag_deletion_is_reported
+test_unqueryable_origin_is_not_read_as_no_remote_tag
+test_unresolvable_fdev_version_stops_before_deleting_anything
+test_explicit_fdev_version_overrides_the_tag
+test_dry_run_shows_the_fdev_version_without_yanking
+
+echo
+if [[ $FAILURES -eq 0 ]]; then
+    echo "release-rollback.sh: all assertions passed"
+    exit 0
+fi
+echo "release-rollback.sh: $FAILURES assertion(s) failed" >&2
+exit 1


### PR DESCRIPTION
## Problem

`scripts/release-rollback.sh --yank-crates` computed the fdev version to yank from the freenet version:

```bash
IFS='.' read -r major minor patch <<< "$VERSION"
minor_plus_2=$((minor + 2))
FDEV_VERSION="0.${minor_plus_2}.${patch}"
```

fdev's version is independent of freenet's — `release.yml` bumps fdev's **own** patch number in `crates/fdev/Cargo.toml` — so the two drifted apart long ago. For freenet `0.2.129` that formula asks crates.io to yank fdev `0.4.129`; the version that actually shipped was `0.3.291`. Today's tree is freenet 0.2.131 / fdev 0.3.293, so both the `minor + 2` heuristic and the reuse of `$patch` are wrong.

Worse, the failure was **swallowed**. The yank's verdict came from grepping cargo's output for `"successfully yanked"` — a string cargo no longer prints — and nothing consumed that verdict either way, so the script printed `✗ (failed or not published)` and then `✅ Rollback complete!` and exited **0**. `--yank-crates` has therefore never yanked an fdev version, and always reported success.

This is the tool an operator reaches for when a release has *already* gone wrong, which is the worst possible place for a silent no-op.

Two smaller instances of the same shape were in the remote-tag step:

- the existence check piped `git ls-remote --tags origin` into `grep -q`. Under `set -o pipefail` the short-circuiting grep kills git with SIGPIPE as soon as it matches, so a **present** tag can read as absent and the deletion is silently skipped — the class documented in `.claude/rules/bug-prevention-patterns.md`;
- the deletion itself ended in `|| true` and printed `✓` regardless.

## Solution

**Read the fdev version, don't compute it — and read it from the release tag.** `.github/workflows/release.yml` already reads `crates/fdev/Cargo.toml` and increments fdev's own patch; this mirrors that source rather than inventing a scheme.

The source is `git show "$TAG:crates/fdev/Cargo.toml"`, not the working tree, because by the time anyone is rolling a release back main has usually bumped fdev again — the working tree names the version that shipped with a *different* release, and a yank cannot be undone. If the tag is gone locally the script falls back to a read-only `git fetch origin refs/tags/<tag>` + `FETCH_HEAD` (this does not recreate the tag).

Resolution runs **before** the destructive steps, because steps 1 and 2 delete the very tag it reads from; discovering the version is unavailable afterwards would leave the operator with nothing to look it up from. When it cannot be resolved the script stops with an error naming the new `--fdev-version X.Y.Z` escape hatch, having deleted nothing.

**Make the exit status honest.** Every step records its own failure and keeps going (a rollback that stops at the first problem leaves the release half-torn-down), and the summary is either `✅ Rollback complete!` with exit 0 or `❌ Rollback INCOMPLETE` listing each failed step with exit 1.

**Distinguish "not published" from "the yank failed",** reusing the tri-state probe `scripts/RELEASE_RECOVERY.md` already documents rather than writing a new one: `200` = published (yank it), `404` = genuinely absent (skip, not an error), anything else = UNKNOWN and a failure. The `-A 'freenet-release-driver'` User-Agent is load-bearing — crates.io answers 403 without one, and a two-state check reads that 403 as "not published" for every version ever released. The yank itself is now judged by cargo's **exit status**, with `already yanked` treated as success so a re-run is safe.

The remote-tag step now asks origin for the one ref and keeps three answers apart — present, absent, and "could not ask" — with no pipe involved.

## Testing

New `scripts/release_rollback_test.sh` (24 assertions), wired into the Fmt job in `ci.yml` alongside the other `*_test.sh` self-tests, and both files added to the `shellcheck -x` line there. `shellcheck -x` is clean on both.

These are **behavioural**, not source pins: both bugs are properties of what the script *does*, and a pin like "does it mention `crates/fdev/Cargo.toml`?" would be satisfied by a mention. The script is run end to end against a throwaway git repo (a copy of itself, an origin it can push to, a release tag whose tree names one fdev version and a later commit on main naming another) with `cargo`, `curl` and `gh` stubbed on `PATH` logging their argv — the `release_driver_test.sh` idiom.

Covered: the yank target is the tag's fdev version and is neither the arithmetic answer nor the working tree's (three distinct values, so no assertion can pass by more than one route); a failed yank exits non-zero and reports INCOMPLETE; a 404 is not a failure and attempts no yank; a 403 is UNKNOWN and does not silently skip; the probe carries a descriptive User-Agent; already-yanked is success; a refused remote tag deletion reaches the exit status; an unqueryable origin is not read as "no remote tag"; an unresolvable fdev version stops before anything destructive; `--fdev-version` overrides; a dry run shows the version without yanking.

**Both directions verified, by swapping the old script under the same suite:**

| | assertions failing |
|---|---|
| previous script | **19 of 24** |
| this PR | **0 of 24** |

Against the previous script the suite prints, among others:

```
FAIL - fdev version was computed from the freenet version (0.4.129)
       |   Yanking fdev v0.4.129... ✗ (failed or not published)
       |
       | ✅ Rollback complete!
       --- exit status: 0
       | cargo yank --vers 0.4.129 fdev
```

The 5 assertions that pass against the old script are the negative ones ("no yank was attempted", "the working tree's version is not used"), which the old script satisfies vacuously by failing earlier — noted rather than dressed up.

Two of the new cases were themselves checked for vacuity: `receive.denyDeletes` turned out **not** to reject a deletion pushed to a local-path remote, so the refused-deletion case uses a declining `pre-receive` hook and asserts the tag really did survive.

No Rust changed, so no `cargo test` / `clippy` impact.

[AI-assisted - Claude]

https://claude.ai/code/session_01P2rYBNhAzY5Eg79eAvEunQ
