### PR TITLE
fix(ci): assert the Windows signer is Freenet, not merely that a signature exists

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -335,7 +335,7 @@ jobs:
             # order and extra attributes added on certificate reissue are the
             # second and third reasons. Match the CN substring.
             if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') {
-              throw "Unexpected signer for ${f}: expected a subject containing 'CN=Freenet Project Inc', got '$($sig.SignerCertificate.Subject)'. Either the Azure certificate profile was repointed, or the certificate was legitimately reissued under a new name. See scripts/RELEASE_RECOVERY.md, 'Windows code signing'. Do NOT delete this check to unblock a release."
+              throw "Unexpected signer for ${f}: expected a subject containing 'CN=Freenet Project Inc', got '$($sig.SignerCertificate.Subject)'. Either the Azure certificate profile was repointed, or the certificate was legitimately reissued under a new name. See docs/RELEASING.md, 'Windows code signing (Authenticode)', and scripts/RELEASE_RECOVERY.md, 'Step 3: Tag Created but GitHub Release Missing'. Do NOT delete this check to unblock a release."
             }
           }
 

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -321,6 +321,22 @@ jobs:
             Write-Host "$f => $($sig.Status) / $($sig.SignerCertificate.Subject)"
             if ($sig.Status -ne 'Valid') { throw "Unsigned or invalid: $f" }
             if (-not $sig.TimeStamperCertificate) { throw "Missing timestamp: $f" }
+            # `Valid` only means "signed by SOMETHING that chains to a trusted
+            # root and is timestamped" -- it does not mean "signed by us". Both
+            # RELEASING.md and RELEASE_RECOVERY.md tell an operator to expect
+            # the subject below, which reads as though CI enforces it; without
+            # this line it did not.
+            #
+            # DO NOT "tighten" this to match the whole DN. The two tools that
+            # render this subject disagree on the state attribute: PowerShell
+            # emits `S=Texas` where osslsigncode emits `ST=Texas`. A full-string
+            # match looks more rigorous, passes every test you would think to
+            # write against one tool, and breaks against the other. Attribute
+            # order and extra attributes added on certificate reissue are the
+            # second and third reasons. Match the CN substring.
+            if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') {
+              throw "Unexpected signer for ${f}: expected a subject containing 'CN=Freenet Project Inc', got '$($sig.SignerCertificate.Subject)'. Either the Azure certificate profile was repointed, or the certificate was legitimately reissued under a new name. See scripts/RELEASE_RECOVERY.md, 'Windows code signing'. Do NOT delete this check to unblock a release."
+            }
           }
 
       - name: Upload freenet binary

--- a/crates/core/tests/windows_signing_order.rs
+++ b/crates/core/tests/windows_signing_order.rs
@@ -391,31 +391,52 @@ fn check_signer_identity_is_asserted(yml: &str) -> Result<(), String> {
     let range = job_range(yml, "build-x86_64-windows")?;
     let lines: Vec<&str> = yml.lines().collect();
 
-    let asserts_signer = (range.0..range.1).any(|i| {
-        let l = lines[i];
-        l.contains("SignerCertificate.Subject")
-            && l.contains("CN=Freenet Project Inc")
-            && !l.trim_start().starts_with('#')
-    });
-
-    if !asserts_signer {
-        return Err(
+    // Anchor on the COMPARISON, not merely on the two names appearing together.
+    //
+    // The obvious predicate — "some non-comment line mentions both
+    // `SignerCertificate.Subject` and `CN=Freenet Project Inc`" — is also
+    // satisfied by the THROW MESSAGE, which quotes the expected CN and
+    // interpolates the observed subject. That makes the guard green for the one
+    // mutation that matters: demote the `if` to a `Write-Host` and the release
+    // stops failing on a wrong signer while this test keeps passing. Requiring
+    // the operator and the pattern verbatim is what separates the enforcing
+    // line from the diagnostic one.
+    let cmp = sole_index(
+        yml,
+        range,
+        "SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*'",
+        1,
+    )
+    .map_err(|e| {
+        format!(
             "the Verify signatures step no longer asserts the SIGNER IDENTITY.\n\
              `Get-AuthenticodeSignature` reporting `Valid` only means the binary chains to a \
-             trusted root and is timestamped — it does NOT mean we signed it. Without a check \
+             trusted root and is timestamped \u{2014} it does NOT mean we signed it. Without a check \
              on `SignerCertificate.Subject` containing `CN=Freenet Project Inc`, a binary \
              signed by a different certificate profile passes the gate, while RELEASING.md and \
              RELEASE_RECOVERY.md both tell operators to expect that subject as though CI had \
-             already verified it."
-                .to_string(),
-        );
+             already verified it.\n\n\
+             Underlying anchor failure: {e}"
+        )
+    })?[0];
+
+    // A comparison whose failure branch does not `throw` is decorative: the step
+    // would print and carry on, while every operator-facing document still
+    // claims CI enforces the publisher.
+    let throws = (cmp..(cmp + 4).min(range.1)).any(|i| lines[i].contains("throw"));
+    if !throws {
+        return Err(format!(
+            "the signer-identity comparison at line {} is no longer followed by a `throw`.\n\
+             A check that cannot fail the job enforces nothing, and RELEASING.md / \
+             RELEASE_RECOVERY.md both tell operators the publisher is verified. Restore the \
+             `throw`, or delete the documentation claiming the guarantee.",
+            cmp + 1
+        ));
     }
 
     Ok(())
 }
 
-/// The timestamp is not optional: Artifact Signing certificates are short-lived
-/// (~3 days), so an untimestamped signature stops validating almost at once.
 #[test]
 fn verification_asserts_the_signer_is_freenet() {
     let yml = cross_compile_yml();
@@ -424,6 +445,8 @@ fn verification_asserts_the_signer_is_freenet() {
     }
 }
 
+/// The timestamp is not optional: Artifact Signing certificates are short-lived
+/// (~3 days), so an untimestamped signature stops validating almost at once.
 #[test]
 fn signing_requests_an_rfc3161_timestamp() {
     let yml = cross_compile_yml();
@@ -471,7 +494,9 @@ fn synthetic_workflow(sign_first: bool, checksums_last: bool) -> String {
           foreach ($f in @('target\\release\\freenet.exe','target\\release\\fdev.exe')) {
             $sig = Get-AuthenticodeSignature $f
             if (-not $sig.TimeStamperCertificate) { throw \"x\" }
-            if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') { throw \"y\" }
+            if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') {
+              throw \"Unexpected signer for ${f}: expected a subject containing 'CN=Freenet Project Inc', got '$($sig.SignerCertificate.Subject)'.\"
+            }
           }
 ";
     let upload_block = "\
@@ -646,8 +671,8 @@ fn guard_accepts_an_asserted_signer_identity() {
 fn guard_rejects_a_dropped_signer_identity_assertion() {
     // Status + timestamp still checked, but nobody checks WHO signed it.
     let bad = synthetic_workflow(true, true).replace(
-        "if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') { throw \"y\" }",
-        "",
+        "if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') {",
+        "if ($false) {",
     );
     let err = check_signer_identity_is_asserted(&bad)
         .expect_err("dropping the signer-identity assertion MUST be rejected");
@@ -660,6 +685,42 @@ fn guard_rejects_a_signer_assertion_naming_someone_else() {
         .replace("CN=Freenet Project Inc", "CN=Someone Else Entirely");
     check_signer_identity_is_asserted(&bad)
         .expect_err("an assertion naming a different publisher MUST be rejected");
+}
+
+/// The two mutations below run against the REAL workflow text, not the
+/// synthetic, because they are the ones the synthetic cannot express.
+///
+/// In `cross-compile.yml` the comparison and its diagnostic live on separate
+/// lines, and the diagnostic quotes the expected CN while interpolating the
+/// observed subject. So a predicate that merely looks for the two names on one
+/// non-comment line is satisfied by the MESSAGE alone, and stays green through
+/// exactly the edits an operator makes to unblock a release under pressure.
+/// Mutating the real file is the only way to pin that.
+#[test]
+fn guard_rejects_a_neutered_signer_check_in_the_real_workflow() {
+    // Demote the enforcing `if` to a print, leaving the diagnostic line - and
+    // therefore both names - untouched. Nothing fails the job any more.
+    let bad = cross_compile_yml().replace(
+        "if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') {",
+        "if ($false) { # signer check disabled",
+    );
+    let err = check_signer_identity_is_asserted(&bad)
+        .expect_err("neutering the signer check MUST be rejected");
+    assert!(err.contains("SIGNER IDENTITY"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_rejects_a_repointed_expected_cn_in_the_real_workflow() {
+    // Change only the publisher the comparison demands, leaving the message
+    // (which still names Freenet) alone. CI would now accept someone else's
+    // signature while every operator-facing document still says otherwise.
+    let bad = cross_compile_yml().replace(
+        "-notlike '*CN=Freenet Project Inc*'",
+        "-notlike '*CN=Someone Else Entirely*'",
+    );
+    let err = check_signer_identity_is_asserted(&bad)
+        .expect_err("repointing the expected CN MUST be rejected");
+    assert!(err.contains("SIGNER IDENTITY"), "unexpected: {err}");
 }
 
 #[test]

--- a/crates/core/tests/windows_signing_order.rs
+++ b/crates/core/tests/windows_signing_order.rs
@@ -372,8 +372,58 @@ fn signing_steps_share_one_gating_condition() {
     );
 }
 
+/// The verification step must assert WHO signed the binaries, not merely that
+/// they are signed.
+///
+/// `Get-AuthenticodeSignature`'s `Valid` status means "chains to a trusted root
+/// and carries a timestamp" — it says nothing about the signer's identity. A
+/// binary signed by a different but validly-issued certificate profile (a test
+/// profile, or another identity inside the same Azure signing account) would
+/// pass a status-only gate.
+///
+/// This is pinned mainly because the DOCS claim it: both `docs/RELEASING.md`
+/// and `scripts/RELEASE_RECOVERY.md` tell an operator to expect
+/// `CN=Freenet Project Inc`, which reads as though CI enforces it. Someone
+/// diagnosing a signing failure at speed will assume a passing gate already
+/// ruled the signer out. Documentation implying an enforcement that does not
+/// exist is worse than documenting nothing.
+fn check_signer_identity_is_asserted(yml: &str) -> Result<(), String> {
+    let range = job_range(yml, "build-x86_64-windows")?;
+    let lines: Vec<&str> = yml.lines().collect();
+
+    let asserts_signer = (range.0..range.1).any(|i| {
+        let l = lines[i];
+        l.contains("SignerCertificate.Subject")
+            && l.contains("CN=Freenet Project Inc")
+            && !l.trim_start().starts_with('#')
+    });
+
+    if !asserts_signer {
+        return Err(
+            "the Verify signatures step no longer asserts the SIGNER IDENTITY.\n\
+             `Get-AuthenticodeSignature` reporting `Valid` only means the binary chains to a \
+             trusted root and is timestamped — it does NOT mean we signed it. Without a check \
+             on `SignerCertificate.Subject` containing `CN=Freenet Project Inc`, a binary \
+             signed by a different certificate profile passes the gate, while RELEASING.md and \
+             RELEASE_RECOVERY.md both tell operators to expect that subject as though CI had \
+             already verified it."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
 /// The timestamp is not optional: Artifact Signing certificates are short-lived
 /// (~3 days), so an untimestamped signature stops validating almost at once.
+#[test]
+fn verification_asserts_the_signer_is_freenet() {
+    let yml = cross_compile_yml();
+    if let Err(e) = check_signer_identity_is_asserted(&yml) {
+        panic!("{e}");
+    }
+}
+
 #[test]
 fn signing_requests_an_rfc3161_timestamp() {
     let yml = cross_compile_yml();
@@ -421,6 +471,7 @@ fn synthetic_workflow(sign_first: bool, checksums_last: bool) -> String {
           foreach ($f in @('target\\release\\freenet.exe','target\\release\\fdev.exe')) {
             $sig = Get-AuthenticodeSignature $f
             if (-not $sig.TimeStamperCertificate) { throw \"x\" }
+            if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') { throw \"y\" }
           }
 ";
     let upload_block = "\
@@ -583,6 +634,32 @@ fn guard_rejects_a_dropped_contents_read_permission() {
         "dropping `contents: read` MUST be rejected — naming any permission zeroes the rest",
     );
     assert!(err.contains("contents: read"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_accepts_an_asserted_signer_identity() {
+    let good = synthetic_workflow(true, true);
+    check_signer_identity_is_asserted(&good).expect("an asserted signer identity must pass");
+}
+
+#[test]
+fn guard_rejects_a_dropped_signer_identity_assertion() {
+    // Status + timestamp still checked, but nobody checks WHO signed it.
+    let bad = synthetic_workflow(true, true).replace(
+        "if ($sig.SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*') { throw \"y\" }",
+        "",
+    );
+    let err = check_signer_identity_is_asserted(&bad)
+        .expect_err("dropping the signer-identity assertion MUST be rejected");
+    assert!(err.contains("SIGNER IDENTITY"), "unexpected: {err}");
+}
+
+#[test]
+fn guard_rejects_a_signer_assertion_naming_someone_else() {
+    let bad = synthetic_workflow(true, true)
+        .replace("CN=Freenet Project Inc", "CN=Someone Else Entirely");
+    check_signer_identity_is_asserted(&bad)
+        .expect_err("an assertion naming a different publisher MUST be rejected");
 }
 
 #[test]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -99,7 +99,11 @@ CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
 
 **Unlike every other secret in the table above, this path is fail-closed.** The
 `Verify signatures` step runs `Get-AuthenticodeSignature` on the runner and
-throws if a binary is unsigned, invalid, or missing its RFC3161 timestamp. A
+throws if a binary is unsigned, invalid, missing its RFC3161 timestamp, or
+**signed by a publisher other than `CN=Freenet Project Inc`**. That last check
+matters because `Valid` on its own only means "chains to a trusted root and is
+timestamped" — it says nothing about who signed it, so without an explicit
+subject assertion a binary signed by a different certificate profile would pass. A
 broken Azure configuration therefore fails `build-x86_64-windows`, and because
 `attach-to-release` needs that job, the release stops as a draft rather than
 shipping unsigned binaries. That is deliberate — but it means Azure-side

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -218,12 +218,20 @@ CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
 the binary WAS signed, just not by us. Three possibilities, in the order worth
 checking: the Azure certificate profile was repointed (misconfiguration); the
 certificate was legitimately reissued under a changed name (e.g. the company
-name changed) — in which case update the expected CN in the `Verify signatures`
-step and its pin in `crates/core/tests/windows_signing_order.rs`, deliberately
-and in a reviewed PR; or, least likely and most serious, someone else signed
-it. Never delete the check to get a release out: that is the one action that
-converts a blocked release into an unsigned one shipped to users whose Windows
-auto-update has no canary (#5341).
+name changed) — in which case update the expected CN deliberately and in a
+reviewed PR, in BOTH the comparison and the thrown message in the `Verify
+signatures` step, and in its pin in
+`crates/core/tests/windows_signing_order.rs`; or, least likely and most
+serious, someone else signed it. Never delete the check to get a release out:
+that is the one action that converts a blocked release into an unsigned one
+shipped to users whose Windows auto-update has no canary (#5341).
+
+Note that a repoint is not guaranteed to surface as `Unexpected signer`. If the
+profile it was repointed to does not chain to a root the runner trusts — an
+Azure Trusted Signing *test* profile, or a private-trust profile — then
+`$sig.Status` is not `Valid` and the step throws `Unsigned or invalid` first, on
+an earlier line. A repoint is therefore worth checking under either message,
+not only this one.
 
 Common causes, in the order worth checking: the `release` environment or the
 `AZURE_*` secrets were changed (the Entra federated credential is pinned to the

--- a/scripts/RELEASE_RECOVERY.md
+++ b/scripts/RELEASE_RECOVERY.md
@@ -204,14 +204,26 @@ failure`, `Upload freenet binary => skipped`, `Upload fdev binary => skipped`.)
 **If this job fails at signing, the failure is Azure-side and cannot be fixed
 from the repo.** Unlike every other release secret, Windows signing is
 fail-closed: the `Verify signatures` step throws if either binary is unsigned,
-invalid, or missing its RFC3161 timestamp, and `attach-to-release` needs this
-job, so the release stops as a draft rather than shipping unsigned binaries.
+invalid, missing its RFC3161 timestamp, or signed by a publisher other than
+`CN=Freenet Project Inc`, and `attach-to-release` needs this job, so the
+release stops as a draft rather than shipping unsigned binaries.
 Read the `Verify signatures` step output first — it prints each binary's status
 and signer subject. Expect:
 
 ```
 CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
 ```
+
+**If the failure is `Unexpected signer`** rather than unsigned/untimestamped,
+the binary WAS signed, just not by us. Three possibilities, in the order worth
+checking: the Azure certificate profile was repointed (misconfiguration); the
+certificate was legitimately reissued under a changed name (e.g. the company
+name changed) — in which case update the expected CN in the `Verify signatures`
+step and its pin in `crates/core/tests/windows_signing_order.rs`, deliberately
+and in a reviewed PR; or, least likely and most serious, someone else signed
+it. Never delete the check to get a release out: that is the one action that
+converts a blocked release into an unsigned one shipped to users whose Windows
+auto-update has no canary (#5341).
 
 Common causes, in the order worth checking: the `release` environment or the
 `AZURE_*` secrets were changed (the Entra federated credential is pinned to the


### PR DESCRIPTION
Follow-up to #5418, which shipped in v0.2.131.

## Problem

`Verify signatures` checked `Get-AuthenticodeSignature`'s `Status -eq 'Valid'` and that a timestamp was present, but never **who** signed the binary. `Valid` means only "chains to a trusted root and is countersigned" — a binary signed by a different but validly-issued certificate profile (a test profile, or another identity inside the same Azure signing account) passed the gate.

The threat model alone would not justify hurrying this. Anyone with enough Azure access to sign under another profile could probably also edit the assertion, so it is defence in depth rather than a control.

**The reason it matters is the mismatch.** `docs/RELEASING.md` and `scripts/RELEASE_RECOVERY.md` both tell an operator to *expect* `CN=Freenet Project Inc`, which reads as though CI enforces it. It did not. Documentation implying an enforcement that does not exist is worse than documenting nothing, and the person most likely to lean on it is someone diagnosing a signing failure at speed, who will assume a passing gate already ruled the signer out.

Raised independently by two review lenses on #5418.

## Approach

One assertion in the existing loop, matched with `-notlike` on the CN substring rather than the whole DN.

**The comment explaining why is the load-bearing part of this PR.** The next person to read it will think "why not pin the whole DN", and the answer is not guessable: the two tools that render this subject disagree on the state attribute — **PowerShell emits `S=Texas` where `osslsigncode` emits `ST=Texas`**. A full-string match looks *more* rigorous, passes every test you would think to write against one tool, and breaks against the other. Attribute ordering and reissue-added attributes are the second and third reasons. Without that comment in the code, tightening it is an attractive-looking change that breaks a release.

The thrown message names the expected publisher, quotes what was actually seen, distinguishes the three causes, and points at the runbook — because when this fires, the operator's first question is which of the three they are looking at:

- the Azure certificate profile was repointed (misconfiguration)
- the certificate was legitimately reissued under a changed name
- someone else signed it

`RELEASE_RECOVERY.md` now answers that directly, including that a legitimate reissue means updating the expected CN **deliberately, in a reviewed PR**, rather than deleting the check.

Written as a single double-quoted string rather than a multi-line concatenation: there is no PowerShell on this machine to execute it with, and an untestable construct inside a release-blocking gate was not worth the elegance.

## New failure mode, stated plainly

This is a second way Windows signing can stop a release: a legitimate certificate reissue under a different CN now blocks until a human looks. That is the intended behaviour for a publisher-identity change — it can only fire when the Azure identity actually changes, which is exactly when someone should be told — but it is new, and it is documented rather than left to be discovered.

## Testing

`verification_asserts_the_signer_is_freenet` pins the assertion, and the guard's own ability to go red is pinned by mutation tests.

**Review round 2 found the first version of that pin was decorative, and fixing it is the second commit here.** The guard accepted any non-comment line in the job containing both `SignerCertificate.Subject` and `CN=Freenet Project Inc`. In the real workflow *two* lines satisfy that: the `if` and the thrown message, which quotes the expected CN and interpolates the observed subject. So demoting the `if` to a `Write-Host` left the pin green while the release stopped failing on a wrong signer — precisely the "reads as a guarantee, enforces nothing" state this PR exists to remove. The three original mutation tests could not see it, because the synthetic workflow collapsed the condition and the throw onto one line, so every mutation rewrote a single line in a way the real file cannot reproduce.

The guard now anchors on `SignerCertificate.Subject -notlike '*CN=Freenet Project Inc*'` verbatim through the fail-closed `sole_index`, and separately requires a `throw` in the guarded block. The synthetic is now two lines, matching the real file on the axis under test.

| Mutation | Against | Result |
|---|---|---|
| Assertion deleted, status + timestamp checks left intact | synthetic | rejected |
| Assertion naming a different publisher | synthetic | rejected |
| `if` demoted to a print, message left intact | **real `cross-compile.yml`** | rejected |
| Expected CN repointed on the `if` only, message left intact | **real `cross-compile.yml`** | rejected |
| Intact wiring | both | accepted |

**26/26 green**, `cargo fmt` clean.

### What this evidence does and does not establish

These are source-scrape tests over the workflow text. **Nothing in this PR executes the PowerShell** — the `Verify signatures` step is gated to release tags and `workflow_dispatch`, so it does not run on this PR's CI. A green run here establishes that the assertion is present and that the guard rejects its removal; it does not establish that the PowerShell is correct. Static reading says it is (`${f}` is braced, so it is not parsed as a scope qualifier; `-notlike` with `*` on both sides is a substring test; `Subject` is the flat DN the docs quote; the ordering means `Status -ne 'Valid'` throws before anything dereferences a possibly-null `SignerCertificate`). The cheap way to actually exercise it is a `workflow_dispatch` run of `cross-compile.yml` on a tag ref, which re-signs and costs 2 of 5,000 monthly signatures.

### What the check does not catch

Worth stating so nobody over-trusts it later:

- The match is a case-insensitive substring, so a sibling profile named `CN=Freenet Project Inc Test` in the same Azure account would pass. That is arguably the most probable repoint. Anchoring the attribute boundary would tighten it without reintroducing the whole-DN problem the comment warns about; it is not done here because it assumes the CN stays the first RDN.
- A DN is not unique across CAs. This binds a *name*, not an identity — proportionate against misconfiguration, not against a determined third party. Thumbprint or issuer+serial would be the binding check.
- A repoint to a profile that does not chain to a root the runner trusts surfaces as `Unsigned or invalid` on an earlier line, not as `Unexpected signer`. `RELEASE_RECOVERY.md` now says so.

Empirically, the subject this asserts is the one live signing produces — observed three times: in the v0.2.131 tag-build runner log, on the **published** release asset, and on the pre-merge dispatch.

```
CN=Freenet Project Inc, O=Freenet Project Inc, L=Austin, S=Texas, C=US
```

## Context: what v0.2.131 verified

For reviewers who want the baseline this builds on — the full trust chain was measured on the published artifacts, not reconstructed locally:

authentic manifest (ed25519, verified against `FREENET_RELEASE_PUBKEY` as baked into `update.rs`) → SHA-256 match against the published `SHA256SUMS.txt` → Authenticode-signed binary with correct publisher and valid timestamp → byte-identical inside the zip.

The one link with the least evidence behind it remains **certificate rotation**: v0.2.131 was signed under the same three-day certificate as the pre-merge test build (same serial), so rotation has never been exercised. The RFC3161 countersignature should make it a non-event; the next release is its first natural test.

[AI-assisted - Claude]

https://claude.ai/code/session_01LxKUxTkoykH3pokzEa1Lab

