### PR TITLE
ci: stop the PR backlog refilling (dependabot grouping, terminal-state rule, staleness sweep)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,44 @@
 version: 2
+
+# Dependency bumps are grouped so routine churn arrives as ONE reviewable PR
+# per ecosystem instead of thirty.
+#
+# Measured 2026-08-24: 25 of the repo's 59 open PRs were dependabot's, 20 of
+# them fully green and simply never merged. That backlog is not free — open PRs
+# rot into conflicts, and a wall of them trains reviewers to skim past the whole
+# list, including the bumps that matter.
+#
+# MAJOR bumps are deliberately left UNGROUPED (one PR each). A major bump is
+# real work, not a chore: `ed25519-dalek 2 -> 3` verifies RELEASE SIGNATURES,
+# and a break there strands the fleet with no recovery path. That must never
+# arrive buried in a 30-crate group PR where the diff is skimmed as routine.
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 50
+    groups:
+      # Everything semver-safe rides in one PR. Anything NOT matched here —
+      # i.e. every major bump — still gets its own PR and its own review.
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    groups:
+      # Action bumps are near-always mechanical; majors (e.g. actions/checkout
+      # v7 -> v8) still land alone because they can change runner behaviour.
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,20 @@ version: 2
 # rot into conflicts, and a wall of them trains reviewers to skim past the whole
 # list, including the bumps that matter.
 #
-# MAJOR bumps are deliberately left UNGROUPED (one PR each). A major bump is
-# real work, not a chore: `ed25519-dalek 2 -> 3` verifies RELEASE SIGNATURES,
-# and a break there strands the fleet with no recovery path. That must never
-# arrive buried in a 30-crate group PR where the diff is skimmed as routine.
+# TWO THINGS THIS GROUPING DOES NOT DO, stated because both would be bad and
+# both are one config key away:
+#
+# 1. It does not group MAJOR bumps. A major bump is not matched by any group
+#    below, so it still arrives as its own PR with its own review. Keep it that
+#    way: `ed25519-dalek 2 -> 3` verifies RELEASE SIGNATURES, and a break there
+#    strands the fleet with no recovery path. It must never arrive buried in a
+#    30-crate diff that gets skimmed as routine.
+#
+# 2. It does not group SECURITY updates. `applies-to` defaults to
+#    `version-updates`, so Dependabot's security PRs are untouched by anything
+#    here and keep arriving one per advisory. Do NOT "finish the job" by adding
+#    `applies-to: security-updates` — a security bump buried in a group PR is
+#    precisely the outcome this file exists to avoid.
 updates:
   - package-ecosystem: "cargo"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,15 @@ jobs:
       # clean when they landed but were not actually in this list, so nothing
       # held them to it. `-x` because the two test scripts `source` the canary.
       - name: Lint install/uninstall scripts (shellcheck)
-        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/rule_lint_shell_assertion_counter_test.sh scripts/release.sh
+        run: shellcheck -x scripts/install.sh scripts/uninstall.sh scripts/test-install-sh.sh scripts/test-uninstall-sh.sh scripts/auto-update-canary.sh scripts/auto-update-canary_test.sh scripts/auto-update-canary_lifecycle_test.sh scripts/release_wait_for_binaries_test.sh scripts/release_canary_wiring_test.sh scripts/rule_lint_shell_assertion_counter_test.sh scripts/release.sh scripts/pr-backlog-sweep.sh scripts/pr-backlog-sweep_test.sh
+      # The PR-backlog sweep reports stalled PRs (see
+      # .github/workflows/pr-backlog-sweep.yml). Its self-test drives the ABORT
+      # paths -- failed query, empty listing the REST probe contradicts,
+      # truncated page -- which a healthy scheduled run never touches and which
+      # are the only thing standing between "nothing is stalled" and "the sweep
+      # is broken" looking identical.
+      - name: Self-test PR backlog sweep
+        run: bash scripts/pr-backlog-sweep_test.sh
       - name: Self-test install.sh service-mode decision
         run: sh scripts/test-install-sh.sh
       - name: Self-test uninstall.sh

--- a/.github/workflows/pr-backlog-sweep.yml
+++ b/.github/workflows/pr-backlog-sweep.yml
@@ -107,6 +107,24 @@ jobs:
         if: failure() && steps.sweep.outcome == 'failure'
         # Best-effort like the other notifier: the job is already red, and a
         # second red X from the notifier would only obscure which thing failed.
+        #
+        # SO WHAT IS THE HONEST WORST CASE, written down rather than assumed
+        # away: this page is the LAST line, not a guaranteed one. If the Freenet
+        # gateway is unreachable, `river-dev-notify` degrades to a `::warning::`
+        # and exits 0 by design, `continue-on-error` swallows anything it does
+        # not, and the only surviving signal is the red X on the Actions tab --
+        # the very channel this step exists because nobody watches. A sweep that
+        # breaks while the gateway is also down is therefore invisible until
+        # someone looks.
+        #
+        # That floor is accepted deliberately, not overlooked. Making the
+        # notifier able to fail the job would trade a missed page for a red X
+        # that blames the notifier instead of the sweep, which is strictly
+        # worse: it corrupts the diagnosis, and the run was already red anyway.
+        # A genuinely better answer is a second, independent channel (a GitHub
+        # issue opened on failure, say) rather than making this one blocking.
+        # Not built here; the floor is stated so the next reader can weigh it
+        # instead of inheriting a guarantee that was never made.
         continue-on-error: true
         uses: ./.github/actions/river-dev-notify
         with:

--- a/.github/workflows/pr-backlog-sweep.yml
+++ b/.github/workflows/pr-backlog-sweep.yml
@@ -1,9 +1,10 @@
 name: PR Backlog Sweep
 
 # Reports open PRs that have stalled: green and unmerged >48h, no activity >7d,
-# or decayed into conflicts. Nothing was measuring this, so nothing reported it,
-# and the backlog reached 59 open PRs -- 26 of them green and simply never
-# merged -- before a manual audit on 2026-08-24 noticed.
+# decayed into conflicts, or sitting behind an unapproved CI run. Nothing was
+# measuring any of it, so nothing reported it: the backlog reached 59 open PRs
+# -- 26 of them green and simply never merged -- and 58 workflow runs sat in
+# `action_required`, before a manual audit on 2026-08-24 noticed either.
 #
 # The job body is deliberately thin: all the logic is in
 # scripts/pr-backlog-sweep.sh, which is shellcheck-linted and has a self-test
@@ -13,7 +14,14 @@ name: PR Backlog Sweep
 # THE POINT IS THAT A BROKEN SWEEP LOOKS BROKEN. The script exits non-zero on
 # any failure to enumerate PRs, and the sweep step below is deliberately NOT
 # continue-on-error, so a red X appears here rather than a green run with an
-# empty report. Only the notifier is best-effort.
+# empty report. Only the notifiers are best-effort.
+#
+# A red X is NOT sufficient on its own, and saying so is the point: this whole
+# workflow exists because nobody was watching a queue, and the GitHub Actions
+# tab is another such queue. So a failed sweep ALSO pages the dev room -- see
+# the `Notify the dev room that the sweep is BROKEN` step. Without it the
+# instrument fails silently into a page nobody reads, which is the exact shape
+# it was built to close.
 
 on:
   schedule:
@@ -68,10 +76,11 @@ jobs:
       # that mattered is filtered out with it.
       #
       # The message is built from the script's own counts plus the run URL. No
-      # PR title and no author login is forwarded: those are attacker-controlled
-      # strings, and the sweep's headline output is pinned by its self-test to
-      # contain neither. Nothing repository-controlled is interpolated into a
-      # `run:` block anywhere in this workflow.
+      # PR title, author login, or branch name is forwarded: those are all
+      # contributor-controlled strings, and the sweep's headline output is
+      # pinned by its self-test to contain none of them. Nothing
+      # repository-controlled is interpolated into a `run:` block anywhere in
+      # this workflow.
       - name: Notify the dev room
         if: steps.sweep.outputs.notify == 'true'
         # Best-effort: a riverctl/gateway hiccup in the notifier must never
@@ -80,6 +89,28 @@ jobs:
         uses: ./.github/actions/river-dev-notify
         with:
           message: "🧹 PR backlog sweep — ${{ steps.sweep.outputs.headline }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}
+
+      # A broken sweep must reach a human, not just the Actions tab. The premise
+      # of this whole workflow is that a queue nobody watches accumulates
+      # silently, and "scheduled runs on the Actions tab" is precisely such a
+      # queue: a cron job that starts failing goes unnoticed for as long as
+      # nobody happens to look. Paging on failure costs nothing in alarm fatigue
+      # because it fires only when the sweep is broken, which should be never.
+      #
+      # No counts here on purpose: if the sweep aborted, its counts are either
+      # unset or meaningless, and a number in this message would be a claim the
+      # run cannot support.
+      - name: Notify the dev room that the sweep is BROKEN
+        if: failure() && steps.sweep.outcome == 'failure'
+        # Best-effort like the other notifier: the job is already red, and a
+        # second red X from the notifier would only obscure which thing failed.
+        continue-on-error: true
+        uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🚨 PR backlog sweep FAILED — it could not enumerate PRs, so nothing is known about the backlog today — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
           room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
           gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}

--- a/.github/workflows/pr-backlog-sweep.yml
+++ b/.github/workflows/pr-backlog-sweep.yml
@@ -1,0 +1,85 @@
+name: PR Backlog Sweep
+
+# Reports open PRs that have stalled: green and unmerged >48h, no activity >7d,
+# or decayed into conflicts. Nothing was measuring this, so nothing reported it,
+# and the backlog reached 59 open PRs -- 26 of them green and simply never
+# merged -- before a manual audit on 2026-08-24 noticed.
+#
+# The job body is deliberately thin: all the logic is in
+# scripts/pr-backlog-sweep.sh, which is shellcheck-linted and has a self-test
+# (scripts/pr-backlog-sweep_test.sh), both run by CI's Fmt job. A workflow file
+# cannot be tested before it reaches the default branch; a script can.
+#
+# THE POINT IS THAT A BROKEN SWEEP LOOKS BROKEN. The script exits non-zero on
+# any failure to enumerate PRs, and the sweep step below is deliberately NOT
+# continue-on-error, so a red X appears here rather than a green run with an
+# empty report. Only the notifier is best-effort.
+
+on:
+  schedule:
+    # 06:00 UTC, after the nightlies, so the morning's first look at Actions
+    # shows the backlog next to the test results.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# One sweep at a time. Not cancel-in-progress: a run that is already talking to
+# the API should finish and report rather than be replaced by a manual trigger.
+concurrency:
+  group: pr-backlog-sweep
+  cancel-in-progress: false
+
+permissions:
+  contents: read # actions/checkout
+  pull-requests: read # gh pr list
+  checks: read # statusCheckRollup: check-run entries
+  statuses: read # statusCheckRollup: legacy commit-status entries
+  actions: read # gh run list --status action_required
+  # Deliberately NOT `actions: write`. This job REPORTS the approval queue; it
+  # must not be able to approve a run. Approving outside-contributor CI is a
+  # human trust decision (it lets that fork's workflow run on this repo's
+  # runners), and the whole point of section (d) is to surface that decision,
+  # not to automate it away.
+
+jobs:
+  sweep:
+    name: Sweep the open PR backlog
+    runs-on: ubuntu-latest
+    # A normal run is under a minute; the cap exists so an API stall shows up as
+    # a failure rather than a job that hangs unnoticed.
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run the sweep
+        id: sweep
+        # NOT continue-on-error, on purpose. See the header comment: the whole
+        # value of this workflow is that "nothing is stalled" and "the sweep is
+        # broken" cannot look the same. The script writes the report to
+        # $GITHUB_STEP_SUMMARY on every run, including a clean one, so a run
+        # that produced no summary is evidence it did not run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # coalesce-exempt: read-only (gh pr list / gh run list / gh api GET); emits no downstream-triggering event, so RELEASE_PAT would only widen the blast radius
+          SWEEP_REPO: ${{ github.repository }}
+        run: bash scripts/pr-backlog-sweep.sh
+
+      # Notify only when the sweep found something. A daily all-clear ping is
+      # how a room learns to filter this notifier out, and then the one message
+      # that mattered is filtered out with it.
+      #
+      # The message is built from the script's own counts plus the run URL. No
+      # PR title and no author login is forwarded: those are attacker-controlled
+      # strings, and the sweep's headline output is pinned by its self-test to
+      # contain neither. Nothing repository-controlled is interpolated into a
+      # `run:` block anywhere in this workflow.
+      - name: Notify the dev room
+        if: steps.sweep.outputs.notify == 'true'
+        # Best-effort: a riverctl/gateway hiccup in the notifier must never
+        # red-X the sweep, and must never be mistaken for a sweep failure.
+        continue-on-error: true
+        uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🧹 PR backlog sweep — ${{ steps.sweep.outputs.headline }} — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,40 @@ When unsure which bucket a change is in, open an issue first.
 3. Check .claude/rules/git-workflow.md for PR requirements
 ```
 
+### AFTER opening a PR
+
+**Do not open a PR you are not going to drive to a terminal state.** A terminal
+state is merged, or closed with a reason. "Opened, CI green, walked away" is not
+an outcome — it is a liability handed to whoever comes next.
+
+```
+1. Watch CI to completion. Fix what it reports; don't leave it red and leave.
+2. Get the review the change's risk tier requires (CONTRIBUTING.md, and the
+   `pr-review` skill it links). Required approving reviews is 0 on this repo —
+   nothing external will stop a PR from sitting unreviewed forever, so the
+   author has to ask for the review.
+3. Merge it (the merge queue rebases and retests), or close it and say why.
+4. If you genuinely cannot finish, say so IN A PR COMMENT before you stop:
+   what is done, what remains, what you would do next. An abandoned PR with a
+   hand-off note is recoverable. A silent one is archaeology.
+```
+
+Why this is a rule and not a preference: measured 2026-08-24, the repo had **59
+open PRs**. Twenty were green, mergeable, and unreviewed — the oldest green and
+untouched since 2026-07-28, and a team member's PR had gone five weeks without a
+reply. None were blocked on CI. They were blocked on nobody owning the last step.
+
+The compounding cost is the real damage. Nine of those PRs had gone from mergeable
+to CONFLICTING, and they conflicted with *each other*, not just with main —
+`ring.rs` was contested by five open PRs at once. Every day a PR waits raises the
+cost of landing it, which lowers the odds it ever lands. That is a doom loop, not
+a static pile, and the only cheap moment to break it is before you walk away.
+
+The same applies to work that never reaches a PR: **an unpushed branch is invisible
+and unrecoverable by anyone but you.** Push before you stop, even mid-change. The
+2026-08-24 sweep found uncommitted work and orphan commits sitting in agent
+worktrees that no live session owned any more.
+
 ### WHEN fixing a bug (fix: PRs)
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ When unsure which bucket a change is in, open an issue first.
 3. Check .claude/rules/git-workflow.md for PR requirements
 ```
 
-### AFTER opening a PR
+### AFTER opening a PR — and before you stop
 
 **Do not open a PR you are not going to drive to a terminal state.** A terminal
 state is merged, or closed with a reason. "Opened, CI green, walked away" is not

--- a/scripts/pr-backlog-sweep.sh
+++ b/scripts/pr-backlog-sweep.sh
@@ -194,6 +194,14 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
     def epoch: if . == null or . == "" then null
                else (try (. | fromdateiso8601) catch null) end;
 
+    # PR titles and branch names are written by whoever opened the PR, and this
+    # report is read as markdown. Rendered raw, a title of the form
+    # "[click me](https://elsewhere)" becomes a working link in a maintainer-only
+    # page. Newlines collapse (they would break the list item); the markdown
+    # metacharacters are backslash-escaped so the text renders as itself.
+    # This is presentation only -- nothing here reaches a shell either way.
+    def md: gsub("[\\r\\n]"; " ") | gsub("(?<x>[\\[\\]<>`\\\\])"; "\\\(.x)");
+
     # "Green since" is when the LAST check finished, not when the PR was last
     # touched: a comment on a green PR must not reset its green age.
     def green_since:
@@ -211,7 +219,7 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
                    + fmt_age(.[$agefield]) + "d — "
                    # Titles are author-controlled text. jq renders them into
                    # markdown here; they never reach a shell as script text.
-                   + (.title | gsub("[\\r\\n]"; " ")))
+                   + (.title | md))
                | join("\n")))
       | if length == 0 then "_none_" else join("\n") end;
 
@@ -293,7 +301,11 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
              else "" end)
           + (if ($awaiting | length) == 0 then "_none_"
              else ($awaiting
-                   | map("- `" + .branch + "` — "
+                   # Bold rather than a code span: a git ref may legitimately
+                   # contain a backtick, and there is no way to escape one
+                   # INSIDE a code span, so a code span here could be broken
+                   # out of by a fork branch name.
+                   | map("- **" + (.branch | md) + "** — "
                          + (.pending | tostring) + " run(s) pending, oldest "
                          + fmt_age(.oldest) + "d"
                          + (if (.prs | length) > 0

--- a/scripts/pr-backlog-sweep.sh
+++ b/scripts/pr-backlog-sweep.sh
@@ -123,8 +123,45 @@ die() {
     exit 1
 }
 
-FIELDS='number,title,author,createdAt,updatedAt,mergeable,isDraft,url,headRefName,statusCheckRollup'
-RUN_FIELDS='databaseId,headBranch,workflowName,createdAt'
+FIELDS='number,title,author,createdAt,updatedAt,mergeable,isDraft,url,headRefName,headRefOid,statusCheckRollup'
+RUN_FIELDS='databaseId,headBranch,headSha,workflowName,createdAt'
+
+# stderr is captured to a FILE, never merged into the JSON capture. `gh` writes
+# upgrade notices and warnings to stderr while exiting 0, and folding those into
+# `$PRS` on the success path poisons the JSON: the array gate below then dies
+# with "auth or API problem", a false red X naming the wrong cause. Same defect
+# shape the repo's SIGPIPE rule calls out -- it corrupts the diagnosis, not just
+# the verdict. stderr is surfaced only when the command actually failed.
+#
+# The result goes into a GLOBAL rather than to stdout on purpose: with
+# `OUT="$(gh_json ...)"` the `die` would run inside the command substitution's
+# subshell, so its `exit 1` would end the SUBSHELL and the script would sail on
+# with an empty variable -- a broken query reporting a clean backlog, which is
+# the one outcome this script exists to make impossible.
+ERRLOG="$(mktemp)" || die "could not create a temp file for gh's stderr"
+trap 'rm -f "$ERRLOG"' EXIT
+GH_JSON_OUT=""
+# Every call site adds `|| exit 1` even though `die` already exits, so that the
+# callers do not silently depend on an invisible property of a function defined
+# elsewhere (that its failure path exits rather than returns).
+#
+# What that buys, stated precisely rather than generously, because it was
+# measured: if `die` were ever replaced by a `return`, the run would STILL abort
+# non-zero -- the array gate below rejects the empty variable. What would be
+# lost is the DIAGNOSIS. Measured with that exact mutation and a failing stub:
+# without `|| exit 1` the run dies saying "the PR query did not return a JSON
+# array (auth or API problem)" instead of naming `gh pr list` and the 401. Same
+# class the SIGPIPE rule calls out -- it corrupts the diagnosis, not the
+# verdict, and a gate that blames the wrong subsystem sends the next reader to
+# the wrong place. Not a silent-success hole; do not describe it as one.
+gh_json() {
+    # gh_json <label> <cmd...>  -> sets GH_JSON_OUT, or dies naming <label>.
+    local what="$1"
+    shift
+    if ! GH_JSON_OUT="$("$@" 2>"$ERRLOG")"; then
+        die "$what failed for $REPO: $(tr '\n' ' ' <"$ERRLOG")"
+    fi
+}
 
 if [ -n "$RUNS_INPUT" ]; then
     [ -f "$RUNS_INPUT" ] || die "--runs-input file not found: $RUNS_INPUT"
@@ -141,29 +178,25 @@ else
     command -v gh >/dev/null 2>&1 || die "the 'gh' CLI is not on PATH"
     command -v jq >/dev/null 2>&1 || die "'jq' is not on PATH"
 
-    if ! PRS="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" 2>&1)"; then
-        die "gh pr list failed for $REPO: $PRS"
-    fi
+    gh_json "gh pr list" gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" || exit 1
+    PRS="$GH_JSON_OUT"
 
     # GitHub computes mergeability lazily: the first query after a push returns
     # UNKNOWN. One cheap refetch resolves most of them; whatever is still
     # UNKNOWN is REPORTED as unknown below rather than quietly counted as clean,
     # so the conflict count is never silently understated.
     if printf '%s' "$PRS" | jq -e 'type == "array" and (map(select(.mergeable == "UNKNOWN")) | length > 0)' >/dev/null 2>&1; then
-        sleep 10
-        if ! REFETCH="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" 2>&1)"; then
-            die "gh pr list (mergeability refetch) failed for $REPO: $REFETCH"
-        fi
-        PRS="$REFETCH"
+        sleep "${SWEEP_REFETCH_SLEEP:-10}"
+        gh_json "gh pr list (mergeability refetch)" gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" || exit 1
+        PRS="$GH_JSON_OUT"
     fi
 
     # The second unwatched queue: workflow runs held for maintainer approval.
     # Same instrument rule as above -- if this query fails we abort rather than
     # report "no runs are waiting", which is what a broken query looks like.
     if [ -z "$RUNS" ]; then
-        if ! RUNS="$(gh run list --repo "$REPO" --status action_required --limit "$LIMIT" --json "$RUN_FIELDS" 2>&1)"; then
-            die "gh run list (action_required) failed for $REPO: $RUNS"
-        fi
+        gh_json "gh run list (action_required)" gh run list --repo "$REPO" --status action_required --limit "$LIMIT" --json "$RUN_FIELDS" || exit 1
+        RUNS="$GH_JSON_OUT"
     fi
 fi
 
@@ -174,6 +207,33 @@ printf '%s' "$RUNS" | jq -e 'type == "array"' >/dev/null 2>&1 \
 
 COUNT="$(printf '%s' "$PRS" | jq 'length')"
 RUN_COUNT="$(printf '%s' "$RUNS" | jq 'length')"
+
+# THE SECOND HALF OF THE SAME PRINCIPLE, and the one that was missing. The REST
+# probe above corroborates that the LISTING is real. Nothing corroborated the
+# FIELDS inside it -- and the green bucket, the section this whole sweep exists
+# for, is computed entirely from `statusCheckRollup`. If that field came back
+# empty for every PR (a missing `checks: read` / `statuses: read` grant, a
+# GraphQL partial response, which `gh` can return alongside exit 0, or a future
+# field rename), the report would say "0 green" and exit 0. "Nothing is stalled"
+# and "the rollup never arrived" would be byte-identical -- the exact confusion
+# the probe above exists to prevent, one level in.
+#
+# Same for `mergeable`, which is the sole input to the conflict count.
+#
+# Both checks are ALL-or-nothing on purpose: an individual PR legitimately has
+# no checks (nothing matched its paths) or an unresolved mergeability. What
+# cannot legitimately happen on a repo with open PRs and CI is that NOT ONE of
+# them carries the field. A repo with genuinely no CI at all would need this
+# relaxed -- freenet-core is not that repo, and a sweep that stayed silent there
+# would be reporting on a repo it cannot see.
+if [ "$COUNT" -gt 0 ]; then
+    if ! printf '%s' "$PRS" | jq -e '[.[] | .statusCheckRollup // [] | length] | add > 0' >/dev/null 2>&1; then
+        die "fetched $COUNT open PRs and NOT ONE carries a statusCheckRollup entry. The green-and-unmerged count is computed from that field, so it would read 0 for every PR. Check the workflow's 'checks: read' and 'statuses: read' permissions, and whether gh returned a partial GraphQL response."
+    fi
+    if ! printf '%s' "$PRS" | jq -e '[.[] | select(.mergeable != null and .mergeable != "")] | length > 0' >/dev/null 2>&1; then
+        die "fetched $COUNT open PRs and NOT ONE carries a mergeable value. The conflict count is computed from that field, so it would read 0. The listing is incomplete; refusing to report a conflict-free backlog."
+    fi
+fi
 
 if [ -z "$INPUT" ]; then
     [ "$COUNT" -lt "$LIMIT" ] \
@@ -192,9 +252,8 @@ if [ -z "$INPUT" ]; then
     # because `gh` surfaces a mid-pagination API error as a non-zero exit, which
     # the check above already turns into a `die` -- but if that ever stops being
     # true, this probe will not be the thing that catches it.
-    if ! PROBE="$(gh api "repos/$REPO/pulls?state=open&per_page=1" --jq 'length' 2>&1)"; then
-        die "corroborating REST probe failed for $REPO: $PROBE"
-    fi
+    gh_json "corroborating REST probe" gh api "repos/$REPO/pulls?state=open&per_page=1" --jq "length" || exit 1
+    PROBE="$GH_JSON_OUT"
     case "$PROBE" in
         ''|*[!0-9]*) die "corroborating REST probe returned a non-number: $PROBE" ;;
     esac
@@ -242,16 +301,35 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
 
     # "Green since" is when the LAST check finished, not when the PR was last
     # touched: a comment on a green PR must not reset its green age.
+    #
+    # A CheckRun has `completedAt`; a legacy StatusContext has only `startedAt`
+    # (verified against live `gh` output -- it carries no completedAt at all).
+    # Both are folded in, because a StatusContext-only PR would otherwise fall
+    # back to `updatedAt` and a comment WOULD reset its green age there -- the
+    # single case the "a comment does not reset the green age" pin cannot see.
+    # A status context is instantaneous, so its start is its finish.
     def green_since:
-      ([.statusCheckRollup[]? | .completedAt? | epoch
-        | select(. != null and . > 0)] | max) // (.updatedAt | epoch);
+      ([ (.statusCheckRollup[]? | select(.__typename == "CheckRun") | .completedAt? | epoch),
+         (.statusCheckRollup[]? | select(.__typename == "StatusContext") | .startedAt? | epoch)
+    # The `> 0` filter drops the "0001-01-01T00:00:00Z" placeholder that GitHub
+    # emits for an unfinished check, which parses to a large negative epoch. It
+    # is DEFENSIVE and deliberately not pinned: no reachable input exercises it.
+    # A PR carrying that sentinel has an incomplete check, so it is already not
+    # green, and `max` would ignore the negative anyway. Kept because the
+    # placeholder is a real value in real output and a future caller of
+    # green_since might not be gated on greenness; recorded as untested rather
+    # than left to look covered.
+    #
+    # (No apostrophes in this block on purpose: the whole jq program is a
+    # single-quoted shell word, so one would terminate it. Caught here twice.)
+       ] | map(select(. != null and . > 0)) | max) // (.updatedAt | epoch);
 
     def fmt_age($t): if $t == null then "?"
                      else (((($now - $t) / 86400) * 10 | floor) / 10 | tostring) end;
 
     def render($prs; $agefield):
       ($prs | group_by(.author.login) | sort_by(.[0] | .[$agefield]))
-      | map("- **@" + (.[0].author.login) + "** (" + (length | tostring) + ")\n"
+      | map("- **@" + (.[0].author.login | tostring | md) + "** (" + (length | tostring) + ")\n"
             + (map("  - [#" + (.number | tostring) + "](" + .url + ") "
                    + (if .isDraft then "_(draft)_ " else "" end)
                    + fmt_age(.[$agefield]) + "d — "
@@ -270,7 +348,13 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
     | map(. + { is_green: ((.states | length) > 0 and (.states | all(. == "PASS"))) })
     | . as $all
 
+    # CONFLICTING is excluded here even when every check is green. The section
+    # is headed "Nothing is blocking these" and a conflicting PR is blocked, so
+    # listing it in both sections made the report contradict itself -- and it
+    # misdirects the action the sweep exists to prompt (merge it vs rebase it).
+    # It still appears, under CONFLICTING, where the useful verb is.
     | ($all | map(select(.is_green and (.isDraft | not)
+          and .mergeable != "CONFLICTING"
           and .green_epoch != null
           and ($now - .green_epoch) > ($green_hours * 3600)))
         | sort_by(.green_epoch)) as $stale_green
@@ -281,19 +365,32 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
     | ($all | map(select(.mergeable == "UNKNOWN")) | length) as $unknown_mergeable
 
     # (d) Runs held for maintainer approval. Grouped BY BRANCH, not by run: 22
-    # pending runs on one branch is ONE stuck PR, and reporting the raw run
-    # count would overstate the problem by an order of magnitude. The PR number
-    # is resolved by matching headRefName; a branch with no open PR (a stale
-    # run, or a closed PR) is still listed, because a queue nobody drains is
-    # the finding regardless of what is in it.
+    # pending runs on one branch is usually ONE stuck PR, and reporting the raw
+    # run count would overstate the problem by an order of magnitude.
+    #
+    # "Usually", not "always", and the difference is a fork problem: neither
+    # `gh run list --json headBranch` nor `gh pr list --json headRefName` carries
+    # the OWNER, so two forks that both use `patch-1` (or both push from their
+    # own `main`) collapse into one group and `awaiting_approval` undercounts.
+    # Section (d) exists for the outside-contributor population, which is exactly
+    # the one that collides. Two mitigations, since the owner is not available:
+    # a run is also matched to a PR by exact head SHA, which cannot collide; and
+    # a group resolving to more than one open PR is LABELLED ambiguous rather
+    # than silently presented as one stuck PR.
     | ($runs
         | group_by(.headBranch)
         | map({
             branch: .[0].headBranch,
             pending: length,
             oldest: ([.[] | .createdAt | epoch | select(. != null)] | min),
+            shas: [.[] | .headSha? | select(. != null)],
           })
-        | map(. as $g | $g + { prs: [$all[] | select(.headRefName == $g.branch) | .number] })
+        | map(. as $g | $g + {
+            prs: ([$all[]
+                   | select(.headRefName == $g.branch
+                            or (.headRefOid != null and (.headRefOid | IN($g.shas[]))))
+                   | .number] | unique),
+          })
         | sort_by(.oldest // 0)) as $awaiting
 
     | {
@@ -348,11 +445,21 @@ RESULT="$(printf '%s' "$PRS" | jq -c \
                          + fmt_age(.oldest) + "d"
                          + (if (.prs | length) > 0
                             then " — " + (.prs | map("#" + tostring) | join(", "))
-                            else " — no open PR (stale runs)" end))
+                            else " — no open PR (stale runs)" end)
+                         + (if (.prs | length) > 1
+                            then " — ⚠ AMBIGUOUS: "
+                                 + (.prs | length | tostring)
+                                 + " open PRs share this branch name, so this"
+                                 + " group may merge distinct PRs and the"
+                                 + " branch count below understates them"
+                            else "" end))
                    | join("\n"))
              end) + "\n"
           + "\n_\($runs | length) pending run(s) across \($awaiting | length) branch(es). "
-          + "Counted per BRANCH: many pending runs on one branch is one stuck PR, not many._\n"
+          + "Counted per BRANCH, because many pending runs on one branch is "
+          + "normally one stuck PR rather than many. Branch names carry no "
+          + "owner, so two forks using the same name group together — any such "
+          + "group is marked AMBIGUOUS above._\n"
         ),
       }
     ')"

--- a/scripts/pr-backlog-sweep.sh
+++ b/scripts/pr-backlog-sweep.sh
@@ -44,6 +44,33 @@
 #
 # Self-test: bash scripts/pr-backlog-sweep_test.sh
 
+# NO `set -e`, deliberately. Every failure here needs a DIAGNOSIS, not just a
+# non-zero exit: "the sweep is broken" and "the backlog is clean" must not look
+# alike, and `set -e` would abort with no `::error::` line saying which query
+# died. `-e` also interacts badly with the `$(...)`-in-a-conditional form used
+# throughout. So the contract is: every command whose failure could change the
+# REPORT is checked explicitly and routed through `die`.
+#
+# That contract was audited site by site (2026-08-24), not assumed:
+#   - `gh pr list` x2, `gh run list`, `gh api`  -> `if ! VAR="$(...)"; then die`
+#   - `command -v gh` / `command -v jq`         -> `|| die`
+#   - the two `jq -e 'type == "array"'` gates   -> `|| die`
+#   - `cat` of an --input file                  -> preceded by `[ -f ]`, and an
+#     empty read still fails the array gate above
+#   - `date +%s` (unchecked)                    -> an empty NOW reaches jq as
+#     `--argjson now ""`, which jq rejects, which empties RESULT, which is
+#     fatal at the `[ -z "$RESULT" ]` check. Verified by running the script
+#     with a non-numeric SWEEP_NOW_EPOCH.
+#   - `jq 'length'` for COUNT/RUN_COUNT         -> unreachable failure (the
+#     array gate already parsed the same input); an empty value would still
+#     fail the `-lt` comparison, which is `|| die`
+#   - the report renderer + the four count reads -> `[ -z "$RESULT" ]`, an
+#     explicit `|| die`, and a numeric `case` over every count
+#   - the `$GITHUB_STEP_SUMMARY` / `$GITHUB_OUTPUT` appends -> `|| die`
+#
+# Nothing here pipes a producer into a short-circuiting consumer (`grep -q`,
+# `head`, `read`), so the repo's SIGPIPE-under-pipefail hazard does not apply;
+# `jq` must read its input to EOF before it can answer. Keep it that way.
 set -uo pipefail
 
 REPO="${SWEEP_REPO:-freenet/freenet-core}"
@@ -339,14 +366,19 @@ done
 printf '%s\n' "$BODY"
 
 # Always write the summary, including when everything is clean: a run that
-# reports "0 / 0 / 0" is evidence the sweep RAN. A run that writes nothing is
-# indistinguishable from a run that never happened.
+# reports "0 / 0 / 0 / 0" is evidence the sweep RAN. A run that writes nothing is
+# indistinguishable from a run that never happened -- so a FAILED write is fatal
+# rather than a silent skip, for the same reason.
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-    printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+    printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY" \
+        || die "could not write \$GITHUB_STEP_SUMMARY ($GITHUB_STEP_SUMMARY); the run would have looked successful with no report attached"
 fi
 
 TOTAL=$((STALE_GREEN + IDLE + CONFLICTING + AWAITING))
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    # Also fatal on failure: the notify step keys off `notify`, so a silently
+    # unwritten output file turns a backlog with findings into a green run that
+    # tells nobody -- which is this script's whole failure mode, one level down.
     {
         echo "stale_green=$STALE_GREEN"
         echo "idle=$IDLE"
@@ -359,7 +391,8 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
         # branch names, so no repository-controlled string is ever forwarded to
         # the notifier. Pinned by the self-test.
         echo "headline=${STALE_GREEN} PR(s) green >${GREEN_HOURS}h unmerged, ${IDLE} idle >${IDLE_DAYS}d, ${CONFLICTING} conflicting, ${AWAITING} branch(es) awaiting CI approval"
-    } >> "$GITHUB_OUTPUT"
+    } >> "$GITHUB_OUTPUT" \
+        || die "could not write \$GITHUB_OUTPUT ($GITHUB_OUTPUT); the notification step reads its trigger from there"
 fi
 
 echo "sweep ok: stale_green=$STALE_GREEN idle=$IDLE conflicting=$CONFLICTING awaiting_approval=$AWAITING" >&2

--- a/scripts/pr-backlog-sweep.sh
+++ b/scripts/pr-backlog-sweep.sh
@@ -70,7 +70,11 @@
 #
 # Nothing here pipes a producer into a short-circuiting consumer (`grep -q`,
 # `head`, `read`), so the repo's SIGPIPE-under-pipefail hazard does not apply;
-# `jq` must read its input to EOF before it can answer. Keep it that way.
+# `jq` must read its input to EOF before it can answer. That was measured, not
+# assumed -- the hazard is volume-dependent, so a claim about it based on small
+# inputs is worthless: at a 1 MB payload all three jq forms used here returned
+# their real verdict (0 / logical-false 1 / 0), none returned 141. Keep it that
+# way: introducing a `grep -q` or `head` whose STATUS is consumed would arm it.
 set -uo pipefail
 
 REPO="${SWEEP_REPO:-freenet/freenet-core}"
@@ -181,6 +185,13 @@ if [ -z "$INPUT" ]; then
     # independent path (REST rather than the GraphQL-backed `gh pr list`) has to
     # agree that there are genuinely no open PRs before we accept "nothing to
     # report" as a fact about the repo.
+    #
+    # What this does NOT cover, stated so nobody reads it as broader than it is:
+    # it detects an EMPTY listing that should not be empty, not a listing that
+    # is merely SHORT. A silent partial page would slip past. That is accepted
+    # because `gh` surfaces a mid-pagination API error as a non-zero exit, which
+    # the check above already turns into a `die` -- but if that ever stops being
+    # true, this probe will not be the thing that catches it.
     if ! PROBE="$(gh api "repos/$REPO/pulls?state=open&per_page=1" --jq 'length' 2>&1)"; then
         die "corroborating REST probe failed for $REPO: $PROBE"
     fi

--- a/scripts/pr-backlog-sweep.sh
+++ b/scripts/pr-backlog-sweep.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Report open PRs that have stalled: green-but-unmerged, idle, decayed into
+# conflicts, or waiting on CI approval. Driven by
+# .github/workflows/pr-backlog-sweep.yml, runnable by hand.
+#
+# WHY THIS EXISTS. Measured 2026-08-24: 59 open PRs, 26 of them green and simply
+# never merged, the oldest untouched since 2026-07-28 and a team member's PR
+# five weeks without a reply. Nine had rotted from mergeable to CONFLICTING and
+# were conflicting with EACH OTHER -- ring.rs was contested by five open PRs at
+# once. Nothing in the repo was measuring that, so nothing reported it.
+#
+# The same measurement found a SECOND unwatched queue: 58 workflow runs sitting
+# in `action_required`, some since 2026-07-26. Outside-contributor CI needs a
+# maintainer to approve each run, and nobody was doing it, so most community PRs
+# had never had the main test suite run at all. They were not unreviewed; they
+# were unreviewABLE, and any "that PR is red/green" claim made about them was
+# made without evidence. The approval gate itself is CORRECT -- letting an
+# untrusted fork run workflows on this repo's runners is a real security
+# problem, and far worse than a slow queue. The gate is not the bug. Nobody
+# watching it was. Section (d) below makes it visible; do not "simplify" this
+# sweep by loosening the approval policy.
+#
+# THE DESIGN CONSTRAINT THAT MATTERS MOST: this is an INSTRUMENT, not a mask.
+# If it cannot enumerate PRs -- no `gh`, no credentials, an API error, a
+# truncated page -- it exits NON-ZERO and says why. It must never print an empty
+# report and exit 0, because then "nothing is stalled" and "the sweep is broken"
+# look identical, and the broken one wins by default. This project has been
+# burned by exactly that shape once already: a backup job that logged
+# "unreachable, skipping" and exited 0 reported SUCCESS for 37 consecutive days
+# while no backups ran.
+#
+# Test hooks (all also useful for debugging by hand):
+#   --input FILE        classify this `gh pr list --json ...` array instead of
+#                       querying GitHub. Skips the fetch and its integrity
+#                       checks; the classification below is what it exercises.
+#   --runs-input FILE   likewise for the `gh run list --status action_required`
+#                       array. Defaults to empty when only --input is given.
+#   SWEEP_NOW_EPOCH     pretend "now" is this unix timestamp.
+#   SWEEP_REPO          owner/name to sweep (default freenet/freenet-core).
+#   SWEEP_GREEN_HOURS   green-and-unmerged threshold (default 48).
+#   SWEEP_IDLE_DAYS     no-activity threshold (default 7).
+#   SWEEP_LIMIT         max PRs to fetch; hitting it is a hard error, not a
+#                       silent truncation (default 300).
+#
+# Self-test: bash scripts/pr-backlog-sweep_test.sh
+
+set -uo pipefail
+
+REPO="${SWEEP_REPO:-freenet/freenet-core}"
+GREEN_HOURS="${SWEEP_GREEN_HOURS:-48}"
+IDLE_DAYS="${SWEEP_IDLE_DAYS:-7}"
+LIMIT="${SWEEP_LIMIT:-300}"
+NOW="${SWEEP_NOW_EPOCH:-$(date +%s)}"
+
+INPUT=""
+RUNS_INPUT=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --input)
+            INPUT="${2:-}"
+            if [ -z "$INPUT" ]; then
+                echo "::error::--input requires a file argument" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        --runs-input)
+            RUNS_INPUT="${2:-}"
+            if [ -z "$RUNS_INPUT" ]; then
+                echo "::error::--runs-input requires a file argument" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,45p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "::error::unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+die() {
+    # Every abort goes through here so a broken sweep is impossible to mistake
+    # for a clean one: a GitHub-annotated error line AND a non-zero exit.
+    echo "::error::PR backlog sweep FAILED: $*" >&2
+    echo "The sweep could not enumerate PRs, so this run reports NOTHING about" >&2
+    echo "the backlog. Do not read the absence of findings as an empty backlog." >&2
+    exit 1
+}
+
+FIELDS='number,title,author,createdAt,updatedAt,mergeable,isDraft,url,headRefName,statusCheckRollup'
+RUN_FIELDS='databaseId,headBranch,workflowName,createdAt'
+
+if [ -n "$RUNS_INPUT" ]; then
+    [ -f "$RUNS_INPUT" ] || die "--runs-input file not found: $RUNS_INPUT"
+    RUNS="$(cat "$RUNS_INPUT")"
+else
+    RUNS=""
+fi
+
+if [ -n "$INPUT" ]; then
+    [ -f "$INPUT" ] || die "--input file not found: $INPUT"
+    PRS="$(cat "$INPUT")"
+    [ -n "$RUNS" ] || RUNS='[]'
+else
+    command -v gh >/dev/null 2>&1 || die "the 'gh' CLI is not on PATH"
+    command -v jq >/dev/null 2>&1 || die "'jq' is not on PATH"
+
+    if ! PRS="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" 2>&1)"; then
+        die "gh pr list failed for $REPO: $PRS"
+    fi
+
+    # GitHub computes mergeability lazily: the first query after a push returns
+    # UNKNOWN. One cheap refetch resolves most of them; whatever is still
+    # UNKNOWN is REPORTED as unknown below rather than quietly counted as clean,
+    # so the conflict count is never silently understated.
+    if printf '%s' "$PRS" | jq -e 'type == "array" and (map(select(.mergeable == "UNKNOWN")) | length > 0)' >/dev/null 2>&1; then
+        sleep 10
+        if ! REFETCH="$(gh pr list --repo "$REPO" --state open --limit "$LIMIT" --json "$FIELDS" 2>&1)"; then
+            die "gh pr list (mergeability refetch) failed for $REPO: $REFETCH"
+        fi
+        PRS="$REFETCH"
+    fi
+
+    # The second unwatched queue: workflow runs held for maintainer approval.
+    # Same instrument rule as above -- if this query fails we abort rather than
+    # report "no runs are waiting", which is what a broken query looks like.
+    if [ -z "$RUNS" ]; then
+        if ! RUNS="$(gh run list --repo "$REPO" --status action_required --limit "$LIMIT" --json "$RUN_FIELDS" 2>&1)"; then
+            die "gh run list (action_required) failed for $REPO: $RUNS"
+        fi
+    fi
+fi
+
+printf '%s' "$PRS" | jq -e 'type == "array"' >/dev/null 2>&1 \
+    || die "the PR query did not return a JSON array (auth or API problem)"
+printf '%s' "$RUNS" | jq -e 'type == "array"' >/dev/null 2>&1 \
+    || die "the action_required workflow-run query did not return a JSON array (auth or API problem)"
+
+COUNT="$(printf '%s' "$PRS" | jq 'length')"
+RUN_COUNT="$(printf '%s' "$RUNS" | jq 'length')"
+
+if [ -z "$INPUT" ]; then
+    [ "$COUNT" -lt "$LIMIT" ] \
+        || die "fetched $COUNT PRs, which is the fetch limit ($LIMIT): the list is TRUNCATED and this report would be incomplete. Raise SWEEP_LIMIT."
+    [ "$RUN_COUNT" -lt "$LIMIT" ] \
+        || die "fetched $RUN_COUNT action_required runs, which is the fetch limit ($LIMIT): the list is TRUNCATED. Raise SWEEP_LIMIT."
+
+    # An empty result and a broken query must not look alike. A second,
+    # independent path (REST rather than the GraphQL-backed `gh pr list`) has to
+    # agree that there are genuinely no open PRs before we accept "nothing to
+    # report" as a fact about the repo.
+    if ! PROBE="$(gh api "repos/$REPO/pulls?state=open&per_page=1" --jq 'length' 2>&1)"; then
+        die "corroborating REST probe failed for $REPO: $PROBE"
+    fi
+    case "$PROBE" in
+        ''|*[!0-9]*) die "corroborating REST probe returned a non-number: $PROBE" ;;
+    esac
+    if [ "$COUNT" -eq 0 ] && [ "$PROBE" -ne 0 ]; then
+        die "gh pr list returned 0 open PRs but the REST API sees at least $PROBE. The listing is wrong; refusing to report an empty backlog."
+    fi
+fi
+
+# jq emits ONE json object carrying both the rendered markdown and the counts,
+# so the notification headline can never disagree with the table a human reads.
+RESULT="$(printf '%s' "$PRS" | jq -c \
+    --argjson runs "$RUNS" \
+    --argjson now "$NOW" \
+    --argjson green_hours "$GREEN_HOURS" \
+    --argjson idle_days "$IDLE_DAYS" \
+    --arg repo "$REPO" '
+    # A rollup entry is a CheckRun (carries .status/.conclusion) or a legacy
+    # StatusContext (carries .state). Reading only one of the two fields is the
+    # classic way to misread CI as permanently pending, so both are handled and
+    # anything unrecognised degrades to UNKNOWN -- which is NOT green.
+    def check_state:
+      if .__typename == "CheckRun" then
+        (if ((.status // "") | ascii_upcase) != "COMPLETED" then "PENDING"
+         else (((.conclusion // "") | ascii_upcase) as $c
+               | if ($c == "SUCCESS" or $c == "SKIPPED" or $c == "NEUTRAL")
+                 then "PASS" else "FAIL" end)
+         end)
+      elif .__typename == "StatusContext" then
+        (((.state // "") | ascii_upcase) as $s
+         | if $s == "SUCCESS" then "PASS"
+           elif ($s == "PENDING" or $s == "EXPECTED") then "PENDING"
+           else "FAIL" end)
+      else "UNKNOWN" end;
+
+    def epoch: if . == null or . == "" then null
+               else (try (. | fromdateiso8601) catch null) end;
+
+    # "Green since" is when the LAST check finished, not when the PR was last
+    # touched: a comment on a green PR must not reset its green age.
+    def green_since:
+      ([.statusCheckRollup[]? | .completedAt? | epoch
+        | select(. != null and . > 0)] | max) // (.updatedAt | epoch);
+
+    def fmt_age($t): if $t == null then "?"
+                     else (((($now - $t) / 86400) * 10 | floor) / 10 | tostring) end;
+
+    def render($prs; $agefield):
+      ($prs | group_by(.author.login) | sort_by(.[0] | .[$agefield]))
+      | map("- **@" + (.[0].author.login) + "** (" + (length | tostring) + ")\n"
+            + (map("  - [#" + (.number | tostring) + "](" + .url + ") "
+                   + (if .isDraft then "_(draft)_ " else "" end)
+                   + fmt_age(.[$agefield]) + "d — "
+                   # Titles are author-controlled text. jq renders them into
+                   # markdown here; they never reach a shell as script text.
+                   + (.title | gsub("[\\r\\n]"; " ")))
+               | join("\n")))
+      | if length == 0 then "_none_" else join("\n") end;
+
+    map(. + {
+      states: [.statusCheckRollup[]? | check_state],
+      idle_epoch: (.updatedAt | epoch),
+      created_epoch: (.createdAt | epoch),
+      green_epoch: green_since,
+    })
+    | map(. + { is_green: ((.states | length) > 0 and (.states | all(. == "PASS"))) })
+    | . as $all
+
+    | ($all | map(select(.is_green and (.isDraft | not)
+          and .green_epoch != null
+          and ($now - .green_epoch) > ($green_hours * 3600)))
+        | sort_by(.green_epoch)) as $stale_green
+    | ($all | map(select(.idle_epoch != null
+          and ($now - .idle_epoch) > ($idle_days * 86400)))
+        | sort_by(.idle_epoch)) as $idle
+    | ($all | map(select(.mergeable == "CONFLICTING")) | sort_by(.created_epoch)) as $conflicting
+    | ($all | map(select(.mergeable == "UNKNOWN")) | length) as $unknown_mergeable
+
+    # (d) Runs held for maintainer approval. Grouped BY BRANCH, not by run: 22
+    # pending runs on one branch is ONE stuck PR, and reporting the raw run
+    # count would overstate the problem by an order of magnitude. The PR number
+    # is resolved by matching headRefName; a branch with no open PR (a stale
+    # run, or a closed PR) is still listed, because a queue nobody drains is
+    # the finding regardless of what is in it.
+    | ($runs
+        | group_by(.headBranch)
+        | map({
+            branch: .[0].headBranch,
+            pending: length,
+            oldest: ([.[] | .createdAt | epoch | select(. != null)] | min),
+          })
+        | map(. as $g | $g + { prs: [$all[] | select(.headRefName == $g.branch) | .number] })
+        | sort_by(.oldest // 0)) as $awaiting
+
+    | {
+        stale_green: ($stale_green | length),
+        idle: ($idle | length),
+        conflicting: ($conflicting | length),
+        awaiting_approval: ($awaiting | length),
+        pending_runs: ($runs | length),
+        total_open: ($all | length),
+        body: (
+            "## PR backlog sweep — \($repo)\n\n"
+          + "\($all | length) open PRs. "
+          + "**\($stale_green | length)** green >\($green_hours)h · "
+          + "**\($idle | length)** idle >\($idle_days)d · "
+          + "**\($conflicting | length)** conflicting · "
+          + "**\($awaiting | length)** branch(es) awaiting CI approval.\n"
+          + (if $unknown_mergeable > 0
+             then "\n> \($unknown_mergeable) PR(s) still report `mergeable: UNKNOWN` after a refetch, so the conflict count is a LOWER BOUND.\n"
+             else "" end)
+          + "\n### Green and unmerged >\($green_hours)h\n"
+          + "Nothing is blocking these. Age is time since the last check finished. Drafts excluded.\n\n"
+          + render($stale_green; "green_epoch") + "\n"
+          + "\n### No activity >\($idle_days)d\n\n"
+          + render($idle; "idle_epoch") + "\n"
+          + "\n### Decayed to CONFLICTING\n"
+          + "Every day these wait, the cost of landing them rises.\n\n"
+          + render($conflicting; "created_epoch") + "\n"
+          + "\n### Waiting on CI approval (`action_required`)\n"
+          + "Outside-contributor runs need a maintainer to approve them. Until "
+          + "someone does, the test suite has NOT run on these branches — they "
+          + "are not unreviewed, they are unreviewable, and any claim that one "
+          + "is red or green is made without evidence.\n\n"
+          + "The approval gate itself is correct and must stay: it is what "
+          + "stops an untrusted fork from running workflows on the CI runners "
+          + "of this repository. "
+          + "Approve the runs; do not loosen the policy.\n\n"
+          # Branch-to-PR resolution needs headRefName. If the PR listing carries
+          # none, every branch would silently read as "no open PR" -- a wrong
+          # answer that looks like a finding. Say so instead.
+          + (if ($awaiting | length) > 0 and ($all | length) > 0
+                and ([$all[] | .headRefName] | all(. == null))
+             then "> The PR listing carries no `headRefName`, so branches could not be resolved to PRs below.\n\n"
+             else "" end)
+          + (if ($awaiting | length) == 0 then "_none_"
+             else ($awaiting
+                   | map("- `" + .branch + "` — "
+                         + (.pending | tostring) + " run(s) pending, oldest "
+                         + fmt_age(.oldest) + "d"
+                         + (if (.prs | length) > 0
+                            then " — " + (.prs | map("#" + tostring) | join(", "))
+                            else " — no open PR (stale runs)" end))
+                   | join("\n"))
+             end) + "\n"
+          + "\n_\($runs | length) pending run(s) across \($awaiting | length) branch(es). "
+          + "Counted per BRANCH: many pending runs on one branch is one stuck PR, not many._\n"
+        ),
+      }
+    ')"
+
+if [ -z "$RESULT" ]; then
+    die "the report renderer produced no output (jq failed on the PR listing)"
+fi
+
+BODY="$(printf '%s' "$RESULT" | jq -r '.body')" || die "could not read the rendered report"
+STALE_GREEN="$(printf '%s' "$RESULT" | jq -r '.stale_green')"
+IDLE="$(printf '%s' "$RESULT" | jq -r '.idle')"
+CONFLICTING="$(printf '%s' "$RESULT" | jq -r '.conflicting')"
+AWAITING="$(printf '%s' "$RESULT" | jq -r '.awaiting_approval')"
+
+for v in "$STALE_GREEN" "$IDLE" "$CONFLICTING" "$AWAITING"; do
+    case "$v" in
+        ''|*[!0-9]*) die "could not parse the sweep counts out of the rendered report" ;;
+    esac
+done
+[ -n "$BODY" ] || die "the rendered report body is empty"
+
+printf '%s\n' "$BODY"
+
+# Always write the summary, including when everything is clean: a run that
+# reports "0 / 0 / 0" is evidence the sweep RAN. A run that writes nothing is
+# indistinguishable from a run that never happened.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+TOTAL=$((STALE_GREEN + IDLE + CONFLICTING + AWAITING))
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "stale_green=$STALE_GREEN"
+        echo "idle=$IDLE"
+        echo "conflicting=$CONFLICTING"
+        echo "awaiting_approval=$AWAITING"
+        # Notify only when there IS something to say. A daily "all clear" ping is
+        # how a channel learns to ignore this notifier.
+        if [ "$TOTAL" -gt 0 ]; then echo "notify=true"; else echo "notify=false"; fi
+        # Counts only -- deliberately no PR titles, no author logins and no
+        # branch names, so no repository-controlled string is ever forwarded to
+        # the notifier. Pinned by the self-test.
+        echo "headline=${STALE_GREEN} PR(s) green >${GREEN_HOURS}h unmerged, ${IDLE} idle >${IDLE_DAYS}d, ${CONFLICTING} conflicting, ${AWAITING} branch(es) awaiting CI approval"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+echo "sweep ok: stale_green=$STALE_GREEN idle=$IDLE conflicting=$CONFLICTING awaiting_approval=$AWAITING" >&2
+exit 0

--- a/scripts/pr-backlog-sweep_test.sh
+++ b/scripts/pr-backlog-sweep_test.sh
@@ -88,9 +88,17 @@ section() {
 }
 
 sweep_counts() {
-    # Prints "<green> <idle> <conflicting> <awaiting>" pulled back out of the rendered
-    # headline, so the test reads the same numbers a human would.
-    printf '%s\n' "$1" | grep -m1 'open PRs\.' \
+    # Prints "<green> <idle> <conflicting> <awaiting>" pulled back out of the
+    # rendered headline, so the test reads the same numbers a human would.
+    #
+    # `awk NR==1{...;exit}` rather than `grep -m1`: `-m1` is a short-circuiting
+    # consumer, and the repo's SIGPIPE-under-pipefail audit grep looks for
+    # `grep -[a-z]*q`, `head` and `read` -- it would not have SEEN this one. It
+    # was benign here (the status is discarded), but a form the project's own
+    # audit cannot find is the wrong form to leave lying around in a file whose
+    # subject is instruments that fail invisibly.
+    printf '%s\n' "$1" \
+        | awk '/open PRs\./ { print; exit }' \
         | grep -oE '\*\*[0-9]+\*\*' | tr -d '*' | paste -sd' ' -
 }
 
@@ -229,6 +237,174 @@ check_contains "the report says not to loosen the approval policy" "$RUNS_REPORT
 NO_RUNS_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" 2>/dev/null)"
 check_contains "an empty approval queue renders as none" "$NO_RUNS_REPORT" "**0** branch(es) awaiting CI approval" yes
 
+# --- Gaps found by review (each of these mutations previously SURVIVED) ------
+
+# A PENDING legacy StatusContext must not read as green. Every open PR on this
+# repo carries StatusContexts (license/cla, rule-review/warnings, snyk), so a
+# mutation making a pending one read as PASS would ship a wrong green list
+# silently -- and `check_state` is the function this file's header says it
+# exists to protect. Only SUCCESS was ever fed to that branch before.
+cat > "$WORK/pending-status.json" <<EOF
+[
+  {
+    "number": 11, "title": "pending legacy status is NOT green", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/11", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"},
+      {"__typename": "StatusContext", "state": "PENDING", "startedAt": "$OLD"}
+    ]
+  },
+  {
+    "number": 12, "title": "expected legacy status is NOT green", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/12", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "StatusContext", "state": "EXPECTED", "startedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+PENDING_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/pending-status.json" 2>/dev/null)"
+check "a pending or expected StatusContext is not green" "0 2 0 0" "$(sweep_counts "$PENDING_REPORT")"
+
+# A StatusContext carries startedAt and no completedAt, so a
+# StatusContext-only PR used to fall back to updatedAt -- meaning a comment DID
+# reset its green age, the one case the CheckRun-based pin cannot see.
+cat > "$WORK/status-only.json" <<EOF
+[
+  {
+    "number": 13, "title": "green via StatusContext, freshly commented", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$FRESH", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/13", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "StatusContext", "state": "SUCCESS", "startedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+STATUS_ONLY="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/status-only.json" 2>/dev/null)"
+check_contains "a StatusContext-only PR dates its green age from the status, not a comment" \
+    "$(section "$STATUS_ONLY" "Green and unmerged")" "/13) 20d" yes
+
+# A green PR that is ALSO conflicting must not be listed under "Nothing is
+# blocking these" -- it is blocked, and the report contradicted itself by
+# putting the same PR in both sections. Live run at the time: 3 of 8.
+cat > "$WORK/green-conflicting.json" <<EOF
+[
+  {
+    "number": 14, "title": "green checks but conflicting", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "CONFLICTING",
+    "isDraft": false, "url": "https://example.invalid/14", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+GC_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/green-conflicting.json" 2>/dev/null)"
+check "a conflicting PR is not counted as green-and-unblocked" "0 1 1 0" "$(sweep_counts "$GC_REPORT")"
+check_contains "the conflicting PR is absent from the green section" \
+    "$(section "$GC_REPORT" "Green and unmerged")" "example.invalid/14" no
+check_contains "the conflicting PR is present in the conflicting section" \
+    "$(section "$GC_REPORT" "Decayed to CONFLICTING")" "example.invalid/14" yes
+
+# The UNKNOWN-mergeability note is the honesty mechanism for the conflict count
+# -- it says the number is a LOWER BOUND. It fired on live data the day this
+# landed (3 PRs), and deleting it previously left the suite green.
+cat > "$WORK/unknown-mergeable.json" <<EOF
+[
+  {
+    "number": 15, "title": "mergeability not yet computed", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "UNKNOWN",
+    "isDraft": false, "url": "https://example.invalid/15", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+UNK_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/unknown-mergeable.json" 2>/dev/null)"
+check_contains "an UNKNOWN mergeability is declared a LOWER BOUND" "$UNK_REPORT" "LOWER BOUND" yes
+check_contains "a fully-resolved listing carries no lower-bound note" "$REPORT" "LOWER BOUND" no
+
+# Branch-to-PR resolution needs headRefName. mixed.json deliberately has none,
+# so combining it with the runs fixture exercises the warning that says so --
+# without it, every branch would silently read "no open PR", a wrong answer
+# that looks like a finding.
+NO_REF="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/mixed.json" --runs-input "$WORK/runs.json" 2>/dev/null)"
+check_contains "a listing with no headRefName says branches could not be resolved" \
+    "$NO_REF" "carries no \`headRefName\`" yes
+check_contains "a listing WITH headRefName carries no such warning" \
+    "$RUNS_REPORT" "carries no \`headRefName\`" no
+
+# Two forks can use the same branch name, and neither gh field carries the
+# owner, so such a group merges distinct PRs and the branch count understates
+# them. It must be labelled rather than presented as one stuck PR.
+cat > "$WORK/fork-collision.json" <<EOF
+[
+  {"number": 100, "title": "fork A", "author": {"login": "a"}, "createdAt": "$OLD",
+   "updatedAt": "$OLD", "mergeable": "MERGEABLE", "isDraft": false,
+   "url": "https://example.invalid/100", "headRefName": "patch-1",
+   "statusCheckRollup": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}]},
+  {"number": 101, "title": "fork B", "author": {"login": "b"}, "createdAt": "$OLD",
+   "updatedAt": "$OLD", "mergeable": "MERGEABLE", "isDraft": false,
+   "url": "https://example.invalid/101", "headRefName": "patch-1",
+   "statusCheckRollup": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}]}
+]
+EOF
+cat > "$WORK/fork-runs.json" <<EOF
+[{"databaseId": 9, "headBranch": "patch-1", "headSha": "deadbeef", "workflowName": "CI", "createdAt": "$OLD"}]
+EOF
+FORK_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/fork-collision.json" --runs-input "$WORK/fork-runs.json" 2>/dev/null)"
+# Needle is the ROW marker "⚠ AMBIGUOUS:", not the bare word: the footer prose
+# explains that such groups are "marked AMBIGUOUS above", so a bare-word search
+# matches the explanation and the negative case can never fail. Same anchor trap
+# as the workflow pins above, hit twice in one file.
+check_contains "a branch name shared by two open PRs is flagged ambiguous" "$FORK_REPORT" "⚠ AMBIGUOUS:" yes
+check_contains "an unambiguous branch is not flagged" "$RUNS_REPORT" "⚠ AMBIGUOUS:" no
+
+# A run whose branch matches nothing is still resolved when its head SHA does.
+# SHA cannot collide across forks, so this is the resolution that survives the
+# ambiguity above.
+cat > "$WORK/sha-runs.json" <<EOF
+[{"databaseId": 10, "headBranch": "renamed-since", "headSha": "cafe1234", "workflowName": "CI", "createdAt": "$OLD"}]
+EOF
+cat > "$WORK/sha-prs.json" <<EOF
+[{"number": 200, "title": "matched by sha", "author": {"login": "a"}, "createdAt": "$OLD",
+  "updatedAt": "$OLD", "mergeable": "MERGEABLE", "isDraft": false,
+  "url": "https://example.invalid/200", "headRefName": "other-name", "headRefOid": "cafe1234",
+  "statusCheckRollup": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}]}]
+EOF
+SHA_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/sha-prs.json" --runs-input "$WORK/sha-runs.json" 2>/dev/null)"
+check_contains "a run is resolved to its PR by head SHA when the branch name does not match" \
+    "$SHA_REPORT" "oldest 20d — #200" yes
+
+# The field-blindness gates: the REST probe corroborates that the LISTING is
+# real, these corroborate that the FIELDS inside it arrived. A rollup that came
+# back empty for every PR would report "0 green" and exit 0 -- indistinguishable
+# from a clean backlog, and the green bucket is what the sweep is FOR.
+BLIND_ROLLUP="$WORK/blind-rollup.json"
+jq -c 'map(. + {statusCheckRollup: []})' "$WORK/mixed.json" > "$BLIND_ROLLUP"
+BLIND_RC=0
+SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$BLIND_ROLLUP" >/dev/null 2>&1 || BLIND_RC=$?
+check "a listing whose every rollup is empty aborts non-zero" "1" "$BLIND_RC"
+
+BLIND_MERGE="$WORK/blind-mergeable.json"
+jq -c 'map(. + {mergeable: null})' "$WORK/mixed.json" > "$BLIND_MERGE"
+BLIND_M_RC=0
+SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$BLIND_MERGE" >/dev/null 2>&1 || BLIND_M_RC=$?
+check "a listing whose every mergeable is null aborts non-zero" "1" "$BLIND_M_RC"
+
+# ...but a SINGLE PR legitimately having no checks must NOT abort, or the sweep
+# cries wolf on a normal repo. mixed.json's #6 is exactly that case and the
+# suite above already runs it clean; assert it explicitly so a future tightening
+# of the gate to per-PR is caught here rather than in production.
+check_contains "a single PR with no checks does not abort the sweep" "$REPORT" "PR backlog sweep" yes
+
 # --- An author-controlled title must not be able to run anything -------------
 CANARY="$WORK/pwned"
 cat > "$WORK/inject.json" <<EOF
@@ -334,6 +510,63 @@ check "a listing truncated at the fetch limit aborts non-zero" "1" "$(sweep_rc)"
 # prints, so it aborts rather than reporting a clean CI-approval queue.
 write_stub_gh runs-fail 1
 check "a failed action_required query aborts non-zero" "1" "$(sweep_rc)"
+
+# The mergeability refetch is a live-network path that nothing exercised:
+# deleting it whole (sleep included) previously left the suite green. The stub
+# below returns UNKNOWN on the first `pr list` and CONFLICTING on the second, so
+# only a sweep that actually refetches reports the conflict. SWEEP_REFETCH_SLEEP
+# exists so this costs no wall-clock; it defaults to the real 10s.
+cat > "$STUB/gh" <<STUBEOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "api" ]; then echo 1; exit 0; fi
+if [ "\${1:-}" = "run" ]; then echo "[]"; exit 0; fi
+CALLS="$WORK/prlist-calls"
+n=\$(( \$(cat "\$CALLS" 2>/dev/null || echo 0) + 1 ))
+echo "\$n" > "\$CALLS"
+if [ "\$n" -eq 1 ]; then M=UNKNOWN; else M=CONFLICTING; fi
+jq -cn --arg m "\$M" '[{number: 1, title: "x", author: {login: "a"}, createdAt: "$OLD", updatedAt: "$OLD", mergeable: \$m, isDraft: false, url: "https://example.invalid/1", headRefName: "b", headRefOid: "abc", statusCheckRollup: [{__typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", completedAt: "$OLD"}]}]'
+STUBEOF
+chmod +x "$STUB/gh"
+rm -f "$WORK/prlist-calls"
+REFETCH_OUT="$(SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 SWEEP_REFETCH_SLEEP=0 PATH="$STUB:$PATH" \
+    "$BASH_BIN" "$SWEEP" 2>/dev/null)"
+check "an UNKNOWN mergeability triggers exactly one refetch" "2" "$(cat "$WORK/prlist-calls")"
+check "the refetched mergeability is the one reported" "0 1 1 0" "$(sweep_counts "$REFETCH_OUT")"
+
+# The action_required listing gets the same truncation guard as the PR listing.
+# Its PR-side twin was covered and this one was not -- an asymmetry that would
+# have let a truncated approval queue report a short, confident number.
+cat > "$STUB/gh" <<STUBEOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "api" ]; then echo 1; exit 0; fi
+if [ "\${1:-}" = "run" ]; then
+  jq -cn --argjson n 5 '[range(\$n) | {databaseId: ., headBranch: "b", headSha: "s", workflowName: "CI", createdAt: "$OLD"}]'
+  exit 0
+fi
+jq -cn '[{number: 1, title: "x", author: {login: "a"}, createdAt: "$OLD", updatedAt: "$OLD", mergeable: "MERGEABLE", isDraft: false, url: "https://example.invalid/1", headRefName: "b", headRefOid: "abc", statusCheckRollup: [{__typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", completedAt: "$OLD"}]}]'
+STUBEOF
+chmod +x "$STUB/gh"
+RUNS_TRUNC_RC=0
+SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 SWEEP_REFETCH_SLEEP=0 PATH="$STUB:$PATH" \
+    "$BASH_BIN" "$SWEEP" >/dev/null 2>&1 || RUNS_TRUNC_RC=$?
+check "an action_required listing truncated at the fetch limit aborts non-zero" "1" "$RUNS_TRUNC_RC"
+
+# gh writes upgrade notices to stderr while exiting 0. Merging stderr into the
+# JSON capture poisoned $PRS and produced a false red X blaming "auth or API
+# problem" -- the wrong cause, which is worse than the wrong verdict.
+cat > "$STUB/gh" <<STUBEOF
+#!/usr/bin/env bash
+echo "A new release of gh is available: 2.86.0 -> 2.87.0" >&2
+if [ "\${1:-}" = "api" ]; then echo 1; exit 0; fi
+if [ "\${1:-}" = "run" ]; then echo "[]"; exit 0; fi
+jq -cn '[{number: 1, title: "x", author: {login: "a"}, createdAt: "$OLD", updatedAt: "$OLD", mergeable: "MERGEABLE", isDraft: false, url: "https://example.invalid/1", headRefName: "b", headRefOid: "abc", statusCheckRollup: [{__typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS", completedAt: "$OLD"}]}]'
+STUBEOF
+chmod +x "$STUB/gh"
+NOISY_RC=0
+NOISY_OUT="$(SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 SWEEP_REFETCH_SLEEP=0 PATH="$STUB:$PATH" \
+    "$BASH_BIN" "$SWEEP" 2>/dev/null)" || NOISY_RC=$?
+check "a gh that warns on stderr but succeeds does not poison the listing" "0" "$NOISY_RC"
+check "the noisy-gh run still classifies correctly" "1 1 0 0" "$(sweep_counts "$NOISY_OUT")"
 
 # The one case that legitimately reports nothing: both paths agree the repo has
 # no open PRs. This must SUCCEED, or the sweep cries wolf forever.

--- a/scripts/pr-backlog-sweep_test.sh
+++ b/scripts/pr-backlog-sweep_test.sh
@@ -253,6 +253,30 @@ else
 fi
 check_contains "the crafted title is rendered as inert text" "$INJECT_REPORT" 'touch' yes
 
+# The report is read as markdown on a maintainer-only page, so a title of the
+# form "[click me](https://elsewhere)" must not become a working link.
+cat > "$WORK/markdown.json" <<EOF
+[
+  {
+    "number": 43, "title": "[click me](https://evil.invalid) and \`code\` and <b>",
+    "author": {"login": "mallory"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/43", "headRefName": "b",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+MD_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/markdown.json" 2>/dev/null)"
+check_contains "a link in a PR title is escaped, not rendered" "$MD_REPORT" '\[click me\](https://evil.invalid)' yes
+check_contains "the raw unescaped link form is absent" "$MD_REPORT" '— [click me](https://evil.invalid)' no
+# The needle is deliberately literal: it is the escaped text the report should
+# contain, backticks included, so SC2016 is an accurate observation about a
+# string that must not expand.
+# shellcheck disable=SC2016
+check_contains "backticks and angle brackets in a title are escaped" "$MD_REPORT" '\`code\` and \<b\>' yes
+
 # --- The failure paths: a broken sweep must never look clean -----------------
 # A stub `gh` drives the abort paths that a healthy CI run never touches.
 STUB="$WORK/stub"
@@ -345,6 +369,9 @@ check_contains "the headline carries no PR title" "$(grep '^headline=' "$OUTPUTS
 : > "$OUTPUTS"
 SWEEP_NOW_EPOCH="$NOW" GITHUB_OUTPUT="$OUTPUTS" "$BASH_BIN" "$SWEEP" \
     --input "$WORK/mixed-branches.json" --runs-input "$WORK/runs.json" >/dev/null 2>&1
+# The paired positive check matters: `check_contains ... no` passes trivially on
+# an empty haystack, so without this a broken $OUTPUTS would look like a pass.
+check_contains "a headline was written for the branch run" "$(grep '^headline=' "$OUTPUTS")" "awaiting CI approval" yes
 check_contains "the headline carries no branch name" "$(grep '^headline=' "$OUTPUTS")" "contrib-branch" no
 
 # A backlog whose ONLY finding is an unapproved CI queue must still notify --

--- a/scripts/pr-backlog-sweep_test.sh
+++ b/scripts/pr-backlog-sweep_test.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Self-test for scripts/pr-backlog-sweep.sh.
+#
+# WHAT THIS PINS, and why it is not decoration. Two properties, and the second
+# is the one the sweep exists for:
+#
+#   1. CLASSIFICATION. A `statusCheckRollup` entry is either a CheckRun (carries
+#      .status/.conclusion) or a legacy StatusContext (carries .state). Reading
+#      only one of the two reads CI as permanently pending -- an easy mistake to
+#      make and an invisible one, because the symptom is a report that just
+#      never lists anything as green. Both shapes, plus queued/failed/unknown,
+#      are exercised here against fixtures.
+#
+#   2. THAT A BROKEN SWEEP CANNOT REPORT SUCCESS. The sweep's whole value is
+#      that "nothing is stalled" and "the query failed" look different. That is
+#      a property of the FAILURE paths, which never run in a healthy CI run and
+#      would otherwise be tested by nobody. The cases below drive it with a stub
+#      `gh` that fails, one that returns an empty list while the corroborating
+#      REST probe says otherwise, and one that truncates at the fetch limit;
+#      each must exit non-zero. The precedent is a backup job that logged
+#      "unreachable, skipping" and exited 0, reporting SUCCESS for 37 straight
+#      days while no backups ran.
+#
+# Also pinned: an author-controlled PR title reaches the report as inert text,
+# and never reaches the chat notification at all.
+#
+# Run manually: bash scripts/pr-backlog-sweep_test.sh
+# Also wired into CI (the Fmt job in .github/workflows/ci.yml).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SWEEP="$SCRIPT_DIR/pr-backlog-sweep.sh"
+# Absolute, because some cases below run the sweep with a deliberately empty
+# PATH and `bash` itself would otherwise be unfindable.
+BASH_BIN="$(command -v bash)"
+FAILURES=0
+
+if [[ ! -x "$SWEEP" ]]; then
+    echo "FAIL - $SWEEP is missing or not executable" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/empty-path"
+
+# Fixed clock so ages are deterministic.
+NOW=1787594400
+iso() { date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ; }
+days_ago() { iso $((NOW - $1 * 86400)); }
+
+check() {
+    # check <description> <expected> <actual>
+    local desc="$1" want="$2" got="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc" >&2
+        echo "         wanted: $want" >&2
+        echo "         got:    $got" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+check_contains() {
+    # check_contains <description> <haystack> <needle> <yes|no>
+    local desc="$1" hay="$2" needle="$3" want="$4" got="no"
+    case "$hay" in *"$needle"*) got="yes" ;; esac
+    if [[ "$got" == "$want" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (wanted contains=$want, got contains=$got)" >&2
+        echo "         needle: $needle" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+section() {
+    # section <report> <heading substring> -> that section's body.
+    # Searching the WHOLE report for a PR url is nearly vacuous: every stalled
+    # PR appears in the idle section too, so "the green bucket lists #2" would
+    # pass with the green bucket empty. Mutation-tested: dropping the
+    # StatusContext branch left the whole-report form green.
+    printf '%s\n' "$1" | awk -v h="$2" '
+        index($0, "### ") == 1 { inblock = (index($0, h) > 0); next }
+        inblock { print }'
+}
+
+sweep_counts() {
+    # Prints "<green> <idle> <conflicting> <awaiting>" pulled back out of the rendered
+    # headline, so the test reads the same numbers a human would.
+    printf '%s\n' "$1" | grep -m1 'open PRs\.' \
+        | grep -oE '\*\*[0-9]+\*\*' | tr -d '*' | paste -sd' ' -
+}
+
+# --- Fixture: one PR per classification case ---------------------------------
+# Everything is 20 days old unless stated, so each case isolates the CI-state or
+# mergeable dimension rather than the clock.
+OLD="$(days_ago 20)"
+FRESH="$(days_ago 1)"
+
+cat > "$WORK/mixed.json" <<EOF
+[
+  {
+    "number": 1, "title": "green via CheckRun", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/1",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"},
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED", "completedAt": "$OLD"}
+    ]
+  },
+  {
+    "number": 2, "title": "green via legacy StatusContext", "author": {"login": "alice"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/2",
+    "statusCheckRollup": [
+      {"__typename": "StatusContext", "state": "SUCCESS"}
+    ]
+  },
+  {
+    "number": 3, "title": "queued check is NOT green", "author": {"login": "bob"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/3",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"},
+      {"__typename": "CheckRun", "status": "QUEUED", "conclusion": "", "completedAt": "0001-01-01T00:00:00Z"}
+    ]
+  },
+  {
+    "number": 4, "title": "failing check is NOT green", "author": {"login": "bob"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/4",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE", "completedAt": "$OLD"}
+    ]
+  },
+  {
+    "number": 5, "title": "unrecognised rollup shape is NOT green", "author": {"login": "bob"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/5",
+    "statusCheckRollup": [
+      {"__typename": "SomethingNew", "verdict": "fine"}
+    ]
+  },
+  {
+    "number": 6, "title": "no checks at all is NOT green", "author": {"login": "bob"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/6",
+    "statusCheckRollup": []
+  },
+  {
+    "number": 7, "title": "green draft is excluded from the green bucket", "author": {"login": "carol"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": true, "url": "https://example.invalid/7",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  },
+  {
+    "number": 8, "title": "green, freshly commented", "author": {"login": "carol"},
+    "createdAt": "$OLD", "updatedAt": "$FRESH", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/8",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  },
+  {
+    "number": 9, "title": "conflicting", "author": {"login": "dave"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "CONFLICTING",
+    "isDraft": false, "url": "https://example.invalid/9",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE", "completedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+
+REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" 2>/dev/null)"
+# green: #1, #2, #8 (draft #7 excluded; #3/#4/#5/#6 are not green)
+# idle:  everything except #8, whose updatedAt is 1 day old  = 8
+# conflicting: #9
+check "mixed fixture classifies green / idle / conflicting / awaiting" "3 8 1 0" "$(sweep_counts "$REPORT")"
+GREEN_SECTION="$(section "$REPORT" "Green and unmerged")"
+check_contains "green bucket lists the CheckRun-green PR" "$GREEN_SECTION" "example.invalid/1" yes
+check_contains "green bucket lists the legacy StatusContext-green PR" "$GREEN_SECTION" "example.invalid/2" yes
+check_contains "green bucket excludes a PR with a queued check" "$GREEN_SECTION" "example.invalid/3" no
+check_contains "green bucket excludes a PR with a failing check" "$GREEN_SECTION" "example.invalid/4" no
+check_contains "green bucket excludes an unrecognised rollup shape" "$GREEN_SECTION" "example.invalid/5" no
+check_contains "green bucket excludes a PR with no checks" "$GREEN_SECTION" "example.invalid/6" no
+check_contains "green bucket excludes the green draft" "$GREEN_SECTION" "example.invalid/7" no
+# The point of measuring green-age from the last check rather than updatedAt: a
+# comment on a green PR must not reset the clock and hide it from the report.
+check_contains "a comment does not reset the green age" "$GREEN_SECTION" "/8) 20d" yes
+check_contains "a draft is labelled as one in the idle bucket" "$(section "$REPORT" "No activity")" "_(draft)_" yes
+check_contains "the report is grouped by author" "$GREEN_SECTION" "**@alice** (2)" yes
+
+# --- (d) Runs held for maintainer approval ------------------------------------
+# Grouped BY BRANCH, not by run. 22 pending runs on one branch is ONE stuck PR;
+# reporting the raw run count would overstate the problem by an order of
+# magnitude, which is the failure mode this grouping exists to avoid.
+cat > "$WORK/runs.json" <<EOF
+[
+  {"databaseId": 1, "headBranch": "contrib-branch", "workflowName": "CI", "createdAt": "$(days_ago 30)"},
+  {"databaseId": 2, "headBranch": "contrib-branch", "workflowName": "CI", "createdAt": "$(days_ago 12)"},
+  {"databaseId": 3, "headBranch": "contrib-branch", "workflowName": "Netcheck", "createdAt": "$(days_ago 12)"},
+  {"databaseId": 4, "headBranch": "abandoned-branch", "workflowName": "CI", "createdAt": "$(days_ago 5)"}
+]
+EOF
+# One PR sits on contrib-branch; abandoned-branch has none.
+jq --arg b "contrib-branch" '.[0].headRefName = $b' "$WORK/mixed.json" > "$WORK/mixed-branches.json"
+
+RUNS_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/mixed-branches.json" --runs-input "$WORK/runs.json" 2>/dev/null)"
+check_contains "branches are counted, not runs" "$RUNS_REPORT" "**2** branch(es) awaiting CI approval" yes
+check_contains "the per-branch pending run count is reported" "$RUNS_REPORT" "3 run(s) pending" yes
+# The age must be of the OLDEST pending run, not the newest or the average:
+# 30 days, not 12.
+check_contains "the age is that of the oldest pending run" "$RUNS_REPORT" "oldest 30d" yes
+check_contains "a branch with an open PR resolves to it" "$RUNS_REPORT" '3 run(s) pending, oldest 30d — #1' yes
+check_contains "a branch with no open PR says so" "$RUNS_REPORT" "no open PR (stale runs)" yes
+check_contains "the raw pending-run total is still stated" "$RUNS_REPORT" "4 pending run(s) across 2 branch(es)" yes
+# The gate is correct; only the fact that nobody watches it is the bug. If this
+# text goes, so does the reason the next reader does not "fix" the queue by
+# letting untrusted forks run workflows on this repo.
+check_contains "the report says not to loosen the approval policy" "$RUNS_REPORT" "do not loosen the policy" yes
+
+NO_RUNS_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" 2>/dev/null)"
+check_contains "an empty approval queue renders as none" "$NO_RUNS_REPORT" "**0** branch(es) awaiting CI approval" yes
+
+# --- An author-controlled title must not be able to run anything -------------
+CANARY="$WORK/pwned"
+cat > "$WORK/inject.json" <<EOF
+[
+  {
+    "number": 42, "title": "\$(touch $CANARY) \`touch $CANARY\` ; touch $CANARY",
+    "author": {"login": "mallory"},
+    "createdAt": "$OLD", "updatedAt": "$OLD", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/42",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$OLD"}
+    ]
+  }
+]
+EOF
+INJECT_REPORT="$(SWEEP_NOW_EPOCH="$NOW" "$BASH_BIN" "$SWEEP" --input "$WORK/inject.json" 2>/dev/null)"
+if [[ -e "$CANARY" ]]; then
+    echo "FAIL - a crafted PR title EXECUTED: $CANARY exists" >&2
+    FAILURES=$((FAILURES + 1))
+else
+    echo "ok   - a crafted PR title does not execute"
+fi
+check_contains "the crafted title is rendered as inert text" "$INJECT_REPORT" 'touch' yes
+
+# --- The failure paths: a broken sweep must never look clean -----------------
+# A stub `gh` drives the abort paths that a healthy CI run never touches.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+
+write_stub_gh() {
+    # write_stub_gh <fail|empty|full|runs-fail> <count the REST probe reports>
+    # MODE and the probe count are baked in at write time; the stub dispatches
+    # on its own first argument to tell `gh api` / `gh run` / `gh pr` apart.
+    cat > "$STUB/gh" <<STUBEOF
+#!/usr/bin/env bash
+MODE="$1"
+case "\${1:-}" in
+  api)
+    echo "$2"
+    exit 0
+    ;;
+  run)
+    if [ "\$MODE" = "runs-fail" ]; then
+      echo "HTTP 403: Resource not accessible by integration" >&2
+      exit 1
+    fi
+    echo "[]"
+    exit 0
+    ;;
+esac
+case "\$MODE" in
+  fail)  echo "HTTP 401: Bad credentials" >&2; exit 1 ;;
+  empty) echo "[]"; exit 0 ;;
+  full)  jq -cn --argjson n 5 '[range(\$n) | {number: ., title: "x", author: {login: "a"}, createdAt: "$OLD", updatedAt: "$OLD", mergeable: "MERGEABLE", isDraft: false, url: "https://example.invalid/x", headRefName: "b", statusCheckRollup: []}]' ;;
+  runs-fail) jq -cn '[{number: 1, title: "x", author: {login: "a"}, createdAt: "$OLD", updatedAt: "$OLD", mergeable: "MERGEABLE", isDraft: false, url: "https://example.invalid/1", headRefName: "b", statusCheckRollup: []}]' ;;
+esac
+STUBEOF
+    chmod +x "$STUB/gh"
+}
+
+sweep_rc() {
+    local rc=0
+    SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 PATH="$STUB:$PATH" \
+        "$BASH_BIN" "$SWEEP" >/dev/null 2>&1 || rc=$?
+    echo "$rc"
+}
+
+write_stub_gh fail 0
+check "an API/auth failure aborts non-zero" "1" "$(sweep_rc)"
+
+write_stub_gh empty 3
+check "an empty listing the REST probe contradicts aborts non-zero" "1" "$(sweep_rc)"
+
+write_stub_gh full 5
+check "a listing truncated at the fetch limit aborts non-zero" "1" "$(sweep_rc)"
+
+# The action_required query is the SECOND unwatched queue this sweep reports.
+# If it fails, "no runs are waiting for approval" is exactly what a broken query
+# prints, so it aborts rather than reporting a clean CI-approval queue.
+write_stub_gh runs-fail 1
+check "a failed action_required query aborts non-zero" "1" "$(sweep_rc)"
+
+# The one case that legitimately reports nothing: both paths agree the repo has
+# no open PRs. This must SUCCEED, or the sweep cries wolf forever.
+write_stub_gh empty 0
+EMPTY_RC=0
+EMPTY_OUT="$(SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 PATH="$STUB:$PATH" \
+    "$BASH_BIN" "$SWEEP" 2>/dev/null)" || EMPTY_RC=$?
+check "a genuinely empty backlog exits 0" "0" "$EMPTY_RC"
+check_contains "a genuinely empty backlog still renders a report" "$EMPTY_OUT" "0 open PRs." yes
+
+# `gh` absent entirely is the same class of breakage as `gh` failing.
+NO_GH_RC=0
+SWEEP_NOW_EPOCH="$NOW" PATH="$WORK/empty-path" "$BASH_BIN" "$SWEEP" >/dev/null 2>&1 || NO_GH_RC=$?
+check "a missing gh CLI aborts non-zero" "1" "$NO_GH_RC"
+
+# --- Step summary and notification wiring ------------------------------------
+SUMMARY="$WORK/summary.md"
+OUTPUTS="$WORK/outputs.txt"
+: > "$SUMMARY"
+: > "$OUTPUTS"
+SWEEP_NOW_EPOCH="$NOW" GITHUB_STEP_SUMMARY="$SUMMARY" GITHUB_OUTPUT="$OUTPUTS" \
+    "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" >/dev/null 2>&1
+check_contains "the step summary is written" "$(cat "$SUMMARY")" "PR backlog sweep" yes
+check_contains "notify is requested when there is something to report" "$(cat "$OUTPUTS")" "notify=true" yes
+check_contains "the headline carries the counts" "$(cat "$OUTPUTS")" "headline=3 PR(s) green" yes
+check_contains "the headline carries the CI-approval count" "$(cat "$OUTPUTS")" "awaiting CI approval" yes
+# The headline is forwarded to a chat room. If a PR title could reach it, a
+# crafted title would be forwarded verbatim into that message.
+check_contains "the headline carries no PR title" "$(grep '^headline=' "$OUTPUTS")" "green via CheckRun" no
+
+# Branch names are attacker-controlled too, and section (d) is the one place a
+# branch name enters the report. It must not ride out to the chat room either.
+: > "$OUTPUTS"
+SWEEP_NOW_EPOCH="$NOW" GITHUB_OUTPUT="$OUTPUTS" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/mixed-branches.json" --runs-input "$WORK/runs.json" >/dev/null 2>&1
+check_contains "the headline carries no branch name" "$(grep '^headline=' "$OUTPUTS")" "contrib-branch" no
+
+# A backlog whose ONLY finding is an unapproved CI queue must still notify --
+# otherwise the queue that had gone unwatched for a month stays unwatched.
+cat > "$WORK/clean.json" <<EOF
+[
+  {
+    "number": 1, "title": "fresh and green", "author": {"login": "alice"},
+    "createdAt": "$FRESH", "updatedAt": "$FRESH", "mergeable": "MERGEABLE",
+    "isDraft": false, "url": "https://example.invalid/1", "headRefName": "contrib-branch",
+    "statusCheckRollup": [
+      {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "$FRESH"}
+    ]
+  }
+]
+EOF
+: > "$OUTPUTS"
+ONLY_RUNS="$(SWEEP_NOW_EPOCH="$NOW" GITHUB_OUTPUT="$OUTPUTS" "$BASH_BIN" "$SWEEP" \
+    --input "$WORK/clean.json" --runs-input "$WORK/runs.json" 2>/dev/null)"
+check "only the approval queue is stalled" "0 0 0 2" "$(sweep_counts "$ONLY_RUNS")"
+check_contains "an approval queue alone still notifies" "$(cat "$OUTPUTS")" "notify=true" yes
+
+write_stub_gh empty 0
+: > "$OUTPUTS"
+SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 GITHUB_OUTPUT="$OUTPUTS" PATH="$STUB:$PATH" \
+    "$BASH_BIN" "$SWEEP" >/dev/null 2>&1
+check_contains "a clean sweep does NOT notify" "$(cat "$OUTPUTS")" "notify=false" yes
+
+# --- The workflow must actually run this script ------------------------------
+# A self-test nothing invokes is coverage in a listing and a gate on nothing;
+# the same is true of a sweep no workflow runs.
+WF="$SCRIPT_DIR/../.github/workflows/pr-backlog-sweep.yml"
+if [[ -f "$WF" ]]; then
+    WF_TEXT="$(cat "$WF")"
+    check_contains "the workflow invokes scripts/pr-backlog-sweep.sh" "$WF_TEXT" "scripts/pr-backlog-sweep.sh" yes
+    check_contains "the workflow is scheduled" "$WF_TEXT" "schedule:" yes
+    check_contains "the workflow can be run on demand" "$WF_TEXT" "workflow_dispatch:" yes
+    # If the sweep step itself were continue-on-error, every abort above would
+    # go back to being a green run with an empty report -- the exact shape the
+    # failure paths exist to prevent.
+    # Comments are stripped first: this step's comment block explains WHY it is
+    # not continue-on-error, and a substring search would otherwise match the
+    # explanation and pass no matter what the step actually does.
+    SWEEP_STEP="$(printf '%s\n' "$WF_TEXT" \
+        | sed -n '/- name: Run the sweep/,/^      - name:/p' \
+        | sed -E 's/^[[:space:]]*#.*$//')"
+    check_contains "the sweep step block was located" "$SWEEP_STEP" "pr-backlog-sweep.sh" yes
+    check_contains "the sweep step is not continue-on-error" "$SWEEP_STEP" "continue-on-error:" no
+else
+    echo "FAIL - .github/workflows/pr-backlog-sweep.yml is missing; nothing runs the sweep" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo "All PR backlog sweep assertions passed."
+else
+    echo "$FAILURES assertion(s) FAILED." >&2
+    exit 1
+fi

--- a/scripts/pr-backlog-sweep_test.sh
+++ b/scripts/pr-backlog-sweep_test.sh
@@ -422,6 +422,12 @@ check "an unwritable output file aborts non-zero" "1" "$OUTPUT_FAIL_RC"
 WF="$SCRIPT_DIR/../.github/workflows/pr-backlog-sweep.yml"
 if [[ -f "$WF" ]]; then
     WF_TEXT="$(cat "$WF")"
+    # Comment-stripped copy for every pin that must find CODE. Mutation-tested:
+    # searching the raw text for the failure-notifier's step NAME passed with
+    # the step deleted, because the file's own header comment quotes that name
+    # while explaining why the step exists. A pin satisfied by the prose that
+    # justifies it is the repo's documented anchor trap, one file over.
+    WF_CODE="$(printf '%s\n' "$WF_TEXT" | sed -E 's/^[[:space:]]*#.*$//')"
     check_contains "the workflow invokes scripts/pr-backlog-sweep.sh" "$WF_TEXT" "scripts/pr-backlog-sweep.sh" yes
     check_contains "the workflow is scheduled" "$WF_TEXT" "schedule:" yes
     check_contains "the workflow can be run on demand" "$WF_TEXT" "workflow_dispatch:" yes
@@ -436,6 +442,21 @@ if [[ -f "$WF" ]]; then
         | sed -E 's/^[[:space:]]*#.*$//')"
     check_contains "the sweep step block was located" "$SWEEP_STEP" "pr-backlog-sweep.sh" yes
     check_contains "the sweep step is not continue-on-error" "$SWEEP_STEP" "continue-on-error:" no
+
+    # A red X on the Actions tab is not a notification. This workflow exists
+    # because a queue nobody watches accumulates silently, and scheduled runs
+    # are exactly such a queue -- so a BROKEN sweep must page the dev room too,
+    # or the instrument fails into the same blind spot it was built to close.
+    check_contains "a failed sweep notifies the dev room" "$WF_CODE" \
+        "Notify the dev room that the sweep is BROKEN" yes
+    check_contains "the failure notifier is gated on the sweep step failing" "$WF_CODE" \
+        "failure() && steps.sweep.outcome == 'failure'" yes
+    # And both notifiers must stay best-effort: a riverctl hiccup must never be
+    # mistaken for a sweep failure, nor add a second red X to an already-red run.
+    NOTIFY_STEPS="$(printf '%s\n' "$WF_CODE" \
+        | sed -n '/- name: Notify the dev room/,$p' \
+        | sed -E 's/^[[:space:]]*#.*$//' | grep -c 'continue-on-error: true')"
+    check "both notifier steps are continue-on-error" "2" "$NOTIFY_STEPS"
 else
     echo "FAIL - .github/workflows/pr-backlog-sweep.yml is missing; nothing runs the sweep" >&2
     FAILURES=$((FAILURES + 1))

--- a/scripts/pr-backlog-sweep_test.sh
+++ b/scripts/pr-backlog-sweep_test.sh
@@ -400,6 +400,22 @@ SWEEP_NOW_EPOCH="$NOW" SWEEP_LIMIT=5 GITHUB_OUTPUT="$OUTPUTS" PATH="$STUB:$PATH"
     "$BASH_BIN" "$SWEEP" >/dev/null 2>&1
 check_contains "a clean sweep does NOT notify" "$(cat "$OUTPUTS")" "notify=false" yes
 
+# An unwritable $GITHUB_STEP_SUMMARY / $GITHUB_OUTPUT is the same defect one
+# level down: the queries all worked, and the run would still go green with the
+# report attached nowhere and the notify step's trigger never written. Both
+# appends are therefore fatal, and these two cases are the only thing that
+# exercises them.
+UNWRITABLE="$WORK/no-such-dir/summary.md"
+SUMMARY_FAIL_RC=0
+SWEEP_NOW_EPOCH="$NOW" GITHUB_STEP_SUMMARY="$UNWRITABLE" \
+    "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" >/dev/null 2>&1 || SUMMARY_FAIL_RC=$?
+check "an unwritable step summary aborts non-zero" "1" "$SUMMARY_FAIL_RC"
+
+OUTPUT_FAIL_RC=0
+SWEEP_NOW_EPOCH="$NOW" GITHUB_OUTPUT="$WORK/no-such-dir/outputs.txt" \
+    "$BASH_BIN" "$SWEEP" --input "$WORK/mixed.json" >/dev/null 2>&1 || OUTPUT_FAIL_RC=$?
+check "an unwritable output file aborts non-zero" "1" "$OUTPUT_FAIL_RC"
+
 # --- The workflow must actually run this script ------------------------------
 # A self-test nothing invokes is coverage in a listing and a gate on nothing;
 # the same is true of a sweep no workflow runs.


### PR DESCRIPTION
## Problem

Measured today (2026-08-24), before any of this drain started:

- **59 open PRs.** 25 dependabot (20 fully green and simply never merged), 20 authored by `sanity`, 14 from outside contributors.
- **All 20 `sanity` PRs had `reviewDecision = NONE`.** CI was not the bottleneck — 26 of the 59 were green and unmerged.
- Oldest green-and-untouched: **#4997, since 2026-07-28.** Oldest overall: **#4820** from a team member, **2026-07-16 — five weeks, zero replies**.
- **9 of the 20 had decayed from mergeable to CONFLICTING, and they conflicted with EACH OTHER**, not just with main: `ring.rs` was contested by 5 open PRs (#4997/#5029/#5033/#5109/#5249), `ring/interest.rs` by 3, `tracing/telemetry.rs` by 3.

That last point is what makes this a doom loop rather than a static pile. Every day a PR waits raises the cost of landing it, which lowers the odds it ever lands.

The same audit found a **second, independent unwatched queue**: **58 workflow runs sitting in `action_required`** — 22 pending on `install_script`, 11 on `nix`, 4 on `bandwidth-graph`, some since 2026-07-26. Outside-contributor CI requires a maintainer to approve each run, and nobody was doing it. The consequence is worse than it sounds: **most community PRs have never had the main test suite run at all.** They were not "unreviewed"; they were unreviewable, and any claim made in recent weeks that a contributor PR was red or green was made without evidence.

**This reframes the root cause.** The backlog was not one failure (nobody merging) but **two independent unwatched queues** — unreviewed PRs, and unapproved CI runs. Both have the same shape: *an action that required a human, with no mechanism to notice that no human had taken it.* Repo config makes that concrete: `required_approving_review_count: 0`, active merge queue, `allow_auto_merge: true`. Nothing external will ever stop a PR from sitting forever. And the sessions that opened these PRs were swept (a 2026-08-22 cleanup plus the 7-day job-scratch cron), so nobody was left to nudge.

**On the approval gate specifically: it is correct and this PR does not touch it.** `approval_policy` is `first_time_contributors`, the right secure default for a repo that accepts fork PRs. Loosening it to auto-approve all contributors would let an untrusted fork run workflows on this repo's runners — a genuine security regression, and a much worse problem than a slow queue. **The gate is right; nobody was watching it.** This PR makes it visible; a future reader should not "simplify" the sweep by turning the gate off. The sweep job is granted `actions: read` and deliberately **not** `actions: write`, so it cannot approve a run even if someone wanted it to.

## Approach

Three changes, one per failure mode.

### 1. `.github/dependabot.yml` — group minor+patch, keep majors alone

Routine churn now arrives as one PR per ecosystem instead of thirty. **Major bumps stay ungrouped, one per PR, deliberately**: a major bump is real work, not a chore. `ed25519-dalek 2 -> 3` verifies **release signatures**, and a break there strands the fleet with no recovery path. That must never arrive buried in a 30-crate group PR where the diff gets skimmed as routine. The rationale is in the file so the next editor doesn't "finish the job" by grouping majors too.

### 2. `AGENTS.md` — a new `### AFTER opening a PR` section

Drive a PR to a terminal state (merged, or closed with a reason), or leave a hand-off comment saying what's done and what remains. An abandoned PR with a hand-off note is recoverable; a silent one is archaeology. Also: push before you stop — the sweep that produced these numbers found uncommitted work and orphan commits in agent worktrees no live session owned.

**On the bar for prompt changes.** `AGENTS.md` is a load-bearing LLM-facing prompt and this repo holds a high bar for changing one. This clears that bar on **measured, multi-data-point evidence** — the numbers above, not a hunch or an N=1 observation. It is deliberately tight (one section, ~30 lines) and states the measurement inline so a future reader can judge whether it is still true rather than inheriting an unfalsifiable instruction.

The drafted text cross-referenced `.claude/rules/pr-quality.md`, which **does not exist in this repo** (it lives in the parent ecosystem directory). Corrected to `CONTRIBUTING.md` and the `pr-review` skill it links.

### 3. `.github/workflows/pr-backlog-sweep.yml` — a daily staleness sweep

Daily at 06:00 UTC plus `workflow_dispatch`. Reports, grouped by author, oldest first, with age in days:

- (a) PRs green and unmerged for >48h
- (b) PRs with no activity for >7 days
- (c) PRs decayed to CONFLICTING
- (d) branches with workflow runs in `action_required`, with the age of the **oldest** pending run

**(d) is reported per BRANCH, not per run.** 22 pending runs on one branch is *one* stuck PR, not 22 problems; the raw run count would overstate it by an order of magnitude. Each row gives the branch, the resolved PR number where one exists, the pending-run count, and the oldest age. The raw total is still stated separately, labelled as such.

#### It must be an instrument, not a mask

This is the design constraint that mattered most, and it drove more of the implementation than the feature did. The sweep exits **non-zero** on any failure to enumerate — `gh` missing, `jq` missing, `gh pr list` failure, `gh run list` failure, a non-array result, a listing truncated at the fetch limit, or **an empty listing that an independent REST probe contradicts**. An empty report and a broken report must never look alike.

The precedent this repo already has: a backup job that logged "unreachable, skipping" and **exited 0**, reporting SUCCESS for 37 consecutive days while no backups ran.

Consequences of taking that seriously:

- The sweep step is **not** `continue-on-error` (pinned by a test that strips comments first, so the step's own explanation of why it isn't can't satisfy the check). Only the notifier is best-effort, so a riverctl hiccup can never mask or redden the sweep result.
- A `GITHUB_STEP_SUMMARY` is written on **every** run, including a clean `0/0/0/0` one — a run that produced no summary is evidence it did not run.
- The one case that legitimately reports nothing (both query paths agree there are no open PRs) succeeds, so the sweep doesn't cry wolf.
- Mergeability is refetched once (GitHub computes it lazily), and whatever is still `UNKNOWN` is **reported as unknown** rather than quietly counted as clean — so the conflict count is never silently understated. On the live run below, that note fired: 14 PRs still UNKNOWN, conflict count flagged as a lower bound.

#### CI state is read from both fields

`statusCheckRollup` entries are either `CheckRun` (`.status`/`.conclusion`) or legacy `StatusContext` (`.state`). Filtering on one alone reads CI as permanently pending. Both are handled; an unrecognised shape degrades to `UNKNOWN`, which is **not** green. "Green since" is the last check's completion time, not `updatedAt`, so a comment on a green PR doesn't reset its clock and hide it.

#### No injection path through any repository-controlled string

Every untrusted field is rendered by `jq` into markdown and never reaches a shell as script text. Nothing is interpolated as `${{ }}` into a `run:` block anywhere in the workflow. The chat notification carries **counts and a run URL only** — no PR title, no author login, no branch name — pinned by three assertions. A fixture whose title is `$(touch …) \`touch …\` ; touch …` is asserted not to execute.

#### Logic in a script, not the workflow

Following the `netcheck-nightly.yml` convention already in this repo: *a workflow file cannot be tested before it reaches the default branch; a script can.* `scripts/pr-backlog-sweep.sh` carries the logic, `scripts/pr-backlog-sweep_test.sh` tests it, and both are wired into `ci.yml`'s Fmt job (shellcheck + self-test), as `rule_lint_shell_assertion_counter_test.sh` requires of any `*_test.sh`.

## Testing

`scripts/pr-backlog-sweep_test.sh` — 40 assertions, run by CI's Fmt job.

The failure paths are the point. They never execute on a healthy scheduled run, so without this they would be tested by nobody. A stub `gh` drives each one:

| case | expected |
|---|---|
| API/auth failure | exit non-zero |
| empty listing the REST probe contradicts | exit non-zero |
| listing truncated at the fetch limit | exit non-zero |
| `action_required` query fails | exit non-zero |
| `gh` absent from PATH entirely | exit non-zero |
| **both paths agree the repo has no open PRs** | **exit 0, report still rendered** |

Classification is fixture-driven: CheckRun-green, legacy-StatusContext-green, queued, failing, unrecognised rollup shape, no checks at all, green draft (excluded from the green bucket, still listed as idle and labelled), green-but-freshly-commented, conflicting, and the per-branch approval queue with one resolvable and one unresolvable branch.

**Every assertion was mutation-tested** — the mutation applied, the suite confirmed red, the mutation reverted:

| mutation | assertions that went red |
|---|---|
| drop the REST corroboration probe | 1 |
| drop the `StatusContext` branch of `check_state` | 4 |
| `green_since` → always `updatedAt` | 3 |
| group runs by `databaseId` instead of `headBranch` | 5 |
| oldest pending run → newest | 2 |
| add `continue-on-error` to the sweep step | 1 |

One finding from doing that: the first draft of the green-bucket assertions searched the **whole** report for a PR's URL, and **passed under the StatusContext mutation** — because every stalled PR also appears in the idle section. That is exactly the vacuous-pin shape `.claude/rules/bug-prevention-patterns.md` warns about. Fixed with a `section()` extractor scoped to one heading, re-run, now red; the reason is recorded in the test file so it isn't undone.

Other verification:

- `shellcheck` clean on both new scripts (added to the Fmt job's lint list).
- `bash scripts/rule_lint_shell_assertion_counter_test.sh` passes — the new test file is visible to the assertion counter and is invoked in the Fmt job, so it gates something rather than just existing.
- `python3 .github/scripts/check_merge_group_concurrency.py .github/workflows` passes.
- `python3 -c "import yaml; yaml.safe_load(...)"` on `dependabot.yml`, `pr-backlog-sweep.yml`, `ci.yml`.
- Token-coalesce guard: the `GH_TOKEN` line carries `# coalesce-exempt:` with the reason (read-only `gh pr list` / `gh run list` / `gh api` GET; emits no downstream-triggering event, so `RELEASE_PAT` would only widen the blast radius).
- **Live end-to-end run against this repo**, real `gh`, no fixtures: exit 0, 52 open PRs, 26 green >48h / 31 idle >7d / 10 conflicting / 8 branches awaiting CI approval, with the lower-bound note firing for the 14 still-UNKNOWN PRs. Branch→PR resolution worked (`install_script` → #4958, `nix` → #5073, `bandwidth-graph` → #5218).

### Honest caveat on the conflict count

GitHub computes mergeability lazily, so a PR touched recently reports
`mergeable: UNKNOWN`. The sweep refetches once, and whatever is still UNKNOWN
is **reported as unknown in the summary** rather than quietly counted as clean.
On the live run below that note fired for 14 PRs. So the conflict figure is a
**lower bound, not a measurement** — both in this report and in the 2026-08-24
audit numbers quoted above. Stating it in the artefact was deliberate: an
understated count that looks precise is worse than one that admits its floor.

## Follow-ups landed after self-review

Two commits after the first, both found by my own adversarial pass and the
coordinator's independent read rather than by CI.

**`a5449399c` — markdown-escape PR-controlled text.** Titles and branch names
were rendered raw into the step summary. Neither ever reaches a shell, so this
was never an execution path, but a title of the form
`[click me](https://elsewhere)` became a **working link** on a maintainer-only
page. Both now pass through a jq `md` helper that collapses newlines and
backslash-escapes markdown metacharacters. Branch names moved from a code span
to bold: a git ref may legitimately contain a backtick and there is no way to
escape one *inside* a code span, so a fork branch name could have broken out.

The same commit paired a `check_contains … no` assertion with a positive guard
on the same haystack — that form passes trivially on an empty haystack, so
"the headline carries no branch name" would have gone green if `$GITHUB_OUTPUT`
were broken and empty. Every other negative assertion already had such a pair;
this one did not.

**`908845626` — audit the unchecked-command surface.** The script sets
`set -uo pipefail` but **not `-e`**, so any command not explicitly checked would
continue silently on failure — the same defect class this PR exists to prevent,
one level down. Asked whether that was audited or assumed: it is now audited
site by site, and the audit is recorded in a comment above `set -uo pipefail` so
the next reader does not "fix" it by adding `-e` (which aborts with no
`::error::` line saying *which* query died — losing the diagnosis is the whole
point of not using it).

The audit found every query, gate and count already routed through `die`, and
two unchecked writes that were not:

- `$GITHUB_STEP_SUMMARY` — an unwritable path meant a green run with the report
  attached nowhere.
- `$GITHUB_OUTPUT` — worse: the notify step reads its trigger from there, so a
  failed write turned a backlog *with findings* into a green run that told
  nobody.

Both are now `|| die`, with self-tests. One call is left unchecked deliberately:
`date +%s`. An empty `NOW` reaches jq as `--argjson now ""`, jq rejects it,
`RESULT` empties, and the existing `[ -z "$RESULT" ]` check is fatal — verified
by running the script with a non-numeric `SWEEP_NOW_EPOCH`, not by reading it.

Also confirmed while auditing: nothing here pipes a producer into a
short-circuiting consumer, so the repo's documented SIGPIPE-under-`pipefail`
hazard does not apply (jq must read to EOF before it can answer). Noted in the
same comment so it stays true.

Additional mutations run for these commits, each confirmed red then reverted:

| mutation | assertions that went red |
|---|---|
| reduce `md` to the old newline-only collapse | 3 |
| drop the CI-approval count from the headline | 2 (incl. the new positive guard) |
| replace either write's `die` with `\|\| true` | 1 each |


## Review round: one blocking finding, five should-fixes

Full-tier review found a genuine blocking defect. Stating it plainly, because
this is the one artefact from the backlog drain that outlasts the drain, and
shipping a *bad* watcher would be worse than shipping none — a silent backlog at
least looks like what it is.

**Blocking — the corroboration covered the listing, not the fields.** The REST
probe existed so "an empty backlog" and "a broken query" could not look alike.
The **check rollup had no such corroboration** — and the green bucket, the
section this sweep exists for, is computed entirely from `statusCheckRollup`. If
that field came back empty for every PR (a missing `checks: read` /
`statuses: read` grant, a partial GraphQL response — `gh` can exit 0 with data
*and* errors — or a future field rename), the report said **"0 green" and exited
0**. Byte-identical to a clean backlog. The same held for `mergeable` and the
conflict count.

The permissions block those gates guard is itself new and cannot be exercised
until it is on the default branch, which is exactly when this would have bitten:
first scheduled run after merge, silently.

Fixed with an all-or-nothing gate on each field. A single PR legitimately has no
checks or an unresolved mergeability; on a repo with open PRs and CI, **not one**
carrying the field means the listing is blind, and the run dies naming the
permission to check.

**Should-fix, in the order they bite:**

- A CONFLICTING PR with green checks appeared under "Nothing is blocking these"
  *and* under "Decayed to CONFLICTING" in the same report — 3 of 8 on the live
  run. Self-contradictory, and it misdirected the action (merge it vs rebase
  it). Excluded from the green bucket; it still appears under CONFLICTING, where
  the useful verb is.
- `2>&1` merged stderr into the JSON capture on the **success** path, so a `gh`
  that prints an upgrade notice and exits 0 poisoned the listing and produced a
  false red X blaming "auth or API problem" — the wrong cause, which is worse
  than the wrong verdict. stderr now goes to a file, surfaced only on real
  failure.
- Branch names carry no owner in either `gh` field, so two forks using `patch-1`
  collapsed into one group while the footer claimed "one branch is one stuck
  PR". Runs are now also matched to PRs by **head SHA**, which cannot collide;
  any group resolving to multiple open PRs is labelled AMBIGUOUS; and the footer
  states the limitation instead of contradicting it.
- Six mutations survived the previous suite. Five now have assertions and are
  mutation-confirmed red: the UNKNOWN lower-bound note, the mergeability
  refetch (a live-network path nothing exercised — `SWEEP_REFETCH_SLEEP` is a
  new test hook so it costs no wall-clock), StatusContext `PENDING`/`EXPECTED`
  reading as PASS, the headRefName-null warning, and the `action_required`
  truncation guard. The sixth — the `0001-01-01` sentinel filter — is dismissed
  because no reachable input exercises it, and it is **marked untested in the
  code** rather than left looking covered.
- A StatusContext-only PR dated its green age from `updatedAt`, so a comment
  *did* reset it there — the one case the existing pin could not see.
  `green_since` now folds in StatusContext `startedAt` (verified against live
  `gh` output: a StatusContext carries no `completedAt`).

**Found in my own read, not by a reviewer, and the one most on-theme:** on
failure the sweep produced a red X on the Actions tab and *nothing else*. This
change exists because a queue nobody watches accumulates silently — and
scheduled runs on the Actions tab are exactly such a queue. A failed sweep now
also pages the dev room, with no counts in the message (an aborted run cannot
support a number). Without it, the instrument failed into the same blind spot it
was built to close.

**Mutation results: 17 run, 16 killed, 1 survived.** The survivor is `die`
replaced by `return` inside the `gh` wrapper, and it is benign — *measured, not
assumed*: the array gate still aborts the run, only the diagnosis degrades. The
`|| exit 1` at each call site preserves the diagnosis, and the comment there
says exactly that rather than claiming a silent-success hole it does not close.
Three round-one "kills" were jq syntax errors rather than semantic mutations;
redone cleanly, all three still kill.

**The anchor trap, hit twice while writing these pins.** The failure-notifier's
step-name assertion passed with the step *deleted*, because the workflow's own
header comment quotes that step name while explaining why it exists. The
AMBIGUOUS assertion had the same shape against the footer prose. Both now match
comment-stripped text or a row-only marker, and the reason is recorded where it
happened so it is not undone.

Self-test is now 71 assertions.

## A third unwatched queue — and a caveat on the green bucket

Found after this PR was written, while draining the backlog, and filed as
**#5451**: a PR touching only `docs/**` can never merge here at all. `ci.yml`'s
`paths-ignore` means 7 of the 8 required contexts never report, GitHub treats
never-reported as "expected" rather than "not applicable", and the merge queue
refuses entry permanently. #5322 has been stuck on exactly that since
2026-08-14.

It is the same shape as the two queues this PR addresses — an automated gate
with no mechanism to notice it is *blocking* rather than *passing* — which is
why it belongs in this description rather than only in its own issue.

**The caveat that follows for this sweep, stated so nobody infers otherwise:**
the green bucket means *"every check that reported, reported success"*. It does
**not** mean mergeable. A docs-only PR blocked by #5451 appears in this report
as green and idle, with nothing to say why, because from the rollup's point of
view there is nothing wrong with it. Fixing that is #5451's job, not the
sweep's; the sweep's job is to make sure such a PR stops being invisible, and it
does that much today.

## Review

Full tier, per the repo's risk tiering for CI/release configuration. Lenses that
produced findings:

- **Skeptical** (`freenet:skeptical-reviewer`, read-only) — 1 blocking, 5
  should-fix, 3 nits. All addressed; see the review round above.
- **An independent read by the session coordinator**, who did not write the
  change — prompted the `set -e` audit and the failure-notifier question, and
  ruled on the `AGENTS.md` heading.
- **The author's own adversarial pass** — produced the markdown escaping, the
  write-failure gates, and the failure-notifier gap.

Two further lenses (`freenet:big-picture-reviewer`, `freenet:testing-reviewer`)
were spawned and **did not return findings before merge**. Recording that
plainly rather than implying a five-lens review: three lenses reported, two were
truncated. The blocking defect was caught by the first of them, and everything
it raised is either fixed or dismissed with the reasoning in the code.

[AI-assisted - Claude]
