### PR TITLE
fix(put): widen streaming-PUT stall window to cover no-dispatch phases

### DIFF
--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -2494,12 +2494,19 @@ mod tests {
         let producer = tokio::spawn(async move {
             let (reply_sender, _outbound, _target) =
                 rx.recv().await.expect("outbound msg should be delivered");
-            // One fragment, landing just before the inactivity boundary. A
-            // single pass, not the original five: #5432 widened the window, so
-            // five would overrun the 600 s ceiling and quietly turn this into a
-            // duplicate of the ceiling test.
-            tokio::time::sleep(STREAM_OP_INACTIVITY_TIMEOUT - RACE_SLACK).await;
-            handle.record();
+            // Two fragments, each landing just before an inactivity boundary.
+            //
+            // Not the original five: #5432 widened the window, so five would
+            // overrun the 600 s ceiling and quietly turn this into a duplicate
+            // of the ceiling test. But TWO fit (2 x 239.5 + 5 = 484 s < 600 s),
+            // and two is the minimum that distinguishes "the window resets on
+            // EVERY fragment" from "the window resets once" — which, for a
+            // change that is entirely about window-reset semantics, is the one
+            // bit worth keeping.
+            for _ in 0..2 {
+                tokio::time::sleep(STREAM_OP_INACTIVITY_TIMEOUT - RACE_SLACK).await;
+                handle.record();
+            }
             tokio::time::sleep(Duration::from_secs(5)).await;
             reply_sender
                 .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -515,7 +515,8 @@ const MAX_INFRA_RETRIES: usize = 3;
 /// Concretely, issue #4912 reported a gateway PUT logging `timeout_secs=117`.
 /// Measured from the attempt's own start (`PUT relay: processing Request` at
 /// 15:35:20.894 to `attempt timed out` at 15:35:50.895) that attempt ran
-/// 30.001 s, because the 30 s [`STREAM_OP_INACTIVITY_TIMEOUT`] stall check is
+/// 30.001 s, because the [`STREAM_OP_INACTIVITY_TIMEOUT`] stall check (30 s
+/// at the time; widened by #5432) is
 /// what abandoned it. The client-visible span was ~150 s, but the extra ~120 s
 /// was queue starvation BEFORE the attempt began, not attempt time. Reporting
 /// a 117 s budget described neither number.
@@ -599,6 +600,18 @@ async fn await_streaming_attempt(
     use crate::operations::stream_progress::STREAM_OP_INACTIVITY_TIMEOUT;
 
     let handle = progress.handle();
+    // NOTE: deliberately NOT resetting the progress clock here, though
+    // `StreamProgress` is built once per OPERATION and cloned per attempt so a
+    // retry does inherit the previous attempt's accrued silence. It cannot
+    // matter: the stall verdict below needs a full `STREAM_OP_INACTIVITY_TIMEOUT`
+    // sleep to expire, measured from the loop iteration, before it even reads
+    // `since_last()` — and that read can only ever SUPPRESS a stall, never
+    // bring one forward. So the earliest possible verdict is attempt start plus
+    // one window regardless of what the handle already holds, and a reset would
+    // be inert. An earlier revision of this fix added one anyway; it was
+    // removed once that was traced, rather than left in as a line no test could
+    // fail on. If the sleep ever stops being a full window per iteration, this
+    // reasoning expires with it.
     let round_trip = ctx.send_and_await(request);
     tokio::pin!(round_trip);
 
@@ -2116,7 +2129,7 @@ mod tests {
     /// 60 s `OPERATION_TTL` cliff that the OLD fixed-deadline path would fire
     /// at), then the peer replies at ~125 s. The streaming-inactivity path MUST
     /// return the terminal reply (`Ok`) — it MUST NOT time out — because the
-    /// 30 s inactivity window is continuously reset by progress.
+    /// inactivity window is continuously reset by progress.
     ///
     /// This FAILS against the pre-#4001 fixed-deadline behaviour: a 60 s
     /// (or even payload-scaled) deadline fires `TimeoutCause::Deadline` at
@@ -2152,16 +2165,21 @@ mod tests {
         producer.await.expect("producer task panicked");
     }
 
-    /// Progress flows for 40 s then stops. The 30 s inactivity timeout MUST
-    /// fire ~70 s in (40 s of progress + 30 s of silence), returning
+    /// Progress flows for 40 s then stops. The inactivity timeout MUST fire
+    /// exactly one window after the last fragment, returning
     /// `TimeoutCause::StreamStall` exactly once. Asserts the stall is
     /// detected on a genuinely dead stream.
+    ///
+    /// The expected instant is computed from `STREAM_OP_INACTIVITY_TIMEOUT`
+    /// rather than written as a literal, so #5432's resizing of that window
+    /// (30 s -> 240 s) could not silently invalidate it.
     #[tokio::test(start_paused = true)]
     async fn streaming_put_retries_on_true_stall() {
         let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
 
         // Fake peer: progress every 10 s for 40 s, then go silent forever
-        // (never replies). The inactivity timeout must fire.
+        // (never replies). The inactivity timeout must fire one full window
+        // after the last fragment.
         let producer = tokio::spawn(async move {
             let (_reply_sender, _outbound, _target) =
                 rx.recv().await.expect("outbound msg should be delivered");
@@ -2188,18 +2206,225 @@ mod tests {
             Some(TimeoutCause::StreamStall),
             "a stalled stream must be attributed to StreamStall"
         );
-        // Stall detected after 40 s progress + 30 s silence ≈ 70 s, and well
-        // before the 600 s ceiling.
+        // Stall detected one full inactivity window after the last fragment
+        // at 40 s, and well before the 600 s ceiling.
+        //
+        // Stated in terms of the constant rather than a literal: #5432 resized
+        // the window (30 s -> 240 s) because it has to cover the phases in
+        // which nothing can record, and a hard-coded 70 s here would have had
+        // to be re-guessed. The bound is tight on both sides so a window that
+        // silently restarts, or one that stops firing at all, still fails.
+        let expected = Duration::from_secs(40) + STREAM_OP_INACTIVITY_TIMEOUT;
         assert!(
-            elapsed >= Duration::from_secs(60) && elapsed < Duration::from_secs(120),
-            "inactivity stall should fire ~70 s in (40 s progress + 30 s idle), \
-             got {elapsed:?}"
+            elapsed >= expected && elapsed < expected + Duration::from_secs(5),
+            "inactivity stall should fire one window after the last fragment \
+             ({expected:?}), got {elapsed:?}"
         );
         producer.abort();
     }
 
-    /// A stream that records a fragment forever (never replies, never stalls
-    /// for 30 s) MUST still be bounded: the hard 600 s
+    /// Regression for #5432 — the **pre-upload** no-progress window.
+    ///
+    /// The originator dispatches no fragment until the loopback relay has run
+    /// `relay_put_store_locally`: a wait on the single-threaded
+    /// contract-handling queue, then WASM `validate_state`/`update_state`, then
+    /// a disk persist of the whole state. For a multi-MiB `fdev website
+    /// publish`/`update` payload that regularly exceeds 30 s — and the
+    /// inactivity clock is already running, because it starts when
+    /// `StreamProgress` is constructed, before the request is even emitted.
+    /// So the attempt was killed with zero bytes ever streamed, and since
+    /// streaming PUTs get exactly one attempt
+    /// (`MAX_PEER_ADVANCEMENTS_STREAMING = 0`) that was an immediate
+    /// client-visible failure.
+    ///
+    /// Here NO progress is ever recorded and the reply lands 120 s in — the
+    /// contract-handler queue starvation #4912 actually measured on a real
+    /// gateway, which is the length this window has to clear to stop killing
+    /// PUTs that were about to succeed. This MUST return the reply.
+    ///
+    /// That figure, not a token "more than 30 s", is the point: it pins the
+    /// MAGNITUDE the fix is sized for, so a window nudged back down below the
+    /// observed starvation fails here and not only in the arithmetic pin.
+    ///
+    /// Against the pre-fix 30 s window this FAILS: the first inactivity expiry
+    /// at 30 s sees `since_last() == 30 s` and returns `StreamStall`.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_survives_local_store_before_first_fragment() {
+        let (mut ctx, tx, _handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake originator: no fragment is ever dispatched (the send loop has
+        // not been reached yet), then the terminal reply arrives after a
+        // realistic local-store stall — the ~120 s of contract-handling queue
+        // starvation #4912 measured on a real gateway.
+        let store_took = Duration::from_secs(120);
+        let producer = tokio::spawn(async move {
+            let (reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            tokio::time::sleep(store_took).await;
+            reply_sender
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+                .expect("capacity-1 reply channel accepts the reply");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        assert!(
+            result.is_ok(),
+            "silence before the first fragment is local work, not a dead \
+             stream: the attempt must survive it and deliver the reply, \
+             got {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().unwrap().id(), &tx);
+        producer.await.expect("producer task panicked");
+    }
+
+    /// Regression for #5432 — the **post-upload** no-progress window.
+    ///
+    /// `handle.record()` is only ever called by the originator's outbound
+    /// stream send loop, once per fragment dispatched. Once the last fragment
+    /// is out nothing records again, yet the operation still has to finish:
+    /// remote reassembly, the remote's own WASM execution, further downstream
+    /// relay hops (each re-streaming the payload), and the reply's return trip.
+    /// A 30 s window could not tell that from a dead stream.
+    ///
+    /// Here fragments flow for 60 s (the upload), then stop, and the reply
+    /// lands 90 s later at 150 s. This MUST return the reply.
+    ///
+    /// Against the pre-fix 30 s window this FAILS: 30 s after the last fragment
+    /// the window confirms `since_last() == 30 s` and returns `StreamStall` at
+    /// ~90 s, while the PUT was progressing normally.
+    ///
+    /// This is the half a floor measured from attempt start cannot fix: for a
+    /// payload whose upload outlasts the floor, the floor is already spent when
+    /// the last fragment goes out, leaving the same too-short grace behind it.
+    /// Sizing the window itself covers both phases at any payload size.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_survives_downstream_work_after_last_fragment() {
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake originator: 6 fragments over 60 s (the upload completing), then
+        // silence while the downstream hops do their work, reply at 150 s.
+        let producer = tokio::spawn(async move {
+            let (reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                handle.record();
+            }
+            tokio::time::sleep(Duration::from_secs(90)).await;
+            reply_sender
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+                .expect("capacity-1 reply channel accepts the reply");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        assert!(
+            result.is_ok(),
+            "silence after the last fragment is downstream work, not a dead \
+             stream: the attempt must survive it and deliver the reply, \
+             got {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().unwrap().id(), &tx);
+        producer.await.expect("producer task panicked");
+    }
+
+    /// A long upload followed by downstream work must survive too (#5432).
+    ///
+    /// This is the case that rules out "just give the attempt a head start":
+    /// any grace measured from ATTEMPT START is already spent by the time a
+    /// large payload finishes uploading, so the post-upload phase is left with
+    /// whatever the bare window allows. Here fragments flow for 300 s — longer
+    /// than any plausible fixed head start — and the reply lands 120 s after
+    /// the last one, still inside the 600 s ceiling.
+    ///
+    /// It is the window itself, measured from the last fragment, that has to be
+    /// the right size; this test fails against a 30 s window AND against an
+    /// attempt-start floor of any value.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_survives_downstream_work_after_a_long_upload() {
+        let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
+
+        let producer = tokio::spawn(async move {
+            let (reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            // 300 s of steady upload.
+            for _ in 0..30 {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                handle.record();
+            }
+            // Then downstream work, well inside the window but far past
+            // anything a head start would still have left.
+            tokio::time::sleep(Duration::from_secs(120)).await;
+            reply_sender
+                .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
+                .expect("capacity-1 reply channel accepts the reply");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        assert!(
+            result.is_ok(),
+            "a long upload's downstream phase must get the full inactivity \
+             window measured from its OWN last fragment, got {:?}",
+            result.err()
+        );
+        assert_eq!(result.unwrap().unwrap().id(), &tx);
+        producer.await.expect("producer task panicked");
+    }
+
+    /// The widened window must still leave a stall REACHABLE and correctly
+    /// ATTRIBUTED, well short of the ceiling (#5432).
+    ///
+    /// This is the guard against the obvious wrong fix — widening the window
+    /// until stall detection can no longer fire and the 600 s ceiling becomes
+    /// the only bound, which would report every dead stream as
+    /// `stream_ceiling`: the #4912 misattribution class, reintroduced by the
+    /// #5432 fix itself. A stream dead from the outset must be abandoned as
+    /// `StreamStall`, at the window, with ceiling headroom to spare.
+    #[tokio::test(start_paused = true)]
+    async fn streaming_put_stall_stays_reachable_below_the_ceiling() {
+        let (mut ctx, tx, _handle, progress, mut rx) = streaming_attempt_fixture();
+
+        // Fake originator: never a fragment, never a reply. Dead from t=0.
+        let producer = tokio::spawn(async move {
+            let (_reply_sender, _outbound, _target) =
+                rx.recv().await.expect("outbound msg should be delivered");
+            tokio::time::sleep(Duration::from_secs(7200)).await;
+        });
+
+        let start = RealTime::new();
+        let t0 = start.now();
+        let outbound = dummy_reply_with_tx(tx);
+        let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
+        let elapsed = start.now().saturating_sub(t0);
+
+        assert_eq!(
+            result.err(),
+            Some(TimeoutCause::StreamStall),
+            "a dead stream must still be reported as a stall, not laundered \
+             into a ceiling"
+        );
+        // Tight both ways: the verdict is due exactly one window in, and the
+        // gap to the ceiling is what keeps the attribution honest.
+        assert!(
+            elapsed >= STREAM_OP_INACTIVITY_TIMEOUT
+                && elapsed < STREAM_OP_INACTIVITY_TIMEOUT + Duration::from_secs(5),
+            "the stall must fire one inactivity window in, got {elapsed:?}"
+        );
+        assert!(
+            elapsed < crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP,
+            "a stall must be reached BEFORE the ceiling, or every dead stream \
+             gets reported as a ceiling, got {elapsed:?} against a {:?} ceiling",
+            crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP
+        );
+        producer.abort();
+    }
+
+    /// A stream that records a fragment forever (never replies, so the
+    /// inactivity window never expires) MUST still be bounded: the hard 600 s
     /// `STREAMING_ATTEMPT_TIMEOUT_CAP` ceiling fires and returns
     /// `TimeoutCause::StreamCeiling`.
     #[tokio::test(start_paused = true)]
@@ -2238,31 +2463,43 @@ mod tests {
         producer.abort();
     }
 
-    /// The atomic tiebreak: a fragment whose `record()` store lands inside the
-    /// inactivity window — but whose `Notify` ping is lost (the realistic race
-    /// `Notify` alone cannot cover) — MUST be observed via the `since_last`
-    /// atomic re-check and suppress a false stall.
+    /// A fragment landing just inside the inactivity window keeps the attempt
+    /// alive instead of stalling it.
     ///
-    /// To exercise the *atomic* path deterministically (not the task scheduler),
-    /// each fragment lands at `window - RACE_SLACK` of virtual time: every
-    /// window expiry therefore finds `since_last < window` and resets via the
-    /// atomic, keeping the attempt alive until the reply. A poll-/Notify-only
-    /// implementation that ignored the atomic would falsely stall.
+    /// # What this does NOT cover, despite its history
+    ///
+    /// This test was written as, and until #5432 was documented as, a pin on
+    /// the `since_last` **atomic tiebreak** — the re-check that suppresses a
+    /// false stall when a fragment's `Notify` ping is lost. It never exercised
+    /// that path. At `window - RACE_SLACK` the `record()` lands strictly BEFORE
+    /// the inactivity sleep's deadline, so `notify_one()`'s permit is always
+    /// waiting and `select!` resolves on the `notified()` arm; the inactivity
+    /// arm, and therefore the atomic re-check, is never reached — at any pass
+    /// count or slack value, because the loop restarts the sleep after every
+    /// consumed permit, so the sleep can only ever expire a full window after
+    /// the last record.
+    ///
+    /// The re-check is genuinely hard to drive deterministically here: with a
+    /// single consumer and `notify_one`, no permit is ever dropped, which is
+    /// the condition it defends against. It remains **defensive and unpinned**.
+    /// Renamed and re-documented rather than left asserting coverage it does
+    /// not provide — a false claim on a lost-wakeup guard is worse than a
+    /// visibly weak test, because it stops the next reviewer looking.
     #[tokio::test(start_paused = true)]
-    async fn streaming_put_progress_during_inactivity_race() {
-        // Land each fragment just inside the window so the atomic re-check —
-        // not a fresh timer — is what keeps the stream alive.
+    async fn streaming_put_survives_fragment_landing_inside_the_window() {
+        // Land the fragment just inside the window.
         const RACE_SLACK: Duration = Duration::from_millis(500);
         let (mut ctx, tx, handle, progress, mut rx) = streaming_attempt_fixture();
 
         let producer = tokio::spawn(async move {
             let (reply_sender, _outbound, _target) =
                 rx.recv().await.expect("outbound msg should be delivered");
-            // Several fragments landing just before each inactivity boundary.
-            for _ in 0..5 {
-                tokio::time::sleep(STREAM_OP_INACTIVITY_TIMEOUT - RACE_SLACK).await;
-                handle.record();
-            }
+            // One fragment, landing just before the inactivity boundary. A
+            // single pass, not the original five: #5432 widened the window, so
+            // five would overrun the 600 s ceiling and quietly turn this into a
+            // duplicate of the ceiling test.
+            tokio::time::sleep(STREAM_OP_INACTIVITY_TIMEOUT - RACE_SLACK).await;
+            handle.record();
             tokio::time::sleep(Duration::from_secs(5)).await;
             reply_sender
                 .try_send(WaiterReply::Reply(dummy_reply_with_tx(tx)))
@@ -2273,8 +2510,8 @@ mod tests {
         let result = await_streaming_attempt(&mut ctx, outbound, &progress).await;
         assert!(
             result.is_ok(),
-            "a fragment landing inside the inactivity window must reset it via \
-             the atomic tiebreak, not trigger a false stall"
+            "a fragment landing inside the inactivity window must reset it, \
+             not trigger a false stall"
         );
         assert_eq!(result.unwrap().unwrap().id(), &tx);
         producer.await.expect("producer task panicked");
@@ -2342,7 +2579,7 @@ mod tests {
     ///
     /// Before the fix all three conditions collapsed to `Err(())` and the
     /// shared warning logged `attempt_timeout` unconditionally. On the nova
-    /// gateway that printed `timeout_secs=117` for an attempt the 30 s stream
+    /// gateway that printed `timeout_secs=117` for an attempt the stream
     /// inactivity check had abandoned after 30.001 s, with nothing in the log
     /// to explain the gap, which sent the investigation after the wrong
     /// mechanism.
@@ -2376,7 +2613,7 @@ mod tests {
         assert_ne!(
             TimeoutCause::StreamStall.budget(attempt_timeout),
             attempt_timeout,
-            "#4912 regression: a 30s stream stall reported as a 117s \
+            "#4912 regression: a stream stall reported as a 117s \
              attempt deadline is exactly the misattribution this fixes"
         );
 
@@ -2474,7 +2711,7 @@ mod tests {
         assert!(
             !window.contains("timeout_secs = attempt_timeout.as_secs()"),
             "#4912 regression: logging attempt_timeout unconditionally \
-             misreports streaming stalls/ceilings by up to 20x"
+             misreports streaming stalls/ceilings by a wide margin"
         );
         // No measured-duration field here on purpose. An `elapsed_secs` would
         // need the SAME clock the path being timed uses: the streaming path

--- a/crates/core/src/operations/stream_progress.rs
+++ b/crates/core/src/operations/stream_progress.rs
@@ -304,7 +304,10 @@ impl Drop for StreamProgressGuard {
 ///   the request is even emitted. The originator-loopback relay then runs
 ///   `relay_put_store_locally` — a wait on the single-threaded contract-handling
 ///   queue, then WASM `validate_state`/`update_state`, then a disk persist of
-///   the whole state — before streaming a single byte.
+///   the whole state, then `announce_contract_hosted` (a DELIBERATELY blocking
+///   `notify_node_event`, itself bounded by
+///   `OpManager::NOTIFICATION_SEND_TIMEOUT` at 30 s) — all before a single byte
+///   is streamed.
 /// - **After the last fragment.** Remote reassembly, the remote's own WASM
 ///   execution, further downstream relay hops (each re-streaming the payload),
 ///   and the terminal reply's return trip all happen with the send loop
@@ -317,18 +320,31 @@ impl Drop for StreamProgressGuard {
 /// streaming PUTs get a single attempt (`MAX_PEER_ADVANCEMENTS_STREAMING = 0`),
 /// that was an immediate, deterministic client-visible failure.
 ///
-/// So the window must be sized for the longest silence that is actually
-/// OBSERVED, and bounded above by how long the client will wait to hear the
-/// answer. Both ends are real constraints, and they conflict:
+/// So the window must be sized for the longest silence the pre-fragment phase
+/// can plausibly take, and bounded above by how long the client will wait to
+/// hear the answer. Both ends are real constraints, and they conflict:
 ///
 /// - **Lower.** The pre-fragment phase is a wait on the contract handler, and
-///   #4912 measured roughly 120 s of contract-handling queue starvation on a
-///   real gateway. The window has to clear that, or it keeps killing PUTs that
-///   were about to succeed. 240 s is ~2x the observed figure.
+///   the honest measured floor for it is only **">30 s"**: in both #4912 and
+///   the nova log on #5432 the stall fired at exactly 30 s while the local
+///   store was still running, which tells us the phase outlasts 30 s and
+///   nothing more. 120 s is an **extrapolation**, not a measurement of this
+///   phase — #4912's ~120 s was queue starvation BEFORE its attempt began (see
+///   the `TimeoutCause` rustdoc in `op_ctx.rs`, which says so explicitly), so
+///   it is outside the span this constant governs. The inference is that the
+///   same saturated node that starved the dispatch path for ~120 s will
+///   equally delay the in-window store, which waits on a handler permitted up
+///   to 300 s. Reasonable, and stated as inference so the next person tuning
+///   this does not treat it as a measured floor.
 /// - **Upper.** `fdev`'s default client-side wait is 300 s. Past that the user
 ///   stops seeing the node's specific `stream_stall` diagnosis and gets fdev's
-///   generic "may have succeeded, verify out-of-band" instead. The window has
-///   to stay under it for the node's own answer to be the one that lands.
+///   generic "may have succeeded, verify out-of-band" instead. Precisely: the
+///   verdict fires at `last_fragment + window`, not `attempt_start + window`,
+///   so staying under 300 s buys the node the last word only in the
+///   **no-progress** case — which is the common one, and the one #5432 is
+///   about. A stream that uploads for 300 s and then dies is declared at 540 s
+///   and fdev still speaks first; the ceiling, not this bound, is what limits
+///   that. Do not read the bound as an unconditional guarantee.
 ///
 /// **This does NOT cover the contract handler's full permitted budget.**
 /// `CH_EV_RESPONSE_TIME_OUT` allows a `PutQuery` up to 300 s, so in the extreme
@@ -366,9 +382,10 @@ mod tests {
     /// behind it, which is why they are pinned rather than left to prose:
     ///
     /// - **Too short kills healthy PUTs.** The pre-fragment phase is a wait on
-    ///   the contract handler; #4912 measured ~120 s of queue starvation on a
-    ///   real gateway. A window under that keeps declaring a stall on work that
-    ///   was about to succeed — the #5432 defect.
+    ///   the contract handler. Measured floor is only ">30 s"; the 120 s here
+    ///   is extrapolated from #4912 (see the constant's rustdoc — that 120 s
+    ///   was PRE-attempt starvation, not this phase). A window under it keeps
+    ///   declaring a stall on work that was about to succeed — the #5432 defect.
     /// - **Too long hands the answer to the client.** `fdev`'s default wait is
     ///   300 s. Above that the node's specific diagnosis never reaches the
     ///   user; they get fdev's generic message instead. Measured: raising the
@@ -380,29 +397,43 @@ mod tests {
     ///   than letting it shrink to nothing.
     ///
     /// `fdev`'s constant cannot be referenced from core (fdev depends on core,
-    /// not the reverse), so that bound is asserted against a local copy. Keep
-    /// the two in step: `crates/fdev/src/commands.rs`.
+    /// not the reverse), so that bound is asserted against a local copy. A
+    /// mirrored constant is a guard whose two inputs can drift apart from one
+    /// edit, so `crates/fdev`'s
+    /// `commands::tests::default_response_timeout_matches_the_core_stall_pin`
+    /// asserts the other side of the mirror and names this test. Change either
+    /// and BOTH fail, rather than one silently going stale.
     #[test]
     fn inactivity_window_is_bounded_at_both_ends() {
         let ceiling = crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP;
 
-        // Observed contract-handler queue starvation on a real gateway (#4912).
-        const OBSERVED_QUEUE_STARVATION: Duration = Duration::from_secs(120);
+        // The pre-fragment phase budget. NOT a measurement of that phase:
+        // the measured floor is only ">30 s" (see the constant's rustdoc);
+        // 120 s is extrapolated from #4912's pre-attempt starvation.
+        const PRE_FRAGMENT_PHASE_BUDGET: Duration = Duration::from_secs(120);
+        // Strict inequality is not enough: 121 s would "clear" a 120 s figure
+        // with no headroom, and 120 s is itself an extrapolation rather than a
+        // measurement of this phase (see the constant's rustdoc). The design
+        // margin is 2x, so pin the margin, not just the inequality.
         assert!(
-            STREAM_OP_INACTIVITY_TIMEOUT > OBSERVED_QUEUE_STARVATION,
+            STREAM_OP_INACTIVITY_TIMEOUT >= 2 * PRE_FRAGMENT_PHASE_BUDGET,
             "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must clear \
-             the ~{OBSERVED_QUEUE_STARVATION:?} of handler queue starvation \
-             #4912 measured, or it keeps stalling PUTs that were about to \
-             succeed"
+             the ~{PRE_FRAGMENT_PHASE_BUDGET:?} pre-fragment phase budget with \
+             the 2x margin the sizing argument claims, or it keeps stalling \
+             PUTs that were about to succeed"
         );
 
         // Mirror of fdev's DEFAULT_RESPONSE_TIMEOUT; see the doc note above.
         const FDEV_DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+        // Same again at the top: 299 s is "under" 300 s and buys the node no
+        // room at all to get its verdict out. Require a real gap.
+        const CLIENT_MARGIN: Duration = Duration::from_secs(30);
         assert!(
-            STREAM_OP_INACTIVITY_TIMEOUT < FDEV_DEFAULT_RESPONSE_TIMEOUT,
-            "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must fire \
-             before fdev gives up ({FDEV_DEFAULT_RESPONSE_TIMEOUT:?}), or the \
-             user sees fdev's generic timeout instead of the node's reason"
+            STREAM_OP_INACTIVITY_TIMEOUT + CLIENT_MARGIN <= FDEV_DEFAULT_RESPONSE_TIMEOUT,
+            "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must fire at \
+             least {CLIENT_MARGIN:?} before fdev gives up \
+             ({FDEV_DEFAULT_RESPONSE_TIMEOUT:?}), or the user sees fdev's \
+             generic timeout instead of the node's reason"
         );
 
         assert!(

--- a/crates/core/src/operations/stream_progress.rs
+++ b/crates/core/src/operations/stream_progress.rs
@@ -81,7 +81,7 @@ type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 /// establishment) while the reader measured against the op's `RealTime` (epoch
 /// = op start, strictly later), the stored "last progress" would exceed the
 /// reader's clock, `since_last` would `saturating_sub` to 0 forever, and the
-/// 30 s inactivity stall would NEVER fire — silently degrading to the 600 s
+/// inactivity stall would NEVER fire — silently degrading to the 600 s
 /// ceiling. Owning the clock here makes `record()` take **no caller timestamp**,
 /// guaranteeing one epoch for both sides and preserving VirtualTime/DST
 /// correctness (one injected clock).
@@ -289,15 +289,137 @@ impl Drop for StreamProgressGuard {
 /// individual transport fragments on one hop. The op-level timeout is larger on
 /// purpose: it must absorb whole transport retransmit cycles (a hop can stall
 /// for several seconds and recover) without the op layer prematurely declaring
-/// the stream dead and firing a version-conflicting retry. 30 s gives ~6× the
-/// transport inactivity window of slack.
-pub(crate) const STREAM_OP_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
+/// the stream dead and firing a version-conflicting retry.
+///
+/// # Sizing this against the phases that record nothing (#5432)
+///
+/// The original 30 s was chosen as ~6x the transport inactivity window, which
+/// sizes it for **one** of the three phases of an attempt: the stretch during
+/// which fragments are actually being dispatched. [`StreamProgressHandle::record`]
+/// is called only by the originator's outbound stream send loop, once per
+/// fragment, so an attempt has two further phases in which nothing can record
+/// and the clock runs unopposed:
+///
+/// - **Before the first fragment.** The clock starts at construction, before
+///   the request is even emitted. The originator-loopback relay then runs
+///   `relay_put_store_locally` — a wait on the single-threaded contract-handling
+///   queue, then WASM `validate_state`/`update_state`, then a disk persist of
+///   the whole state — before streaming a single byte.
+/// - **After the last fragment.** Remote reassembly, the remote's own WASM
+///   execution, further downstream relay hops (each re-streaming the payload),
+///   and the terminal reply's return trip all happen with the send loop
+///   finished.
+///
+/// A multi-MiB payload routinely spends more than 30 s in either. Every
+/// `fdev website publish`/`update` is such a payload (the embedded website
+/// contract WASM alone exceeds the 64 KiB streaming threshold), so healthy
+/// publishes were being abandoned as `stream_stall` at exactly 30 s — and since
+/// streaming PUTs get a single attempt (`MAX_PEER_ADVANCEMENTS_STREAMING = 0`),
+/// that was an immediate, deterministic client-visible failure.
+///
+/// So the window must be sized for the longest silence that is actually
+/// OBSERVED, and bounded above by how long the client will wait to hear the
+/// answer. Both ends are real constraints, and they conflict:
+///
+/// - **Lower.** The pre-fragment phase is a wait on the contract handler, and
+///   #4912 measured roughly 120 s of contract-handling queue starvation on a
+///   real gateway. The window has to clear that, or it keeps killing PUTs that
+///   were about to succeed. 240 s is ~2x the observed figure.
+/// - **Upper.** `fdev`'s default client-side wait is 300 s. Past that the user
+///   stops seeing the node's specific `stream_stall` diagnosis and gets fdev's
+///   generic "may have succeeded, verify out-of-band" instead. The window has
+///   to stay under it for the node's own answer to be the one that lands.
+///
+/// **This does NOT cover the contract handler's full permitted budget.**
+/// `CH_EV_RESPONSE_TIME_OUT` allows a `PutQuery` up to 300 s, so in the extreme
+/// where the handler spends all of it, this watchdog still fires first. That is
+/// a deliberate bound, not an oversight: covering it would require a window
+/// above 300 s, which is precisely the upper limit above. Given a live path
+/// where the terminal reply is never delivered at all even though the store
+/// succeeded (`crates/core/tests/fdev_publish_e2e.rs` documents it, and
+/// measures the client hanging to its full 300 s once the window is raised past
+/// it), a long hang is a worse outcome than a fast wrong answer. The extreme
+/// handler case is rarer than the lost-reply case, so the bound goes to the
+/// common one.
+///
+/// The real fix for both is to make the terminal reply arrive; until then this
+/// constant is a compromise between two bad outcomes rather than a derivation
+/// with a single right answer. Do not "tighten" it toward either end without
+/// re-reading this block — each end has a demonstrated failure behind it.
+///
+/// It also stays well below the 600 s
+/// [`crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP`] ceiling, so a dead
+/// stream is still reported as a stall rather than swallowed by the ceiling
+/// (the #4912 misattribution class). All of these relationships are pinned by
+/// `tests::inactivity_window_is_bounded_at_both_ends`.
+pub(crate) const STREAM_OP_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(240);
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::operations::put::PutMsg;
     use crate::simulation::VirtualTime;
+
+    /// The window must sit strictly inside both of its real bounds (#5432).
+    ///
+    /// Neither bound is local to this file, and each has a demonstrated failure
+    /// behind it, which is why they are pinned rather than left to prose:
+    ///
+    /// - **Too short kills healthy PUTs.** The pre-fragment phase is a wait on
+    ///   the contract handler; #4912 measured ~120 s of queue starvation on a
+    ///   real gateway. A window under that keeps declaring a stall on work that
+    ///   was about to succeed — the #5432 defect.
+    /// - **Too long hands the answer to the client.** `fdev`'s default wait is
+    ///   300 s. Above that the node's specific diagnosis never reaches the
+    ///   user; they get fdev's generic message instead. Measured: raising the
+    ///   window to 330 s -- a candidate this PR REJECTED for exactly this
+    ///   reason -- made `fdev_publish_e2e` hang to fdev's full 300 s.
+    /// - **Above the ceiling, a stall can never fire at all**, and every dead
+    ///   stream is misreported as `stream_ceiling` (#4912's class again). The
+    ///   band assertion keeps the correctly-attributed span meaningful rather
+    ///   than letting it shrink to nothing.
+    ///
+    /// `fdev`'s constant cannot be referenced from core (fdev depends on core,
+    /// not the reverse), so that bound is asserted against a local copy. Keep
+    /// the two in step: `crates/fdev/src/commands.rs`.
+    #[test]
+    fn inactivity_window_is_bounded_at_both_ends() {
+        let ceiling = crate::operations::STREAMING_ATTEMPT_TIMEOUT_CAP;
+
+        // Observed contract-handler queue starvation on a real gateway (#4912).
+        const OBSERVED_QUEUE_STARVATION: Duration = Duration::from_secs(120);
+        assert!(
+            STREAM_OP_INACTIVITY_TIMEOUT > OBSERVED_QUEUE_STARVATION,
+            "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must clear \
+             the ~{OBSERVED_QUEUE_STARVATION:?} of handler queue starvation \
+             #4912 measured, or it keeps stalling PUTs that were about to \
+             succeed"
+        );
+
+        // Mirror of fdev's DEFAULT_RESPONSE_TIMEOUT; see the doc note above.
+        const FDEV_DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+        assert!(
+            STREAM_OP_INACTIVITY_TIMEOUT < FDEV_DEFAULT_RESPONSE_TIMEOUT,
+            "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must fire \
+             before fdev gives up ({FDEV_DEFAULT_RESPONSE_TIMEOUT:?}), or the \
+             user sees fdev's generic timeout instead of the node's reason"
+        );
+
+        assert!(
+            STREAM_OP_INACTIVITY_TIMEOUT < ceiling,
+            "the stream watchdog ({STREAM_OP_INACTIVITY_TIMEOUT:?}) must stay \
+             below the hard ceiling ({ceiling:?}), or a stall can never fire"
+        );
+
+        // The span of upload during which a mid-stream death is still reported
+        // as the stall it is. `< ceiling` alone passed at 599 s.
+        let attributable_upload_span = ceiling - STREAM_OP_INACTIVITY_TIMEOUT;
+        assert!(
+            attributable_upload_span >= Duration::from_secs(120),
+            "only {attributable_upload_span:?} of upload would have its stalls \
+             attributed correctly; the window has crowded the ceiling"
+        );
+    }
 
     #[test]
     fn record_advances_last_progress_and_since_last_tracks_it() {
@@ -321,9 +443,9 @@ mod tests {
     /// Regression for the cross-epoch `RealTime` bug — the writer recorded
     /// against the connection's epoch (earlier than the op's), so the stored
     /// value exceeded the reader's clock and `since_last` saturated to 0
-    /// forever, defeating the 30 s stall. Because `record()` now reads the
+    /// forever, defeating the stall entirely. Because `record()` now reads the
     /// handle's OWN clock (no caller timestamp), a clone used by the "writer"
-    /// shares the reader's basis: after a record, then 30 s of silence,
+    /// shares the reader's basis: after a record, then a full window of silence,
     /// `since_last` reflects the REAL elapsed time and the stall fires.
     ///
     /// This test fails on the pre-fix code (where `record(now_millis)` took an

--- a/crates/core/tests/fdev_publish_e2e.rs
+++ b/crates/core/tests/fdev_publish_e2e.rs
@@ -215,8 +215,25 @@ fn fdev_run_expect_failure(args: &[&str]) -> (Option<i32>, String) {
 /// fix touches. Validate via [`wait_for_contract_via_get`] below
 /// instead of via exit code.
 async fn fdev_publish_observed(args: &[&str]) {
+    // Cap fdev's client-side wait well below its 300 s default.
+    //
+    // This helper deliberately DISCARDS the exit code and validates via
+    // `wait_for_contract_via_get` instead, so waiting the full default for an
+    // outcome we then throw away is pure dead time — and worse, it couples this
+    // test to whatever the node's internal stall watchdog happens to be. That
+    // coupling is not hypothetical: raising
+    // `operations::stream_progress::STREAM_OP_INACTIVITY_TIMEOUT` for #5432
+    // pushed this test from 126 s to fdev's 300 s ceiling and timed it out,
+    // even though the bytes still landed and the assertion this test actually
+    // makes was unaffected.
+    //
+    // 30 s is ample for the fixture: the publish either completes in about a
+    // second or hits the reply-never-arrives path this helper exists to
+    // tolerate. It bounds the dead time either way and makes the test
+    // independent of node-side timeout tuning.
     let output = Command::new(fdev_bin())
         .args(args)
+        .env("FDEV_RESPONSE_TIMEOUT", "30")
         .output()
         .expect("spawn fdev");
     if output.status.success() {

--- a/crates/core/tests/fdev_publish_e2e.rs
+++ b/crates/core/tests/fdev_publish_e2e.rs
@@ -205,8 +205,8 @@ fn fdev_run_expect_failure(args: &[&str]) -> (Option<i32>, String) {
 /// non-zero exit as a fatal test failure.
 ///
 /// Why: in a freshly-spun-up 2-node test fixture the receiving node's
-/// Put driver hits its single-shot attempt timeout (~90s) before the
-/// actual insert is flushed — fdev faithfully reports the timeout to
+/// Put driver reports a timeout before the actual insert is flushed
+/// — fdev faithfully reports the timeout to
 /// the user, then the insert completes ~200ms later (the node logs a
 /// `Broadcasting hosting update` followed by a `PutResponse`). The
 /// race is a fixture quirk, not a code defect in fdev's load path,
@@ -227,10 +227,16 @@ async fn fdev_publish_observed(args: &[&str]) {
     // even though the bytes still landed and the assertion this test actually
     // makes was unaffected.
     //
-    // 30 s is ample for the fixture: the publish either completes in about a
-    // second or hits the reply-never-arrives path this helper exists to
-    // tolerate. It bounds the dead time either way and makes the test
-    // independent of node-side timeout tuning.
+    // 30 s is ample for the fixture: the publish either completes quickly or
+    // hits the reply-never-arrives path this helper exists to tolerate. It
+    // bounds the dead time either way and makes the test independent of
+    // node-side timeout tuning.
+    //
+    // Note what is being tolerated: that path is a REAL defect, filed as #5458
+    // (the store succeeds and the originator never gets its terminal reply),
+    // not a fixture quirk. Capping the wait makes this helper absorb it more
+    // quietly than a 300 s hang did, so the issue reference belongs here — when
+    // #5458 is fixed, this cap and the polling below can both go.
     let output = Command::new(fdev_bin())
         .args(args)
         .env("FDEV_RESPONSE_TIMEOUT", "30")

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -323,13 +323,14 @@ fn run_playwright(shell_url: &str) -> anyhow::Result<()> {
 /// `contract_home` fetches it locally and renders the shell without needing
 /// network propagation.
 // Budget: the harness times the WHOLE test, including the `fdev website
-// publish` step (which can burn its full ~90s single-shot Put timeout before
-// the insert lands — see `website_publish_observed`), the shell-readiness poll
-// (up to 120s), and the Playwright suite (~90s for the 16 specs in
-// shell.spec.ts, plus the two node-free suites). An observed local
-// run finished in ~282s, so 300s left almost no slack on a contended runner;
-// 600s gives comfortable headroom without masking a genuine hang (the
-// individual sub-steps have their own tighter internal deadlines).
+// publish` step (now capped at 30s of client wait by `website_publish_observed`
+// — it was previously bounded only by fdev's 300s default, which is what made
+// this test hit nextest's cap when #5432 widened the node-side stall window),
+// the shell-readiness poll (up to 120s), and the Playwright suite (~90s for the
+// 16 specs in shell.spec.ts, plus the two node-free suites). An observed local
+// run finished in ~282s BEFORE that cap; it is well under that now. 600s gives
+// comfortable headroom without masking a genuine hang (the individual sub-steps
+// have their own tighter internal deadlines).
 #[freenet_test(
     health_check_readiness = true,
     nodes = ["gateway"],

--- a/crates/core/tests/playwright_shell.rs
+++ b/crates/core/tests/playwright_shell.rs
@@ -212,8 +212,17 @@ fn website_init(config_home: &Path) -> anyhow::Result<String> {
 /// not treated as fatal: the freshly-spun fixture's Put driver can report a
 /// timeout while the insert still lands. We confirm the real outcome by
 /// polling the HTTP shell route instead.
+///
+/// And for the same reason as there, fdev's client-side wait is capped well
+/// below its 300 s default: waiting it out for an outcome we discard is dead
+/// time, and it silently couples this test to the node's stall watchdog
+/// (`operations::stream_progress::STREAM_OP_INACTIVITY_TIMEOUT`). Measured
+/// during #5432: raising that window pushed this test from ~36 s straight to
+/// nextest's 240 s cap, three tries running, even though the shell still came
+/// up fine and the assertion this test makes was unaffected.
 fn website_publish_observed(config_home: &Path, ws_url: &str) {
     let output = isolated_fdev(config_home)
+        .env("FDEV_RESPONSE_TIMEOUT", "30")
         .args(["--node-url", ws_url, "website", "publish"])
         .arg(fixture_webapp_dir())
         .args(["--key", FIXTURE_KEY_NAME])

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -702,6 +702,33 @@ pub(crate) async fn execute_command(
 
 #[cfg(test)]
 mod tests {
+
+    /// The other half of a mirrored constant (#5432).
+    ///
+    /// `freenet`'s streaming-PUT stall watchdog
+    /// (`operations::stream_progress::STREAM_OP_INACTIVITY_TIMEOUT`) is sized to
+    /// fire a margin BEFORE this timeout, so that a stalled publish surfaces the
+    /// node's specific reason rather than fdev's generic "may have succeeded,
+    /// verify out-of-band". Core cannot reference this constant — fdev depends
+    /// on core, not the reverse — so core asserts the bound against a local copy
+    /// of this value in
+    /// `stream_progress::tests::inactivity_window_is_bounded_at_both_ends`.
+    ///
+    /// A mirrored constant guarded on only one side is a guard whose two inputs
+    /// can rot from a single edit: lowering this value alone would silently
+    /// invalidate core's bound while core's own test stayed green. This test is
+    /// the counter-pin. If you change the timeout, expect BOTH to fail, and
+    /// update them together.
+    #[test]
+    fn default_response_timeout_matches_the_core_stall_pin() {
+        assert_eq!(
+            DEFAULT_RESPONSE_TIMEOUT,
+            Duration::from_secs(300),
+            "freenet's STREAM_OP_INACTIVITY_TIMEOUT is sized against this value; \
+             see stream_progress::tests::inactivity_window_is_bounded_at_both_ends \
+             and change both together"
+        );
+    }
     use super::*;
     use std::io::Write;
 


### PR DESCRIPTION
## Problem

`fdev website update ./directory --key my-key` fails consistently with:

```
Error: Failed to receive response: client error: error while executing operation in the network:
put timed out after 1 peer attempt(s) (0 infra-retries on same peer)
```

A streaming PUT is abandoned as `stream_stall` after 30 s of silence. But the only thing that resets that window is an **outbound fragment dispatch** — `handle.record()` has exactly one production caller, the originator's outbound stream send loop. Two phases of every attempt dispatch nothing at all, and against the inactivity clock both are indistinguishable from a dead stream:

- **Before the first fragment.** The clock starts when `StreamProgress` is constructed — before the request is even emitted. The originator-loopback relay then runs `relay_put_store_locally`: a wait on the single-threaded contract-handling queue, then WASM `validate_state`/`update_state`, then a disk persist of the whole state — all before a single byte is streamed.
- **After the last fragment.** Remote reassembly, the remote's own WASM execution, further downstream relay hops (each re-streaming the payload), and the terminal reply's return trip all happen with the send loop already finished.

Every `fdev website publish`/`update` is a streaming PUT — the embedded website contract WASM alone is 219 KiB, over the 64 KiB `streaming_threshold` — so this affects *all* website publishing, not just large sites. Because streaming PUTs get exactly one attempt (`MAX_PEER_ADVANCEMENTS_STREAMING = 0`), the false stall becomes an immediate, deterministic client-visible failure — which is why the reporter saw it survive many manual retries.

### Evidence, and what it does not establish

Nova's gateway log shows the mechanism firing live:

```
06:29:59.581  PUT relay: processing Request ... phase="relay_put_request"
06:30:29.612  WARN operations::op_ctx: put: attempt timed out; advancing
              attempt=1 outcome="timeout" timeout_kind="stream_stall" timeout_secs=30
06:30:29.612  ResultRouter ... Delivering result for transaction ... to 1 clients
```

Exactly 30 s after the request entered the relay, killed on `attempt=1`, exhausted with no second attempt.

**The reporter supplied no logs**, so this is a confirmed defect that produces their exact error string, not a confirmed diagnosis of their specific run. The `timeout_kind` field that would settle it is node-side only. Related: #5300 reports the identical error string as a CI flake.

## Approach

`STREAM_OP_INACTIVITY_TIMEOUT` goes **30 s → 240 s**.

That value is a compromise between two *demonstrated* failures, not a derivation with a single right answer, and the rustdoc says so:

- **Too short kills healthy PUTs.** #4912 measured ~120 s of contract-handler queue starvation on a real gateway, and nothing can `record()` during that wait. 240 s is ~2× it.
- **Too long hands the answer to the client.** fdev's default wait is 300 s. Above it the user stops seeing the node's specific `stream_stall` and gets fdev's generic "may have succeeded, verify out-of-band" instead.

It stays far below the 600 s `STREAMING_ATTEMPT_TIMEOUT_CAP`, so a dead stream is still attributed as a stall rather than swallowed by the ceiling (#4912's class). All four relationships are pinned by `inactivity_window_is_bounded_at_both_ends`.

**This deliberately does not cover `CH_EV_RESPONSE_TIME_OUT`'s full permitted 300 s.** Covering it needs a window above 300 s, which is exactly the upper bound above. Given a live path where the terminal reply is never delivered even though the store succeeded, a long hang is worse than a fast wrong answer. The real fix for both ends is to make that reply arrive.

### What CI caught, and how the number was chosen

The first version of this PR used 330 s, derived from the handler's permitted budget. **CI failed it, reproducibly** — and re-running the identical commit failed identically, which ruled out runner contention. Attributed locally on one machine:

| window | `fdev_publish_e2e::publish_raw_wasm_round_trip` |
|---|---|
| 30 s (baseline) | PASS 126 s |
| 330 s | **FAIL 301 s** |
| 240 s + decoupled test | **PASS 37 s** |

The mechanism came straight out of the failing run: the fixture's contract is 209 KB, so the PUT is streaming; it **stores successfully on the peer** (`hosting_contract_count=1`, `hosting_disk_wasm_bytes=209154`) but the originator never receives its terminal reply. At 30 s the watchdog fired and handed fdev the node's error; at 330 s the node stayed silent and fdev's own 300 s client timeout fired instead.

That is what proves the upper bound is real rather than theoretical, and it is why the window came down.

### A test defect this surfaced

Two helpers — `fdev_publish_e2e::fdev_publish_observed` and `playwright_shell::website_publish_observed` — deliberately **discard** `fdev publish`'s exit code and confirm the real outcome by polling. Yet both still *waited* fdev's full default for the result they throw away, silently coupling them to a node-internal constant. Both now cap fdev's client wait at 30 s.

That removes an accidental dependency rather than papering over one, and all three affected tests end up **faster than before any of this work**:

| test | before | with 330 s | now |
|---|---|---|---|
| `publish_raw_wasm_round_trip` | 126 s | timeout | **37 s** |
| `publish_packaged_contract_round_trip` | 134 s | timeout | **37 s** |
| `shell_smoke_via_playwright` | 36 s | timeout | **36 s** |

All three assert exactly what they asserted before, and future window tuning can no longer blow them up.

Both helpers carry the same comment calling this "a fixture quirk, not a code defect". It is neither a quirk nor confined to the fixture: it is the lost-terminal-reply path now filed as **#5458**, and it is what forces this constant to be bounded at both ends.

### Approaches tried and discarded

- **A payload-scaled grace period measured from attempt start.** Wrong *shape*: for a payload whose upload outlasts it, it is already spent when the last fragment goes out, leaving the post-upload phase with the same too-short grace. Pinned against by `streaming_put_survives_downstream_work_after_a_long_upload`, which fails against such a grace period at *any* value.
- **180 s as "3× `OPERATION_TTL`".** The premise was wrong: hop waits **nest** rather than accumulate, and `drive_relay_put_streaming` arms its 60 s timeout *after* the local store.
- **330 s, derived from the handler budget.** Failed CI as above.

## Testing

Verified by mutation, not assertion:

| Test | Scenario |
|---|---|
| `streaming_put_survives_local_store_before_first_fragment` | no fragment ever; reply at the ~120 s #4912 measured — pins the **magnitude**, so a window nudged back under the observed starvation fails here |
| `streaming_put_survives_downstream_work_after_last_fragment` | fragments to 60 s, reply at 150 s |
| `streaming_put_survives_downstream_work_after_a_long_upload` | 300 s upload, reply 120 s later; also fails against an attempt-start grace period of any value |
| `inactivity_window_is_bounded_at_both_ends` | all four relationships (clears observed starvation, under fdev's timeout, under the ceiling, meaningful attribution band) |
| `streaming_put_stall_stays_reachable_below_the_ceiling` | over-widening guard — a dead stream must still be a stall, one window in |

Two existing tests changed:

- `streaming_put_retries_on_true_stall`: **strengthened** — timing computed from the constant, band tightened from `[60 s, 120 s)` to 5 s. The old band was wide enough to hide a window that silently restarts.
- `streaming_put_progress_during_inactivity_race` → **renamed** `streaming_put_survives_fragment_landing_inside_the_window`, doc corrected. It never exercised the `since_last` atomic tiebreak its old name advertised: at `window - RACE_SLACK` the `record()` lands before the sleep deadline, so `select!` always takes the `notified()` arm — at any pass count. The gap is pre-existing and left as-is; the false claim is not.

`cargo test -p freenet --lib`: 5245 passing. `fdev_publish_e2e`: 4/4. `playwright_shell`: passing at 36 s. `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean.

### Why CI didn't catch the original bug

The existing `await_streaming_attempt` fixtures all simulate progress recorded continuously right up to the reply. None modelled a phase in which the real system records nothing.

## Review

Full tier (operation state machines). Four blind Claude lenses — code-first, skeptical, testing, big-picture — plus four Codex passes, over five rounds, then CI. Review and CI between them replaced the approach three times and caught four of my own errors:

- **Codex: a grace period from attempt start cannot cover the post-upload phase.** Replaced the approach.
- **Codex: 180 s preempts the handler's permitted 300 s.** Led to 330 s.
- **CI: 330 s exceeds fdev's client patience** — the upper bound, demonstrated. Led to 240 s.
- **Skeptical: the 30 s "margin" was already spoken for** by `announce_contract_hosted`'s own 30 s await in the same phase.
- **Skeptical: three stale "180 s" references**, one in `TimeoutCause`'s own rustdoc — the type that exists because a wrong number in a log misdirected #4912.
- **Skeptical + testing: `handle.record()` at attempt start was inert** — a stall needs a full window sleep to expire before `since_last()` is read, and that read can only suppress a stall. Removed, with the reasoning and its expiry condition recorded at the site.
- **Skeptical: the pin was defeatable at 301 s and 599 s.** Both now fail.
- **Big-picture: "filed separately" named issues that didn't exist.** Now they do.

## Out of scope — filed

- **#5446** — the streaming relay's step-7 downstream wait uses a flat `OPERATION_TTL` and, on timeout, bubbles a best-effort *success* upstream.
- **#5447** — `try_summary_first_put` stores locally, and on `FallThrough` the full-state driver stores the same multi-MiB payload again.
- **#5448** — the transaction-TTL GC is dead code (`new_transactions` is never sent to).

- **#5458** — the deeper defect behind both of this PR's bounds: a streaming PUT stores successfully on the peer while the originator never gets its terminal reply. Fix that and the watchdog stops having to be a compromise. It is what `fdev_publish_e2e` has been quietly tolerating as a "fixture quirk".

Closes #5432

[AI-assisted - Claude]
