### PR TITLE
fix(ci): let the fix: test gate see scripts/test-*.sh self-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,18 +514,28 @@ jobs:
             #
             # KNOWN FALSE NEGATIVES, left in rather than chased. All three are
             # real in this repo today:
-            #   1. `printf`-style success reporting. An earlier version of this
-            #      comment DELETED this entry, on the stated ground that
+            #   1. `printf`-style success reporting -- but ONLY the reporter's
+            #      DEFINITION line. An earlier version of this comment DELETED
+            #      this entry, on the stated ground that
             #      `grep -rnE "printf .*['\"](ok|PASS)"` over scripts/ returned
             #      nothing. It returns two:
             #      `scripts/test-install-sh.sh` and `scripts/test-uninstall-sh.sh`,
-            #      both `pass() { printf 'PASS  %s\\n' "$1"; }`. They escape this
-            #      counter only because the diff above is scoped to
-            #      `**/*_test.sh` and those are named `test-*.sh` -- a naming
-            #      accident, not the absence of the convention. The moment
-            #      someone writes that reporter in a `*_test.sh`, it scores zero.
-            #      `rule_lint_shell_assertion_counter_test.sh` now RECOMPUTES
-            #      this rather than trusting the sentence.
+            #      both `pass() { printf 'PASS  %s\\n' "$1"; }`.
+            #      Those two files used to escape this counter entirely, because
+            #      the diff above was scoped to `**/*_test.sh` and they are named
+            #      `test-*.sh` -- a naming accident, not the absence of the
+            #      convention. `'**/test-*.sh'` above closes that; PR #4958 was
+            #      rejected by this gate for having no test while adding ten
+            #      `check_eq` assertions to `test-install-sh.sh`, which this job
+            #      RUNS.
+            #      What remains a blind spot is narrower than it looks, and was
+            #      measured rather than assumed: their `pass "..."` and
+            #      `check_eq "..."` CALL SITES both score (via the `pass` and
+            #      `check_`-prefix alternatives), so neither file is invisible.
+            #      Only `pass() { printf ... }` itself scores zero -- which is
+            #      correct, since declaring a helper is not adding a test.
+            #      `rule_lint_shell_assertion_counter_test.sh` RECOMPUTES this
+            #      rather than trusting the sentence.
             #   2. An assertion whose only added line is its FAIL branch.
             #      Deliberate: counting FAIL would let a PR score by adding an
             #      error message alone.
@@ -534,7 +544,7 @@ jobs:
             #      live instance. Adding a file there genuinely extends what is
             #      audited, and the added line is a bare string.
             # The error text below tells the contributor all three.
-            NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' \
+            NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' '**/test-*.sh' \
               | grep -E '^\+' | grep -vF '+++' \
               | grep -cE '^\+[[:space:]]*(check|ok|pass|expect)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
             # Browser-asset fixes have the SAME problem the shell escape hatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,10 +524,17 @@ jobs:
             #      Those two files used to escape this counter entirely, because
             #      the diff above was scoped to `**/*_test.sh` and they are named
             #      `test-*.sh` -- a naming accident, not the absence of the
-            #      convention. `'**/test-*.sh'` above closes that; PR #4958 was
-            #      rejected by this gate for having no test while adding ten
+            #      convention. `'scripts/test-*.sh'` above closes that; PR #4958
+            #      was rejected by this gate for having no test while adding ten
             #      `check_eq` assertions to `test-install-sh.sh`, which this job
             #      RUNS.
+            #      SCOPED to `scripts/` rather than `'**/test-*.sh'`: `*` crosses
+            #      `/` in a git pathspec, so the unscoped form ALSO matches
+            #      `docker/test-runner/entrypoint.sh` and `.../run.sh` -- docker
+            #      plumbing, not tests, and outside the self-test's `find`, so
+            #      nothing would audit them. A `fix:` PR adding a plausible
+            #      `check_image_exists` line to a docker wrapper would then
+            #      satisfy this gate with no test at all.
             #      What remains a blind spot is narrower than it looks, and was
             #      measured rather than assumed: their `pass "..."` and
             #      `check_eq "..."` CALL SITES both score (via the `pass` and
@@ -544,7 +551,7 @@ jobs:
             #      live instance. Adding a file there genuinely extends what is
             #      audited, and the added line is a bare string.
             # The error text below tells the contributor all three.
-            NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' '**/test-*.sh' \
+            NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' 'scripts/test-*.sh' \
               | grep -E '^\+' | grep -vF '+++' \
               | grep -cE '^\+[[:space:]]*(check|ok|pass|expect)[[:space:]]|^\+[[:space:]]*echo[[:space:]]+["'"'"'](ok[[:space:]]+-|PASS[[:space:]])|^\+[[:space:]]*(check|pin|assert|expect|test)_[a-z0-9_]*([[:space:]]|$)|^\+[[:space:]]*[a-z_][a-z0-9_]*_case[[:space:]]' || true)
             # Browser-asset fixes have the SAME problem the shell escape hatch

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -377,7 +377,7 @@ fi
 #    COVERAGE IS DECIDED BY GIT, NOT BY A MODEL OF GIT. The first version of
 #    this check compared `basename` against `${spec##*/}` -- a hand-written
 #    imitation of pathspec matching -- and review demonstrated it wrong three
-#    ways, each by mutation: `':(exclude)**/test-*.sh'` (the pathspec whose job
+#    ways, each by mutation: `':(exclude)scripts/test-*.sh'` (the pathspec whose job
 #    is to make git SKIP the file) read as coverage OF it, a directory-scoped
 #    `'scripts/**/*_test.sh'` read as covering all 13 files where git matches 4,
 #    and `'crates/**/*_test.sh'` read as full coverage where git matches none.
@@ -493,8 +493,9 @@ else
     echo "       reached: those assertions score zero. Add a printf pattern to the" >&2
     echo "       alternation and a MUST-COUNT row above, then update ci.yml's list." >&2
     echo "       (scripts/test-install-sh.sh and scripts/test-uninstall-sh.sh are" >&2
-    echo "       no longer out of scope -- ci.yml's diff glob now includes" >&2
-    echo "       '**/test-*.sh'. They are excluded from THIS grep on purpose: only" >&2
+    echo "       no longer out of scope -- ci.yml's diff pathspec now includes" >&2
+    echo "       'scripts/test-*.sh'. They are excluded from THIS grep on purpose:" >&2
+    echo "       only" >&2
     echo "       their 'pass() { printf ... }' DEFINITION is unmatched, while their" >&2
     echo "       'pass \"...\"' and 'check_eq \"...\"' call sites both score. A helper" >&2
     echo "       definition scoring zero is correct, not a blind spot.)" >&2

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -282,8 +282,32 @@ while IFS= read -r f; do
                                 # matches, because the closing quote sits where
                                 # the boundary should be. The explicit echo test
                                 # is belt to that braces.
+                                #
+                                # KNOWN RESIDUAL, recorded rather than papered
+                                # over (PR #5443 review). The boundary here is
+                                # "any whitespace", so ANY whitespace-delimited
+                                # literal sh/bash token immediately before the
+                                # path satisfies it -- including a future
+                                # `shellcheck -x -s sh scripts/test-install-sh.sh`
+                                # in the lint step, where sh is a DIALECT FLAG and
+                                # not a shell at all. This closes the case that
+                                # exists today (`...-sh.sh <needle>`, where the sh
+                                # is preceded by a dot) and no more.
+                                # The real fix is to require COMMAND position --
+                                # string start, newline, a ;|& separator, or the
+                                # YAML run: colon -- instead of any whitespace.
+                                # That also wants an optional /path/ prefix so
+                                # `/bin/sh x_test.sh` counts, and an optional flag
+                                # run so `bash -x x_test.sh` counts: the two
+                                # false-BLOCKING forms this currently rejects, and
+                                # false-blocking is the worse direction per the
+                                # note above. Not done here because it is a fiddly
+                                # awk-quoting change that this PR battery could
+                                # not validate in one pass. Do it as its own
+                                # change. NOTE: no apostrophes in this block --
+                                # it lives inside a single-quoted awk program.
                                 if (step[i] ~ ("(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle "([[:space:]]|$)") \
-                                    && step[i] !~ ("echo[^;|&$]*(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle) \
+                                    && step[i] !~ ("echo[^;|&$\n]*(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle) \
                                     && step[i] !~ /\n[[:space:]]+if:/) {
                                     print "RUNS"
                                 }
@@ -349,44 +373,100 @@ fi
 #    against files it finds with its OWN `find`, so a file the ci.yml pathspec
 #    excludes still scores fine here. The two scopes have to be compared to
 #    each other, which is what this does.
+#
+#    COVERAGE IS DECIDED BY GIT, NOT BY A MODEL OF GIT. The first version of
+#    this check compared `basename` against `${spec##*/}` -- a hand-written
+#    imitation of pathspec matching -- and review demonstrated it wrong three
+#    ways, each by mutation: `':(exclude)**/test-*.sh'` (the pathspec whose job
+#    is to make git SKIP the file) read as coverage OF it, a directory-scoped
+#    `'scripts/**/*_test.sh'` read as covering all 13 files where git matches 4,
+#    and `'crates/**/*_test.sh'` read as full coverage where git matches none.
+#    `git ls-files` is definitionally correct, handles exclude magic and any
+#    future pathspec syntax, and cannot drift from what the counter's own
+#    `git diff` does.
+#
+#    `--cached --others --exclude-standard` rather than a plain `ls-files`: a
+#    contributor adding a test file has not necessarily staged it, and that
+#    unstaged file is exactly the one whose convention the counter may not know
+#    -- the same reason the population below comes from `find`. Ignored files
+#    stay out.
 uncovered=()
-PATHSPEC_LINE="$(grep -F 'NEW_SHELL_TESTS=$(git diff' "$CI_YML" || true)"
+pathspec_measured=0
+PATHSPEC_HITS="$(grep -cF 'NEW_SHELL_TESTS=$(git diff' "$CI_YML" || true)"
+PATHSPEC_LINE="$(grep -F 'NEW_SHELL_TESTS=$(git diff' "$CI_YML" | tail -1 || true)"
 if [[ -z "$PATHSPEC_LINE" ]]; then
     echo "FAIL - could not find the NEW_SHELL_TESTS git-diff line in ci.yml." >&2
     echo "       Without it the pathspec scope is unknown and this check examined" >&2
     echo "       nothing; it fails rather than passing vacuously." >&2
     FAILURES=$((FAILURES + 1))
+elif [[ "$PATHSPEC_HITS" -ne 1 ]]; then
+    # Unbounded `grep -F` would let a COMMENT restating the command union its
+    # pathspecs with the live ones, so narrowing the real pathspec stayed green.
+    echo "FAIL - found $PATHSPEC_HITS lines matching the NEW_SHELL_TESTS git-diff" >&2
+    echo "       command in ci.yml; expected exactly 1. A second occurrence -- even" >&2
+    echo "       in a comment -- unions its pathspecs into this measurement and hides" >&2
+    echo "       a narrowing of the live one." >&2
+    FAILURES=$((FAILURES + 1))
 else
     # Everything after the `-- ` separator, as single-quoted words.
     mapfile -t PATHSPECS < <(printf '%s\n' "${PATHSPEC_LINE#*-- }" | grep -oE "'[^']+'" | tr -d "'")
+    REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
     if [[ ${#PATHSPECS[@]} -eq 0 ]]; then
         echo "FAIL - parsed zero pathspecs from ci.yml's NEW_SHELL_TESTS line." >&2
         echo "       An empty list would report every file as uncovered OR as covered" >&2
         echo "       depending on the loop's sense; either way it is not a measurement." >&2
         FAILURES=$((FAILURES + 1))
+    elif [[ -z "$REPO_ROOT" ]]; then
+        echo "FAIL - not inside a git work tree, so git cannot be asked what the" >&2
+        echo "       pathspecs match. This check refuses to guess." >&2
+        FAILURES=$((FAILURES + 1))
     else
+        covered_set=()
+        mapfile -t covered_set < <(
+            git -C "$REPO_ROOT" ls-files --cached --others --exclude-standard \
+                -- "${PATHSPECS[@]}" 2>/dev/null | sort -u)
         while IFS= read -r f; do
-            rel="${f#"$SCRIPT_DIR"/}"
+            rel="${f#"$REPO_ROOT"/}"
             covered=0
-            for spec in "${PATHSPECS[@]}"; do
-                # git's `**/x` matches at any depth including the top level, which
-                # bash's `==` does not, so compare the basename against the tail.
-                # shellcheck disable=SC2053
-                [[ "$(basename "$f")" == ${spec##*/} ]] && covered=1 && break
+            for c in ${covered_set[@]+"${covered_set[@]}"}; do
+                [[ "$c" == "$rel" ]] && covered=1 && break
             done
-            [[ "$covered" -eq 1 ]] || uncovered+=("scripts/$rel")
+            [[ "$covered" -eq 1 ]] || uncovered+=("$rel")
         done < <(find "$SCRIPT_DIR" \( -name '*_test.sh' -o -name 'test-*.sh' \) -type f | sort)
+        pathspec_measured=1
     fi
 fi
 
-if [[ ${#uncovered[@]} -eq 0 ]]; then
-    echo "ok   - ci.yml's diff pathspecs reach every shell self-test on disk"
-else
+if [[ ${#uncovered[@]} -gt 0 ]]; then
     echo "FAIL - these shell self-tests are outside ci.yml's NEW_SHELL_TESTS pathspecs:" >&2
     for f in "${uncovered[@]}"; do echo "         $f" >&2; done
     echo "       The counter never sees their added lines, so a fix: PR whose only" >&2
     echo "       regression test lives there is rejected for having no test -- however" >&2
     echo "       many assertions it adds. Add a pathspec to the git diff in ci.yml." >&2
+    FAILURES=$((FAILURES + 1))
+elif [[ "$pathspec_measured" -eq 1 ]]; then
+    # Gated on the flag, not on an empty array: `uncovered` is also empty when
+    # the measurement never ran, and an `ok` printed beside its own FAIL asserts
+    # exactly the property that was not measured.
+    echo "ok   - ci.yml's diff pathspecs reach every shell self-test on disk (asked git)"
+fi
+
+# 1c. ...and the count must still be CONSUMED by the gate.
+#    Everything above measures how the number is COMPUTED. None of it notices if
+#    the number stops being read. Deleting `&& [ "$NEW_SHELL_TESTS" -eq 0 ]`
+#    from the gate condition -- the obvious "simplify this" edit -- restores
+#    PR #4958's exact failure (a fix: PR whose only regression test is a shell
+#    self-test is rejected for having none) while every other assertion in this
+#    file stays green. Found by review, not by the author's own battery.
+if grep -qE '\[ "\$NEW_SHELL_TESTS" -eq 0 \]' "$CI_YML" \
+   && grep -qE 'if \[ "\$NEW_TESTS" -eq 0 \].*NEW_SHELL_TESTS.*NEW_JS_TESTS' "$CI_YML"; then
+    echo "ok   - the fix: gate still consumes NEW_SHELL_TESTS"
+else
+    echo "FAIL - ci.yml's fix:-needs-a-test condition no longer reads NEW_SHELL_TESTS." >&2
+    echo "       The count would be computed and thrown away, so a fix: PR whose only" >&2
+    echo "       regression test is a shell self-test is rejected for having none --" >&2
+    echo "       PR #4958's failure, restored. Expected all three counters in one" >&2
+    echo "       condition: NEW_TESTS, NEW_SHELL_TESTS, NEW_JS_TESTS." >&2
     FAILURES=$((FAILURES + 1))
 fi
 
@@ -405,7 +485,7 @@ done < <(grep -rnE "printf[[:space:]]+.*['\"](ok|PASS)" \
     "$SCRIPT_DIR"/*_test.sh "$SCRIPT_DIR"/release-agent/*_test.sh 2>/dev/null || true)
 
 if [[ ${#printf_in_scanned[@]} -eq 0 ]]; then
-    echo "ok   - no printf-style success reporter in any file the counter scans (blind spot still theoretical)"
+    echo "ok   - no printf-style success reporter in any *_test.sh (the two test-*.sh are excluded on purpose)"
 else
     echo "FAIL - a printf-style success reporter now exists in a file the counter SCANS:" >&2
     for hit in "${printf_in_scanned[@]}"; do echo "         $hit" >&2; done

--- a/scripts/rule_lint_shell_assertion_counter_test.sh
+++ b/scripts/rule_lint_shell_assertion_counter_test.sh
@@ -282,8 +282,8 @@ while IFS= read -r f; do
                                 # matches, because the closing quote sits where
                                 # the boundary should be. The explicit echo test
                                 # is belt to that braces.
-                                if (step[i] ~ ("bash[[:space:]]+[^[:space:]]*" needle "([[:space:]]|$)") \
-                                    && step[i] !~ ("echo[^;|&$]*bash[[:space:]]+[^[:space:]]*" needle) \
+                                if (step[i] ~ ("(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle "([[:space:]]|$)") \
+                                    && step[i] !~ ("echo[^;|&$]*(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle) \
                                     && step[i] !~ /\n[[:space:]]+if:/) {
                                     print "RUNS"
                                 }
@@ -299,7 +299,7 @@ while IFS= read -r f; do
     # know. Mutation-tested -- with `git ls-files` an untracked probe file was
     # invisible to this very check, so the check that exists to find invisible
     # files could not see the newest one.
-done < <(find "$SCRIPT_DIR" -name '*_test.sh' -type f | sort)
+done < <(find "$SCRIPT_DIR" \( -name '*_test.sh' -o -name 'test-*.sh' \) -type f | sort)
 
 if [[ ! -f "$CI_YML" ]]; then
     echo "FAIL - ci.yml not found at $CI_YML; cannot check that test files are run." >&2
@@ -310,14 +310,15 @@ elif [[ -z "$FMT_JOB" ]]; then
     echo "       every test file as run." >&2
     FAILURES=$((FAILURES + 1))
 elif [[ ${#unrun[@]} -eq 0 ]]; then
-    echo "ok   - every *_test.sh is invoked by 'bash <path>' in ci.yml's Fmt job"
+    echo "ok   - every shell self-test is invoked by 'bash|sh <path>' in ci.yml's Fmt job"
 else
     echo "FAIL - these *_test.sh files are never RUN by ci.yml:" >&2
     for f in "${unrun[@]}"; do echo "         $f" >&2; done
     echo "       They are scored by the assertion counter and executed by nothing," >&2
     echo "       so they look like coverage in a listing while gating nothing. Add a" >&2
     echo "       'run: bash scripts/<name>' step to the Fmt job in ci.yml." >&2
-    echo "       Checked as a real 'bash <path>' invocation inside the Fmt JOB, so:" >&2
+    echo "       Checked as a real 'bash <path>' or 'sh <path>' invocation, anchored at a
+       word boundary, inside the Fmt JOB, so:" >&2
     echo "       a mention in a comment does not count, nor inside an echo, nor a" >&2
     echo "       step in a job that only runs on workflow_dispatch. A multi-line" >&2
     echo "       'run: |' block DOES count." >&2
@@ -336,12 +337,67 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# 1b. The counter's diff PATHSPECS must reach every shell self-test on disk.
+#    Being visible to the alternation is worthless if the diff never shows the
+#    file to it in the first place -- that is a SECOND way to be invisible, and
+#    it is the one that actually bit us. PR #4958 added ten `check_eq`
+#    assertions to `scripts/test-install-sh.sh`, a file ci.yml's Fmt job RUNS,
+#    and the `fix:` gate rejected it for having no test: the pathspec was
+#    `'**/*_test.sh'` and the file is named `test-*.sh`.
+#
+#    Check 1 above could never have caught that. It measures the alternation
+#    against files it finds with its OWN `find`, so a file the ci.yml pathspec
+#    excludes still scores fine here. The two scopes have to be compared to
+#    each other, which is what this does.
+uncovered=()
+PATHSPEC_LINE="$(grep -F 'NEW_SHELL_TESTS=$(git diff' "$CI_YML" || true)"
+if [[ -z "$PATHSPEC_LINE" ]]; then
+    echo "FAIL - could not find the NEW_SHELL_TESTS git-diff line in ci.yml." >&2
+    echo "       Without it the pathspec scope is unknown and this check examined" >&2
+    echo "       nothing; it fails rather than passing vacuously." >&2
+    FAILURES=$((FAILURES + 1))
+else
+    # Everything after the `-- ` separator, as single-quoted words.
+    mapfile -t PATHSPECS < <(printf '%s\n' "${PATHSPEC_LINE#*-- }" | grep -oE "'[^']+'" | tr -d "'")
+    if [[ ${#PATHSPECS[@]} -eq 0 ]]; then
+        echo "FAIL - parsed zero pathspecs from ci.yml's NEW_SHELL_TESTS line." >&2
+        echo "       An empty list would report every file as uncovered OR as covered" >&2
+        echo "       depending on the loop's sense; either way it is not a measurement." >&2
+        FAILURES=$((FAILURES + 1))
+    else
+        while IFS= read -r f; do
+            rel="${f#"$SCRIPT_DIR"/}"
+            covered=0
+            for spec in "${PATHSPECS[@]}"; do
+                # git's `**/x` matches at any depth including the top level, which
+                # bash's `==` does not, so compare the basename against the tail.
+                # shellcheck disable=SC2053
+                [[ "$(basename "$f")" == ${spec##*/} ]] && covered=1 && break
+            done
+            [[ "$covered" -eq 1 ]] || uncovered+=("scripts/$rel")
+        done < <(find "$SCRIPT_DIR" \( -name '*_test.sh' -o -name 'test-*.sh' \) -type f | sort)
+    fi
+fi
+
+if [[ ${#uncovered[@]} -eq 0 ]]; then
+    echo "ok   - ci.yml's diff pathspecs reach every shell self-test on disk"
+else
+    echo "FAIL - these shell self-tests are outside ci.yml's NEW_SHELL_TESTS pathspecs:" >&2
+    for f in "${uncovered[@]}"; do echo "         $f" >&2; done
+    echo "       The counter never sees their added lines, so a fix: PR whose only" >&2
+    echo "       regression test lives there is rejected for having no test -- however" >&2
+    echo "       many assertions it adds. Add a pathspec to the git diff in ci.yml." >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
 # 2. The `printf`-style reporter, which ci.yml lists as a known blind spot. That
 #    entry was once DELETED on the stated ground that the grep returned nothing;
-#    it returns two, in `test-*.sh` files the counter's `**/*_test.sh` glob does
-#    not reach. The sentence was wrong and nothing could tell. So: if that
-#    convention ever appears in a file the counter DOES scan, the blind spot has
-#    stopped being theoretical and this fails.
+#    it returns two, in `test-*.sh` files the counter's glob did not used to
+#    reach. The sentence was wrong and nothing could tell. The glob now reaches
+#    them, and this grep stays scoped to `*_test.sh` deliberately -- see the
+#    parenthetical in the failure branch. So: if that convention ever appears in
+#    a file the counter DOES scan, the blind spot has stopped being theoretical
+#    and this fails.
 printf_in_scanned=()
 while IFS= read -r hit; do
     printf_in_scanned+=("$hit")
@@ -356,9 +412,12 @@ else
     echo "       ci.yml lists this as a known-but-unreached blind spot. It is now" >&2
     echo "       reached: those assertions score zero. Add a printf pattern to the" >&2
     echo "       alternation and a MUST-COUNT row above, then update ci.yml's list." >&2
-    echo "       (The two pre-existing hits, scripts/test-install-sh.sh and" >&2
-    echo "       scripts/test-uninstall-sh.sh, are OUT of scope by filename: the diff" >&2
-    echo "       is globbed to '**/*_test.sh' and they are 'test-*.sh'.)" >&2
+    echo "       (scripts/test-install-sh.sh and scripts/test-uninstall-sh.sh are" >&2
+    echo "       no longer out of scope -- ci.yml's diff glob now includes" >&2
+    echo "       '**/test-*.sh'. They are excluded from THIS grep on purpose: only" >&2
+    echo "       their 'pass() { printf ... }' DEFINITION is unmatched, while their" >&2
+    echo "       'pass \"...\"' and 'check_eq \"...\"' call sites both score. A helper" >&2
+    echo "       definition scoring zero is correct, not a blind spot.)" >&2
     FAILURES=$((FAILURES + 1))
 fi
 


### PR DESCRIPTION
## Problem

The `fix:`-requires-a-regression-test gate in Rule Lint counts added shell assertions with:

```sh
NEW_SHELL_TESTS=$(git diff "$BASE"..."$HEAD" -- '**/*_test.sh' ...)
```

Two of the repo's own shell self-tests are named `test-*.sh`, not `*_test.sh`:

- `scripts/test-install-sh.sh`
- `scripts/test-uninstall-sh.sh`

The pathspec never showed either file to the counter — even though the Fmt job **runs both** (`ci.yml:278` and `:280`, `sh scripts/test-install-sh.sh` / `sh scripts/test-uninstall-sh.sh`). So any `fix:` PR whose regression tests live in either file scored zero and was rejected for having no test, however many assertions it added.

**This is not hypothetical.** PR #4958 (an outside contributor's SELinux fix) adds ten `check_eq` assertions to `test-install-sh.sh` and Rule Lint failed it for having no regression test. It is the first PR to hit the hole; it had been sitting behind an unapproved CI run, so nothing had exercised the gate against those files before.

The hole was **documented rather than fixed**. `ci.yml`'s own comment calls it out:

> They escape this counter only because the diff above is scoped to `**/*_test.sh` and those are named `test-*.sh` — **a naming accident, not the absence of the convention.**

And `rule_lint_shell_assertion_counter_test.sh` — the self-test written specifically to find test files invisible to the counter — discovers candidates with its own `find -name '*_test.sh'` (`:302`) and names both files as out of scope (`:359-361`). So the check that exists to find invisible test files shared the blind spot it documents.

## Approach

**1. Widen the counter's pathspec** (`ci.yml`): add `'**/test-*.sh'`.

Safe by construction: `NEW_SHELL_TESTS` feeds a "does this PR have enough tests" threshold, so raising the count can only turn a rejection into a pass, never the reverse. It cannot make a currently-passing PR fail.

**2. Add check 1b to the self-test** — compare `ci.yml`'s pathspecs against every shell self-test on disk.

This is the part that keeps the fix from rotting, and it is a genuinely different property from what check 1 measures. Check 1 asks *"is this file's convention visible to the alternation?"* against files it finds with its **own** `find`. A file the ci.yml pathspec excludes still scores fine there — which is exactly why check 1 was green throughout while the gate was broken. Being visible to the alternation and being shown to it by the diff are two different things, and only the second one failed. The two scopes have to be compared **to each other**.

**3. Widen the run-check's interpreter, with a word-boundary anchor.**

Widening the `find` at `:302` pulls both files into the "must actually be RUN" assertion, which matched only `bash <path>`. Both are invoked with `sh`, so the naive widening produces a **false** red. Fixed by accepting `(bash|sh)` — but anchored:

```awk
("(^|[[:space:]])(bash|sh)[[:space:]]+[^[:space:]]*" needle "([[:space:]]|$)")
```

**The anchor is load-bearing, and this is the trap worth flagging.** A bare `(bash|sh)` lets the shellcheck step satisfy the gate by accident, because its argument list contains:

```
... scripts/test-install-sh.sh scripts/test-uninstall-sh.sh ...
```

`install-sh.sh` ends in `sh`, followed by a space, followed by a token containing the needle. That re-opens precisely the false-satisfaction class the run-check was built to close ("a real `bash <path>` invocation kills the third"). Verified by mutation, not by reading: see M4 vs M4' below.

**4. Corrected the now-stale prose** in both files, and narrowed the `printf`-reporter claim to what was actually measured rather than what was assumed.

The `ci.yml` comment lists those two files' `pass() { printf 'PASS  %s\n' "$1"; }` as known false-negative #1, implying they are invisible. Measured against the live extracted pattern:

| probe | score |
|---|---|
| `pass "some message"` (call site) | 1 |
| `check_eq "x" "y" "z"` (call site) | 1 |
| `pass() { printf 'PASS  %s\n' "$1"; }` (definition) | 0 |

So their assertions **do** score — 16 matches in `test-install-sh.sh`, 30 in `test-uninstall-sh.sh`. Only the reporter *definition* scores zero, which is correct: `ci.yml` states that declaring a helper should score nothing. I therefore left the `printf` canary's own glob alone rather than widening it, which would have produced a red on a line that correctly scores zero. That reasoning is now written down in the failure branch instead of the stale "out of scope by filename" note.

## Testing

`scripts/rule_lint_shell_assertion_counter_test.sh` is itself the regression test, extended with check 1b. Mutation-tested — every row **run**, not reasoned about:

| mutation | result | what it proves |
|---|---|---|
| baseline | GREEN | |
| narrow the `ci.yml` glob back to `'**/*_test.sh'` | **RED** | check 1b pins the actual fix — without it nothing detected the regression |
| replace pathspecs with a bogus `'**/nothing.sh'` | **RED** | |
| rename `NEW_SHELL_TESTS` so the line can't be found | **RED** | fails closed rather than passing vacuously |
| remove a real `sh scripts/test-*.sh` run step | **RED** | the run-check still detects a missing invocation for newly-in-scope files |
| same, **with the word-boundary anchor dropped** | **GREEN** | the hole — the anchor is required, not cosmetic |

Before this PR, narrowing the glob was green in every existing check; that gap is what check 1b closes.

Also verified:

- `shellcheck -x` clean over the exact file list `ci.yml:276` uses (exit 0).
- `sh scripts/test-install-sh.sh` and `sh scripts/test-uninstall-sh.sh` both pass.
- `ci.yml` parses as YAML.

## Note

I did **not** relabel #4958 to hide its red. It is currently unblocked with the `test-exempt` label plus a justification comment, using the escape hatch the gate's own error text prescribes. Once this lands, that PR's tests will be counted normally and the label can come off.

Refs #4958

[AI-assisted - Claude]
