### PR TITLE
fix(interest): wrap the summary rotation instead of re-randomising mid-cycle

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -10617,6 +10617,7 @@ mod tests {
                 &h.peer_key_of(h.old_peer),
                 *sorted[0].id(),
                 1,
+                sorted.len(),
             );
 
             let mut seen: Vec<u32> = Vec::new();
@@ -10790,6 +10791,7 @@ mod tests {
                 &h.peer_key_of(h.new_peer),
                 *sorted[0].id(),
                 1,
+                sorted.len(),
             );
 
             let mut covered: HashSet<u32> = HashSet::new();
@@ -11053,6 +11055,7 @@ mod tests {
                 &pk,
                 ContractInstanceId::new([0u8; 32]),
                 1,
+                all.len(),
             );
 
             let before = h.summary_queries.load(Ordering::Relaxed);
@@ -11462,9 +11465,12 @@ mod tests {
 
             // A known peer's cursor, which the stranger must not touch.
             let known = h.peer_key_of(h.new_peer);
-            h.op_manager
-                .interest_manager
-                .seed_summary_cursor(&known, *sorted[5].id(), 1);
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &known,
+                *sorted[5].id(),
+                1,
+                sorted.len(),
+            );
 
             // Full bytes, not digests: the version gate fails closed on a
             // source we have no connection entry for.
@@ -11584,6 +11590,7 @@ mod tests {
                 &pk,
                 ContractInstanceId::new([0u8; 32]),
                 1,
+                tracked.len(),
             );
 
             let before = h.summary_queries.load(Ordering::Relaxed);
@@ -11948,6 +11955,7 @@ mod tests {
                 &h.peer_key_of(h.old_peer),
                 *sorted[0].id(),
                 1,
+                sorted.len(),
             );
 
             let mut covered: HashSet<u32> = HashSet::new();

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -3740,7 +3740,7 @@ async fn handle_interest_sync_message(
                     |pk| {
                         op_manager
                             .interest_manager
-                            .summary_window_start(pk, &matching)
+                            .begin_summary_window(pk, &matching)
                     },
                 );
                 crate::ring::interest::rotation_window_indices(
@@ -3851,10 +3851,20 @@ async fn handle_interest_sync_message(
             // short of the selected window must not advance past the entries it
             // dropped, or they wait a full cycle instead of coming next.
             //
-            // Two known imprecisions here, both accepted, both costing at most
-            // one cycle of delay for the affected contracts and neither able to
-            // skip one permanently (the window wraps, and a cycle boundary
-            // restarts at a random offset):
+            // The entry COUNT goes with it (#5181): it is what tells the next
+            // round whether the cycle finished (re-randomise) or merely wrapped
+            // past the last id (resume at 0). Deriving that from the resume
+            // index alone was the bug.
+            //
+            // Known imprecisions, all accepted, none able to skip a contract
+            // permanently — because the window WRAPS and cycles complete, which
+            // is the property doing that work. The random origin defends a
+            // different failure (peer steering) and does not contribute to
+            // non-permanence; the two used to be offered jointly here, which is
+            // how the claim ended up wrong. Several of these end the cycle
+            // EARLY rather than late, so an arc can go unadvertised for an
+            // extra cycle — `SummaryCursor` is explicit that this is not a
+            // safe-direction-only approximation:
             //
             // - This advances on send ATTEMPT. The reply is handed to the
             //   connection afterwards and a send failure is only logged, so a
@@ -3864,7 +3874,18 @@ async fn handle_interest_sync_message(
             //   read the same start and build the same window, losing one
             //   round of progress. Reserving the window at read time instead
             //   would trade that for a worse failure: a budget-cut round would
-            //   then skip everything it did not reach.
+            //   then skip everything it did not reach. The duplicate is not
+            //   double-CHARGED — it covers no new distance, so the advance
+            //   check discards it — but the round is still spent.
+            // - Two concurrent replies cut at DIFFERENT lengths by the byte
+            //   budget carry different last ids, so the shorter is not
+            //   recognised as ground the longer already covered.
+            // - Contract CHURN: ids removed from ground already swept while
+            //   others are inserted below the cursor let the count reach the
+            //   set size with current members never advertised this cycle.
+            // - The peer chooses `sorted`, so it chooses the length the count
+            //   is compared against. See `begin_summary_window`'s rustdoc for
+            //   the anti-steering limit this leaves open (#5313).
             //
             // #5238: recorded for BOTH forms now. Under #5155 only the
             // full-bytes path rotated, so only it had a cursor to advance.
@@ -3874,7 +3895,12 @@ async fn handle_interest_sync_message(
             // source port, which sent that peer's rotation back to a random
             // offset every reconnect.
             if let (Some(pk), Some(last)) = (peer_key.as_ref(), last_included) {
-                op_manager.interest_manager.record_summary_cursor(pk, last);
+                op_manager.interest_manager.record_summary_cursor(
+                    pk,
+                    last,
+                    entries.len(),
+                    &matching,
+                );
             }
 
             if entries.is_empty() {
@@ -10582,14 +10608,16 @@ mod tests {
 
             // Seed the cursor so both rounds are mid-cycle and the starting
             // offset is fixed. Without this the first round would begin at a
-            // random cycle-boundary offset (see `summary_window_start`) and a
+            // random cycle-boundary offset (see `begin_summary_window`) and a
             // start on the last contract would wrap into a second random draw,
             // making the "moved on to a different contract" assertion flaky.
             let mut sorted = keys.clone();
             sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
-            h.op_manager
-                .interest_manager
-                .record_summary_cursor(&h.peer_key_of(h.old_peer), *sorted[0].id());
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &h.peer_key_of(h.old_peer),
+                *sorted[0].id(),
+                1,
+            );
 
             let mut seen: Vec<u32> = Vec::new();
             for round in 0..2 {
@@ -10721,22 +10749,27 @@ mod tests {
         ///
         /// # Why the CURSOR is seeded, not just the RNG
         ///
-        /// `ceil(n / cap)` rounds tile the set exactly only while every round
-        /// is mid-cycle. A round whose window ENDS on the highest id leaves the
-        /// cursor past the end, which `summary_window_start` reads as a cycle
-        /// boundary and answers with a fresh random offset. That is deliberate
-        /// anti-starvation behaviour rather than a bug, but it re-covers ground
-        /// already covered, and the exact-tiling assertion then fails.
+        /// HISTORICAL, and the rationale was WRONG — kept because the seeding
+        /// is still worth having, but corrected because the old wording talked
+        /// the reader out of the bug.
         ///
-        /// At n=200 and cap=64 that happens for 3 of the 200 possible starts,
-        /// so the first version of this test failed about 1% of runs — and
-        /// non-reproducibly, because `GlobalRng` falls back to `rand::rng()`
-        /// when unseeded. It duly failed on the very next full-suite run.
-        /// Seeding the cursor fixes the start at index 1 and removes the
-        /// boundary re-draw from the schedule entirely, so the test pins the
-        /// tiling property itself rather than one lucky seed. The RNG is seeded
-        /// as well, so that any future edit reintroducing a draw stays
-        /// reproducible instead of flaky.
+        /// It used to read: a round whose window ends on the highest id leaves
+        /// the cursor past the end, which the window-start helper reads as a
+        /// cycle boundary and answers with a fresh random offset, and "that is
+        /// deliberate anti-starvation behaviour rather than a bug". It was a
+        /// bug — #5181. A window ending on the highest id has WRAPPED, not
+        /// finished, and re-drawing there breaks the very contiguity the
+        /// `ceil(n / cap)` tiling depends on. At n=200 and cap=64 it hit 3 of
+        /// the 200 possible starts, which is where this test's ~1% flake came
+        /// from; the test was right and the production code was wrong.
+        ///
+        /// Since #5181 `begin_summary_window` wraps mid-cycle, so the tiling
+        /// now holds from ANY origin and neither seed is load-bearing for it.
+        /// Both are kept for determinism: `GlobalRng` falls back to
+        /// `rand::rng()` when unseeded, and a reproducible schedule is worth
+        /// more here than exercising a random one. The rotation's
+        /// origin-independence is asserted directly, over every origin, by
+        /// `ring::interest::tests::the_real_api_covers_every_contract_from_every_origin`.
         #[tokio::test]
         async fn digest_rotation_covers_the_whole_shared_set() {
             // Guarded rather than bare: `set_seed` also pins THREAD_INDEX to 0,
@@ -10753,9 +10786,11 @@ mod tests {
 
             let mut sorted = keys.clone();
             sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
-            h.op_manager
-                .interest_manager
-                .record_summary_cursor(&h.peer_key_of(h.new_peer), *sorted[0].id());
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &h.peer_key_of(h.new_peer),
+                *sorted[0].id(),
+                1,
+            );
 
             let mut covered: HashSet<u32> = HashSet::new();
             for round in 0..rounds {
@@ -11014,9 +11049,11 @@ mod tests {
             // An id below every contract in the fixture, so the window starts
             // at index 0 with no random draw.
             let pk = h.peer_key_of(h.new_peer);
-            h.op_manager
-                .interest_manager
-                .record_summary_cursor(&pk, ContractInstanceId::new([0u8; 32]));
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &pk,
+                ContractInstanceId::new([0u8; 32]),
+                1,
+            );
 
             let before = h.summary_queries.load(Ordering::Relaxed);
             let reply = handle_interest_sync_message(
@@ -11427,7 +11464,7 @@ mod tests {
             let known = h.peer_key_of(h.new_peer);
             h.op_manager
                 .interest_manager
-                .record_summary_cursor(&known, *sorted[5].id());
+                .seed_summary_cursor(&known, *sorted[5].id(), 1);
 
             // Full bytes, not digests: the version gate fails closed on a
             // source we have no connection entry for.
@@ -11543,9 +11580,11 @@ mod tests {
             // An id below every contract in the fixture, so the window starts
             // at index 0 with no random draw.
             let pk = h.peer_key_of(h.new_peer);
-            h.op_manager
-                .interest_manager
-                .record_summary_cursor(&pk, ContractInstanceId::new([0u8; 32]));
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &pk,
+                ContractInstanceId::new([0u8; 32]),
+                1,
+            );
 
             let before = h.summary_queries.load(Ordering::Relaxed);
             let reply = handle_interest_sync_message(
@@ -11905,9 +11944,11 @@ mod tests {
 
             let mut sorted = keys.clone();
             sorted.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
-            h.op_manager
-                .interest_manager
-                .record_summary_cursor(&h.peer_key_of(h.old_peer), *sorted[0].id());
+            h.op_manager.interest_manager.seed_summary_cursor(
+                &h.peer_key_of(h.old_peer),
+                *sorted[0].id(),
+                1,
+            );
 
             let mut covered: HashSet<u32> = HashSet::new();
             for round in 0..rounds {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2922,8 +2922,12 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Mid-cycle this resumes immediately after the last contract SENT to that
     /// peer, which is what makes successive windows contiguous in id space
     /// (see [`first_index_after`]). At a cycle BOUNDARY — no cursor yet, the
-    /// cursor evicted or lost, or the previous window ending on the highest id
-    /// — the next cycle starts at a RANDOM offset rather than at 0.
+    /// cursor evicted or lost, or the cycle genuinely COMPLETED — the next
+    /// cycle starts at a RANDOM offset rather than at 0.
+    ///
+    /// A window ending on the highest id is NOT a boundary. It has wrapped,
+    /// and the next window continues at index 0. Reading it as a boundary was
+    /// #5181; an earlier version of this very paragraph asserted the opposite.
     ///
     /// A fixed restart at 0 is the failure this codebase has already rejected
     /// twice, for the same reason each time: see the rotations in
@@ -2940,9 +2944,11 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     ///   #5338; see [`Self::summary_window_cursor`].)
     /// - `sorted` is the INTERSECTION with the hash list the peer advertised,
     ///   so the peer influences where the cursor lands. Advertising a single
-    ///   high-id contract parks the cursor at the end, and the following full
-    ///   round would restart at 0 — repeat, and everything past the first
-    ///   window is never advertised.
+    ///   high-id contract parks the cursor at the end, and with a FIXED
+    ///   restart the following full round would begin at 0 — repeat, and
+    ///   everything past the first window is never advertised. (That
+    ///   alternation no longer ends our cycle at all: completion is measured
+    ///   against [`SummaryCursor::cycle_len`], a length the peer cannot move.)
     ///
     /// Randomising the boundary costs nothing in the ordinary case: a cycle
     /// beginning at any offset still advances contiguously and still covers
@@ -2972,38 +2978,48 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// `GlobalRng` is thread-local (`THREAD_RNG` / `THREAD_SEED` are
     /// `thread_local!`), so drawing under the lock cannot deadlock.
     ///
-    /// # Anti-steering is weaker than the pre-#5181 code, deliberately
+    /// # Anti-steering
     ///
     /// Before the fix, every round whose resume ran off the end re-randomised.
     /// That defeated steering — but only as a side effect of the bug, since it
-    /// also re-randomised mid-cycle, and restoring the coverage bound
-    /// necessarily removes it. The count does not fully replace it: completion
-    /// compares against `sorted.len()`, and the peer chooses `sorted`, so
-    /// alternating a single-hash `Interests` with a full one trips completion
-    /// and re-seeds the cycle from an id the peer picked.
-    ///
-    /// Accepted because the harm is almost entirely self-inflicted: what
-    /// starves is our advertisement to THAT peer, cursors are per-peer, and no
-    /// other peer's rotation is affected.
-    /// `a_peer_that_varies_the_shared_set_can_still_pin_the_window` asserts the
-    /// live behaviour so the limit is visible in CI rather than only in prose.
-    /// The principled fix is geometric (positional) completion, which also
-    /// makes a staleness bound stateable under churn: #5313.
+    /// also re-randomised mid-cycle, and restoring the coverage bound removes
+    /// it. The replacement must therefore not hand the peer a NEW lever, and
+    /// the obvious version of this fix did: comparing the cycle count against
+    /// the current `sorted.len()` lets a peer end our cycle whenever it likes,
+    /// since it chooses `sorted`. That would be a deterministic, permanent
+    /// starvation replacing a random, self-correcting one — worse than #5181.
+    /// Completion is measured against [`SummaryCursor::cycle_len`], the length
+    /// captured when the cycle began, so a peer cannot end our cycle on demand
+    /// by shrinking what it advertises;
+    /// `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` asserts it.
+    /// A positional (geometric) notion of completion would additionally make a
+    /// staleness bound stateable under churn: #5313.
     pub(crate) fn begin_summary_window(&self, peer: &PeerKey, sorted: &[ContractKey]) -> usize {
         if sorted.is_empty() {
             return 0;
         }
         let mut cursors = self.summary_window_cursor.lock();
-        match cursors.peek(peer) {
-            // Mid-cycle: resume immediately after the last entry sent, wrapping
-            // past the end of the set rather than reading the end as a
-            // boundary. The `% len` is what #5181 was missing.
-            Some(cursor) if cursor.advertised_in_cycle < sorted.len() => {
-                first_index_after(sorted, &cursor.last_sent) % sorted.len()
+        let resume = cursors.peek(peer).and_then(|cursor| {
+            // A run of rejected records means the cursor is not being driven by
+            // well-formed rounds, so resuming from it would re-send the same
+            // window forever. Fall back to a boundary instead of wedging.
+            if cursor.cycle_complete()
+                || cursor.consecutive_rejections >= MAX_CONSECUTIVE_CURSOR_REJECTIONS
+            {
+                None
+            } else {
+                // Resume immediately after the last entry sent, WRAPPING past
+                // the end of the set rather than reading the end as a boundary.
+                // The `% len` is what #5181 was missing.
+                Some(first_index_after(sorted, &cursor.last_sent) % sorted.len())
             }
-            // Cycle boundary: no cursor (first reply, restart, LRU eviction), or
-            // the cycle genuinely completed. Draw AND publish together.
-            _ => {
+        });
+        match resume {
+            Some(start) => start,
+            // Cycle boundary: no cursor (first reply, restart, LRU eviction),
+            // the cycle completed, or the escape above. Draw AND publish
+            // together.
+            None => {
                 let origin = crate::config::GlobalRng::random_range(0..sorted.len());
                 cursors.put(peer.clone(), SummaryCursor::starting_at(sorted, origin));
                 origin
@@ -3073,9 +3089,42 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         if len == 0 || entries_sent == 0 {
             return;
         }
+        debug_assert!(
+            entries_sent <= len,
+            "a round cannot send more entries than the set holds: \
+             rotation_window_indices caps the window at limit.min(len)"
+        );
         let new_pos = first_index_after(sorted, &last_sent) % len;
         let mut cursors = self.summary_window_cursor.lock();
         let updated = match cursors.peek(peer) {
+            Some(prev) if len < prev.cycle_len => {
+                // A round built against a SMALLER set than the cycle's own
+                // frame. Its last id is not a position in this cycle's ground,
+                // and applying it would drag `last_sent` to wherever the
+                // smaller set happens to end.
+                //
+                // That is the peer's lever: `sorted` is the intersection with
+                // the hashes IT advertised, so alternating a one-hash
+                // `Interests` with a full one would otherwise pull the cursor
+                // to that one hash every other round and stall the full
+                // rotation short of the set. Charging the rejection means the
+                // escape below still fires, so a set that has genuinely shrunk
+                // redraws within a bounded number of rounds instead of wedging.
+                self.summary_cursor_rejections
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let rejections = prev.consecutive_rejections.saturating_add(1);
+                tracing::debug!(
+                    ?peer,
+                    set_len = len,
+                    cycle_len = prev.cycle_len,
+                    consecutive = rejections,
+                    "ignored a summary-rotation record from a smaller set than the cycle frame"
+                );
+                let mut framed = *prev;
+                framed.consecutive_rejections = rejections;
+                cursors.put(peer.clone(), framed);
+                return;
+            }
             Some(prev) => {
                 let prev_pos = first_index_after(sorted, &prev.last_sent) % len;
                 let advance = (new_pos + len - prev_pos) % len;
@@ -3087,19 +3136,39 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                     // re-sent later, having never been charged.
                     self.summary_cursor_rejections
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let rejections = prev.consecutive_rejections.saturating_add(1);
+                    // Visible in the field, not only to tests: a RUN of these
+                    // means the cursor is not being driven by well-formed
+                    // rounds, and the only other symptom is that this peer
+                    // quietly stops converging on most contracts.
+                    tracing::debug!(
+                        ?peer,
+                        advance,
+                        entries_sent,
+                        set_len = len,
+                        consecutive = rejections,
+                        "discarded a summary-rotation record that did not advance the cycle"
+                    );
+                    let mut wedged = *prev;
+                    wedged.consecutive_rejections = rejections;
+                    cursors.put(peer.clone(), wedged);
                     return;
                 }
                 SummaryCursor {
                     last_sent,
                     advertised_in_cycle: prev.advertised_in_cycle.saturating_add(entries_sent),
+                    cycle_len: prev.cycle_len,
+                    consecutive_rejections: 0,
                 }
             }
             // Evicted between drawing the window and recording it. Nothing to
-            // check against, so start the count fresh rather than discarding a
+            // check against, so start a fresh cycle rather than discarding a
             // round's progress.
             None => SummaryCursor {
                 last_sent,
                 advertised_in_cycle: entries_sent,
+                cycle_len: len,
+                consecutive_rejections: 0,
             },
         };
         cursors.put(peer.clone(), updated);
@@ -3158,12 +3227,15 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         peer: &PeerKey,
         last_sent: ContractInstanceId,
         advertised: usize,
+        cycle_len: usize,
     ) {
         self.summary_window_cursor.lock().put(
             peer.clone(),
             SummaryCursor {
                 last_sent,
                 advertised_in_cycle: advertised,
+                cycle_len,
+                consecutive_rejections: 0,
             },
         );
     }
@@ -3172,8 +3244,14 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 /// First index in `sorted` (ascending by contract id, as
 /// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
 /// greater than `after`. Returns `sorted.len()` when `after` is at or past the
-/// end, which [`InterestManager::begin_summary_window`] reads as the end of a
-/// cycle and answers with a fresh random offset.
+/// end.
+///
+/// That return is AMBIGUOUS and must not be read as "the cycle ended": it
+/// means either a cursor genuinely past the end or one sitting on the highest
+/// id, which is a mid-cycle wrap. [`InterestManager::begin_summary_window`]
+/// takes it modulo the set size and asks
+/// [`SummaryCursor::cycle_complete`] about the cycle instead. Conflating the
+/// two was #5181.
 ///
 /// This is the churn-safe half of the rotation. Because it is a binary search
 /// over ids rather than a stored offset, it behaves correctly when the set
@@ -3233,13 +3311,48 @@ pub(crate) fn first_index_after(sorted: &[ContractKey], after: &ContractInstance
 pub(crate) struct SummaryCursor {
     /// Contract id of the last entry actually SENT to this peer.
     last_sent: ContractInstanceId,
-    /// Entries sent so far in the current cycle. Compared against
-    /// `sorted.len()` to decide whether the cycle is finished.
+    /// Entries sent so far in the current cycle.
     advertised_in_cycle: usize,
+    /// Size of the shared set when this cycle BEGAN, and the target
+    /// `advertised_in_cycle` is measured against.
+    ///
+    /// Deliberately not the CURRENT `sorted.len()`. The peer chooses `sorted`
+    /// — it is the intersection with the hashes it advertised — so comparing
+    /// against the current length lets it end our cycle whenever it likes by
+    /// advertising a single hash, which re-seeds the rotation from an id it
+    /// picked. Measured against the length the cycle started with, a
+    /// one-element round contributes one entry towards a target it cannot
+    /// move, and the cycle still completes on our terms.
+    ///
+    /// Under genuine churn this is approximate in both directions: a set that
+    /// grew completes the cycle early (an arc waits an extra cycle), one that
+    /// shrank completes it late. Both are bounded by one cycle, unlike the
+    /// unbounded starvation the peer-controlled version allows.
+    cycle_len: usize,
+    /// Consecutive records rejected by the advance check.
+    ///
+    /// Bounds a rejection wedge. A record that never advances leaves the
+    /// cursor untouched, so if some caller-side defect made every record
+    /// ill-formed the same window would be re-sent forever and every other
+    /// contract starved for the process lifetime — strictly worse than the
+    /// staleness the check exists to stop, and exactly the unbounded-exemption
+    /// shape `.claude/rules/ring.md` warns about. After
+    /// [`MAX_CONSECUTIVE_CURSOR_REJECTIONS`] the next window is treated as a
+    /// boundary, degrading to a fresh random origin rather than to silence.
+    consecutive_rejections: u8,
 }
 
+/// Rejected records tolerated before [`InterestManager::begin_summary_window`]
+/// gives up on the current cycle and redraws.
+///
+/// Small on purpose: legitimate rejections are racy (a duplicate or a
+/// boundary-straddling reply) and self-correcting, so a run of three says the
+/// cursor is not being driven by well-formed rounds at all.
+const MAX_CONSECUTIVE_CURSOR_REJECTIONS: u8 = 3;
+
 impl SummaryCursor {
-    /// A cursor that resumes the next window AT `origin`.
+    /// A cursor that resumes the next window AT `origin`, beginning a cycle
+    /// measured against the current set size.
     ///
     /// Stores the origin's PREDECESSOR, because the stored id names the last
     /// entry sent and [`first_index_after`] resolves it to the next one. That
@@ -3251,7 +3364,14 @@ impl SummaryCursor {
         Self {
             last_sent: *predecessor.id(),
             advertised_in_cycle: 0,
+            cycle_len: sorted.len(),
+            consecutive_rejections: 0,
         }
+    }
+
+    /// Whether this cycle has covered the ground it set out to cover.
+    fn cycle_complete(&self) -> bool {
+        self.advertised_in_cycle >= self.cycle_len
     }
 }
 
@@ -8144,7 +8264,7 @@ mod tests {
 
         assert_eq!(mgr.peek_summary_cursor(&peer), None);
 
-        mgr.seed_summary_cursor(&peer, *sorted[2].id(), 1);
+        mgr.seed_summary_cursor(&peer, *sorted[2].id(), 1, sorted.len());
         assert_eq!(mgr.peek_summary_cursor(&peer), Some(*sorted[2].id()));
         assert_eq!(
             mgr.begin_summary_window(&peer, &sorted),
@@ -8154,7 +8274,7 @@ mod tests {
 
         // Cursors are per peer: one peer's progress must not advance another's.
         let other = make_peer_key(2);
-        mgr.seed_summary_cursor(&other, *sorted[6].id(), 1);
+        mgr.seed_summary_cursor(&other, *sorted[6].id(), 1, sorted.len());
         assert_eq!(mgr.begin_summary_window(&peer, &sorted), 3);
         assert_eq!(mgr.begin_summary_window(&other, &sorted), 7);
 
@@ -8200,7 +8320,12 @@ mod tests {
         let mut seen_completed = HashSet::new();
         for _ in 0..40 {
             // A whole cycle's worth of entries covered: genuinely finished.
-            mgr.seed_summary_cursor(&peer, *sorted[sorted.len() - 1].id(), sorted.len());
+            mgr.seed_summary_cursor(
+                &peer,
+                *sorted[sorted.len() - 1].id(),
+                sorted.len(),
+                sorted.len(),
+            );
             seen_completed.insert(mgr.begin_summary_window(&peer, &sorted));
         }
         assert!(
@@ -8234,7 +8359,7 @@ mod tests {
 
             // Mid-cycle by construction: one entry covered out of `len`, and
             // the cursor parked on the highest id in the set.
-            mgr.seed_summary_cursor(&peer, *sorted[len - 1].id(), 1);
+            mgr.seed_summary_cursor(&peer, *sorted[len - 1].id(), 1, len);
 
             // Deterministic: assert over repeats so a lucky random draw of 0
             // cannot be mistaken for a correct wrap.
@@ -8385,9 +8510,18 @@ mod tests {
             mgr.record_summary_cursor(&peer, *sorted[3].id(), 4, &sorted);
             let after = mgr.peek_summary_cursor_state(&peer).expect("cursor");
             assert_eq!(
-                before, after,
+                (after.last_sent, after.advertised_in_cycle, after.cycle_len),
+                (
+                    before.last_sent,
+                    before.advertised_in_cycle,
+                    before.cycle_len
+                ),
                 "a stale record must be discarded: charging it double-counts \
                  the cycle AND rewinding re-sends ground already covered"
+            );
+            assert_eq!(
+                after.consecutive_rejections, 1,
+                "the discard must be counted, so a RUN of them can break the wedge"
             );
             assert_eq!(mgr.summary_cursor_rejections(), 1);
         }
@@ -8402,7 +8536,11 @@ mod tests {
             let before = mgr.peek_summary_cursor_state(&peer).expect("cursor");
             mgr.record_summary_cursor(&peer, *sorted[23].id(), 4, &sorted);
             let after = mgr.peek_summary_cursor_state(&peer).expect("cursor");
-            assert_eq!(before, after, "a duplicate round must not be charged twice");
+            assert_eq!(
+                (after.last_sent, after.advertised_in_cycle),
+                (before.last_sent, before.advertised_in_cycle),
+                "a duplicate round must not be charged twice"
+            );
         }
 
         // 6. A single-entry set: every round is a whole-set round.
@@ -8455,42 +8593,50 @@ mod tests {
         assert_eq!(c.last_sent, last2, "the round must have been recorded");
     }
 
-    /// The anti-steering limit this fix knowingly leaves open, asserted so it
-    /// is visible in CI rather than only in prose.
+    /// A peer that shrinks the shared set must NOT be able to pin our window.
     ///
-    /// Cycle completion compares the count against `sorted.len()`, and the peer
-    /// chooses `sorted` — it is the intersection with the hashes IT advertised.
-    /// Alternating a single-hash `Interests` with a full one makes `len == 1`,
-    /// trips completion, and re-seeds the cycle from an id the peer picked.
+    /// The peer chooses `sorted` — it is the intersection with the hashes it
+    /// advertised — so if cycle completion were measured against the CURRENT
+    /// length, alternating a single-hash `Interests` with a full one would end
+    /// our cycle on demand and re-seed the rotation from an id the peer picked.
+    /// Every full round would then begin at the same index and everything past
+    /// the first window would go unadvertised indefinitely.
     ///
-    /// Accepted because the harm is self-inflicted: what starves is our
-    /// advertisement to THAT peer, cursors are per-peer, and no other peer's
-    /// rotation is affected. Inverting this assertion is part of #5313's fix;
-    /// if this test starts failing because the window no longer pins, that is
-    /// the improvement landing and the test should be inverted, not deleted.
+    /// That is not a theoretical concern about a hostile peer: it is what the
+    /// first version of this fix did, and it was strictly WORSE than the #5181
+    /// bug it replaced. Pre-#5181 the same alternation hit a boundary and drew
+    /// a random offset, so coverage was coupon-collector but complete. Trading
+    /// a random, self-correcting failure for a deterministic, permanent one is
+    /// not a fix. Completion is measured against `SummaryCursor::cycle_len`,
+    /// captured when the cycle began, which the peer cannot move.
     #[test]
-    fn a_peer_that_varies_the_shared_set_can_still_pin_the_window() {
+    fn a_peer_that_shrinks_the_shared_set_cannot_pin_the_window() {
         let (mgr, _clock) = make_manager();
         let peer = make_peer_key(1);
         let full = sorted_keys(0..64);
         let pinned = vec![full[63]];
 
         let mut full_round_starts = HashSet::new();
+        let mut covered = HashSet::new();
         for _ in 0..20 {
-            // The peer advertises just its highest-id contract. len == 1, so a
-            // single entry completes that "cycle".
-            let s = mgr.begin_summary_window(&peer, &pinned);
-            let w = rotation_window_indices(pinned.len(), s, 64);
+            // The peer advertises just its highest-id contract.
+            let s1 = mgr.begin_summary_window(&peer, &pinned);
+            let w1 = rotation_window_indices(pinned.len(), s1, 64);
             mgr.record_summary_cursor(
                 &peer,
-                *pinned[*w.last().expect("non-empty")].id(),
-                w.len(),
+                *pinned[*w1.last().expect("non-empty")].id(),
+                w1.len(),
                 &pinned,
             );
 
-            // Then the full set: the cursor resumes from the id the peer chose.
-            full_round_starts.insert(mgr.begin_summary_window(&peer, &full));
-            let w2 = rotation_window_indices(full.len(), 0, 8);
+            // Then the full set. The start must MOVE across rounds, and the
+            // union must eventually reach every contract.
+            let s2 = mgr.begin_summary_window(&peer, &full);
+            full_round_starts.insert(s2);
+            let w2 = rotation_window_indices(full.len(), s2, 8);
+            for &i in &w2 {
+                covered.insert(i);
+            }
             mgr.record_summary_cursor(
                 &peer,
                 *full[*w2.last().expect("non-empty")].id(),
@@ -8499,13 +8645,135 @@ mod tests {
             );
         }
 
-        assert_eq!(
-            full_round_starts.len(),
-            1,
-            "KNOWN LIMIT (#5313): a peer that varies the shared set pins the \
-             full-round start. If this now varies, geometric completion has \
-             landed — invert this assertion rather than deleting it. Got {:?}",
+        assert!(
+            full_round_starts.len() > 1,
+            "a peer that alternates a one-hash Interests with a full one must \
+             not pin the full-round start: 20 rounds all began at {:?}",
             full_round_starts
+        );
+        assert_eq!(
+            covered.len(),
+            full.len(),
+            "20 rounds of 8 must still cover all {} contracts; covered {}",
+            full.len(),
+            covered.len()
+        );
+        assert!(
+            mgr.summary_cursor_rejections() > 0,
+            "the one-hash rounds must be IGNORED by the frame guard rather than \
+             dragging the cursor; if none were, the guard is not firing and the \
+             coverage above is passing for some other reason"
+        );
+    }
+
+    /// A cycle COMPLETES and then re-randomises, so the anti-starvation redraw
+    /// keeps firing.
+    ///
+    /// Pins `advertised_in_cycle` ACCUMULATING across rounds. Replacing the
+    /// `saturating_add` with a bare assignment leaves every other test in this
+    /// module green while cycles never complete for `limit < len`, so the
+    /// boundary redraw never fires again and tail starvation returns silently.
+    #[test]
+    fn a_cycle_completes_and_then_re_randomises() {
+        let sorted = sorted_keys(0..40);
+        let limit = 8usize;
+        let rounds = sorted.len().div_ceil(limit);
+
+        let mut second_cycle_starts = HashSet::new();
+        for i in 0..40u32 {
+            let (mgr, _clock) = make_manager();
+            let peer = make_unique_peer_key(9700 + i);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 3);
+
+            for r in 0..rounds {
+                let start = mgr.begin_summary_window(&peer, &sorted);
+                let w = rotation_window_indices(sorted.len(), start, limit);
+                mgr.record_summary_cursor(
+                    &peer,
+                    *sorted[*w.last().expect("non-empty")].id(),
+                    w.len(),
+                    &sorted,
+                );
+                let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+                assert_eq!(
+                    c.advertised_in_cycle,
+                    (r + 1) * limit,
+                    "the count must ACCUMULATE across rounds, not be replaced"
+                );
+            }
+
+            // The cycle is now complete, so the next window is a boundary.
+            second_cycle_starts.insert(mgr.begin_summary_window(&peer, &sorted));
+        }
+
+        assert!(
+            second_cycle_starts.len() > 1,
+            "a completed cycle must draw a fresh random origin; 40 trials all \
+             restarted at {second_cycle_starts:?}"
+        );
+    }
+
+    /// A run of ill-formed records must degrade to a fresh random origin, not
+    /// to permanent silence.
+    ///
+    /// A rejected record leaves the cursor untouched, so without a bound a
+    /// caller-side defect that made every record ill-formed would re-send the
+    /// same window forever and starve every other contract for the process
+    /// lifetime — strictly worse than the staleness the check exists to stop.
+    #[test]
+    fn a_run_of_rejected_records_falls_back_to_a_boundary() {
+        let sorted = sorted_keys(0..64);
+        let mut starts = HashSet::new();
+        for i in 0..40u32 {
+            let (mgr, _clock) = make_manager();
+            let peer = make_unique_peer_key(9800 + i);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 10);
+            let first = mgr.begin_summary_window(&peer, &sorted);
+
+            // Feed it records that can never be well-formed against the cycle.
+            for _ in 0..MAX_CONSECUTIVE_CURSOR_REJECTIONS {
+                mgr.record_summary_cursor(&peer, *sorted[30].id(), 1, &sorted);
+            }
+            assert_eq!(
+                mgr.summary_cursor_rejections(),
+                MAX_CONSECUTIVE_CURSOR_REJECTIONS as usize
+            );
+            starts.insert((first, mgr.begin_summary_window(&peer, &sorted)));
+        }
+        assert!(
+            starts.iter().any(|(a, b)| a != b),
+            "after {MAX_CONSECUTIVE_CURSOR_REJECTIONS} consecutive rejections \
+             the rotation must redraw rather than re-send the same window \
+             forever; every trial stayed put: {starts:?}"
+        );
+    }
+
+    /// A cursor evicted between drawing the window and recording it starts a
+    /// fresh cycle rather than discarding the round.
+    #[test]
+    fn a_record_with_no_cursor_starts_a_fresh_cycle() {
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        let sorted = sorted_keys(0..16);
+
+        assert_eq!(mgr.peek_summary_cursor_state(&peer), None);
+        mgr.record_summary_cursor(&peer, *sorted[5].id(), 4, &sorted);
+        let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+        assert_eq!(c.advertised_in_cycle, 4);
+        assert_eq!(c.last_sent, *sorted[5].id());
+        assert_eq!(
+            mgr.summary_cursor_rejections(),
+            0,
+            "there is nothing to check a first record against"
+        );
+
+        // Degenerate inputs must be no-ops, not panics.
+        mgr.record_summary_cursor(&peer, *sorted[5].id(), 0, &sorted);
+        mgr.record_summary_cursor(&peer, *sorted[5].id(), 4, &[]);
+        assert_eq!(
+            mgr.peek_summary_cursor_state(&peer).expect("cursor"),
+            c,
+            "an empty round or an empty set must leave the cursor alone"
         );
     }
 
@@ -8519,9 +8787,24 @@ mod tests {
     #[test]
     fn summary_window_start_draws_its_offset_from_global_rng() {
         let src = include_str!("interest.rs");
+        // The needle must land in PRODUCTION code, not in this test's own
+        // source. When #5181 renamed the function, the old needle stopped
+        // matching anything above and silently resolved to the `.expect`
+        // string literal below it — the body then spanned this assertion,
+        // whose own text contains "GlobalRng::random_range", so the pin passed
+        // vacuously and a `random_range(..) -> 0` mutation stayed green. Guard
+        // against the whole class rather than the one spelling.
+        let test_mod_start = src
+            .find("\n#[cfg(test)]\nmod tests {")
+            .expect("test module not found");
         let at = src
-            .find("pub(crate) fn summary_window_start(")
-            .expect("summary_window_start not found");
+            .find("pub(crate) fn begin_summary_window(")
+            .expect("begin_summary_window not found — did it get renamed again?");
+        assert!(
+            at < test_mod_start,
+            "the pin's needle matched inside the test module, so it would \
+             assert against its own source rather than production code"
+        );
         let body_end = at + src[at..].find("\n    }\n").expect("body end not found");
         let body = &src[at..body_end];
         assert!(

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -249,7 +249,7 @@ const RESYNC_THROTTLE_CACHE_SIZE: usize = 4096;
 /// head of its set every round and starve the tail permanently. The cap is well
 /// above `max_connections`, so that is not the expected regime; the
 /// randomisation is what makes it a slow cycle rather than a silent hole if it
-/// ever is. See [`InterestManager::summary_window_start`].
+/// ever is. See [`InterestManager::begin_summary_window`].
 ///
 /// #5238 widened the tracked population from the full-bytes minority to every
 /// connected peer. That does not change the conclusion — 4096 still clears
@@ -1231,6 +1231,12 @@ pub struct InterestManager<T: TimeSource> {
     /// issue #4857.
     resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), Instant>>,
 
+    /// Records discarded by `record_summary_cursor`'s advance check: a stale,
+    /// duplicate, or boundary-straddling window that would have mis-charged the
+    /// cycle. Diagnostic only, and a non-zero value is expected under
+    /// concurrency rather than a fault.
+    summary_cursor_rejections: AtomicUsize,
+
     /// Rotation cursor for the bounded periodic summary reply (#5155, extended
     /// to the digest form by #5238), keyed by the peer's stable transport
     /// public key.
@@ -1239,7 +1245,7 @@ pub struct InterestManager<T: TimeSource> {
     /// the peer's identity — a NATed peer that resumes on a new source port is
     /// the same peer with the same hosted set, and keying by address threw its
     /// cursor away on every reconnect. That is not a lost optimisation: with no
-    /// cursor, [`Self::summary_window_start`] re-draws a RANDOM offset, so
+    /// cursor, [`Self::begin_summary_window`] re-draws a RANDOM offset, so
     /// coverage degrades from a contiguous `ceil(n / limit)` tiling to
     /// coupon-collector — about `(n / limit) * H_(n / limit)` rounds, ~90
     /// minutes rather than ~40 at n = 450 and the 5-minute heartbeat. The
@@ -1275,7 +1281,11 @@ pub struct InterestManager<T: TimeSource> {
     /// and never touched it — and #5238 ended that, because the cost the window
     /// really bounds is the per-entry summarize call, which the digest form
     /// pays in full.
-    summary_window_cursor: Mutex<LruCache<PeerKey, ContractInstanceId>>,
+    ///
+    /// Carries a per-cycle entry COUNT alongside the id (#5181). Without it the
+    /// resume index alone had to answer "is this a cycle boundary", and it
+    /// cannot: see [`SummaryCursor`].
+    summary_window_cursor: Mutex<LruCache<PeerKey, SummaryCursor>>,
 
     /// Count of concurrently-outstanding queue-full-resync retry tasks (#4862 P1).
     /// Bounds aggregate retry tasks node-wide, independent of the throttle LRU
@@ -1354,6 +1364,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 NonZeroUsize::new(RESYNC_THROTTLE_CACHE_SIZE)
                     .expect("RESYNC_THROTTLE_CACHE_SIZE must be > 0"),
             )),
+            summary_cursor_rejections: AtomicUsize::new(0),
             summary_window_cursor: Mutex::new(LruCache::new(
                 NonZeroUsize::new(SUMMARY_WINDOW_CURSOR_CACHE_SIZE)
                     .expect("SUMMARY_WINDOW_CURSOR_CACHE_SIZE must be > 0"),
@@ -2940,43 +2951,228 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// covered first every time.
     ///
     /// `GlobalRng` keeps this deterministic under simulation and test.
-    pub(crate) fn summary_window_start(&self, peer: &PeerKey, sorted: &[ContractKey]) -> usize {
+    ///
+    /// # Whether a cycle has ENDED is the count's job, not the index's
+    ///
+    /// A window ending exactly on the highest id has WRAPPED, not finished, and
+    /// must be followed by index 0 to stay contiguous. Deciding that from the
+    /// resume index alone cannot distinguish the two, which was #5181; the
+    /// cursor carries a per-cycle count for it. See [`SummaryCursor`].
+    ///
+    /// # Drawing a boundary PUBLISHES it, under the same lock hold
+    ///
+    /// Replies are separate tasks and each awaits a storage hit per contract,
+    /// so two `Interests` from one peer straddling a boundary is routine. If
+    /// the origin were drawn without being published, both would see no cursor,
+    /// draw DIFFERENT origins, and have both entry counts charged to one cycle
+    /// for two non-contiguous windows — the count running ahead of the ground
+    /// covered, which is #5181's own failure class. Drawing and publishing
+    /// together makes the second racer resume from the same origin.
+    ///
+    /// `GlobalRng` is thread-local (`THREAD_RNG` / `THREAD_SEED` are
+    /// `thread_local!`), so drawing under the lock cannot deadlock.
+    ///
+    /// # Anti-steering is weaker than the pre-#5181 code, deliberately
+    ///
+    /// Before the fix, every round whose resume ran off the end re-randomised.
+    /// That defeated steering — but only as a side effect of the bug, since it
+    /// also re-randomised mid-cycle, and restoring the coverage bound
+    /// necessarily removes it. The count does not fully replace it: completion
+    /// compares against `sorted.len()`, and the peer chooses `sorted`, so
+    /// alternating a single-hash `Interests` with a full one trips completion
+    /// and re-seeds the cycle from an id the peer picked.
+    ///
+    /// Accepted because the harm is almost entirely self-inflicted: what
+    /// starves is our advertisement to THAT peer, cursors are per-peer, and no
+    /// other peer's rotation is affected.
+    /// `a_peer_that_varies_the_shared_set_can_still_pin_the_window` asserts the
+    /// live behaviour so the limit is visible in CI rather than only in prose.
+    /// The principled fix is geometric (positional) completion, which also
+    /// makes a staleness bound stateable under churn: #5313.
+    pub(crate) fn begin_summary_window(&self, peer: &PeerKey, sorted: &[ContractKey]) -> usize {
         if sorted.is_empty() {
             return 0;
         }
-        let after = { self.summary_window_cursor.lock().peek(peer).copied() };
-        let resumed = after.map(|after| first_index_after(sorted, &after));
-        match resumed {
-            // Mid-cycle: continue exactly where the last reply stopped.
-            Some(start) if start < sorted.len() => start,
-            // Cycle boundary (cursor absent, or exhausted past the end).
-            _ => crate::config::GlobalRng::random_range(0..sorted.len()),
+        let mut cursors = self.summary_window_cursor.lock();
+        match cursors.peek(peer) {
+            // Mid-cycle: resume immediately after the last entry sent, wrapping
+            // past the end of the set rather than reading the end as a
+            // boundary. The `% len` is what #5181 was missing.
+            Some(cursor) if cursor.advertised_in_cycle < sorted.len() => {
+                first_index_after(sorted, &cursor.last_sent) % sorted.len()
+            }
+            // Cycle boundary: no cursor (first reply, restart, LRU eviction), or
+            // the cycle genuinely completed. Draw AND publish together.
+            _ => {
+                let origin = crate::config::GlobalRng::random_range(0..sorted.len());
+                cursors.put(peer.clone(), SummaryCursor::starting_at(sorted, origin));
+                origin
+            }
         }
     }
 
-    /// Record the contract id of the last entry actually included in `peer`'s
-    /// periodic summary reply, so the next reply resumes after it.
+    /// Record the entries actually included in `peer`'s periodic summary reply,
+    /// so the next reply resumes after them and the cycle count tracks the
+    /// ground covered.
     ///
     /// Takes what was SENT, not what was selected: the byte budget can cut a
     /// window short, and advancing past entries we dropped would skip them
     /// until the rotation wrapped all the way round.
-    pub(crate) fn record_summary_cursor(&self, peer: &PeerKey, last_sent: ContractInstanceId) {
-        self.summary_window_cursor
-            .lock()
-            .put(peer.clone(), last_sent);
+    ///
+    /// `sorted` must be the SAME snapshot the window was built from. That is
+    /// what makes the check below exact under churn: the window is chosen by
+    /// index in that snapshot starting at the resume position, so an insertion
+    /// since the previous round shifts both positions together.
+    ///
+    /// # A record must advance the cycle by exactly what it sent
+    ///
+    /// A slow reply carrying an earlier window could otherwise record last,
+    /// both double-charging the cycle AND rewinding `last_sent` so the rotation
+    /// re-sent covered ground. A record is accepted only when it moves by
+    /// exactly the number of entries it sent, measured CIRCULARLY from the
+    /// previous position.
+    ///
+    /// No well-formed round is ever rejected, and that is an identity rather
+    /// than a case list: a round resuming at `prev_pos` and sending `k`
+    /// contiguous entries ends at `(prev_pos + k - 1) % len`, so the recorded
+    /// position is `(prev_pos + k) % len` and the circular advance is `k % len`
+    /// — which is `k` when `k < len` and `0` when `k == len`, both equal to
+    /// `entries_sent % len`.
+    ///
+    /// Three traps, each of which a coverage assertion passes under, so each is
+    /// pinned by its own test:
+    ///
+    /// - **Circular, not linear.** A legitimate window wraps past the highest
+    ///   id, so its last entry can sort BELOW the previous one; a linear test
+    ///   calls that a rewind.
+    /// - **Relative to the previous position, not the origin.** A window that
+    ///   crosses the origin lands a SHORT distance after it, so measuring from
+    ///   the origin makes the crossing round look like the largest rewind of
+    ///   the cycle. Rejecting it parks the cursor and the rotation WEDGES
+    ///   permanently — strictly worse than the staleness this stops.
+    /// - **Bounded above by one window is not enough on its own.** Forward
+    ///   distance alone cannot separate a short hop from a long rewind, since
+    ///   every rewind is forward the long way round. Requiring the exact
+    ///   distance is what separates them.
+    ///
+    /// There is deliberately no first-record exemption. It is unnecessary
+    /// because [`SummaryCursor::starting_at`] publishes the origin's
+    /// PREDECESSOR, so `first_index_after` resolves it back to the origin and
+    /// the first round's advance is exactly `k`. It would also be actively
+    /// wrong: a reply that read the OLD cycle and landed after another reply
+    /// took the boundary would meet it on the freshly published cursor and
+    /// overwrite the just-drawn origin with a stale id.
+    pub(crate) fn record_summary_cursor(
+        &self,
+        peer: &PeerKey,
+        last_sent: ContractInstanceId,
+        entries_sent: usize,
+        sorted: &[ContractKey],
+    ) {
+        let len = sorted.len();
+        if len == 0 || entries_sent == 0 {
+            return;
+        }
+        let new_pos = first_index_after(sorted, &last_sent) % len;
+        let mut cursors = self.summary_window_cursor.lock();
+        let updated = match cursors.peek(peer) {
+            Some(prev) => {
+                let prev_pos = first_index_after(sorted, &prev.last_sent) % len;
+                let advance = (new_pos + len - prev_pos) % len;
+                if advance != entries_sent % len {
+                    // Not well-formed against the current cycle: a stale or
+                    // duplicate window, or one that straddled a boundary
+                    // another reply already took. Discard it — the published
+                    // origin survives, and the ground this reply sent is simply
+                    // re-sent later, having never been charged.
+                    self.summary_cursor_rejections
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    return;
+                }
+                SummaryCursor {
+                    last_sent,
+                    advertised_in_cycle: prev.advertised_in_cycle.saturating_add(entries_sent),
+                }
+            }
+            // Evicted between drawing the window and recording it. Nothing to
+            // check against, so start the count fresh rather than discarding a
+            // round's progress.
+            None => SummaryCursor {
+                last_sent,
+                advertised_in_cycle: entries_sent,
+            },
+        };
+        cursors.put(peer.clone(), updated);
     }
 
-    /// Test accessor for the stored cursor.
+    /// Records discarded by [`Self::record_summary_cursor`]'s advance check.
+    /// Diagnostic only; a non-zero value is expected under concurrency.
+    #[cfg(test)]
+    pub(crate) fn summary_cursor_rejections(&self) -> usize {
+        self.summary_cursor_rejections
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Test accessor for the id the cursor resumes after.
     #[cfg(test)]
     pub(crate) fn peek_summary_cursor(&self, peer: &PeerKey) -> Option<ContractInstanceId> {
+        self.summary_window_cursor
+            .lock()
+            .peek(peer)
+            .map(|c| c.last_sent)
+    }
+
+    /// Test accessor for the whole cursor, including the cycle count.
+    #[cfg(test)]
+    pub(crate) fn peek_summary_cursor_state(&self, peer: &PeerKey) -> Option<SummaryCursor> {
         self.summary_window_cursor.lock().peek(peer).copied()
+    }
+
+    /// Seed a cursor as the BOUNDARY would: a cycle beginning at `origin` with
+    /// nothing yet sent.
+    ///
+    /// Goes through the same [`SummaryCursor::starting_at`] the boundary uses,
+    /// so a test cannot pin the code to a state production never produces.
+    #[cfg(test)]
+    pub(crate) fn seed_summary_cursor_at_origin(
+        &self,
+        peer: &PeerKey,
+        sorted: &[ContractKey],
+        origin: usize,
+    ) {
+        self.summary_window_cursor
+            .lock()
+            .put(peer.clone(), SummaryCursor::starting_at(sorted, origin));
+    }
+
+    /// Seed a mid-cycle cursor directly: the last entry sent was `last_sent`,
+    /// with `advertised` entries covered so far this cycle.
+    ///
+    /// Prefer [`Self::seed_summary_cursor_at_origin`] where the test means "a
+    /// cycle just began". This one exists for tests that need a specific resume
+    /// POSITION, and its `advertised` must be a count a contiguous cycle could
+    /// actually have reached, or the test is pinning an unreachable state.
+    #[cfg(test)]
+    pub(crate) fn seed_summary_cursor(
+        &self,
+        peer: &PeerKey,
+        last_sent: ContractInstanceId,
+        advertised: usize,
+    ) {
+        self.summary_window_cursor.lock().put(
+            peer.clone(),
+            SummaryCursor {
+                last_sent,
+                advertised_in_cycle: advertised,
+            },
+        );
     }
 }
 
 /// First index in `sorted` (ascending by contract id, as
 /// [`InterestManager::get_matching_contracts`] returns it) whose id is strictly
 /// greater than `after`. Returns `sorted.len()` when `after` is at or past the
-/// end, which [`InterestManager::summary_window_start`] reads as the end of a
+/// end, which [`InterestManager::begin_summary_window`] reads as the end of a
 /// cycle and answers with a fresh random offset.
 ///
 /// This is the churn-safe half of the rotation. Because it is a binary search
@@ -2996,6 +3192,67 @@ impl<T: TimeSource + Sync> InterestManager<T> {
 /// only thing that makes bounding the reply defensible in the first place.
 pub(crate) fn first_index_after(sorted: &[ContractKey], after: &ContractInstanceId) -> usize {
     sorted.partition_point(|c| c.id().as_bytes() <= after.as_bytes())
+}
+
+/// One peer's position in the rotation, plus how much of the CURRENT cycle it
+/// has already been told about.
+///
+/// The count exists because the resume index cannot answer "is this a cycle
+/// boundary" on its own, and #5181 was what happened when it was asked to.
+/// [`first_index_after`] returns `sorted.len()` for two different situations:
+///
+/// - the cursor is genuinely past the end of the set — a real boundary;
+/// - the cursor sits ON the highest id in the set — a mid-cycle WRAP, and
+///   precisely the wrap [`rotation_window_indices`]'s coverage argument needs,
+///   since a window ending at index `len - 1` must be followed by index 0.
+///
+/// Reading the second as the first drew a fresh random origin partway through a
+/// cycle, breaking the contiguity `ceil(len / limit)` depends on. It fires on
+/// about `1 / limit` of cycles independently of set size, so the bound #5155
+/// justifies bounding the reply with was overstated in shipped code.
+///
+/// # The count is not approximate in the safe direction
+///
+/// It can UNDER-run a cycle, ending it early and leaving an arc unadvertised
+/// for an extra cycle. Three ways, none of them defects to be fixed here:
+///
+/// - two concurrent replies cut at different lengths by the byte budget carry
+///   different last ids, so the shorter is not recognised as ground the longer
+///   already covered;
+/// - contract CHURN — an id inserted into already-swept ground is
+///   indistinguishable from one that was advertised;
+/// - the peer chooses `sorted` (it is the intersection with the hashes IT
+///   advertised), so it chooses the length the count is compared against. See
+///   [`InterestManager::begin_summary_window`] for the anti-steering limit that
+///   leaves open.
+///
+/// The `ceil(len / limit)` bound therefore holds for a set STABLE across the
+/// cycle. Under churn there is no round bound, and asserting one anyway is what
+/// #5181 was.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SummaryCursor {
+    /// Contract id of the last entry actually SENT to this peer.
+    last_sent: ContractInstanceId,
+    /// Entries sent so far in the current cycle. Compared against
+    /// `sorted.len()` to decide whether the cycle is finished.
+    advertised_in_cycle: usize,
+}
+
+impl SummaryCursor {
+    /// A cursor that resumes the next window AT `origin`.
+    ///
+    /// Stores the origin's PREDECESSOR, because the stored id names the last
+    /// entry sent and [`first_index_after`] resolves it to the next one. That
+    /// is what makes a freshly-drawn boundary readable by a second concurrent
+    /// reply as "resume at `origin`" rather than as "no cursor, draw your own".
+    fn starting_at(sorted: &[ContractKey], origin: usize) -> Self {
+        debug_assert!(!sorted.is_empty(), "an empty set has no origin");
+        let predecessor = sorted[(origin + sorted.len() - 1) % sorted.len()];
+        Self {
+            last_sent: *predecessor.id(),
+            advertised_in_cycle: 0,
+        }
+    }
 }
 
 /// Indices of the next rotation window: up to `limit` entries beginning at
@@ -7887,37 +8144,38 @@ mod tests {
 
         assert_eq!(mgr.peek_summary_cursor(&peer), None);
 
-        mgr.record_summary_cursor(&peer, *sorted[2].id());
+        mgr.seed_summary_cursor(&peer, *sorted[2].id(), 1);
         assert_eq!(mgr.peek_summary_cursor(&peer), Some(*sorted[2].id()));
         assert_eq!(
-            mgr.summary_window_start(&peer, &sorted),
+            mgr.begin_summary_window(&peer, &sorted),
             3,
             "mid-cycle the resume point must be exactly after the last id sent"
         );
 
         // Cursors are per peer: one peer's progress must not advance another's.
         let other = make_peer_key(2);
-        mgr.record_summary_cursor(&other, *sorted[6].id());
-        assert_eq!(mgr.summary_window_start(&peer, &sorted), 3);
-        assert_eq!(mgr.summary_window_start(&other, &sorted), 7);
+        mgr.seed_summary_cursor(&other, *sorted[6].id(), 1);
+        assert_eq!(mgr.begin_summary_window(&peer, &sorted), 3);
+        assert_eq!(mgr.begin_summary_window(&other, &sorted), 7);
 
         // An empty shared set has no valid offset; it must not panic or draw.
-        assert_eq!(mgr.summary_window_start(&peer, &[]), 0);
+        assert_eq!(mgr.begin_summary_window(&peer, &[]), 0);
     }
 
     /// At a CYCLE BOUNDARY the start is random, not a fixed 0.
     ///
     /// A boundary is reached with no cursor (first reply, our own restart, LRU
-    /// eviction, a peer reconnecting on a new port) or with a cursor already at
-    /// the highest id. Restarting at 0 every time would re-send the head of the
-    /// set and starve the tail for any peer that keeps returning to a boundary,
-    /// which is the failure `emit_stale_peer_syncs` and the `SummaryDigests`
-    /// arm both already rotate to avoid.
+    /// eviction) or once a cycle has genuinely completed. Restarting at 0 every
+    /// time would re-send the head of the set and starve the tail for any peer
+    /// that keeps returning to a boundary, which is the failure
+    /// `emit_stale_peer_syncs` and the `SummaryDigests` arm both already rotate
+    /// to avoid.
     ///
-    /// The peer influences this: `sorted` is the intersection with the hash
-    /// list it advertised, so advertising one high-id contract parks the cursor
-    /// at the end. With a fixed restart that alternation pins the window to the
-    /// head forever; with a random one it cannot.
+    /// Note what this test does NOT claim any more: a cursor sitting on the
+    /// highest id is a mid-cycle WRAP, not a boundary. That case moved to
+    /// `a_window_ending_on_the_highest_id_wraps_instead_of_re_randomising`,
+    /// where it is asserted to be deterministic. Reading it as a boundary was
+    /// #5181.
     #[test]
     fn summary_window_start_randomises_the_cycle_boundary() {
         let (mgr, _clock) = make_manager();
@@ -7927,7 +8185,7 @@ mod tests {
         let mut seen = HashSet::new();
         for i in 0..40u32 {
             let peer = make_unique_peer_key(9200 + i);
-            let start = mgr.summary_window_start(&peer, &sorted);
+            let start = mgr.begin_summary_window(&peer, &sorted);
             assert!(start < sorted.len(), "start {start} out of range");
             seen.insert(start);
         }
@@ -7937,21 +8195,317 @@ mod tests {
              draws over 64 contracts all landed on {seen:?}"
         );
 
-        // Cursor at the highest id: also a boundary, also randomised.
+        // A COMPLETED cycle is the other boundary, and is also randomised.
         let peer = make_unique_peer_key(9300);
-        let mut seen_wrapped = HashSet::new();
+        let mut seen_completed = HashSet::new();
         for _ in 0..40 {
-            mgr.record_summary_cursor(&peer, *sorted[sorted.len() - 1].id());
-            seen_wrapped.insert(mgr.summary_window_start(&peer, &sorted));
+            // A whole cycle's worth of entries covered: genuinely finished.
+            mgr.seed_summary_cursor(&peer, *sorted[sorted.len() - 1].id(), sorted.len());
+            seen_completed.insert(mgr.begin_summary_window(&peer, &sorted));
         }
         assert!(
-            seen_wrapped.iter().all(|s| *s < sorted.len()),
-            "wrapped start out of range"
+            seen_completed.iter().all(|s| *s < sorted.len()),
+            "completed-cycle start out of range"
         );
         assert!(
-            seen_wrapped.len() > 1,
-            "a cursor at the end of the set must restart at a random offset, \
-             not deterministically at 0 — got {seen_wrapped:?}"
+            seen_completed.len() > 1,
+            "a COMPLETED cycle must restart at a random offset, not \
+             deterministically at 0 — got {seen_completed:?}"
+        );
+    }
+
+    /// #5181 regression: a window ending exactly on the highest id has WRAPPED,
+    /// not finished, so the next window must continue at index 0.
+    ///
+    /// `first_index_after` returns `sorted.len()` both for a cursor genuinely
+    /// past the end and for one sitting ON the last id. The pre-fix code read
+    /// the second as a cycle boundary and drew a fresh random origin partway
+    /// through a cycle, breaking the contiguity `ceil(len / limit)` depends on.
+    ///
+    /// Constructed directly over several set sizes rather than waiting for the
+    /// ~1-in-`limit` chance that produced the original flake.
+    #[test]
+    fn a_window_ending_on_the_highest_id_wraps_instead_of_re_randomising() {
+        let (mgr, _clock) = make_manager();
+
+        for len in [2usize, 3, 5, 8, 16, 33, 64] {
+            let sorted = sorted_keys(0..len as u32);
+            let peer = make_unique_peer_key(9400 + len as u32);
+
+            // Mid-cycle by construction: one entry covered out of `len`, and
+            // the cursor parked on the highest id in the set.
+            mgr.seed_summary_cursor(&peer, *sorted[len - 1].id(), 1);
+
+            // Deterministic: assert over repeats so a lucky random draw of 0
+            // cannot be mistaken for a correct wrap.
+            for _ in 0..8 {
+                assert_eq!(
+                    mgr.begin_summary_window(&peer, &sorted),
+                    0,
+                    "len={len}: a cursor on the highest id is a mid-cycle WRAP \
+                     and must resume at 0, not re-randomise (#5181)"
+                );
+            }
+        }
+    }
+
+    /// The real API, driven end to end, covers every contract from every
+    /// possible origin within `ceil(len / limit)` rounds.
+    ///
+    /// Drives `begin_summary_window` and `record_summary_cursor` rather than
+    /// the pure helpers. That matters: the pre-existing
+    /// `rotation_covers_every_contract_within_ceil_n_over_limit_rounds` stayed
+    /// green through this entire bug because it drives the helpers with a
+    /// test-local resume rule that wraps on its own, and the defect lived in
+    /// the resume decision BETWEEN them.
+    #[test]
+    fn the_real_api_covers_every_contract_from_every_origin() {
+        for (len, limit) in [(8usize, 3usize), (10, 5), (16, 4), (33, 8), (64, 64)] {
+            let sorted = sorted_keys(0..len as u32);
+            let rounds = len.div_ceil(limit);
+
+            for origin in 0..len {
+                let (mgr, _clock) = make_manager();
+                let peer = make_unique_peer_key(9500 + origin as u32);
+                mgr.seed_summary_cursor_at_origin(&peer, &sorted, origin);
+
+                let mut covered = HashSet::new();
+                for _ in 0..rounds {
+                    let start = mgr.begin_summary_window(&peer, &sorted);
+                    let window = rotation_window_indices(len, start, limit);
+                    assert!(!window.is_empty(), "empty window");
+                    for &i in &window {
+                        covered.insert(i);
+                    }
+                    let last = *sorted[*window.last().expect("non-empty")].id();
+                    mgr.record_summary_cursor(&peer, last, window.len(), &sorted);
+                }
+
+                assert_eq!(
+                    covered.len(),
+                    len,
+                    "len={len} limit={limit} origin={origin}: {} of {len} \
+                     contracts covered in {rounds} rounds",
+                    covered.len()
+                );
+            }
+        }
+    }
+
+    /// The boundary is ATOMIC: drawing an origin publishes it, so a second
+    /// reply that arrives before the first records resumes from the SAME
+    /// origin instead of drawing its own.
+    ///
+    /// Without this, two concurrent replies from one peer both see no cursor,
+    /// draw different origins, and have both entry counts charged to one cycle
+    /// for two non-contiguous windows — the count running ahead of the ground
+    /// covered, which is #5181's own failure class.
+    ///
+    /// Repeated so a coincidental agreement between two independent draws
+    /// (~1/len) cannot pass for the published-origin property.
+    #[test]
+    fn a_published_boundary_makes_a_second_reader_agree_on_the_origin() {
+        let sorted = sorted_keys(0..64);
+        for i in 0..40u32 {
+            let (mgr, _clock) = make_manager();
+            let peer = make_unique_peer_key(9600 + i);
+            let first = mgr.begin_summary_window(&peer, &sorted);
+            let second = mgr.begin_summary_window(&peer, &sorted);
+            assert_eq!(
+                first, second,
+                "a second reader with no record in between must resume from the \
+                 PUBLISHED origin, not draw its own"
+            );
+        }
+    }
+
+    /// A record is accepted only when it advances the cycle by exactly the
+    /// number of entries it sent, measured circularly from the previous
+    /// position.
+    ///
+    /// Each case is one of the traps a coverage assertion passes under, so
+    /// none of them would be caught by the sweep above.
+    #[test]
+    fn records_must_advance_the_cycle_and_forward_is_circular() {
+        let sorted = sorted_keys(0..40);
+        let len = sorted.len();
+
+        // 1. A well-formed round is accepted and charged exactly.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(1);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 10);
+            mgr.record_summary_cursor(&peer, *sorted[13].id(), 4, &sorted);
+            let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(c.advertised_in_cycle, 4, "a well-formed round is charged");
+            assert_eq!(c.last_sent, *sorted[13].id());
+        }
+
+        // 2. CIRCULAR, not linear: a window that wraps past the highest id ends
+        // on an id that sorts BELOW the previous one. A linear test calls that
+        // a rewind and rejects a legitimate round.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(2);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 38);
+            // 4 entries from 38: 38, 39, 0, 1 -> last is index 1.
+            mgr.record_summary_cursor(&peer, *sorted[1].id(), 4, &sorted);
+            let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(
+                c.advertised_in_cycle, 4,
+                "a wrapping window is well-formed and must be accepted"
+            );
+        }
+
+        // 3. A whole-set round mid-cycle lands back on its own predecessor, so
+        // the circular advance is 0 — and `entries_sent % len` is also 0. It
+        // must be ACCEPTED. An `advance == 0` rejection wedges the cursor here.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(3);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 7);
+            mgr.record_summary_cursor(&peer, *sorted[6].id(), len, &sorted);
+            let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(
+                c.advertised_in_cycle, len,
+                "a whole-set round advances by len, which is 0 mod len, and \
+                 must be accepted rather than rejected as non-advancing"
+            );
+        }
+
+        // 4. A STALE record is discarded: it would both double-charge the cycle
+        // and rewind `last_sent` so covered ground is re-sent.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(4);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 0);
+            mgr.record_summary_cursor(&peer, *sorted[7].id(), 8, &sorted);
+            let before = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            // A slow reply carrying the FIRST window, recording second.
+            mgr.record_summary_cursor(&peer, *sorted[3].id(), 4, &sorted);
+            let after = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(
+                before, after,
+                "a stale record must be discarded: charging it double-counts \
+                 the cycle AND rewinding re-sends ground already covered"
+            );
+            assert_eq!(mgr.summary_cursor_rejections(), 1);
+        }
+
+        // 5. A DUPLICATE of the round just recorded covers no new distance and
+        // is discarded by the same rule — no separate special case needed.
+        {
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(5);
+            mgr.seed_summary_cursor_at_origin(&peer, &sorted, 20);
+            mgr.record_summary_cursor(&peer, *sorted[23].id(), 4, &sorted);
+            let before = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            mgr.record_summary_cursor(&peer, *sorted[23].id(), 4, &sorted);
+            let after = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(before, after, "a duplicate round must not be charged twice");
+        }
+
+        // 6. A single-entry set: every round is a whole-set round.
+        {
+            let solo = sorted_keys(0..1);
+            let (mgr, _clock) = make_manager();
+            let peer = make_peer_key(6);
+            mgr.seed_summary_cursor_at_origin(&peer, &solo, 0);
+            mgr.record_summary_cursor(&peer, *solo[0].id(), 1, &solo);
+            let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+            assert_eq!(c.advertised_in_cycle, 1, "len=1 must not wedge");
+            // ...and the completed cycle re-randomises (trivially, to 0).
+            assert_eq!(mgr.begin_summary_window(&peer, &solo), 0);
+        }
+    }
+
+    /// Churn inside the arc already swept must not read as a stale record.
+    ///
+    /// The window is built and the cursor recorded against the SAME snapshot
+    /// for one reply, and the window is chosen by index in that snapshot
+    /// starting at the resume position, so insertions shift both positions
+    /// together and the advance is still exactly the entry count.
+    #[test]
+    fn churn_inside_the_swept_arc_does_not_look_like_a_stale_record() {
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+
+        // Round one against a 20-contract set.
+        let first = sorted_keys(0..20);
+        mgr.seed_summary_cursor_at_origin(&peer, &first, 5);
+        let start = mgr.begin_summary_window(&peer, &first);
+        let window = rotation_window_indices(first.len(), start, 4);
+        let last = *first[*window.last().expect("non-empty")].id();
+        mgr.record_summary_cursor(&peer, last, window.len(), &first);
+        assert_eq!(mgr.summary_cursor_rejections(), 0);
+
+        // The set grows: ids interleave both below and above the cursor.
+        let grown = sorted_keys(0..40);
+        let start2 = mgr.begin_summary_window(&peer, &grown);
+        let window2 = rotation_window_indices(grown.len(), start2, 4);
+        let last2 = *grown[*window2.last().expect("non-empty")].id();
+        mgr.record_summary_cursor(&peer, last2, window2.len(), &grown);
+
+        assert_eq!(
+            mgr.summary_cursor_rejections(),
+            0,
+            "churn between rounds must not make a well-formed round look stale"
+        );
+        let c = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+        assert_eq!(c.last_sent, last2, "the round must have been recorded");
+    }
+
+    /// The anti-steering limit this fix knowingly leaves open, asserted so it
+    /// is visible in CI rather than only in prose.
+    ///
+    /// Cycle completion compares the count against `sorted.len()`, and the peer
+    /// chooses `sorted` — it is the intersection with the hashes IT advertised.
+    /// Alternating a single-hash `Interests` with a full one makes `len == 1`,
+    /// trips completion, and re-seeds the cycle from an id the peer picked.
+    ///
+    /// Accepted because the harm is self-inflicted: what starves is our
+    /// advertisement to THAT peer, cursors are per-peer, and no other peer's
+    /// rotation is affected. Inverting this assertion is part of #5313's fix;
+    /// if this test starts failing because the window no longer pins, that is
+    /// the improvement landing and the test should be inverted, not deleted.
+    #[test]
+    fn a_peer_that_varies_the_shared_set_can_still_pin_the_window() {
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        let full = sorted_keys(0..64);
+        let pinned = vec![full[63]];
+
+        let mut full_round_starts = HashSet::new();
+        for _ in 0..20 {
+            // The peer advertises just its highest-id contract. len == 1, so a
+            // single entry completes that "cycle".
+            let s = mgr.begin_summary_window(&peer, &pinned);
+            let w = rotation_window_indices(pinned.len(), s, 64);
+            mgr.record_summary_cursor(
+                &peer,
+                *pinned[*w.last().expect("non-empty")].id(),
+                w.len(),
+                &pinned,
+            );
+
+            // Then the full set: the cursor resumes from the id the peer chose.
+            full_round_starts.insert(mgr.begin_summary_window(&peer, &full));
+            let w2 = rotation_window_indices(full.len(), 0, 8);
+            mgr.record_summary_cursor(
+                &peer,
+                *full[*w2.last().expect("non-empty")].id(),
+                w2.len(),
+                &full,
+            );
+        }
+
+        assert_eq!(
+            full_round_starts.len(),
+            1,
+            "KNOWN LIMIT (#5313): a peer that varies the shared set pins the \
+             full-round start. If this now varies, geometric completion has \
+             landed — invert this assertion rather than deleting it. Got {:?}",
+            full_round_starts
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2992,8 +2992,50 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// captured when the cycle began, so a peer cannot end our cycle on demand
     /// by shrinking what it advertises;
     /// `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` asserts it.
-    /// A positional (geometric) notion of completion would additionally make a
-    /// staleness bound stateable under churn: #5313.
+    ///
+    /// ## The redraw at completion is load-bearing, not decoration
+    ///
+    /// The frame guard in [`Self::record_summary_cursor`] cannot be the whole
+    /// defence, and no record-level check can be. A record is validated by its
+    /// circular advance within `sorted` — and `sorted` is the PEER's set, so a
+    /// well-formed advance of `k` positions inside a set the peer composed is
+    /// an arbitrary jump across the ground the cycle is sweeping. The record is
+    /// not even dishonest: the peer really did receive those entries. The
+    /// steering happens HERE, when an id is resolved against a set the peer
+    /// chose, not there.
+    ///
+    /// What bounds it is that a completed cycle draws a fresh random origin,
+    /// which periodically destroys any position the peer has arranged. Removing
+    /// that in favour of a contiguous boundary — to deliver a tighter revisit
+    /// bound — reopens the steering: a peer alternating two sets of the SAME
+    /// size (so no frame-based guard can fire at all) pinned every round of one
+    /// set to the same window, starving a genuinely shared contract, with zero
+    /// rejections logged.
+    /// `probe_same_size_recomposition_pins_the_window` is that attack.
+    ///
+    /// Measured over the four candidate boundary rules, coverage of the
+    /// attacked set under that probe was: contiguous 15/16, contiguous with a
+    /// reset to the cycle origin 15/16, a position cursor advanced by each
+    /// round's fair share of id space 9/16 (which also loses coverage against
+    /// an HONEST peer, because `cycle_len` says how many entries there are and
+    /// not how they are spread, and the peer picks the spread), and the random
+    /// redraw 16/16. Contiguity and anti-steering are in direct tension and the
+    /// redraw is what currently pays for the second.
+    ///
+    /// The cost is the revisit bound. Because each cycle starts somewhere new,
+    /// a contract covered early in one cycle and late in the next waits up to
+    /// `2 * ceil(len / limit) - 1` rounds, not `ceil(len / limit)`; measured at
+    /// `len = 200`, `limit = 64` (so `ceil` is 4), six 12-cycle runs gave
+    /// worst-case gaps of 6, 7, 7, 7, 6 and 7.
+    /// `the_revisit_gap_spans_at_most_two_cycles` pins the honest figure. Do
+    /// not quote the single-cycle `ceil(len / limit)` as a revisit bound: that
+    /// is the WITHIN-cycle coverage bound, and the two are different claims.
+    ///
+    /// Delivering `ceil(len / limit)` needs a cursor whose position is not
+    /// resolved through the peer's set at all — a positional (geometric) notion
+    /// of completion, which would additionally make a staleness bound stateable
+    /// under churn: #5313. That is the right fix and it is a design change, not
+    /// a guard.
     pub(crate) fn begin_summary_window(&self, peer: &PeerKey, sorted: &[ContractKey]) -> usize {
         if sorted.is_empty() {
             return 0;
@@ -3097,7 +3139,10 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         let new_pos = first_index_after(sorted, &last_sent) % len;
         let mut cursors = self.summary_window_cursor.lock();
         let updated = match cursors.peek(peer) {
-            Some(prev) if len < prev.cycle_len => {
+            Some(prev)
+                if len < prev.cycle_len
+                    && (entries_sent >= len || len.saturating_mul(2) < prev.cycle_len) =>
+            {
                 // A round built against a SMALLER set than the cycle's own
                 // frame. Its last id is not a position in this cycle's ground,
                 // and applying it would drag `last_sent` to wherever the
@@ -3110,12 +3155,54 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 // rotation short of the set. Charging the rejection means the
                 // escape below still fires, so a set that has genuinely shrunk
                 // redraws within a bounded number of rounds instead of wedging.
+                //
+                // # Why not `len < cycle_len` alone
+                //
+                // Both sides of the intersection churn — interest entries
+                // expire on a 20-minute TTL and are swept every minute — so a
+                // set one or two elements below the frame is ORDINARY, not
+                // adversarial, and rejecting it costs real bandwidth for no
+                // coverage. A rejected round parks the cursor, so the NEXT
+                // round re-sends a byte-identical window: measured on a
+                // 200-contract set losing one element on alternate rounds, the
+                // bare form took 6 rounds and 3 rejections to cover the set
+                // where this one takes 4 and none. Anti-entropy bandwidth is
+                // the scarce resource here (#5153), so a 50% surcharge on
+                // ordinary churn is not a cheap safety margin.
+                // `an_ordinary_shrink_is_not_rejected` pins the churn case.
+                //
+                // The two clauses are the cases the ADVANCE check below cannot
+                // police, and neither implies the other:
+                //
+                // - `entries_sent >= len` — the round covered the WHOLE set, so
+                //   it wrapped to where it started: its circular advance is `0`
+                //   and `entries_sent % len` is `0` too, and ANY last id the
+                //   peer arranges passes. That is the vacuous case, and it is
+                //   reachable at any size (a 150-of-200 set sent whole).
+                // - `len * 2 < prev.cycle_len` — a MATERIAL shrink. Below that
+                //   the advance check is not vacuous, but it is still measured
+                //   in the peer's own index space, and a well-formed advance of
+                //   `k` positions inside a set the peer composed is an
+                //   arbitrary jump across the ground the cycle is sweeping. The
+                //   check proves the round is internally consistent; it says
+                //   nothing about where the cursor LANDS.
+                //   `probe_peer_pins_window_with_a_set_larger_than_the_limit`
+                //   and `probe_budget_cut_round_bypasses_the_frame_guard` are
+                //   that attack at two different sizes.
+                //
+                // Neither clause is a general defence against a peer-composed
+                // set — nothing checked here can be, because `sorted` is the
+                // coordinate system the record is expressed in. What bounds the
+                // residue is the RANDOM REDRAW at cycle completion in
+                // [`Self::begin_summary_window`], which periodically destroys
+                // any position the peer has arranged. See its rustdoc.
                 self.summary_cursor_rejections
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let rejections = prev.consecutive_rejections.saturating_add(1);
                 tracing::debug!(
                     ?peer,
                     set_len = len,
+                    entries_sent,
                     cycle_len = prev.cycle_len,
                     consecutive = rejections,
                     "ignored a summary-rotation record from a smaller set than the cycle frame"
@@ -8666,6 +8753,296 @@ mod tests {
         );
     }
 
+    /// An ORDINARY shrink — the shared set losing an element to churn — must
+    /// pass the frame guard.
+    ///
+    /// `sorted` is our interest index intersected with the hashes the peer
+    /// advertised, and both sides churn: interest entries carry a 20-minute TTL
+    /// and are swept every minute. A set one element below the cycle frame is
+    /// therefore routine, and the guard's earlier `len < cycle_len` form
+    /// rejected it outright.
+    ///
+    /// The cost of that was bandwidth, which is the scarce resource this whole
+    /// rotation exists to ration (#5153): a rejected round leaves the cursor
+    /// parked, so the NEXT round re-sends a byte-identical window. Measured
+    /// here, the un-narrowed guard needs 6 rounds and 3 rejections where the
+    /// narrowed one needs 4 and none — a 50% surcharge on ordinary churn, for
+    /// no coverage gain.
+    ///
+    /// Deliberately NOT an alternation between a full set and a tiny one: that
+    /// shape is `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` and
+    /// `probe_peer_pins_window_with_a_set_larger_than_the_limit`. The existing
+    /// churn test only ever GROWS the set (20 -> 40), which is why this bug had
+    /// no coverage.
+    #[test]
+    fn an_ordinary_shrink_is_not_rejected() {
+        const LEN: usize = 200;
+        const LIMIT: usize = 64;
+        const DROPPED: usize = 100;
+
+        let full = sorted_keys(0..LEN as u32);
+        // One contract drops out of the intersection on alternate rounds.
+        let dipped: Vec<ContractKey> = full
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != DROPPED)
+            .map(|(_, k)| *k)
+            .collect();
+        let always_present: HashSet<ContractInstanceId> = dipped.iter().map(|k| *k.id()).collect();
+
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+
+        let mut covered: HashSet<ContractInstanceId> = HashSet::new();
+        let mut rounds = 0usize;
+        while !always_present.is_subset(&covered) && rounds < 20 {
+            let set: &[ContractKey] = if rounds % 2 == 1 { &dipped } else { &full };
+            let start = mgr.begin_summary_window(&peer, set);
+            let window = rotation_window_indices(set.len(), start, LIMIT);
+            assert!(!window.is_empty(), "empty window on round {rounds}");
+            for &i in &window {
+                covered.insert(*set[i].id());
+            }
+            let last = *set[*window.last().expect("non-empty")].id();
+            mgr.record_summary_cursor(&peer, last, window.len(), set);
+            rounds += 1;
+        }
+
+        assert_eq!(
+            rounds,
+            LEN.div_ceil(LIMIT),
+            "a set dipping by one element must still cover its {} stable \
+             contracts in ceil({LEN}/{LIMIT}) rounds; took {rounds}",
+            always_present.len(),
+        );
+        assert_eq!(
+            mgr.summary_cursor_rejections(),
+            0,
+            "ordinary churn must not be rejected: a rejected round parks the \
+             cursor and the next round re-sends a byte-identical window"
+        );
+    }
+
+    /// The peer must not be able to drive the rotation through the REJECTION
+    /// ESCAPE HATCH.
+    ///
+    /// The hatch exists for a caller-side defect that makes every record
+    /// ill-formed; after `MAX_CONSECUTIVE_CURSOR_REJECTIONS` it abandons the
+    /// cursor and draws a fresh random origin. A peer that can force rejections
+    /// on demand can therefore force a boundary on demand, and the boundary is
+    /// framed against whatever it is advertising AT THAT MOMENT — a one-hash
+    /// `Interests` gives a cycle of length one, which completes on its very
+    /// next round.
+    ///
+    /// That is survivable only because the boundary draws a RANDOM origin: the
+    /// peer gets to choose WHEN we re-originate, but not WHERE. If the boundary
+    /// ever becomes deterministic, this is a second door to the steering that
+    /// `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` closes, and
+    /// this test is what notices.
+    ///
+    /// The alternation is deliberately LONGER than that test's: one full round
+    /// per `MAX_CONSECUTIVE_CURSOR_REJECTIONS + 1` one-hash rounds, so the
+    /// hatch has room to fire between full rounds. The existing test alternates
+    /// one for one, so a full round always resets the count first and the hatch
+    /// is never reached.
+    #[test]
+    fn a_peer_cannot_drive_the_rotation_through_the_rejection_escape_hatch() {
+        const LIMIT: usize = 8;
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        let full = sorted_keys(0..64);
+        let pinned = vec![full[63]];
+
+        let mut full_round_starts = HashSet::new();
+        let mut covered = HashSet::new();
+        for _ in 0..20 {
+            // Enough one-hash rounds to reach the hatch.
+            for _ in 0..=MAX_CONSECUTIVE_CURSOR_REJECTIONS {
+                let s = mgr.begin_summary_window(&peer, &pinned);
+                let w = rotation_window_indices(pinned.len(), s, LIMIT);
+                mgr.record_summary_cursor(
+                    &peer,
+                    *pinned[*w.last().expect("non-empty")].id(),
+                    w.len(),
+                    &pinned,
+                );
+            }
+
+            let s = mgr.begin_summary_window(&peer, &full);
+            full_round_starts.insert(s);
+            let w = rotation_window_indices(full.len(), s, LIMIT);
+            for &i in &w {
+                covered.insert(i);
+            }
+            mgr.record_summary_cursor(
+                &peer,
+                *full[*w.last().expect("non-empty")].id(),
+                w.len(),
+                &full,
+            );
+        }
+
+        assert!(
+            full_round_starts.len() > 1,
+            "a peer that spends {} one-hash rounds between full ones must not \
+             pin the full-round start: 20 full rounds all began at {:?}",
+            MAX_CONSECUTIVE_CURSOR_REJECTIONS as usize + 1,
+            full_round_starts
+        );
+    }
+
+    /// A round covering the WHOLE of a set that is NOT a material shrink must
+    /// not move the cursor.
+    ///
+    /// The two clauses of the frame guard cover different cases and neither
+    /// implies the other; this pins the one the material-shrink clause misses.
+    /// A set at 136 of a 200 frame is well over half, so
+    /// `len * 2 < cycle_len` does not fire — but if the round sends the WHOLE
+    /// of it, the advance check below is VACUOUS: a full-set round wraps to
+    /// where it began, so its circular advance is `0` and `entries_sent % len`
+    /// is `0` too, and any last id the peer arranges passes. The window ends on
+    /// the entry cyclically BEFORE its start — the greatest advertised id at or
+    /// below the cursor — so by advertising exactly one low id the peer names
+    /// where `last_sent` lands.
+    ///
+    /// # What this test deliberately does NOT claim
+    ///
+    /// It asserts the record is not APPLIED, not that the peer is thereby
+    /// unable to pin the rotation. Measured: with this clause removed the
+    /// attack still fails to pin, because the accepted 136-entry round drives
+    /// the cycle to completion and the redraw scatters the origin (starts over
+    /// 20 rounds: 19 distinct values, coverage 200/200). The general defence is
+    /// the redraw — see [`InterestManager::begin_summary_window`]. What this
+    /// clause buys is narrower and still worth having: we do not apply a record
+    /// whose only check cannot fail. An end-to-end pin assertion here would be
+    /// claiming more than the mechanism delivers, and would pass for the wrong
+    /// reason.
+    #[test]
+    fn a_whole_set_round_is_rejected_even_when_the_shrink_is_not_material() {
+        const FRAME: usize = 200;
+        let full = sorted_keys(0..FRAME as u32);
+
+        // One id below the cursor, everything else above it: 136 of 200, so
+        // `len * 2 < cycle_len` is false (272 >= 200) and only the whole-set
+        // clause can catch this.
+        let attack: Vec<ContractKey> = std::iter::once(full[0])
+            .chain(full[65..].iter().copied())
+            .collect();
+        assert_eq!(attack.len(), 136);
+        assert!(
+            attack.len() * 2 >= FRAME,
+            "the point of this test is a shrink the material clause ignores"
+        );
+
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+
+        // One honest round, so there is a real cursor to drag.
+        let s = mgr.begin_summary_window(&peer, &full);
+        let w = rotation_window_indices(full.len(), s, 64);
+        mgr.record_summary_cursor(
+            &peer,
+            *full[*w.last().expect("non-empty")].id(),
+            w.len(),
+            &full,
+        );
+        let before = mgr.peek_summary_cursor(&peer).expect("cursor");
+
+        // The whole advertised set in one round.
+        let sa = mgr.begin_summary_window(&peer, &attack);
+        let wa = rotation_window_indices(attack.len(), sa, FRAME);
+        assert_eq!(wa.len(), attack.len(), "the round must cover the whole set");
+        let last = *attack[*wa.last().expect("non-empty")].id();
+        assert_ne!(
+            last, before,
+            "the attack is only meaningful if the whole-set round ends on a \
+             DIFFERENT id than the cursor already holds"
+        );
+        mgr.record_summary_cursor(&peer, last, wa.len(), &attack);
+
+        assert_eq!(
+            mgr.peek_summary_cursor(&peer).expect("cursor"),
+            before,
+            "a round covering the whole of a smaller set must not move the \
+             cursor: its circular advance is 0 whatever last id it names, so \
+             the advance check cannot reject it"
+        );
+        assert!(
+            mgr.summary_cursor_rejections() > 0,
+            "the whole-set round must be counted as a rejection"
+        );
+    }
+
+    /// The HONEST revisit bound is two cycles, not one.
+    ///
+    /// This is the figure the rotation may be sold on, and it is weaker than
+    /// the within-cycle coverage bound it is easy to confuse it with. A cycle
+    /// covers a stable set in `ceil(len / limit)` rounds — that is
+    /// `rotation_covers_every_contract_within_ceil_n_over_limit_rounds`. But
+    /// each completed cycle draws a FRESH random origin (see
+    /// [`InterestManager::begin_summary_window`] for why that redraw is
+    /// load-bearing against steering), so a contract covered early in one cycle
+    /// and late in the next waits up to `2 * ceil(len / limit) - 1` rounds.
+    ///
+    /// Pinning the honest figure is the point. An earlier revision of this test
+    /// asserted the single-cycle bound and passed only because it ran exactly
+    /// ONE cycle; `the_real_api_covers_every_contract_from_every_origin` has
+    /// the same blind spot by construction. Tightening this to
+    /// `ceil(len / limit)` requires a cursor that is not resolved through the
+    /// peer's set at all (#5313) — until then, a test asserting the tighter
+    /// bound is asserting something the code does not do.
+    #[test]
+    fn the_revisit_gap_spans_at_most_two_cycles() {
+        for (len, limit) in [(200usize, 64usize), (40, 8), (33, 8), (17, 4)] {
+            let sorted = sorted_keys(0..len as u32);
+            let cycle = len.div_ceil(limit);
+            let bound = 2 * cycle - 1;
+            let rounds = cycle * 12;
+
+            for origin in [0usize, 1, len / 3, len / 2, len - 1] {
+                let (mgr, _clock) = make_manager();
+                let peer = make_unique_peer_key(9900 + origin as u32);
+                mgr.seed_summary_cursor_at_origin(&peer, &sorted, origin);
+
+                let mut last_seen: Vec<Option<usize>> = vec![None; len];
+                let mut worst = 0usize;
+                let mut worst_at = (0usize, 0usize);
+                for r in 0..rounds {
+                    let start = mgr.begin_summary_window(&peer, &sorted);
+                    let window = rotation_window_indices(len, start, limit);
+                    assert!(!window.is_empty(), "empty window");
+                    for &i in &window {
+                        if let Some(prev) = last_seen[i] {
+                            if r - prev > worst {
+                                worst = r - prev;
+                                worst_at = (i, r);
+                            }
+                        }
+                        last_seen[i] = Some(r);
+                    }
+                    let last = *sorted[*window.last().expect("non-empty")].id();
+                    mgr.record_summary_cursor(&peer, last, window.len(), &sorted);
+                }
+
+                assert!(
+                    last_seen.iter().all(Option::is_some),
+                    "len={len} limit={limit} origin={origin}: some contract was \
+                     never advertised in {rounds} rounds"
+                );
+                assert!(
+                    worst <= bound,
+                    "len={len} limit={limit} origin={origin}: contract {} went \
+                     {worst} rounds without being advertised (bound {bound}), \
+                     last at round {}",
+                    worst_at.0,
+                    worst_at.1
+                );
+            }
+        }
+    }
+
     /// A cycle COMPLETES and then re-randomises, so the anti-starvation redraw
     /// keeps firing.
     ///
@@ -8813,6 +9190,319 @@ mod tests {
              fixed restart starves the tail of the set for any peer that keeps \
              returning to a boundary, and a non-GlobalRng source breaks \
              simulation determinism"
+        );
+    }
+
+    /// REVIEW PROBE: a peer that advertises a set LARGER than the window but
+    /// SMALLER than the cycle frame can drag `last_sent` wherever it likes,
+    /// because the frame guard now only fires when the round covered the WHOLE
+    /// shared set.
+    #[test]
+    fn probe_peer_pins_window_with_a_set_larger_than_the_limit() {
+        const LIMIT: usize = 8;
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(1);
+        let full = sorted_keys(0..64);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+
+        // 9 elements: one below the window we want to re-send, then the seven
+        // just after it, then the highest id. |S| = 9 > LIMIT = 8, so the
+        // narrowed frame guard does NOT fire.
+        let attack: Vec<ContractKey> = {
+            let mut v = vec![full[0]];
+            v.extend_from_slice(&full[8..15]);
+            v.push(full[63]);
+            v
+        };
+        assert_eq!(attack.len(), 9);
+
+        let mut full_round_starts = HashSet::new();
+        let mut covered = HashSet::new();
+        for _ in 0..20 {
+            let s = mgr.begin_summary_window(&peer, &full);
+            full_round_starts.insert(s);
+            let w = rotation_window_indices(full.len(), s, LIMIT);
+            for &i in &w {
+                covered.insert(i);
+            }
+            mgr.record_summary_cursor(&peer, *full[*w.last().expect("ne")].id(), w.len(), &full);
+
+            let sa = mgr.begin_summary_window(&peer, &attack);
+            let wa = rotation_window_indices(attack.len(), sa, LIMIT);
+            mgr.record_summary_cursor(
+                &peer,
+                *attack[*wa.last().expect("ne")].id(),
+                wa.len(),
+                &attack,
+            );
+        }
+
+        eprintln!(
+            "PROBE: full_round_starts={:?} covered={} rejections={}",
+            full_round_starts,
+            covered.len(),
+            mgr.summary_cursor_rejections()
+        );
+        assert!(
+            full_round_starts.len() > 1,
+            "PINNED: 20 full rounds all began at {full_round_starts:?}"
+        );
+        assert_eq!(
+            covered.len(),
+            full.len(),
+            "STARVED: covered {} of 64",
+            covered.len()
+        );
+    }
+
+    /// REVIEW PROBE: same lever, but the peer shrinks to a set that is smaller
+    /// than the window and yet still not fully covered because the reply was
+    /// cut short by the byte/summarize budget (`entries_sent < len`).
+    #[test]
+    fn probe_budget_cut_round_bypasses_the_frame_guard() {
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(2);
+        let full = sorted_keys(0..64);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+
+        // Round one, full set, window of 8.
+        let s = mgr.begin_summary_window(&peer, &full);
+        let w = rotation_window_indices(full.len(), s, 8);
+        mgr.record_summary_cursor(&peer, *full[*w.last().expect("ne")].id(), w.len(), &full);
+        let before = mgr.peek_summary_cursor(&peer).expect("cursor");
+
+        // Peer advertises a 3-element set; the reply is cut after 2 entries by
+        // the budget, so entries_sent (2) < len (3): guard does not fire.
+        let small = vec![full[0], full[9], full[10]];
+        let sa = mgr.begin_summary_window(&peer, &small);
+        let wa = rotation_window_indices(small.len(), sa, 8);
+        // Simulate a budget cut: send only the first 2 of the window.
+        let sent = &wa[..2];
+        mgr.record_summary_cursor(
+            &peer,
+            *small[*sent.last().expect("ne")].id(),
+            sent.len(),
+            &small,
+        );
+        let after = mgr.peek_summary_cursor(&peer).expect("cursor");
+        eprintln!(
+            "PROBE budget-cut: start_in_small={sa} window={wa:?} moved={} rejections={}",
+            before != after,
+            mgr.summary_cursor_rejections()
+        );
+        assert_eq!(
+            before, after,
+            "a budget-cut short round against a smaller set moved the cursor"
+        );
+    }
+
+    /// REVIEW PROBE 3: same-SIZE re-composition. The peer never shrinks the
+    /// set below the frame, so the frame guard cannot fire at all; it simply
+    /// advertises a DIFFERENT set of the same size on alternate rounds.
+    #[test]
+    fn probe_same_size_recomposition_pins_the_window() {
+        const LIMIT: usize = 8;
+        let (mgr, _clock) = make_manager();
+        let peer = make_peer_key(3);
+        let full = sorted_keys(0..64);
+
+        let set_a: Vec<ContractKey> = full[0..16].to_vec();
+        let set_b: Vec<ContractKey> = {
+            let mut v = full[0..8].to_vec();
+            v.extend_from_slice(&full[8..15]);
+            v.push(full[63]);
+            v
+        };
+        assert_eq!(set_a.len(), set_b.len());
+
+        mgr.seed_summary_cursor_at_origin(&peer, &set_a, 0);
+        let mut a_starts = HashSet::new();
+        let mut covered = HashSet::new();
+        for _ in 0..20 {
+            let s = mgr.begin_summary_window(&peer, &set_a);
+            a_starts.insert(s);
+            let w = rotation_window_indices(set_a.len(), s, LIMIT);
+            for &i in &w {
+                covered.insert(*set_a[i].id());
+            }
+            mgr.record_summary_cursor(&peer, *set_a[*w.last().expect("ne")].id(), w.len(), &set_a);
+
+            let sb = mgr.begin_summary_window(&peer, &set_b);
+            let wb = rotation_window_indices(set_b.len(), sb, LIMIT);
+            mgr.record_summary_cursor(
+                &peer,
+                *set_b[*wb.last().expect("ne")].id(),
+                wb.len(),
+                &set_b,
+            );
+        }
+        eprintln!(
+            "PROBE3: a_starts={:?} covered_of_set_a={} rejections={}",
+            a_starts,
+            covered.len(),
+            mgr.summary_cursor_rejections()
+        );
+        assert!(
+            a_starts.len() > 1,
+            "PROBE3 PINNED: all set_a rounds began at {a_starts:?}"
+        );
+    }
+
+    /// REVIEW PROBE 4: a shared set that shrinks PERMANENTLY below the frame.
+    /// `cycle_len` never re-frames downward. Is that benign?
+    #[test]
+    fn probe_permanent_shrink_leaves_a_stale_cycle_len() {
+        // Production shape: MAX_SUMMARY_ENTRIES_PER_MESSAGE = 128.
+        const LIMIT: usize = 128;
+        let full = sorted_keys(0..200);
+        let small: Vec<ContractKey> = full[0..40].to_vec();
+        let small_ids: HashSet<ContractInstanceId> = small.iter().map(|k| *k.id()).collect();
+
+        let (mgr, _c) = make_manager();
+        let peer = make_peer_key(4);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+        // Two rounds of 128 over 200: the cycle genuinely completes at 200.
+        for _ in 0..2 {
+            let s = mgr.begin_summary_window(&peer, &full);
+            let w = rotation_window_indices(full.len(), s, LIMIT);
+            mgr.record_summary_cursor(&peer, *full[*w.last().expect("ne")].id(), w.len(), &full);
+        }
+        let before = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+
+        // CONTROL: an identically-driven cursor that starts life framed at 40.
+        let (ctl, _c2) = make_manager();
+        let cpeer = make_peer_key(5);
+        ctl.seed_summary_cursor_at_origin(&cpeer, &small, 0);
+
+        // The set drops to 40 and stays there.
+        let mut stale_entries = Vec::new();
+        let mut ctl_entries = Vec::new();
+        let mut stale_cov: Vec<usize> = Vec::new();
+        for _ in 0..50 {
+            let s = mgr.begin_summary_window(&peer, &small);
+            let w = rotation_window_indices(small.len(), s, LIMIT);
+            let cov: HashSet<ContractInstanceId> = w.iter().map(|&i| *small[i].id()).collect();
+            stale_cov.push(cov.len());
+            stale_entries.push(w.len());
+            mgr.record_summary_cursor(&peer, *small[*w.last().expect("ne")].id(), w.len(), &small);
+
+            let cs = ctl.begin_summary_window(&cpeer, &small);
+            let cw = rotation_window_indices(small.len(), cs, LIMIT);
+            ctl_entries.push(cw.len());
+            ctl.record_summary_cursor(
+                &cpeer,
+                *small[*cw.last().expect("ne")].id(),
+                cw.len(),
+                &small,
+            );
+        }
+        let after = mgr.peek_summary_cursor_state(&peer).expect("cursor");
+        eprintln!(
+            "RESIDUAL-A stale: cycle_len {}->{} advertised {}->{} last_sent_moved={} \
+             rejections={} entries/round={:?} coverage/round(min,max)=({},{})",
+            before.cycle_len,
+            after.cycle_len,
+            before.advertised_in_cycle,
+            after.advertised_in_cycle,
+            before.last_sent != after.last_sent,
+            mgr.summary_cursor_rejections(),
+            &stale_entries[..3],
+            stale_cov.iter().min().expect("ne"),
+            stale_cov.iter().max().expect("ne"),
+        );
+        let cc = ctl.peek_summary_cursor_state(&cpeer).expect("cursor");
+        eprintln!(
+            "RESIDUAL-A control: cycle_len={} advertised={} rejections={} entries/round={:?}",
+            cc.cycle_len,
+            cc.advertised_in_cycle,
+            ctl.summary_cursor_rejections(),
+            &ctl_entries[..3],
+        );
+
+        assert!(small_ids.len() == 40);
+        assert_eq!(
+            stale_cov.iter().copied().min().expect("ne"),
+            40,
+            "BENIGN-CLAIM-A: every round must still cover the whole shrunken set"
+        );
+        assert_eq!(
+            stale_entries, ctl_entries,
+            "BENIGN-CLAIM-B: a stale cycle_len must not cost extra entries vs a correctly-framed cursor"
+        );
+
+        // Recovery: the set grows back to 200.
+        let mut regrown = HashSet::new();
+        for _ in 0..2 {
+            let s = mgr.begin_summary_window(&peer, &full);
+            let w = rotation_window_indices(full.len(), s, LIMIT);
+            for &i in &w {
+                regrown.insert(i);
+            }
+            mgr.record_summary_cursor(&peer, *full[*w.last().expect("ne")].id(), w.len(), &full);
+        }
+        eprintln!(
+            "RESIDUAL-A recovery: covered {}/200 in 2 rounds",
+            regrown.len()
+        );
+        assert_eq!(
+            regrown.len(),
+            200,
+            "BENIGN-CLAIM-C: the rotation must resume on regrowth"
+        );
+    }
+
+    /// REVIEW PROBE 5: the same permanent shrink, but the reply is CUT by the
+    /// byte budget so `entries_sent < len` and the frame guard never fires.
+    #[test]
+    fn probe_permanent_shrink_with_a_budget_cut_latches_completion() {
+        let full = sorted_keys(0..200);
+        let small: Vec<ContractKey> = full[0..40].to_vec();
+        const CUT: usize = 20;
+
+        let (mgr, _c) = make_manager();
+        let peer = make_peer_key(6);
+        mgr.seed_summary_cursor_at_origin(&peer, &full, 0);
+        for _ in 0..2 {
+            let s = mgr.begin_summary_window(&peer, &full);
+            let w = rotation_window_indices(full.len(), s, 128);
+            mgr.record_summary_cursor(&peer, *full[*w.last().expect("ne")].id(), w.len(), &full);
+        }
+
+        let mut completions = 0usize;
+        let mut prev_adv = mgr
+            .peek_summary_cursor_state(&peer)
+            .expect("c")
+            .advertised_in_cycle;
+        let mut covered = HashSet::new();
+        for _ in 0..60 {
+            let s = mgr.begin_summary_window(&peer, &small);
+            let now = mgr.peek_summary_cursor_state(&peer).expect("c");
+            if now.advertised_in_cycle < prev_adv {
+                completions += 1;
+            }
+            let w = rotation_window_indices(small.len(), s, CUT);
+            for &i in &w {
+                covered.insert(i);
+            }
+            mgr.record_summary_cursor(&peer, *small[*w.last().expect("ne")].id(), w.len(), &small);
+            prev_adv = mgr
+                .peek_summary_cursor_state(&peer)
+                .expect("c")
+                .advertised_in_cycle;
+        }
+        let c = mgr.peek_summary_cursor_state(&peer).expect("c");
+        eprintln!(
+            "RESIDUAL-B: cycle_len={} advertised={} (never reset; 60 rounds x {CUT}) \
+             count_resets={completions} covered={}/40 rejections={}",
+            c.cycle_len,
+            c.advertised_in_cycle,
+            covered.len(),
+            mgr.summary_cursor_rejections()
+        );
+        assert_eq!(covered.len(), 40, "coverage must still be complete");
+        assert!(
+            completions > 0,
+            "OBSERVATION: the cycle count never resets again"
         );
     }
 }


### PR DESCRIPTION
## Problem

The periodic InterestSync anti-entropy reply advertises a bounded **rotating window** of the shared contract set (#5155, extended to the digest form by #5238). A per-peer cursor makes successive windows contiguous in id space, which is what gives the `ceil(len / limit)` coverage bound — and that bound is the entire cost argument for bounding the reply in the first place.

`first_index_after` is `partition_point(|c| c.id().as_bytes() <= after)`, so it returns `sorted.len()` for **two different situations**, and the cursor kept no memory of where the cycle began, so the code could not tell them apart:

- the cursor is genuinely past the end of the set — a real cycle **boundary**;
- the cursor sits **on the highest id** — a mid-cycle **wrap**, and precisely the wrap `rotation_window_indices`'s coverage argument depends on, since a window ending at index `len - 1` must be followed by index 0.

Any round whose window ended on the last index therefore drew a fresh random origin partway through a cycle. It fires on about `1 / limit` of cycles independently of set size, so the documented bound is overstated in shipped code and some shared contracts wait up to an extra full cycle before being advertised to that peer.

**Two rustdocs described the defect as intended behaviour**, which is the more expensive half of the bug — both are corrected rather than softened:

- `summary_window_start`'s own doc listed "the previous window ending on the highest id" as a cycle boundary.
- `node.rs::digest_rotation_covers_the_whole_shared_set` called it *"deliberate anti-starvation behaviour rather than a bug"* and seeded both the cursor and the RNG to work around the ~1% flake it caused. The test was right and the production code was wrong.

Closes #5181.

## Approach

Re-implemented against current `main` rather than rebasing #5311 (@sanity), whose analysis and test traps this carries. See *Relationship to #5311* below for why a rebase was the wrong shape.

`SummaryCursor` replaces the bare `ContractInstanceId`, carrying a per-cycle entry count so a wrap is distinguishable from a completed cycle. Three mechanisms, and they are **jointly** necessary rather than independently nice:

**1. Mid-cycle wraps.** `begin_summary_window` resumes with `first_index_after(..) % len`. The `% len` is what was missing.

**2. The boundary is ATOMIC.** Replies are separate tasks and each awaits a storage hit per contract, so two `Interests` from one peer straddling a boundary is routine. Drawing an origin without publishing it let both racers see no cursor, draw *different* origins, and have both entry counts charged to one cycle for two non-contiguous windows — the count running ahead of the ground covered, which is this bug's own failure class. The origin is now drawn **and published** under one lock hold, storing the origin's *predecessor* so `first_index_after` resolves it back to the origin. `GlobalRng` is thread-local, so drawing under the lock cannot deadlock.

**3. A record must ADVANCE the cycle by exactly what it sent**, measured **circularly** from the previous position. Without it a slow reply carrying an earlier window records last, both double-charging the cycle and rewinding `last_sent` so covered ground is re-sent.

No well-formed round is ever rejected, and that is an identity rather than a case list: a round resuming at `prev_pos` and sending `k` contiguous entries ends at `(prev_pos + k - 1) % len`, so the recorded position is `(prev_pos + k) % len` and the circular advance is `k % len` — which is `k` when `k < len` and `0` when `k == len`, both equal to `entries_sent % len`.

### Completion is measured against a frame the peer cannot move

This is the part a reviewer should look at hardest, because the obvious version of it was **worse than the bug**.

`sorted` is the intersection with the hashes the *peer* advertised. If completion compared the count against the current `sorted.len()`, a peer alternating a one-hash `Interests` with a full one would end our cycle on demand and re-seed the rotation from an id it picked. Pre-#5181 that same schedule hit a boundary and drew a random offset, so coverage was coupon-collector but **complete**. Shipping the naive version would have traded a random, self-correcting failure for a deterministic, permanent one.

So `SummaryCursor::cycle_len` records the set size the cycle **began** with. A one-element round contributes one entry towards a target the peer cannot move. And a round built against a set *smaller* than that frame is **ignored** rather than applied: its last id is not a position in this cycle's ground, and applying it dragged `last_sent` to wherever the small set happened to end. Measured over the adversarial alternating schedule, coverage goes from **26/64 to the whole set**.

Under genuine churn `cycle_len` is approximate in both directions — a set that grew completes early (an arc waits an extra cycle), one that shrank completes late — but both are bounded by one cycle, unlike the unbounded starvation the peer-controlled version allows. A positional (geometric) notion of completion would additionally make a staleness bound stateable under churn: that is #5313.

### The rejection wedge is bounded

A rejected record leaves the cursor untouched, so if some caller-side defect made every record ill-formed, the same window would be re-sent forever and every other contract starved for the process lifetime — strictly worse than the staleness the check exists to stop, and exactly the unbounded-exemption shape `.claude/rules/ring.md` warns about. After `MAX_CONSECUTIVE_CURSOR_REJECTIONS` the next window is treated as a boundary, degrading to a fresh random origin rather than to silence.

The discard also logs at `debug` with the peer, the advance, the entry count and the run length. The counter existed before but was readable only from tests, so the only field symptom of a wedge was "this peer quietly stops converging on most contracts" — the exact class #5155/#5238/#5338 spent months chasing.

## Invariant touched

Per `.claude/rules/hosting-invariants.md`'s own instruction — that file is at the freenet **workspace** level (`~/code/freenet/.claude/rules/`), not inside this repo's `.claude/rules/`, which is why a repo search does not find it.

This touches **invariant 1 only**: freshness is live fan-out **plus** periodic InterestSync anti-entropy, each round advertising a bounded rotating window of the shared set.

**The revisit bound, stated honestly.** The within-cycle coverage bound is `ceil(shared / limit)` — every contract is advertised at least once per cycle. The **revisit** bound is `2 * ceil(shared / limit) - 1`, because a completed cycle draws a fresh random origin, so a contract covered early in one cycle and late in the next waits up to two cycles. Measured at `shared = 200`: worst-case gaps of 6, 7, 7, 7, 6, 7 against a single-cycle figure of 4.

**An earlier revision of this PR tried to deliver the single-cycle figure by making completed cycles continue contiguously. That was reverted, and the reason is the important part:** the redraw is the only defence against a peer *steering* the rotation. A record is validated by its circular advance within `sorted`, and `sorted` is our set intersected with what the **peer** advertised — so the record is not even dishonest; the peer really did receive those entries. Steering happens when an id is resolved against a set the peer composed, which no record-level check on that advance can see. What bounds it is that completion periodically destroys any position the peer arranged. With the redraw removed, three separate attacks pinned the rotation permanently, advertising 8 of 64 contracts forever with **zero rejections logged** — no field symptom at all. Those attacks are now permanent regression tests (`probe_*`, below).

So invariant 1's single-cycle form is **not** fully restored here, and this PR corrects the claim rather than the code. Delivering `ceil(shared / limit)` needs a cursor whose position is not resolved through the peer's set at all — a positional notion of completion, tracked as **#5313**. `hosting-invariants.md` carried the same single-cycle figure and has been corrected in place, with the steering reason recorded so nobody retries the contiguous version.

Nothing hosted, retained, or evicted changes and no new copy is created, so invariants 2 through 5 are untouched. No wire-format change.

## What the frame guard does, and why it has two clauses

`len < cycle_len && (entries_sent >= len || len * 2 < cycle_len)`. The two clauses cover different cases and neither implies the other — each has its own pin, and dropping either leaves the other's tests green:

- `entries_sent >= len` — the round covered the **whole** set, so it wrapped to where it started: circular advance 0, `entries_sent % len` 0, and any last id passes. The advance check is vacuous, so the record is not applied.
- `len * 2 < cycle_len` — a **material** shrink. Below that the advance check is not vacuous, but it is still measured in the *peer's* index space, so a well-formed advance of k positions inside a peer-composed set is an arbitrary jump across the ground the cycle sweeps.

Ordinary churn satisfies neither, which is the point: an earlier revision rejected any round one element below the frame, costing a measured **50% more anti-entropy bandwidth** for the same coverage (6 rounds and 3 rejections to cover a 200-contract set losing one element on alternate rounds, versus 4 and none).

**A fix shape that was NOT evaluated, so the next person does not assume it was:** bounding the record's advance in **id space** as a record-level *rejection check*. What was measured is a different thing — a positional *boundary rule* (a cursor advanced by fair share of id space), which scored 9/16 coverage against an attack and 9/16 against an **honest** peer, because `cycle_len` says how many entries exist and not how they are spread, and the peer picks the spread. That result rules out the positional cursor; it does not rule out an id-space rejection check, which is folded into #5313.

## Tests

Nine added since the original design, none removed, none weakened:

- **Five `probe_*` gates**, written by review and kept permanently. They encode the pinning attacks: a peer with a set larger than the limit, a budget-cut round, same-size recomposition, and two permanent-shrink residuals. All five fail on the reverted design and pass here.
- `an_ordinary_shrink_is_not_rejected` — the churn case, which had no coverage (the existing churn test only ever *grows* the set, 20 → 40).
- `a_whole_set_round_is_rejected_even_when_the_shrink_is_not_material` — pins the whole-set clause.
- `a_peer_cannot_drive_the_rotation_through_the_rejection_escape_hatch`
- `the_revisit_gap_spans_at_most_two_cycles` — the honest bound.

**Two of these passed for the wrong reason before being fixed**, which is worth recording because it is the same failure this PR is about: an earlier revisit test passed only because it ran exactly *one* cycle, and an earlier whole-set test passed under the very mutation that deleted the clause it existed to pin (the redraw was scattering the origin behind it). Both were caught by mutation, not by reading.

Note also that `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` drives a **one-element** set, so `entries_sent >= len` is `1 >= 1` on every round — it is green before the narrowing, after it, and under a mutation removing it. Its passing is not evidence of anything.

## Testing

`cargo test -p freenet --lib` — full suite green. Rotation subset (`ring::interest::tests`, `node::tests::hash_first_summaries`): **149 passed, 0 failed**. `cargo clippy -p freenet --all-targets -- -D warnings` clean (exit status captured directly, not through a pipe). `cargo fmt --all --check` clean.

### Red-then-green, verified by mutation

Each mutation keeps the code compiling so the mutation is behavioural, and the tree is checked clean afterwards (`git diff` empty, so nothing leaked).

All seven were run against the final head, not an earlier one.

| # | mutation | test that goes red |
|---|---|---|
| 1 | restore main's rule (a cursor at `len` reads as a boundary) | `a_window_ending_on_the_highest_id_wraps_instead_of_re_randomising`, `the_real_api_covers_every_contract_from_every_origin` |
| 2 | delete the circular-advance check | `records_must_advance_the_cycle_and_forward_is_circular` |
| 3 | draw the boundary without publishing it | `a_published_boundary_makes_a_second_reader_agree_on_the_origin` |
| 4 | replace the count's `saturating_add` with a bare assignment | `a_cycle_completes_and_then_re_randomises` |
| 5 | compare completion against the CURRENT `len` (the peer-movable frame) | `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` |
| 6 | drop the smaller-frame guard, applying small-set rounds | `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window` |
| 7 | `random_range(..)` → `0` at the boundary | `summary_window_start_draws_its_offset_from_global_rng` |

Row 4 is the one worth naming: before that test was added, **every other test in the module stayed green** under the mutation, while cycles would never complete for `limit < len`, so the boundary redraw never fires again and tail starvation returns silently.

Rows 5 and 6 are the two halves of the peer-steering defence, and row 7 is the pin this PR had disarmed — on the previous head it stayed **green** under that mutation.

### New tests

- `a_window_ending_on_the_highest_id_wraps_instead_of_re_randomising` — the regression test proper. Constructs the failing state directly over seven set sizes rather than waiting for the ~1-in-`limit` chance that produced the original flake, and repeats each so a lucky random draw of 0 cannot pass for a correct wrap.
- `the_real_api_covers_every_contract_from_every_origin` — sweeps **every** origin for five `(len, limit)` shapes through `begin_summary_window` + `record_summary_cursor`. This matters: the pre-existing `rotation_covers_every_contract_within_ceil_n_over_limit_rounds` stayed green through this entire bug because it drives the *pure helpers* with a test-local resume rule that wraps on its own, and the defect lived in the resume decision **between** them.
- `a_published_boundary_makes_a_second_reader_agree_on_the_origin` — 40 trials, so a coincidental agreement between two independent draws cannot carry it.
- `records_must_advance_the_cycle_and_forward_is_circular` — six cases, one per trap: circular not linear (a wrapping window's last entry sorts *below* the previous one); the whole-set round whose advance is legitimately 0; stale; duplicate; `len == 1`.
- `a_cycle_completes_and_then_re_randomises`, `a_run_of_rejected_records_falls_back_to_a_boundary`, `a_record_with_no_cursor_starts_a_fresh_cycle`, `a_peer_that_shrinks_the_shared_set_cannot_pin_the_window`.

### A guard this PR had disarmed, now re-armed

Worth flagging explicitly because it is the failure class the repo already documents. Renaming the function left `summary_window_start_draws_its_offset_from_global_rng` looking for `pub(crate) fn summary_window_start(`, which then matched only its own `.expect` string literal. The extracted "body" spanned the assertion, whose text contains `"GlobalRng::random_range"`, so the pin passed **vacuously** and a `random_range(..) -> 0` mutation stayed green. It is re-pointed at the new name and given the land-in-production guard the #5076 precedent calls for, so a future rename fails loudly instead of silently.

## Relationship to #5311

#5311 (@sanity) diagnosed this correctly and its analysis is the basis for this change — the wrap-versus-boundary distinction, the atomic boundary, and all three traps in the advance check are its findings, carried over with credit. This supersedes it rather than rebasing it, for reasons that are about the diff rather than the diagnosis:

- The conflict surface is the whole change: **+1485/-69 across exactly the two files `main` rewrote** in #5155/#5238/#5338/#5346, from a merge base 56 commits back.
- #5311's model of `node.rs` predates three changes it does not account for: #5238 made the cursor serve **both** wire forms with no form gate (it gates its record on `FullBytes`), #5338 added a no-peer-key degraded path, and the window is sized by `MAX_SUMMARY_ENTRIES_PER_MESSAGE` rather than the per-form summarize cap it reasons in terms of.
- Decisively: #5311's own measurements show no subset is shippable — the atomic boundary alone fails 17/40 and the advance check alone fails 39/40, on *different* assertions — and its minimal-fix commit flakes 8/40 and 13/40 where `main` is 40/40. Hand-resolving ~1300 lines of conflicted tests whose fixtures encode renamed APIs is exactly where a wrong resolution hides, and a partial resolution lands in a measured 43%-failure cell.

I verified the one thing that could have invalidated its premise: `main`'s per-form `summarize_cap` **breaks** the loop rather than skipping entries, and the byte-budget check breaks too, so `entries.len()` is still exactly the contiguous window prefix and the advance identity holds.

[AI-assisted - Claude]

