### PR TITLE
fix(ping): send the difference from get_state_delta, not the whole state

### DIFF
--- a/apps/freenet-ping/contracts/ping/src/lib.rs
+++ b/apps/freenet-ping/contracts/ping/src/lib.rs
@@ -184,6 +184,20 @@ impl ContractInterface for Contract {
         )))
     }
 
+    /// The summary is the whole state, deliberately.
+    ///
+    /// A summary's job is to let the far side work out exactly what we are missing,
+    /// and for this contract the state IS the set of observations — there is no
+    /// smaller thing that still answers "which timestamps do you not have". A
+    /// contract with a compressible state (a version vector, a Merkle root, a set of
+    /// per-peer high-water marks) should summarise instead of copying, and would
+    /// send far less over the wire on every sync.
+    ///
+    /// What matters for the merge laws is that the DELTA is small, and
+    /// `get_state_delta` below makes it so. Sending a large summary costs one
+    /// round-trip's bandwidth; returning a large delta costs the whole state on
+    /// every update, which is what the `whole_state_self_delta` diagnostic exists to
+    /// flag.
     fn summarize_state(
         _parameters: Parameters<'static>,
         state: State<'static>,
@@ -211,6 +225,17 @@ impl ContractInterface for Contract {
         Ok(StateSummary::from(state.to_vec()))
     }
 
+    /// The delta is what we hold and the recipient does not — not the whole state.
+    ///
+    /// This used to merge the summary into our state and return the result, so every
+    /// delta was a full state copy and a delta against our OWN summary was still the
+    /// entire state. The conformance verifier reports that as `self_delta_empty` and
+    /// `whole_state_self_delta` (#5072): both are diagnostics, so neither breaks a
+    /// merge law, but "synchronisation saves nothing" is not what this contract
+    /// should be teaching.
+    ///
+    /// See `Ping::delta_against` for why a difference is sufficient: `merge` is a
+    /// union, so applying `S \ R` to `R` reaches the same state as applying `S`.
     fn get_state_delta(
         parameters: Parameters<'static>,
         state: State<'static>,
@@ -223,13 +248,20 @@ impl ContractInterface for Contract {
             summary.as_ref().len()
         ));
 
+        // Parsed for validation only. The TTL is deliberately NOT applied here:
+        // pruning is the receiving merge's job, and pruning on the sender's side
+        // would be deciding what the recipient may keep on its behalf.
+        // Only the log line below reads this, and that is compiled out without the
+        // `contract` feature — but the parse itself is NOT decoration: a malformed
+        // parameters blob must be rejected here as it is in every other entry point.
+        #[cfg_attr(not(feature = "contract"), allow(unused_variables))]
         let opts = serde_json::from_slice::<PingContractOptions>(parameters.as_ref())
             .map_err(|e| ContractError::Deser(e.to_string()))?;
 
         #[cfg(feature = "contract")]
         freenet_stdlib::log::info(&format!("[GET_STATE_DELTA] Contract options: {opts:?}"));
 
-        let mut ping = if state.is_empty() {
+        let ping = if state.is_empty() {
             #[cfg(feature = "contract")]
             freenet_stdlib::log::info("[GET_STATE_DELTA] Empty state, using default Ping");
 
@@ -258,12 +290,19 @@ impl ContractInterface for Contract {
             ps
         };
 
-        ping.merge(ping_summary, opts.ttl);
+        let Some(delta) = ping.delta_against(&ping_summary) else {
+            #[cfg(feature = "contract")]
+            freenet_stdlib::log::info("[GET_STATE_DELTA] Recipient is up to date, empty delta");
+
+            // Nothing to send. An empty delta is the honest answer and is what makes
+            // the `self_delta_empty` law hold; `update_state` skips empty deltas.
+            return Ok(StateDelta::from(Vec::new()));
+        };
 
         #[cfg(feature = "contract")]
-        freenet_stdlib::log::info(&format!("[GET_STATE_DELTA] Merged result: {ping:?}"));
+        freenet_stdlib::log::info(&format!("[GET_STATE_DELTA] Delta: {delta:?}"));
 
-        let result = serde_json::to_vec(&ping).map_err(|e| ContractError::Other(e.to_string()))?;
+        let result = serde_json::to_vec(&delta).map_err(|e| ContractError::Other(e.to_string()))?;
 
         #[cfg(feature = "contract")]
         freenet_stdlib::log::info(&format!(

--- a/apps/freenet-ping/types/src/lib.rs
+++ b/apps/freenet-ping/types/src/lib.rs
@@ -993,6 +993,91 @@ mod tests {
         );
     }
 
+    /// Padding alone can be the whole difference.
+    ///
+    /// The case is two peers that already agree on every observation and disagree
+    /// only on padding: `missing` is empty and the delta exists solely to carry the
+    /// side that wins. Nothing covered it —
+    /// `applying_the_delta_reaches_the_same_state_as_applying_the_whole_state` also
+    /// has a `from` difference, so it cannot distinguish padding being handled from
+    /// padding riding along, and `a_delta_against_our_own_state_is_nothing` has both
+    /// sides identical.
+    ///
+    /// The assertions are deliberately not a restatement of the tie-break, because a
+    /// restatement would agree with a broken rule as readily as a correct one. Both
+    /// are derived from what `merge` actually does with the whole state: the delta
+    /// must leave the recipient where the whole state would have left it, and it must
+    /// carry padding exactly when the whole state would have changed the recipient's.
+    #[test]
+    fn a_delta_can_be_nothing_but_padding() {
+        let ttl = Duration::from_secs(60);
+        let observed = vec![
+            Utc::now() - Duration::from_secs(10),
+            Utc::now() - Duration::from_secs(20),
+        ];
+
+        // Both arms of the length comparison, both arms of the equal-length content
+        // tie-break, both `None` arms, and the case where there is nothing to choose.
+        let cases = [
+            (Some(vec![0xAA_u8; 32]), None),
+            (None, Some(vec![0xAA; 32])),
+            (Some(vec![0xAA; 64]), Some(vec![0xAA; 32])),
+            (Some(vec![0xAA; 32]), Some(vec![0xAA; 64])),
+            (Some(vec![0x02; 16]), Some(vec![0x01; 16])),
+            (Some(vec![0x01; 16]), Some(vec![0x02; 16])),
+            (Some(vec![0xAA; 16]), Some(vec![0xAA; 16])),
+        ];
+
+        for (ours, theirs) in cases {
+            let mut recipient = Ping::new();
+            recipient.from.insert("Alice".to_string(), observed.clone());
+            recipient.padding = theirs;
+            let mut sender = Ping::new();
+            sender.from.insert("Alice".to_string(), observed.clone());
+            sender.padding = ours;
+
+            let delta = sender.delta_against(&recipient);
+            if let Some(delta) = &delta {
+                assert!(
+                    delta.from.is_empty(),
+                    "the observations are identical, so a non-empty `from` means \
+                     this fixture is exercising some other branch: {sender:?} \
+                     against {recipient:?}"
+                );
+            }
+
+            let mut via_state = recipient.clone();
+            via_state.merge(sender.clone(), ttl);
+            let mut via_delta = recipient.clone();
+            if let Some(delta) = delta.clone() {
+                via_delta.merge(delta, ttl);
+            }
+
+            assert_eq!(
+                via_delta.padding, via_state.padding,
+                "sending the difference must leave the recipient's padding where \
+                 sending the whole state would have left it, or two peers that \
+                 agree on every observation disagree forever on padding neither is \
+                 wrong about: ours {:?}, theirs {:?}",
+                sender.padding, recipient.padding
+            );
+            assert_eq!(
+                *via_delta, *via_state,
+                "and it must not disturb the observations either"
+            );
+            assert_eq!(
+                delta.as_ref().and_then(|d| d.padding.as_ref()).is_some(),
+                via_state.padding != recipient.padding,
+                "the delta must carry padding exactly when merging the whole state \
+                 would have changed the recipient's: carrying it otherwise is \
+                 bandwidth the recipient discards, and not carrying it when the \
+                 whole state would have is a lost update. ours {:?}, theirs {:?}",
+                sender.padding,
+                recipient.padding
+            );
+        }
+    }
+
     /// The difference must not be quadratic in the size of the state.
     ///
     /// Nothing between the wire and here bounds the input: `validate_state` accepts

--- a/apps/freenet-ping/types/src/lib.rs
+++ b/apps/freenet-ping/types/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, fmt::Display, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+    time::Duration,
+};
 
 use chrono::{DateTime, Utc};
 
@@ -391,6 +395,22 @@ impl Ping {
     /// Padding is carried only when ours would win the merge's comparison, for the
     /// same reason: sending it otherwise changes nothing on arrival.
     ///
+    /// # Membership goes through a set, and that is not a micro-optimisation
+    ///
+    /// The obvious way to write the difference is to scan the recipient's vector for
+    /// each of our timestamps. That is `O(n·m)`, and nothing upstream of here bounds
+    /// `n` or `m`: `validate_state` accepts any state that deserializes, so the only
+    /// ceiling is the node's 50 MiB `MAX_STATE_SIZE` — on the order of a million
+    /// timestamps. Measured on the linear version: 2.5 ms at 3,000 entries, 289 ms at
+    /// 30,000, 3.4 s at 100,000, which extrapolates past any plausible WASM execution
+    /// budget well before the state limit is reached.
+    ///
+    /// Building a set once per peer name makes it `O((n + m) log m)` for a few lines,
+    /// and it does not assume the vectors are sorted. `retain_history` does sort them,
+    /// so a binary search would usually work — but "usually" is the wrong standard
+    /// here, because a client can PUT hand-built JSON that `validate_state` accepts
+    /// unsorted, and the difference would then silently be wrong rather than slow.
+    ///
     /// # Example
     ///
     /// ```
@@ -422,10 +442,17 @@ impl Ping {
     pub fn delta_against(&self, recipient: &Self) -> Option<Self> {
         let mut missing: BTreeMap<String, Vec<DateTime<Utc>>> = BTreeMap::new();
         for (name, timestamps) in &self.from {
-            let held = recipient.from.get(name);
+            // A set, not a scan of the recipient's vector: see the note on
+            // complexity above. `BTreeSet` rather than `HashSet` because this
+            // compiles into a contract and a std hasher is one more thing that has
+            // to behave identically on every node.
+            let held: Option<BTreeSet<DateTime<Utc>>> = recipient
+                .from
+                .get(name)
+                .map(|held| held.iter().copied().collect());
             let new_entries: Vec<DateTime<Utc>> = timestamps
                 .iter()
-                .filter(|t| held.is_none_or(|h| !h.contains(t)))
+                .filter(|t| held.as_ref().is_none_or(|h| !h.contains(*t)))
                 .copied()
                 .collect();
             if !new_entries.is_empty() {
@@ -963,6 +990,89 @@ mod tests {
             "a peer that already holds our exact state must be sent nothing; \
              returning the state instead makes synchronisation cost as much as a \
              full transfer every time"
+        );
+    }
+
+    /// The difference must not be quadratic in the size of the state.
+    ///
+    /// Nothing between the wire and here bounds the input: `validate_state` accepts
+    /// any state that deserializes, so the ceiling is the node's 50 MiB
+    /// `MAX_STATE_SIZE`. A scan of the recipient's vector per timestamp is `O(n·m)`
+    /// and stops being merely slow well before that.
+    ///
+    /// This is a wall-clock assertion, which is normally a bad idea, so the numbers
+    /// it rests on are worth stating. Measured in the debug profile CI builds, at
+    /// the 50,000 entries used here: about 40 ms with set membership and about 8.6 s
+    /// with the linear scan. The budget below sits roughly 75x above the first and
+    /// 3x below the second, and a slower machine moves both of them in the same
+    /// direction — so it fails on the algorithm, not on the load average.
+    #[test]
+    fn the_difference_is_not_quadratic_in_the_size_of_the_state() {
+        const N: i64 = 50_000;
+        const BUDGET: Duration = Duration::from_secs(3);
+
+        let base = Utc::now();
+        let shared: Vec<DateTime<Utc>> = (0..N)
+            .map(|i| base + chrono::TimeDelta::seconds(i))
+            .collect();
+
+        let mut recipient = Ping::new();
+        recipient.from.insert("Alice".to_string(), shared.clone());
+        let mut sender = Ping::new();
+        let mut ours = shared;
+        ours.push(base + chrono::TimeDelta::seconds(N + 1));
+        sender.from.insert("Alice".to_string(), ours);
+
+        let started = std::time::Instant::now();
+        let delta = sender
+            .delta_against(&recipient)
+            .expect("the sender holds one entry the recipient does not");
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            delta["Alice"],
+            vec![base + chrono::TimeDelta::seconds(N + 1)],
+            "the difference must still be exactly the entries the recipient lacks"
+        );
+        assert!(
+            elapsed < BUDGET,
+            "computing the difference over {N} entries took {elapsed:?}, over the \
+             {BUDGET:?} budget: membership has gone back to scanning the \
+             recipient's vector, which is quadratic and unbounded"
+        );
+    }
+
+    /// The difference must not assume the vectors are sorted.
+    ///
+    /// `retain_history` does sort them, which makes a binary search look available
+    /// and makes this the tempting way to fix the complexity. It is not safe: a
+    /// client can PUT hand-built JSON, `validate_state` accepts it unsorted, and the
+    /// difference would then be silently wrong rather than slow.
+    #[test]
+    fn the_difference_does_not_assume_sorted_input() {
+        let base = Utc::now();
+        let at = |s: i64| base + chrono::TimeDelta::seconds(s);
+
+        // Deliberately not descending, and with a duplicate, exactly as a hand-built
+        // payload could arrive.
+        let mut recipient = Ping::new();
+        recipient
+            .from
+            .insert("Alice".to_string(), vec![at(10), at(30), at(20), at(30)]);
+        let mut sender = Ping::new();
+        sender
+            .from
+            .insert("Alice".to_string(), vec![at(20), at(40), at(10), at(30)]);
+
+        let delta = sender
+            .delta_against(&recipient)
+            .expect("the sender holds one entry the recipient does not");
+        assert_eq!(
+            delta["Alice"],
+            vec![at(40)],
+            "only the genuinely new entry may be sent; a membership test that \
+             assumes ordering reports entries the recipient already holds, or \
+             misses ones it does not"
         );
     }
 

--- a/apps/freenet-ping/types/src/lib.rs
+++ b/apps/freenet-ping/types/src/lib.rs
@@ -361,6 +361,98 @@ impl Ping {
     pub fn is_empty(&self) -> bool {
         self.from.is_empty()
     }
+
+    /// What this state holds that `recipient` does not: the payload a delta should
+    /// carry.
+    ///
+    /// Returns `None` when the recipient is already up to date, which is the case a
+    /// delta exists to make cheap.
+    ///
+    /// # Why a delta is a difference and not the whole state
+    ///
+    /// A contract is free to return its entire state from `get_state_delta` and
+    /// still be correct — this one used to — but then synchronising costs the same
+    /// as transferring the state from scratch every time, and the conformance
+    /// verifier reports it (`self_delta_empty`, `whole_state_self_delta`; #5072).
+    /// Those are diagnostics rather than merge-law violations: wasteful, not wrong.
+    /// For the contract we hold up as the worked example, wasteful is reason enough.
+    ///
+    /// The correctness argument is short, and worth following because it is the
+    /// argument any delta implementation owes:
+    ///
+    /// - The recipient's summary IS its state (see `summarize_state`), so
+    ///   `recipient` here is exactly what the far side holds.
+    /// - `merge` is a union followed by a prune, so merging the difference gives
+    ///   `R ∪ (S \ R)`, which is `R ∪ S` — the same set as merging the whole state.
+    /// - The prune is anchored on the newest timestamp in that union, and dropping
+    ///   entries the recipient already has cannot change its maximum, so both paths
+    ///   prune identically too.
+    ///
+    /// Padding is carried only when ours would win the merge's comparison, for the
+    /// same reason: sending it otherwise changes nothing on arrival.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use freenet_ping_types::Ping;
+    /// # use std::time::Duration;
+    /// let ttl = Duration::from_secs(60);
+    ///
+    /// let mut recipient = Ping::new();
+    /// recipient.insert("alice".to_string());
+    ///
+    /// let mut sender = recipient.clone();
+    /// sender.insert("bob".to_string());
+    ///
+    /// // Only bob's observation is new, so only bob's is sent.
+    /// let delta = sender.delta_against(&recipient).expect("bob is missing");
+    /// assert!(delta.contains_key("bob"));
+    /// assert!(!delta.contains_key("alice"));
+    ///
+    /// // Applying it reaches the same state as sending everything.
+    /// let mut via_delta = recipient.clone();
+    /// via_delta.merge(delta, ttl);
+    /// let mut via_state = recipient.clone();
+    /// via_state.merge(sender.clone(), ttl);
+    /// assert_eq!(*via_delta, *via_state);
+    ///
+    /// // And a peer already holding our state is sent nothing at all.
+    /// assert!(sender.delta_against(&sender.clone()).is_none());
+    /// ```
+    pub fn delta_against(&self, recipient: &Self) -> Option<Self> {
+        let mut missing: BTreeMap<String, Vec<DateTime<Utc>>> = BTreeMap::new();
+        for (name, timestamps) in &self.from {
+            let held = recipient.from.get(name);
+            let new_entries: Vec<DateTime<Utc>> = timestamps
+                .iter()
+                .filter(|t| held.is_none_or(|h| !h.contains(t)))
+                .copied()
+                .collect();
+            if !new_entries.is_empty() {
+                missing.insert(name.clone(), new_entries);
+            }
+        }
+
+        // Exactly the comparison `merge` uses, so the delta carries padding in
+        // precisely the cases where merging the full state would have adopted ours.
+        let padding = match (&self.padding, &recipient.padding) {
+            (Some(ours), Some(theirs)) => match ours.len().cmp(&theirs.len()) {
+                std::cmp::Ordering::Greater => Some(ours.clone()),
+                std::cmp::Ordering::Less => None,
+                std::cmp::Ordering::Equal => (theirs < ours).then(|| ours.clone()),
+            },
+            (Some(ours), None) => Some(ours.clone()),
+            (None, _) => None,
+        };
+
+        if missing.is_empty() && padding.is_none() {
+            return None;
+        }
+        Some(Self {
+            from: missing,
+            padding,
+        })
+    }
 }
 
 impl Display for Ping {
@@ -793,6 +885,84 @@ mod tests {
             "two of the three tail entries are inside the window and one is not, so \
              pruning genuinely ran; equal-but-unpruned would satisfy commutativity \
              while saying nothing about it"
+        );
+    }
+
+    /// Applying the delta must reach the same state as applying the whole thing.
+    ///
+    /// This is the property that makes shrinking the delta safe, and it is the one
+    /// worth copying: a delta is an optimisation, and an optimisation you cannot
+    /// state an equivalence for is a guess. The pair here straddles the expiry
+    /// boundary on purpose, because the prune is where the two paths could most
+    /// easily diverge — the reference instant is derived from the union, and the
+    /// delta path unions a smaller set.
+    #[test]
+    fn applying_the_delta_reaches_the_same_state_as_applying_the_whole_state() {
+        let ttl = Duration::from_secs(60);
+        let newest = Utc::now() - Duration::from_secs(600);
+
+        let mut timestamps: Vec<DateTime<Utc>> = (0..MAX_HISTORY_PER_PEER)
+            .map(|i| newest - Duration::from_secs(i as u64))
+            .collect();
+        timestamps.push(newest - Duration::from_secs(45));
+        timestamps.push(newest - Duration::from_secs(75));
+
+        // Overlapping, not disjoint: the recipient already holds most of what the
+        // sender does, which is the ordinary case and the one where a difference is
+        // worth computing at all.
+        let mut recipient = Ping::new();
+        recipient
+            .from
+            .insert("Alice".to_string(), timestamps[..8].to_vec());
+        let mut sender = Ping::new();
+        sender.from.insert("Alice".to_string(), timestamps.clone());
+        sender.padding = Some(vec![0xAB; 32]);
+
+        // What the recipient reaches by being sent the sender's whole state.
+        let mut via_state = recipient.clone();
+        via_state.merge(sender.clone(), ttl);
+
+        // What it reaches by being sent only the difference.
+        let delta = sender
+            .delta_against(&recipient)
+            .expect("the sender holds entries the recipient does not");
+        let mut via_delta = recipient.clone();
+        via_delta.merge(delta.clone(), ttl);
+
+        assert_eq!(
+            *via_state, *via_delta,
+            "merging the difference must reach the same state as merging the whole \
+             state, or shrinking the delta silently loses observations"
+        );
+        assert_eq!(
+            via_state.padding, via_delta.padding,
+            "the delta must carry padding in exactly the cases where merging the \
+             full state would have adopted it"
+        );
+        assert!(
+            delta.len() < sender.len() || delta["Alice"].len() < sender["Alice"].len(),
+            "the delta must actually be smaller than the state, or nothing has been \
+             gained and this test would pass against the old whole-state delta"
+        );
+    }
+
+    /// A delta against an exact copy of our own state has nothing in it.
+    ///
+    /// `self_delta_empty` (#5072) in the conformance verifier, pinned here so it is
+    /// checked without needing to build the WASM and replay a corpus.
+    #[test]
+    fn a_delta_against_our_own_state_is_nothing() {
+        let mut ping = Ping::new();
+        ping.insert("Alice".to_string());
+        ping.insert("Bob".to_string());
+        ping.padding = Some(vec![0xAB; 16]);
+        ping.merge(Ping::new(), Duration::from_secs(60));
+
+        assert!(
+            ping.delta_against(&ping.clone()).is_none(),
+            "a peer that already holds our exact state must be sent nothing; \
+             returning the state instead makes synchronisation cost as much as a \
+             full transfer every time"
         );
     }
 


### PR DESCRIPTION
**Stacked on #5463** — base is `fix/5462-ping-merge-purity`, not `main`. Merge that one first. Split out of it on rule review: the two changes are independently motivated and close different issues, and bundling them was flagged (correctly) as scope creep.

## Problem

`get_state_delta` merged the recipient's summary into our state and returned the whole result:

```rust
ping.merge(ping_summary, opts.ttl);
Ok(StateDelta::from(serde_json::to_vec(&ping)?))
```

So every delta was a full state copy, and a delta against the recipient's *own* summary was still the entire state. `fdev verify-merge` reports both: `self_delta_empty` ("delta against an exact summary of the same state is N bytes, not empty") and `whole_state_self_delta` ("synchronisation saves nothing").

**Both are Diagnostic severity and can never justify removing a contract, so this is not a correctness fix.** Two reasons to do it anyway:

1. It is real bandwidth, spent on every update, for nothing. On a state of any size a peer that is already up to date still receives the whole thing.
2. This is the contract we point new developers at. "Synchronisation saves nothing" is the wrong lesson to hand someone reading it as the reference for how to implement `get_state_delta`.

## Approach

`Ping::delta_against(&self, recipient)` returns what we hold and the recipient does not, or `None` when they are already up to date.

The correctness argument, which is the one any delta implementation owes and is why it is written out in the doc comment rather than assumed:

- The recipient's summary **is** its state (`summarize_state` returns the state), so the argument is exactly what the far side holds.
- `merge` is a union followed by a prune, so applying `S \ R` to `R` gives `R ∪ S` — the same set as applying `S`.
- The prune is anchored on the newest timestamp in that union (see #5463), and dropping entries the recipient already holds cannot lower the maximum, so both paths prune identically too.

Padding is carried only when ours would win the merge's own comparison, by the same reasoning: sending it otherwise changes nothing on arrival.

`summarize_state` still returns the whole state, now with a comment saying why — for this state shape there is no smaller thing that answers "which timestamps do you not have". A contract with a compressible state (a version vector, a Merkle root, per-peer high-water marks) should summarise rather than copy, and the comment points at that. Only the *delta* needs to be small for these two properties.

An empty delta is returned as zero bytes, which is what makes `self_delta_empty` hold; `update_state` already skips empty deltas.

## Testing

Measured with `fdev verify-merge` (v0.2.131) against a corpus with realistic hour-scale TTLs:

| | holds | findings |
|---|---|---|
| **before** | 52/56 | 4 × `self_delta_empty` |
| **after** | **56/56** | **none of any kind** |

The engineered boundary-crossing corpus from #5463 also stays at 32/32 with zero findings.

Two new unit tests, plus a doctest:

- `applying_the_delta_reaches_the_same_state_as_applying_the_whole_state` — the equivalence that makes shrinking the delta safe, over an *overlapping* pair (not disjoint, which would make the delta equal the state and the test vacuous) straddling the expiry boundary, where the two paths could most easily diverge. Asserts the resulting state and padding match, and that the delta is genuinely smaller than the state.
- `a_delta_against_our_own_state_is_nothing` — `self_delta_empty` pinned without needing to build the WASM and replay a corpus.
- A `# Example` doctest on `delta_against` showing both the equivalence and the up-to-date case.

The real multi-node suite passes locally — `cargo test -p freenet-ping-app --features testing --test run_app` → 4/4, including `test_ping_multi_node` and `test_ws_streaming_large_payload`, which exercise the changed delta path end to end against real nodes. `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Rule-review Info items from #5463, addressed here

- `_opts` in `get_state_delta` is now plain `opts` with a `#[cfg_attr(not(feature = "contract"), allow(unused_variables))]` and a comment noting the parse is not decoration: a malformed parameters blob must still be rejected here as it is at every other entry point. Only the log line reads the value, and that is compiled out without the feature.
- `delta_against` now has the `# Example` section `code-style.md` asks for on complex public functions.

## Contract key

Combined with #5463 this changes the WASM, so the contract key changes. Nothing in the repo pins the old key — see #5463 for the check.

[AI-assisted - Claude]

https://claude.ai/code/session_0131oS6YAD9gMWigX8v4QR4J
