### PR TITLE
docs(tracing): stop recommending the attempts-based GET split #4852 abandoned

### DIFF
--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -316,12 +316,14 @@ async fn emit_get_terminal_event(
 /// network — those paths never call [`start_client_get`], so the driver's
 /// terminal event never fires for them.
 ///
-/// `attempts = 0` is the convention marking a local hit (a networked GET
-/// always sends >= 1 request, so `attempts >= 1`), letting analysts split
-/// "all client GET successes" from "network GET findability" without a new
-/// field. Keeps the client-visible findability metric covering ALL client
-/// GET successes — gateways serve many local hits, which would otherwise
-/// bias the number toward network misses.
+/// `attempts = 0` is the convention marking a local hit: this path sends no
+/// request at all. It is NOT the network-vs-local split — `attempts >= 1`
+/// also covers a loopback `LocalCompletion`, which bumps `requests_sent`
+/// without a network round-trip, so `summarize_client_get_outcomes` splits on
+/// `hop_count` instead (#4852 P2, #5248). Emitting here keeps the
+/// client-visible findability metric covering ALL client GET successes —
+/// gateways serve many local hits, which would otherwise bias the number
+/// toward network misses.
 pub(crate) async fn emit_local_get_terminal_event(
     op_manager: &OpManager,
     instance_id: ContractInstanceId,

--- a/crates/core/src/tracing.rs
+++ b/crates/core/src/tracing.rs
@@ -503,9 +503,17 @@ pub struct ClientGetOutcomeSummary {
     /// `requests_sent` (attempts >= 1) with no network round-trip, so
     /// classifying by `attempts` over-counts those loopback completions as
     /// network successes (#4852 P2).
+    ///
+    /// Known bias in the other direction: `GetMsg::ResponseStreaming` carries
+    /// no hop count, so a streamed (> 64 KB) success always has
+    /// `hop_count == None` and lands in `local_successes`. This count
+    /// therefore UNDER-reports network successes where large contracts
+    /// dominate (#5471).
     pub network_successes: u64,
     /// Subset of `successes` served locally with no forward network hop
-    /// (`hop_count` None or 0) — includes loopback local completions.
+    /// (`hop_count` None or 0) — includes loopback local completions and,
+    /// per the caveat on `network_successes`, streamed successes that did
+    /// traverse the network but carry no hop count (#5471).
     pub local_successes: u64,
 }
 

--- a/crates/core/src/tracing/event_kind.rs
+++ b/crates/core/src/tracing/event_kind.rs
@@ -1323,14 +1323,47 @@ pub(crate) enum GetEvent {
         /// Sub-operation GET (phantom-repair, renewal, related-fetch);
         /// excluded from client-findability metrics.
         is_sub_op: bool,
-        /// GET requests actually SENT before this terminal outcome. `1` means
-        /// the first peer answered; `0` is the convention for a LOCAL-cache
-        /// hit that never routed to the network (see
-        /// `emit_local_get_terminal_event`), letting analysts split "all
-        /// client GET successes" (`attempts >= 0`) from "network GET
-        /// findability" (`attempts >= 1`).
+        /// GET requests actually SENT before this terminal outcome — one per
+        /// `build_request`, taken from `driver.requests_sent`. `1` means the
+        /// terminal arrived on the first request sent; `0` is the convention
+        /// for a client GET served from a LOCAL copy that never entered the
+        /// driver at all (see `emit_local_get_terminal_event`), which is the
+        /// only way a `ClientTerminal` carries `0`.
+        ///
+        /// **Do not use `attempts` to split network from local successes.**
+        /// This comment used to recommend exactly that (`attempts >= 1` =
+        /// "network GET findability"); #4852 P2 abandoned the split in the
+        /// code but left the comment stale, and the stale advice then produced
+        /// a published GET success rate an order of magnitude off (#5248). It
+        /// is wrong because a loopback `LocalCompletion` — the driver's own
+        /// Request echoed back when the originator itself holds the contract —
+        /// increments `requests_sent` with no network round-trip, so
+        /// `attempts >= 1` counts those local completions as network
+        /// successes. The split the node uses is `hop_count` (see below and
+        /// [`crate::tracing::summarize_client_get_outcomes`], pinned by
+        /// `client_loopback_completion_counts_as_local`).
         attempts: usize,
-        /// Forward-path hop count when carried by the terminal reply.
+        /// Forward-path hop count when carried by the terminal reply, which in
+        /// practice means only the inline-`Found` terminal: `GetMsg::Response`
+        /// carries `hop_count`, `GetMsg::ResponseStreaming` does not. `None`
+        /// on the streaming, loopback-`LocalCompletion`, local-hit and
+        /// retry-exhausted paths; `Some(0)` when the reply reported no forward
+        /// hop (an originator loopback). `None` therefore does NOT mean "the
+        /// GET is known to have traversed zero hops", only that no hop count
+        /// was reported.
+        ///
+        /// `hop_count >= 1` is the network-vs-local test
+        /// [`crate::tracing::summarize_client_get_outcomes`] applies, and the
+        /// field is exported verbatim in the OTLP event body (`null` for
+        /// `None`), so a downstream consumer applying the same test computes
+        /// exactly what the node computes. Know its bias before quoting it as
+        /// a findability rate: because a streamed reply carries no hop count,
+        /// **every streaming (> 64 KB `streaming_threshold`) network success
+        /// is classified LOCAL**, so `hop_count >= 1` UNDER-counts network
+        /// successes wherever large contracts dominate (#5471). Neither field
+        /// gives an exact split — `attempts >= 1` over-counts by including
+        /// loopback completions, `hop_count >= 1` under-counts by excluding
+        /// streamed ones.
         hop_count: Option<usize>,
         /// Fragments received on the streaming path. `None` for non-streaming
         /// terminals and where no stream was ever claimed. On the streaming

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -10210,14 +10210,14 @@ fn test_get_reliability_diagnostic() {
         success_rate * 100.0
     );
     // Network-traversal floor (#4361): before this assertion existed, every
-    // "success" in the failing runs was a local cache hit (attempts == 0)
-    // on a node that already held the contract — multi-hop GET was never
-    // exercised at all. This also guards the one gap in the retrievability
-    // metric above: `nodes_with_state` counts a node whether it obtained the
+    // "success" in the failing runs was a local cache hit on a node that
+    // already held the contract — multi-hop GET was never exercised at all.
+    // This also guards the one gap in the retrievability metric above:
+    // `nodes_with_state` counts a node whether it obtained the
     // contract over the network OR via relay-path caching, so on its own a high
     // count could in principle be reached with few client GETs actually
     // completing. Requiring a number of client GET operations that actually
-    // routed (`attempts >= 1`) closes that: broad routing must have happened,
+    // routed (`hop_count >= 1`) closes that: broad routing must have happened,
     // not just storage population. This now gates on the CLIENT-visible
     // network-success count (per client op) rather than the per-tx count. The
     // lattice run measured 73/100 client GETs routing over the network (27 were
@@ -10226,7 +10226,7 @@ fn test_get_reliability_diagnostic() {
     // routing happened, not just storage population (#4852/#4361).
     assert!(
         client_network_successes >= 30,
-        "Only {} client GET operations traversed the network (attempts >= 1) \
+        "Only {} client GET operations traversed the network (hop_count >= 1) \
          — too few client GETs actually routed; the success/retrievability \
          metrics may be measuring local availability, not routing (#4852/#4361)",
         client_network_successes


### PR DESCRIPTION
## Problem

The doc comment on `GetEvent::ClientTerminal::attempts` told readers to split "all client GET successes" from "network GET findability" using `attempts >= 1`. The codebase abandoned that split six days after introducing it: #4852 P2 found it wrong (a loopback `LocalCompletion` bumps `requests_sent` with no network round-trip, so `attempts >= 1` counts local completions as network successes) and replaced it with a `hop_count`-based split in `summarize_client_get_outcomes`, pinned by `client_loopback_completion_counts_as_local`.

The comment was never updated. It then misled the telemetry dashboard into publishing a GET success rate of ~95% while network-routed GET success was ~8.5%: a wrong number that was public and plausible, produced by following the instruction the code had already rejected.

The same stale advice appeared in three places, not one:

- `crates/core/src/tracing/event_kind.rs`, the `attempts` field doc (the one #5248 reports)
- `crates/core/src/operations/get/op_ctx_task.rs`, `emit_local_get_terminal_event`'s doc, repeating "letting analysts split ... network GET findability"
- `crates/core/tests/simulation_integration.rs`, where the network-traversal floor's comment and assertion message both said `attempts >= 1` while the value asserted (`client_summary.network_successes`) has been `hop_count`-based since #4852

Only the text was stale. **No code implements the abandoned split**: `client_network_successes` at `simulation_integration.rs:9880` reads the `hop_count`-based summary, and every emit site already passes `driver.requests_sent` for `attempts`. So this stayed a docs change.

## Approach

Say what `attempts` is (requests actually sent, one per `build_request`; `0` only for a local GET served outside the driver), say plainly that it must not be used for the network/local split and why, and point at the `hop_count` split and its pin test.

Then state the caveat the issue asks for, on the field that carries it. Adversarial review caught a wrong claim in the first draft of this fix: that `hop_count` is not reconstructable downstream, with `attempts >= 1` offered as the external proxy. That is false, and it would have re-created the original bug for the same audience. `hop_count` is exported verbatim in the OTLP event body (`telemetry.rs`, `"hop_count": hop_count`, `null` for `None`), so a downstream consumer applying `hop_count >= 1` computes exactly what the node computes.

What is true, and is now documented, is that the `hop_count` split is biased in the *other* direction: `GetMsg::ResponseStreaming` carries no hop count, so every streaming (> 64 KB) success lands in `local_successes` even when it crossed the network. `attempts >= 1` over-counts network successes, `hop_count >= 1` under-counts them, and neither is exact. That under-count is a real telemetry defect rather than a doc problem, and fixing it means adding a field to a protocol enum, so it is filed separately as #5471 and cross-referenced from both the field doc and `ClientGetOutcomeSummary`.

The historical framing is corrected too: #4852 P2 never touched `event_kind.rs`, so it did not "remove" the recommendation there. It abandoned the approach in the code and left this comment behind, which is what #5248 is.

## Testing

Nothing to test. The change is comments plus one assertion *message*; no expression, threshold, or asserted value is touched, so there is no behavior a test could distinguish.

The correctness that matters here is whether the new text is true, which was checked by reading the code rather than by running it. Every claim was traced to its source: all six `emit_get_terminal_event` call sites enumerated for `hop_count` population, the OTLP export path, the summarizer, the pin test name, and the sim test's value provenance, plus a repo-wide grep for other places repeating the abandoned split.

`cargo fmt --all -- --check` and `cargo clippy --all-targets -p freenet` are clean. No source-scrape pin test asserts on the edited text: `event_kind.rs` is not `include_str!`'d anywhere, and `emit_local_get_terminal_event_marks_local_hit` scrapes the function *body* (the untouched `0, // local hit: no network request was sent`), not its doc comment.

Closes #5248
Refs #4852, #5471

[AI-assisted - Claude]
