### PR TITLE
fix(server): delete the vestigial /tmp/freenet/webs mkdir that panicked at startup

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -251,19 +251,17 @@ impl HttpClientApi {
         // (no HTTPS required). Includes is_unspecified() so that 0.0.0.0 bindings
         // (network mode) allow HTTP cookies — most home users lack TLS.
         let localhost = socket.ip().is_loopback() || socket.ip().is_unspecified();
-        let contract_web_path = std::env::temp_dir().join("freenet").join("webs");
-        std::fs::create_dir_all(&contract_web_path).unwrap_or_else(|e| {
-            panic!(
-                "Failed to create contract web directory at {}: {}. \
-                 This may happen if {} was created by another user. \
-                 Try: sudo rm -rf {}",
-                contract_web_path.display(),
-                e,
-                std::env::temp_dir().join("freenet").display(),
-                std::env::temp_dir().join("freenet").display(),
-            )
-        });
 
+        // NOTE: do NOT re-add a `create_dir_all` here. Until #5291 this function
+        // created `$TMPDIR/freenet/webs` and PANICKED the node if it could not —
+        // a directory that stopped being read in April 2025 when the real
+        // webapp cache moved to `webapp_cache` (and later to the XDG cache dir).
+        // The only surviving effect was aborting startup: it took down the
+        // v0.2.124 release canary, which stages its binary at `$TMPDIR/freenet`,
+        // so the mkdir hit ENOTDIR. Unpacked web contracts live under the
+        // config-driven `webapp_cache_dir` below, and `WebappCache::with_root`
+        // creates it — warning rather than aborting, which is the right
+        // response to a directory the node can serve everything else without.
         let (proxy_request_sender, request_to_server) = mpsc::channel(1);
 
         let config = Config::new(localhost, webapp_cache_dir);
@@ -1132,6 +1130,87 @@ mod tests {
     fn dead_request_sender() -> HttpClientApiRequest {
         let (tx, _rx) = mpsc::channel(1);
         HttpClientApiRequest::from_sender(tx)
+    }
+
+    /// Regression for #5291: composing the router must not abort the process
+    /// because something in the system temp directory is in the way.
+    ///
+    /// `as_router_with_origin_contracts` used to `create_dir_all` a vestigial
+    /// `$TMPDIR/freenet/webs` and `panic!` on failure. Nothing had read that
+    /// directory since the real webapp cache was renamed in April 2025, so its
+    /// only remaining effect was to kill the node at startup when `$TMPDIR`
+    /// happened to hold a non-directory (or another user's) `freenet` entry.
+    /// That is exactly what blocked release v0.2.124: the auto-update canary
+    /// stages the binary it gates AT `$TMPDIR/freenet`, so the mkdir hit
+    /// ENOTDIR and the node exited 101 before the update check could run.
+    ///
+    /// Run in a **child process** (a re-exec of this test binary filtered to
+    /// this one test) for two reasons: the hostile condition is a process-wide
+    /// environment variable, which `set_var` makes unsound to install from a
+    /// test thread in edition 2024, and the failure mode is a `panic!` in a
+    /// non-async constructor, which a child's exit status observes directly.
+    /// The child fails every time without the fix and passes every time with
+    /// it.
+    #[test]
+    fn router_construction_survives_a_hostile_temp_dir() {
+        const CHILD_ENV: &str = "FREENET_TEST_5291_CHILD";
+        const CHILD_TEST: &str =
+            "server::client_api::tests::router_construction_survives_a_hostile_temp_dir";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            // Premise: the environment really is the hostile one the parent
+            // built. If `temp_dir()` ignored our variables the child would pass
+            // vacuously, so assert the collision exists before relying on it.
+            let clash = std::env::temp_dir().join("freenet");
+            assert!(
+                clash.is_file(),
+                "premise: {} must exist as a FILE for this child to reproduce \
+                 the #5291 condition; got metadata {:?}",
+                clash.display(),
+                std::fs::metadata(&clash)
+            );
+
+            let (api, _router) = HttpClientApi::as_router(&"127.0.0.1:0".parse().unwrap());
+            drop(api);
+            return;
+        }
+
+        let tmp = crate::util::tests::get_temp_dir();
+        // The obstruction: `$TMPDIR/freenet` exists, as a file.
+        std::fs::write(tmp.path().join("freenet"), b"not a directory")
+            .expect("stage the blocking file");
+        // Keep the child's REAL webapp cache off the developer's home cache;
+        // this is deliberately a different knob from the one under test, which
+        // honours neither it nor `--data-dir`.
+        let cache = tmp.path().join("webapp_cache");
+
+        let exe = std::env::current_exe().expect("test binary path");
+        let output = std::process::Command::new(exe)
+            .args(["--exact", "--test-threads=1", "--nocapture", CHILD_TEST])
+            .env(CHILD_ENV, "1")
+            // `temp_dir()` reads TMPDIR on unix and TMP/TEMP on Windows.
+            .env("TMPDIR", tmp.path())
+            .env("TMP", tmp.path())
+            .env("TEMP", tmp.path())
+            .env("FREENET_WEBAPP_CACHE_DIR", &cache)
+            .output()
+            .expect("re-exec the test binary");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "composing the router must not panic when $TMPDIR/freenet is not a \
+             directory (#5291).\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        );
+        // Fail CLOSED on a rename: libtest exits 0 when its filter matches
+        // nothing, so without this the check goes vacuous the moment this
+        // function moves or is renamed.
+        assert!(
+            stdout.contains("1 passed"),
+            "the child must actually have run {CHILD_TEST} — if this function \
+             was renamed or moved, update CHILD_TEST.\nstdout:\n{stdout}\n\
+             stderr:\n{stderr}",
+        );
     }
 
     #[test]

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -1228,6 +1228,19 @@ mod tests {
                  stdout:\n{stdout}\nstderr:\n{stderr}",
             );
         }
+
+        // The other half of the premise. The child asserts the TMPDIR knob took
+        // effect; this asserts the CACHE-ROOT knob did. If
+        // `FREENET_WEBAPP_CACHE_DIR` ever stopped being read, the obstructed
+        // case would quietly resolve to the ProjectDirs default, create it
+        // successfully, and pass while testing nothing.
+        assert!(
+            benign.is_dir(),
+            "premise: the child must honour FREENET_WEBAPP_CACHE_DIR — {} was \
+             never created, so the obstructed case did not exercise the \
+             surviving create_dir_all",
+            benign.display()
+        );
     }
 
     #[test]

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -1179,38 +1179,55 @@ mod tests {
         // The obstruction: `$TMPDIR/freenet` exists, as a file.
         std::fs::write(tmp.path().join("freenet"), b"not a directory")
             .expect("stage the blocking file");
-        // Keep the child's REAL webapp cache off the developer's home cache;
-        // this is deliberately a different knob from the one under test, which
-        // honours neither it nor `--data-dir`.
-        let cache = tmp.path().join("webapp_cache");
 
-        let exe = std::env::current_exe().expect("test binary path");
-        let output = std::process::Command::new(exe)
-            .args(["--exact", "--test-threads=1", "--nocapture", CHILD_TEST])
-            .env(CHILD_ENV, "1")
-            // `temp_dir()` reads TMPDIR on unix and TMP/TEMP on Windows.
-            .env("TMPDIR", tmp.path())
-            .env("TMP", tmp.path())
-            .env("TEMP", tmp.path())
-            .env("FREENET_WEBAPP_CACHE_DIR", &cache)
-            .output()
-            .expect("re-exec the test binary");
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            output.status.success(),
-            "composing the router must not panic when $TMPDIR/freenet is not a \
-             directory (#5291).\nstdout:\n{stdout}\nstderr:\n{stderr}",
-        );
-        // Fail CLOSED on a rename: libtest exits 0 when its filter matches
-        // nothing, so without this the check goes vacuous the moment this
-        // function moves or is renamed.
-        assert!(
-            stdout.contains("1 passed"),
-            "the child must actually have run {CHILD_TEST} — if this function \
-             was renamed or moved, update CHILD_TEST.\nstdout:\n{stdout}\n\
-             stderr:\n{stderr}",
-        );
+        // Two cache roots, because the deleted mkdir was not the only
+        // `create_dir_all` this function reaches.
+        //
+        // `benign` keeps the child's REAL webapp cache off the developer's home
+        // cache while the obstruction sits where the DELETED mkdir used to
+        // point. That is the #5291 case proper.
+        //
+        // `obstructed` puts the cache root itself under the blocking file, so
+        // the surviving `create_dir_all` in `WebappCache::with_root` fails too.
+        // `with_root` is documented to warn and carry on, and
+        // `with_root_tolerates_a_root_that_is_not_a_directory` pins that
+        // directly — but a guard on `with_root` says nothing about the caller,
+        // and it is this function's job not to turn that warning back into a
+        // dead node. Without this case, making `with_root` fatal would
+        // reinstate the whole #5291 class with the test still green.
+        let benign = tmp.path().join("webapp_cache");
+        let obstructed = tmp.path().join("freenet").join("webapp_cache");
+
+        for (label, cache) in [("benign", &benign), ("obstructed", &obstructed)] {
+            let exe = std::env::current_exe().expect("test binary path");
+            let output = std::process::Command::new(exe)
+                .args(["--exact", "--test-threads=1", "--nocapture", CHILD_TEST])
+                .env(CHILD_ENV, "1")
+                // `temp_dir()` reads TMPDIR on unix and TMP/TEMP on Windows.
+                .env("TMPDIR", tmp.path())
+                .env("TMP", tmp.path())
+                .env("TEMP", tmp.path())
+                .env("FREENET_WEBAPP_CACHE_DIR", cache)
+                .output()
+                .expect("re-exec the test binary");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                output.status.success(),
+                "[{label}] composing the router must not panic when \
+                 $TMPDIR/freenet is not a directory (#5291).\nstdout:\n{stdout}\n\
+                 stderr:\n{stderr}",
+            );
+            // Fail CLOSED on a rename: libtest exits 0 when its filter matches
+            // nothing, so without this the check goes vacuous the moment this
+            // function moves or is renamed.
+            assert!(
+                stdout.contains("1 passed"),
+                "[{label}] the child must actually have run {CHILD_TEST} — if \
+                 this function was renamed or moved, update CHILD_TEST.\n\
+                 stdout:\n{stdout}\nstderr:\n{stderr}",
+            );
+        }
     }
 
     #[test]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -908,8 +908,9 @@ curl -sS -o /dev/null -w '%{http_code}\n' -A 'freenet-release-driver' \
 
    A clean run here is **not** evidence that the harness is sound. CI stages
    the binary differently — `cross-compile.yml` puts it at `/tmp/freenet`,
-   which used to collide with a directory the node creates under `$TMPDIR` and
-   blocked v0.2.124 on a healthy binary. Running from `./target/release/` is
+   which used to collide with a directory the node created under `$TMPDIR` and
+   blocked v0.2.124 on a healthy binary. That mkdir is gone (#5291), but the
+   staging-environment difference it exposed is not, so the warning stands. Running from `./target/release/` is
    precisely the environment where that class of fault cannot occur, which is
    why local validation went 4/4 green while CI blocked. If local reproduces
    nothing, suspect the staging environment before the binary.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -910,7 +910,8 @@ curl -sS -o /dev/null -w '%{http_code}\n' -A 'freenet-release-driver' \
    the binary differently — `cross-compile.yml` puts it at `/tmp/freenet`,
    which used to collide with a directory the node created under `$TMPDIR` and
    blocked v0.2.124 on a healthy binary. That mkdir is gone (#5291), but the
-   staging-environment difference it exposed is not, so the warning stands. Running from `./target/release/` is
+   staging-environment difference it exposed is not, so the warning stands.
+   Running from `./target/release/` is
    precisely the environment where that class of fault cannot occur, which is
    why local validation went 4/4 green while CI blocked. If local reproduces
    nothing, suspect the staging environment before the binary.

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -60,9 +60,8 @@
 #
 # TMPDIR is in that list for a reason and must stay there, and the reason is not
 # the one it looks like. `client_api.rs` (through v0.2.124) unconditionally
-# `create_dir_all`s
-# `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it builds
-# the router. That directory is VESTIGIAL: nothing in the tree reads or writes
+# `create_dir_all`s `std::env::temp_dir()/freenet/webs` (`let contract_web_path
+# =`) when it builds the router. That directory is VESTIGIAL: nothing in the tree reads or writes
 # it, and web contracts are unpacked elsewhere (`default_webapp_cache_dir`). Its
 # one surviving effect is the panic when the mkdir FAILS -- `$TMPDIR/freenet`
 # being a FILE, or a directory owned by another user. Through v0.2.124 this file
@@ -882,12 +881,19 @@ NODE_EXIT=""
 run_node_until_check() {
   local binary="$1" work="$2"
   # `$work/tmp` is created HERE, with the rest of the tree, rather than inside
-  # the subshell next to the `export TMPDIR` that uses it. BOTH gates need it.
-  # Gate A used to be indifferent, because the node's own vestigial
-  # `create_dir_all` built its parents on the way past -- #5291 deleted that,
-  # so from that release on a node built from main creates nothing under
-  # `$TMPDIR` and this `mkdir` is the only thing that puts it there. Do not
-  # scope it to the Gate B path. Gate B needs it independently anyway: the
+  # the subshell next to the `export TMPDIR` that uses it. Do NOT scope it to
+  # the Gate B path.
+  #
+  # Gate A used to have a node-side backstop: the vestigial `create_dir_all`
+  # built `$TMPDIR` on its way past. #5291 deleted it, so Gate A no longer has
+  # that backstop -- and the RELEASED binaries this gate runs (through
+  # v0.2.124) still write there, so the directory has to exist for them. (A
+  # node built from main does still create `$TMPDIR/freenet/webapp_cache` in
+  # one case, the `ProjectDirs`-returns-None fallback in
+  # `resolve_webapp_cache_dir`; the canary excludes it by exporting HOME,
+  # XDG_CACHE_HOME and FREENET_WEBAPP_CACHE_DIR below. Do not rely on it.)
+  #
+  # Gate B needs it independently anyway: the
   # real updater stages through `tempfile::tempdir()` (`update.rs`),
   # which requires TMPDIR to EXIST and will not create it. A `mkdir` inside the
   # backgrounded subshell also fails invisibly (no `set -e`, and its output

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -59,7 +59,8 @@
 # outside it is touched.
 #
 # TMPDIR is in that list for a reason and must stay there, and the reason is not
-# the one it looks like. `client_api.rs` unconditionally `create_dir_all`s
+# the one it looks like. `client_api.rs` (through v0.2.124) unconditionally
+# `create_dir_all`s
 # `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it builds
 # the router. That directory is VESTIGIAL: nothing in the tree reads or writes
 # it, and web contracts are unpacked elsewhere (`default_webapp_cache_dir`). Its
@@ -881,9 +882,13 @@ NODE_EXIT=""
 run_node_until_check() {
   local binary="$1" work="$2"
   # `$work/tmp` is created HERE, with the rest of the tree, rather than inside
-  # the subshell next to the `export TMPDIR` that uses it. Gate A would not
-  # care -- the node's own `create_dir_all` builds its parents -- but Gate B
-  # does: the real updater stages through `tempfile::tempdir()` (`update.rs`),
+  # the subshell next to the `export TMPDIR` that uses it. BOTH gates need it.
+  # Gate A used to be indifferent, because the node's own vestigial
+  # `create_dir_all` built its parents on the way past -- #5291 deleted that,
+  # so from that release on a node built from main creates nothing under
+  # `$TMPDIR` and this `mkdir` is the only thing that puts it there. Do not
+  # scope it to the Gate B path. Gate B needs it independently anyway: the
+  # real updater stages through `tempfile::tempdir()` (`update.rs`),
   # which requires TMPDIR to EXIST and will not create it. A `mkdir` inside the
   # backgrounded subshell also fails invisibly (no `set -e`, and its output
   # goes to `node.out`), so a broken workdir would surface as a mystery
@@ -940,9 +945,10 @@ run_node_until_check() {
     # `client_api.rs` (through v0.2.124) unconditionally `create_dir_all`s
     # `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it
     # builds the router, and that path does NOT follow `--data-dir`. The
-    # directory itself is VESTIGIAL -- nothing reads or writes it (`"webs"` has
-    # exactly one occurrence in `crates/`, the mkdir), and unpacked web
-    # contracts live under `default_webapp_cache_dir` instead. So the only thing
+    # directory itself is VESTIGIAL -- nothing reads or writes it (at the time,
+    # `"webs"` had exactly one occurrence in `crates/`, the mkdir itself; after
+    # #5291 it has none), and unpacked web contracts live under
+    # `default_webapp_cache_dir` instead. So the only thing
     # it can still do is PANIC when the mkdir fails, which it does two ways:
     #
     #   1. `$TMPDIR/freenet` is a FILE. `cross-compile.yml` stages the binary it

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -885,9 +885,13 @@ run_node_until_check() {
   # the Gate B path.
   #
   # Gate A used to have a node-side backstop: the vestigial `create_dir_all`
-  # built `$TMPDIR` on its way past. #5291 deleted it, so Gate A no longer has
-  # that backstop -- and the RELEASED binaries this gate runs (through
-  # v0.2.124) still write there, so the directory has to exist for them. (A
+  # built `$TMPDIR` on its way past (it builds missing parents, so the
+  # directory did not have to pre-exist). #5291 deleted it, so on a main-built
+  # binary this `mkdir` is now the ONLY thing that creates `$TMPDIR` -- the
+  # RELEASED binaries this gate runs (through v0.2.124) still bring their own.
+  # Do not read that as "Gate A needs it": Gate A works either way today. The
+  # point is that the backstop is gone, so scoping this line to Gate B leaves
+  # nothing creating the directory for anything else that may want it. (A
   # node built from main does still create `$TMPDIR/freenet/webapp_cache` in
   # one case, the `ProjectDirs`-returns-None fallback in
   # `resolve_webapp_cache_dir`; the canary excludes it by exporting HOME,

--- a/scripts/auto-update-canary.sh
+++ b/scripts/auto-update-canary.sh
@@ -70,6 +70,13 @@
 # the update task spawned, and Gate A blocked a release whose binary was
 # perfectly healthy. See `run_node_until_check`.
 #
+# The mkdir itself is GONE from the tree as of #5291. The isolation stays, and
+# deleting it on the strength of that fix would be a mistake: this canary gates
+# RELEASED binaries, and every release up to and including v0.2.124 still
+# carries the panicking mkdir. The isolation is what lets the gate run them at
+# all. It is also still doing the ordinary job of keeping a throwaway node's
+# files out of the caller's temp dir.
+#
 # PORTS are the exception, and an earlier version of this header overstated it
 # by calling the runs "safe to run on a machine already running a node". They
 # bind real ports, so a run collides with anything already holding them --
@@ -924,7 +931,13 @@ run_node_until_check() {
     # var removes the class outright for the cost of one line. Only the
     # canary's own throwaway node is affected.
     export FREENET_DISABLE_LOG_RATE_LIMIT=1
-    # `client_api.rs` unconditionally `create_dir_all`s
+    # #5291 DELETED the mkdir described below, so a node built from current
+    # main no longer has this failure mode. Keep the isolation anyway: the
+    # binaries this canary gates are RELEASES, and everything up to and
+    # including v0.2.124 still panics exactly as described. The measurements
+    # below were taken against those artifacts and still stand for them.
+    #
+    # `client_api.rs` (through v0.2.124) unconditionally `create_dir_all`s
     # `std::env::temp_dir()/freenet/webs` (`let contract_web_path =`) when it
     # builds the router, and that path does NOT follow `--data-dir`. The
     # directory itself is VESTIGIAL -- nothing reads or writes it (`"webs"` has

--- a/scripts/auto-update-canary_lifecycle_test.sh
+++ b/scripts/auto-update-canary_lifecycle_test.sh
@@ -470,7 +470,15 @@ fi
 # 9. The canary must not let its own TMPDIR reach the node.
 #
 #    This is the #5290 fault, and it blocked v0.2.124 on a binary that was
-#    perfectly healthy. `client_api.rs` unconditionally `create_dir_all`s
+#    perfectly healthy.
+#
+#    #5291 has since deleted the mkdir, so a node built from current main
+#    cannot fail this way. The case stays, and the fake node below deliberately
+#    keeps modelling the OLD behaviour, because the canary gates RELEASED
+#    binaries: every release through v0.2.124 still panics like this, and the
+#    canary has to be able to run them.
+#
+#    `client_api.rs` (through v0.2.124) unconditionally `create_dir_all`s
 #    `std::env::temp_dir()/freenet/webs` when it builds the router and PANICS
 #    (exit 101) if it cannot -- and `cross-compile.yml` stages the binary it is
 #    about to gate at `/tmp/freenet`, which is exactly the path that mkdir
@@ -512,8 +520,10 @@ while [ \$# -gt 0 ]; do
     esac
 done
 mkdir -p "\$logdir"
-# Models client_api.rs: hardwired to temp_dir(), does NOT follow --data-dir,
-# and panics rather than degrading when the directory cannot be created.
+# Models client_api.rs THROUGH v0.2.124 (the mkdir was deleted in #5291):
+# hardwired to temp_dir(), does NOT follow --data-dir, and panics rather than
+# degrading when the directory cannot be created. Kept as-is on purpose -- this
+# canary gates released binaries, which still behave this way.
 webdir="\${TMPDIR:-/tmp}/freenet/webs"
 if ! mkdir -p "\$webdir" 2>/dev/null; then
     echo "thread 'main' panicked at crates/core/src/server/client_api.rs:256:13:" >&2

--- a/scripts/auto-update-canary_test.sh
+++ b/scripts/auto-update-canary_test.sh
@@ -1625,7 +1625,10 @@ else
 fi
 
 # --- TMPDIR must be scoped before either process starts ---------------------
-# `client_api.rs` unconditionally `create_dir_all`s
+# #5291 removed the mkdir below from the tree. This pin stays: the canary gates
+# RELEASED binaries, and every release through v0.2.124 still carries it.
+#
+# `client_api.rs` (through v0.2.124) unconditionally `create_dir_all`s
 # `std::env::temp_dir()/freenet/webs` at router construction. The directory is
 # vestigial (nothing reads it), but the mkdir can FAIL -- `$TMPDIR/freenet`
 # being a file, or another user's directory -- and it panics when it does, exit


### PR DESCRIPTION
## Problem

`crates/core/src/server/client_api.rs` created `$TMPDIR/freenet/webs` while composing the router and **panicked the node** if it could not:

```rust
let contract_web_path = std::env::temp_dir().join("freenet").join("webs");
std::fs::create_dir_all(&contract_web_path).unwrap_or_else(|e| panic!(...));
```

The directory is vestigial. `6956277e6` (2022) added it when `contract_web_path(key)` really did resolve per-contract paths under it, but `98a689278` ("A variety of changes made to get River working", 2025-04-12) renamed the serving path's leaf directory to `webapp_cache` without touching this sibling mkdir, and `0ed32c806` (2025-12) moved the real cache off `temp_dir()` entirely onto the XDG cache dir. Since April 2025 nothing has read or written it — `grep -rn '"webs"'` returns exactly this one site — so its only surviving effect was the ability to abort startup.

That is what **blocked release v0.2.124**. The auto-update canary stages the binary it is gating at `$TMPDIR/freenet`, so `create_dir_all` tried to mkdir under a regular file, got `ENOTDIR`, and the node exited 101 before the update task spawned. Gate A correctly reported "the startup update check never ran" and refused to publish a binary that was healthy. The same panic fires on any shared host where `/tmp/freenet` is another user's directory (`EACCES`) — which is the case on nova today.

## Approach

Option 1 from the issue: **delete it.** Nothing needs replacement plumbing. Unpacked web contracts live under the config-driven `webapp_cache_dir` that this same function already receives (`--data-dir`- and `FREENET_WEBAPP_CACHE_DIR`-aware), created two lines later by `WebappCache::with_root` — which already handles exactly this failure by warning and carrying on, because a node serves everything except web contracts perfectly well without it. That is the precedent this line was violating.

I checked the panic is not reachable by another route before relying on the deletion:

- `default_webapp_cache_dir()` can also fall back to `temp_dir().join("freenet")` (`config.rs:3109`) when `ProjectDirs` finds no home, but its creation site is the warn-and-continue `WebappCache::with_root`, so it does not crash under the same condition.
- Every other non-`?` `create_dir_all(...).unwrap()/.expect()` in `crates/core/src/` is inside a `#[cfg(test)]` module. The production directory creation in `ConfigPathsArgs::build()` and `config/secret.rs` uses `?` and surfaces through `main()` as a clean error, not a panic.
- In a release build `ConfigPathsArgs::default_dirs` never touches `temp_dir()` at all (that branch is gated on `cfg!(any(test, debug_assertions)) || id.is_some()`).

So this was the only reachable filesystem panic on the startup path.

A guard comment replaces the deleted lines, since "add a mkdir for the temp dir you are about to use" is an easy thing to re-add.

### Canary comments

`scripts/auto-update-canary*.sh` document this mkdir at length as the reason they isolate `TMPDIR` (#5290). Nothing there breaks — the lifecycle test's fake node *models* the behaviour rather than invoking a real binary, and both suites pass unchanged — but the rationale would now read as obsolete, and someone could reasonably delete the isolation on the strength of this fix. That would be wrong: **the canary gates released binaries, and every release through v0.2.124 still carries the panicking mkdir.** The comments now say so. Comment-only; no assertions or behaviour touched.

One of those comments was not merely stale but inverted. `run_node_until_check` explained that `$work/tmp` is created up front "rather than inside the subshell" because *Gate B* needs it, noting Gate A "would not care — the node's own `create_dir_all` builds its parents". That incidental parent-creation was the very mkdir being deleted, so after this change **Gate A depends on that `mkdir -p` too**, and the old comment pointed a future editor at scoping it to the Gate B path. Corrected. `docs/RELEASING.md` had a matching present-tense sentence, also corrected.

## Testing

`router_construction_survives_a_hostile_temp_dir` (`client_api.rs`) reproduces the release-blocking condition: it stages `$TMPDIR/freenet` as a regular **file** and composes the router against it.

It runs in a **child process** (a re-exec of the test binary filtered to this one test), following the existing `util/test_log_capture.rs` idiom, for two reasons: the hostile condition is a process-wide environment variable, and `set_var` is `unsafe` in edition 2024 precisely because a racing writer here would be a flake rather than a finding; and the failure is a `panic!` in a non-async constructor, which a child's exit status observes directly. The child asserts its own premise (`$TMPDIR/freenet` really is a file) so it cannot pass vacuously, and the parent asserts `1 passed` so a rename fails closed instead of silently matching no tests.

The child runs **twice**, because the deleted mkdir was not the only `create_dir_all` this function reaches. The `benign` case points the webapp cache at a harmless path, so the obstruction sits only where the deleted mkdir used to. The `obstructed` case puts the cache root itself under the blocking file, so the *surviving* `create_dir_all` in `WebappCache::with_root` fails too. `with_root` is documented to warn and carry on, and `with_root_tolerates_a_root_that_is_not_a_directory` pins that directly — but a guard on `with_root` says nothing about its caller, and it is this function's job not to turn that warning back into a dead node.

Verified by mutation in three directions, not assumed:

- **With the fix:** `test ... ok`
- **With the deletion reverted:** `FAILED`, `Failed to create contract web directory at /tmp/.tmpJYUiso/freenet/webs: Not a directory (os error 20)` — the same `ENOTDIR` that blocked v0.2.124.
- **With `WebappCache::with_root`'s `Err` arm made fatal:** `FAILED` on the `obstructed` case — so a change that reinstates this class through the surviving path cannot land green.

Also green: `cargo test -p freenet --lib server::client_api` (168 passed), `server::path_handlers` + the webapp-cache config tests (147 passed), `bash scripts/auto-update-canary_test.sh`, `bash scripts/auto-update-canary_lifecycle_test.sh`, `cargo fmt --all --check`, `cargo clippy --all-targets -p freenet`, and `shellcheck` on the three edited scripts.

Closes #5291

[AI-assisted - Claude]
