### PR TITLE
fix(update): resolve the code hash from the instance id on UPDATE

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2952,16 +2952,23 @@ mod update_by_instance_id_tests {
     //! at face value and fed straight to the
     //! `code_blob_stored(key.code_hash())` gate in
     //! `bridged_upsert_contract_state_inner`. Clients that address a contract by
-    //! its instance id alone — the TypeScript SDK's `fromInstanceId()`, which
-    //! emits an empty code vector, and `fdev update`, which fills in an all-zero
+    //! its instance id alone — `fdev update`, which fills in an all-zero
     //! `CodeHash` placeholder — therefore failed that gate with
     //! `MissingContract` on a node that was holding the contract all along.
+    //!
+    //! Scope note: the TypeScript SDK's `fromInstanceId()` emits a
+    //! present-but-EMPTY code vector, which stdlib 0.8.5's
+    //! `ContractKey::try_decode_fbs` refuses at the wire boundary — so that
+    //! client is not fixed here and cannot be tested here. Only a well-formed
+    //! but wrong 32-byte hash reaches this gate.
     //!
     //! These drive a real `Executor<Runtime>` (real `ContractStore`, real
     //! `StateStore`, no network) because the gate under test exists only there:
     //! `MockRuntime`'s executor keys everything by instance id and has no
-    //! code-hash probe at all, so a mock-backed test would pass with the fix
-    //! reverted.
+    //! code-hash probe at all, so a `MockRuntime`-backed test would pass with
+    //! the fix reverted. (`MockWasmRuntime` does wrap a real `ContractStore` and
+    //! would hit the gate; a real `Runtime` is used anyway so the test exercises
+    //! the production type.)
 
     use std::sync::Arc;
 
@@ -3055,13 +3062,22 @@ mod update_by_instance_id_tests {
 
     /// True when `err` is the `code_blob_stored` gate's refusal.
     ///
-    /// Matched on the typed `Debug` marker `MissingContract`, NOT on the
-    /// Display text: `StdContractError` also renders a DIFFERENT failure as
-    /// "missing contract parameters" (the `state_store.get_params` miss, which
-    /// happens BEFORE the gate), so a lowercase "missing contract" substring
-    /// would conflate the two and report the wrong cause as the right one.
+    /// Two near-misses this deliberately excludes, because the negative control
+    /// below would silently accept either and report a broken fix as working:
+    ///
+    /// - the Display text "missing contract parameters" — a DIFFERENT failure
+    ///   (`state_store.get_params` missing), raised BEFORE the gate, so a
+    ///   lowercased "missing contract" substring would conflate the two;
+    /// - `StateStoreError::MissingContract`, which renders the same `Debug`
+    ///   marker from a different error type entirely.
+    ///
+    /// So match the gate's own shape: `ExecutorError`'s inner
+    /// `StdContractError::MissingContract` carries a bare `key` field and no
+    /// `cause`, which is what distinguishes it from the parameter miss
+    /// (`StdContractError::Put { key, cause }`).
     fn missing_contract(err: &crate::contract::ExecutorError) -> bool {
-        format!("{err:?}").contains("MissingContract")
+        let rendered = format!("{err:?}");
+        rendered.contains("ContractError(MissingContract")
     }
 
     /// An UPDATE addressed by instance id — the code hash a client that only
@@ -3191,6 +3207,93 @@ mod update_by_instance_id_tests {
             missing_contract(&err),
             "an unresolvable instance must still be refused with MissingContract, \
              got: {err:?}"
+        );
+    }
+
+    /// The other direction, and the one this change actually NARROWS: a code
+    /// hash naming a DIFFERENT contract's stored blob.
+    ///
+    /// Before the fix that hash passed `code_blob_stored` (the blob is on disk,
+    /// it just belongs to another contract) and was carried onward as the key —
+    /// into the state store, whose backends persist `key.code_hash()` into the
+    /// hosting-metadata row they rebuild the `ContractKey` from on restart. So
+    /// the pre-fix gate accepted the one wrong hash it should have caught and
+    /// rejected the harmless one. After the fix the store's instance->code row
+    /// overrides it and the key is the contract's own.
+    ///
+    /// The all-zero fixtures cannot see this: they exercise a hash that names no
+    /// blob at all. Without this test, "a wrong hash is corrected rather than
+    /// trusted" is an unverified claim.
+    #[tokio::test]
+    async fn update_with_another_contracts_code_hash_resolves_to_its_own() {
+        let (mut executor, _temp) = build_executor("update-foreign-code-hash").await;
+
+        let (container_a, key_a) = make_contract(7, 7);
+        seed_held_contract(
+            &mut executor,
+            container_a,
+            key_a,
+            WrappedState::new(vec![1u8; 8]),
+        )
+        .await;
+
+        // A second, genuinely-held contract with DIFFERENT code, so its blob is
+        // on disk and `code_blob_stored` says yes for its hash.
+        let (container_b, key_b) = make_contract(11, 11);
+        seed_held_contract(
+            &mut executor,
+            container_b,
+            key_b,
+            WrappedState::new(vec![1u8; 8]),
+        )
+        .await;
+        assert_ne!(
+            key_a.code_hash(),
+            key_b.code_hash(),
+            "the fixtures must have distinct code blobs"
+        );
+        assert!(
+            executor.runtime.code_blob_stored(key_b.code_hash()),
+            "B's blob must really be on disk, or this fixture proves nothing"
+        );
+
+        // A's instance, B's code hash: the shape that used to sail through.
+        let mismatched = ContractKey::from_id_and_code(*key_a.id(), *key_b.code_hash());
+
+        // The resolution is what is under test, so assert it directly rather
+        // than inferring it from an error string.
+        assert_eq!(
+            executor
+                .lookup_key(mismatched.id())
+                .expect("A is held, so its instance must resolve")
+                .code_hash(),
+            key_a.code_hash(),
+            "the store's instance->code row must win over the caller's hash"
+        );
+
+        let err = executor
+            .upsert_contract_state(
+                mismatched,
+                Either::Left(WrappedState::new(vec![2u8; 8])),
+                RelatedContracts::default(),
+                None,
+            )
+            .await
+            .expect_err("synthetic WASM cannot validate, so this must fail");
+        assert!(
+            !missing_contract(&err),
+            "a held contract must not be refused by the gate: {err:?}"
+        );
+        // The error carries the key the executor settled on, so it witnesses
+        // WHICH contract the update was attributed to — B's hash here would mean
+        // the foreign hash had been carried into the state store.
+        assert!(
+            format!("{err:?}").contains(&format!("{:?}", key_a.code_hash())),
+            "the update must be attributed to A's own code hash, got: {err:?}"
+        );
+        assert!(
+            !format!("{err:?}").contains(&format!("{:?}", key_b.code_hash())),
+            "the foreign code hash must not survive resolution, got: {err:?}"
         );
     }
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -947,6 +947,88 @@ mod executor_pin_tests {
         );
     }
 
+    /// Source pin for freenet/freenet-core#4978: BOTH UPDATE apply paths must
+    /// resolve the code hash from the instance id BEFORE they touch the state
+    /// store.
+    ///
+    /// This is a source scrape rather than a behavioural test because the two
+    /// sites are not equally reachable. The network site
+    /// (`bridged_upsert_contract_state_inner`) is covered behaviourally by
+    /// `update_by_instance_id_tests`, but `perform_contract_update` lives in
+    /// `impl Executor<Runtime>` and only reaches the durable write after a real
+    /// WASM `update_state` succeeds — so exercising it needs a compiled test
+    /// contract, and nothing else in the tree calls it at all. Without this pin
+    /// the local-mode resolution can be deleted with the whole suite green,
+    /// which is exactly how it got missed the first time.
+    ///
+    /// Ordering matters, not just presence: the harm is what the UNRESOLVED key
+    /// writes durably (`StateStorage::store` persists `key.code_hash()` into the
+    /// hosting-metadata row), so a resolution placed after the first state-store
+    /// access would pin nothing.
+    #[test]
+    fn update_apply_paths_resolve_code_hash_before_touching_the_state_store() {
+        // Anchored on the API surface (`bridged_lookup_key(`), not on the `let
+        // key =` binding, so a rename of the local does not silently unpin it.
+        const RESOLVE: &str = "bridged_lookup_key(";
+
+        // Scan CODE only. Both sites carry long `//` rationale blocks that name
+        // `state_store` and `code_blob_stored` in prose, and an offset comparison
+        // against prose measures the comments rather than the code — this pin
+        // failed on exactly that before the strip was added.
+        fn code_only(src: &str) -> String {
+            src.lines()
+                .map(|line| match line.find("//") {
+                    Some(i) => &line[..i],
+                    None => line,
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+
+        // --- local mode ---
+        let contract_ops = code_only(include_str!("runtime/contract_ops.rs"));
+        let body = contract_ops
+            .split("async fn perform_contract_update(")
+            .nth(1)
+            .expect("perform_contract_update must exist");
+        let resolve_at = body.find(RESOLVE).unwrap_or_else(|| {
+            panic!(
+                "perform_contract_update must resolve the code hash from the \
+                 instance id (#4978): local mode has no code_blob_stored gate, so \
+                 an unresolved key reaches the durable hosting-metadata write"
+            )
+        });
+        let store_at = body
+            .find("state_store")
+            .expect("perform_contract_update must touch the state store");
+        assert!(
+            resolve_at < store_at,
+            "perform_contract_update must resolve BEFORE its first state_store \
+             access (#4978) — the persisted code hash is the thing being fixed"
+        );
+
+        // --- network path ---
+        let executor_impl = code_only(include_str!("runtime/executor_impl.rs"));
+        let inner = executor_impl
+            .split("async fn bridged_upsert_contract_state_inner(")
+            .nth(1)
+            .expect("bridged_upsert_contract_state_inner must exist");
+        let resolve_at = inner.find(RESOLVE).unwrap_or_else(|| {
+            panic!(
+                "bridged_upsert_contract_state_inner must resolve the code hash \
+                 from the instance id when no container is supplied (#4978)"
+            )
+        });
+        let gate_at = inner
+            .find("code_blob_stored(")
+            .expect("the disk gate must still exist");
+        assert!(
+            resolve_at < gate_at,
+            "the resolution must precede the code_blob_stored gate (#4978), or \
+             an instance-id-addressed UPDATE is still refused"
+        );
+    }
+
     /// Pin: `perform_contract_update` MUST NOT route the network branch
     /// through `UpdateContract` / `self.op_request` / `request_update`.
     /// Network-mode UPDATEs flow through `start_client_update`.
@@ -3068,13 +3150,21 @@ mod update_by_instance_id_tests {
     /// - the Display text "missing contract parameters" — a DIFFERENT failure
     ///   (`state_store.get_params` missing), raised BEFORE the gate, so a
     ///   lowercased "missing contract" substring would conflate the two;
-    /// - `StateStoreError::MissingContract`, which renders the same `Debug`
-    ///   marker from a different error type entirely.
+    /// - `StateStoreError::MissingContract`, a different error type that shares
+    ///   the variant NAME. (It reaches `ExecutorError` through
+    ///   `ExecutorError::other(anyhow)`, whose `Debug` prints the Display chain
+    ///   rather than the derived variant, so it would not in fact match the
+    ///   needle below — but the name collision is exactly the kind of thing a
+    ///   looser match would start catching, so the needle is anchored anyway.)
     ///
-    /// So match the gate's own shape: `ExecutorError`'s inner
-    /// `StdContractError::MissingContract` carries a bare `key` field and no
-    /// `cause`, which is what distinguishes it from the parameter miss
-    /// (`StdContractError::Put { key, cause }`).
+    /// So match the gate's own shape, `RequestError::ContractError` wrapping
+    /// `StdContractError::MissingContract`.
+    ///
+    /// This predicate is only honest while something asserts it POSITIVELY: two
+    /// of the three tests below assert `!missing_contract(..)`, which a needle
+    /// that stopped matching would satisfy vacuously. That job belongs to
+    /// `update_for_an_unheld_contract_still_reports_missing_contract` — do not
+    /// `#[ignore]` or weaken it.
     fn missing_contract(err: &crate::contract::ExecutorError) -> bool {
         let rendered = format!("{err:?}");
         rendered.contains("ContractError(MissingContract")
@@ -3142,16 +3232,22 @@ mod update_by_instance_id_tests {
             !missing_contract(&full_key_err),
             "the fully-specified control must not hit the gate either: {full_key_err:?}"
         );
-        // `ExecutorError` is a struct, so there is no variant to compare; the
-        // rendered error is the observable. Once the code hash is resolved the
-        // two calls are the same call, so their errors must be identical — a
-        // stronger claim than "both got past the gate", and the one that says
-        // instance-id addressing IS full-key addressing.
-        assert_eq!(
-            format!("{err:?}"),
-            format!("{full_key_err:?}"),
-            "instance-id addressing must fail in the same way as full-key \
-             addressing, not merely fail differently"
+        // `ExecutorError` is a struct, so there is no variant to compare, and
+        // the observable is the rendered error. Compare only the CONTRACT KEY
+        // each error carries, not the whole rendering: the full text includes
+        // the WASM engine's message, so equality on it would turn any engine
+        // bump — or any future per-attempt annotation — into an intermittent
+        // red with no useful diagnostic. The key is the part that says
+        // instance-id addressing resolved to the same contract full-key
+        // addressing did.
+        let key_witness = format!("{:?}", key.code_hash());
+        assert!(
+            format!("{err:?}").contains(&key_witness),
+            "the instance-id-addressed error must witness the resolved key: {err:?}"
+        );
+        assert!(
+            format!("{full_key_err:?}").contains(&key_witness),
+            "the full-key control must witness the same key: {full_key_err:?}"
         );
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2941,3 +2941,256 @@ mod idempotency_probe_convergence_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod update_by_instance_id_tests {
+    //! Regression tests for freenet/freenet-core#4978.
+    //!
+    //! GET and SUBSCRIBE carry only an instance id on the wire, so the executor
+    //! resolves the real code hash for them via `lookup_key`. UPDATE carries a
+    //! full `ContractKey`, so whatever code hash the client put in it was taken
+    //! at face value and fed straight to the
+    //! `code_blob_stored(key.code_hash())` gate in
+    //! `bridged_upsert_contract_state_inner`. Clients that address a contract by
+    //! its instance id alone — the TypeScript SDK's `fromInstanceId()`, which
+    //! emits an empty code vector, and `fdev update`, which fills in an all-zero
+    //! `CodeHash` placeholder — therefore failed that gate with
+    //! `MissingContract` on a node that was holding the contract all along.
+    //!
+    //! These drive a real `Executor<Runtime>` (real `ContractStore`, real
+    //! `StateStore`, no network) because the gate under test exists only there:
+    //! `MockRuntime`'s executor keys everything by instance id and has no
+    //! code-hash probe at all, so a mock-backed test would pass with the fix
+    //! reverted.
+
+    use std::sync::Arc;
+
+    use either::Either;
+    use freenet_stdlib::prelude::{
+        CodeHash, ContractCode, ContractContainer, ContractInstanceId, ContractKey,
+        ContractWasmAPIVersion, Parameters, RelatedContracts, WrappedContract, WrappedState,
+    };
+
+    use crate::contract::executor::{ContractExecutor, Executor};
+    use crate::contract::storages::Storage;
+    use crate::wasm_runtime::{
+        ContractStore, ContractStoreBridge, DelegateStore, Runtime, SecretsStore, StateStore,
+    };
+
+    /// Build a disk-backed `Executor<Runtime>`, holding the `TempDir` alive for
+    /// the duration of the test.
+    async fn build_executor(name: &str) -> (Executor<Runtime>, tempfile::TempDir) {
+        let temp_dir = crate::util::tests::get_temp_dir();
+        let db = Storage::new(temp_dir.path())
+            .await
+            .expect("create storage db");
+        let contract_store = ContractStore::new(
+            temp_dir.path().join(format!("contracts-{name}")),
+            10_000,
+            db.clone(),
+        )
+        .expect("create contract store");
+        let delegate_store =
+            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
+                .expect("create delegate store");
+        let secrets_store = SecretsStore::new(
+            temp_dir.path().join("secrets"),
+            Default::default(),
+            db.clone(),
+        )
+        .expect("create secrets store");
+        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
+        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
+            .expect("build runtime");
+        let executor = Executor::new(
+            state_store,
+            || Ok(()),
+            crate::contract::executor::OperationMode::Local,
+            runtime,
+            None,
+        )
+        .await
+        .expect("create executor");
+        (executor, temp_dir)
+    }
+
+    /// A synthetic contract container. The WASM bytes are deliberately garbage:
+    /// the gate under test runs BEFORE any module is compiled, so an UPDATE that
+    /// gets past it dies later in WASM validation instead. That asymmetry —
+    /// refused-at-the-gate versus reached-the-engine — is what makes these
+    /// assertions discriminating rather than a blanket "UPDATE fails".
+    fn make_contract(code_seed: u8, param_seed: u8) -> (ContractContainer, ContractKey) {
+        let code = ContractCode::from(vec![code_seed; 64]);
+        let params = Parameters::from(vec![param_seed; 8]);
+        let key = ContractKey::from_params_and_code(&params, &code);
+        let wrapped = WrappedContract::new(Arc::new(code), params);
+        (
+            ContractContainer::Wasm(ContractWasmAPIVersion::V1(wrapped)),
+            key,
+        )
+    }
+
+    /// Seed the code blob, its instance→code index row, and the contract's
+    /// params + state, so the executor is a node that genuinely holds the
+    /// contract. Done through the store/state-store directly because this is
+    /// setup, not the behaviour under test — routing it through a PUT would die
+    /// in WASM validation on the synthetic bytes and remove the blob again.
+    async fn seed_held_contract(
+        executor: &mut Executor<Runtime>,
+        container: ContractContainer,
+        key: ContractKey,
+        state: WrappedState,
+    ) {
+        let params = container.params().into_owned();
+        executor
+            .runtime
+            .store_contract(container)
+            .expect("seeding the code blob must succeed");
+        executor
+            .state_store
+            .store(key, state, params)
+            .await
+            .expect("seeding params + state must succeed");
+    }
+
+    /// True when `err` is the `code_blob_stored` gate's refusal.
+    ///
+    /// Matched on the typed `Debug` marker `MissingContract`, NOT on the
+    /// Display text: `StdContractError` also renders a DIFFERENT failure as
+    /// "missing contract parameters" (the `state_store.get_params` miss, which
+    /// happens BEFORE the gate), so a lowercase "missing contract" substring
+    /// would conflate the two and report the wrong cause as the right one.
+    fn missing_contract(err: &crate::contract::ExecutorError) -> bool {
+        format!("{err:?}").contains("MissingContract")
+    }
+
+    /// An UPDATE addressed by instance id — the code hash a client that only
+    /// knows the base58 instance id can supply — must reach the same place a
+    /// fully-specified UPDATE reaches, on a node that holds the contract.
+    ///
+    /// Before the fix the placeholder-keyed call returned `MissingContract` from
+    /// the `code_blob_stored` gate while the correctly-keyed call sailed past
+    /// it, so this test fails on the first assertion with the fix reverted.
+    #[tokio::test]
+    async fn update_with_placeholder_code_hash_resolves_from_instance_id() {
+        let (mut executor, _temp) = build_executor("update-by-instance-id").await;
+
+        let (container, key) = make_contract(7, 7);
+        seed_held_contract(
+            &mut executor,
+            container,
+            key,
+            WrappedState::new(vec![1u8; 8]),
+        )
+        .await;
+
+        // Exactly what `fdev update` and the TS SDK's `fromInstanceId()` produce:
+        // the right instance id, a code hash that names no blob.
+        let placeholder = ContractKey::from_id_and_code(*key.id(), CodeHash::new([0u8; 32]));
+        assert_ne!(
+            placeholder.code_hash(),
+            key.code_hash(),
+            "the fixture must actually carry a wrong code hash"
+        );
+
+        let by_instance_id = executor
+            .upsert_contract_state(
+                placeholder,
+                Either::Left(WrappedState::new(vec![2u8; 8])),
+                RelatedContracts::default(),
+                None,
+            )
+            .await;
+        let err = by_instance_id
+            .expect_err("synthetic WASM cannot validate, so this must fail somewhere");
+        assert!(
+            !missing_contract(&err),
+            "an UPDATE addressed by instance id must resolve the code hash from \
+             the store instead of failing the code_blob_stored gate (#4978), \
+             got: {err:?}"
+        );
+
+        // Control: the fully-specified key must land in the same place, which is
+        // what "addressing by instance id now works like GET/SUBSCRIBE" means.
+        let by_full_key = executor
+            .upsert_contract_state(
+                key,
+                Either::Left(WrappedState::new(vec![2u8; 8])),
+                RelatedContracts::default(),
+                None,
+            )
+            .await;
+        let full_key_err =
+            by_full_key.expect_err("synthetic WASM cannot validate, so this must fail too");
+        assert!(
+            !missing_contract(&full_key_err),
+            "the fully-specified control must not hit the gate either: {full_key_err:?}"
+        );
+        // `ExecutorError` is a struct, so there is no variant to compare; the
+        // rendered error is the observable. Once the code hash is resolved the
+        // two calls are the same call, so their errors must be identical — a
+        // stronger claim than "both got past the gate", and the one that says
+        // instance-id addressing IS full-key addressing.
+        assert_eq!(
+            format!("{err:?}"),
+            format!("{full_key_err:?}"),
+            "instance-id addressing must fail in the same way as full-key \
+             addressing, not merely fail differently"
+        );
+    }
+
+    /// The resolution must not paper over a genuinely absent contract: with no
+    /// instance→code row to resolve, the caller's key stands and the existing
+    /// `MissingContract` refusal is unchanged. Without this the fix could look
+    /// like it works simply because it stopped rejecting anything.
+    #[tokio::test]
+    async fn update_for_an_unheld_contract_still_reports_missing_contract() {
+        let (mut executor, _temp) = build_executor("update-unheld-contract").await;
+
+        // A different contract is held, so the store is populated but has no row
+        // for the instance under test.
+        let (container, held_key) = make_contract(7, 7);
+        seed_held_contract(
+            &mut executor,
+            container,
+            held_key,
+            WrappedState::new(vec![1u8; 8]),
+        )
+        .await;
+
+        let (_absent_container, absent_key) = make_contract(9, 9);
+        let absent_instance: ContractInstanceId = *absent_key.id();
+        assert!(
+            executor.lookup_key(&absent_instance).is_none(),
+            "fixture must leave the instance unresolvable"
+        );
+
+        // Params are seeded so the failure is the code gate rather than the
+        // earlier "missing contract parameters" refusal.
+        executor
+            .state_store
+            .store(
+                absent_key,
+                WrappedState::new(vec![1u8; 8]),
+                Parameters::from(vec![9u8; 8]),
+            )
+            .await
+            .expect("seeding params + state must succeed");
+
+        let placeholder = ContractKey::from_id_and_code(absent_instance, CodeHash::new([0u8; 32]));
+        let err = executor
+            .upsert_contract_state(
+                placeholder,
+                Either::Left(WrappedState::new(vec![2u8; 8])),
+                RelatedContracts::default(),
+                None,
+            )
+            .await
+            .expect_err("an UPDATE for a contract this node does not hold must fail");
+        assert!(
+            missing_contract(&err),
+            "an unresolvable instance must still be refused with MissingContract, \
+             got: {err:?}"
+        );
+    }
+}

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -166,6 +166,18 @@ impl Executor<Runtime> {
         key: ContractKey,
         update: UpdateData<'_>,
     ) -> Response {
+        // #4978: resolve the code hash from the instance id, the same way
+        // `bridged_upsert_contract_state_inner` does for the network path. Local
+        // mode never hit the `code_blob_stored` gate, so this is not about
+        // letting the UPDATE through — it is about what the unresolved key
+        // DURABLY writes. `commit_state_update` below reaches
+        // `StateStore::update` → the backend `store()`, and both backends
+        // persist `key.code_hash()` into the hosting-metadata row used to
+        // reconstruct the `ContractKey` on restart (`storages/redb.rs`,
+        // `storages/sqlite.rs`). A placeholder hash there yields a hosting-cache
+        // key whose code half is zeros, so a later `remove_contract` computes
+        // the blob path from zeros and never reclaims the real `.wasm`.
+        let key = self.bridged_lookup_key(key.id()).unwrap_or(key);
         let parameters = {
             self.state_store
                 .get_params(&key)

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -177,6 +177,14 @@ impl Executor<Runtime> {
         // `storages/sqlite.rs`). A placeholder hash there yields a hosting-cache
         // key whose code half is zeros, so a later `remove_contract` computes
         // the blob path from zeros and never reclaims the real `.wasm`.
+        //
+        // `unwrap_or` keeps the caller's key when nothing resolves, which does
+        // NOT fully close that hole: local mode has no `code_blob_stored` gate
+        // downstream, and `state_store.get_params` is instance-keyed, so a
+        // contract with state and params but no contract-index row still writes
+        // the placeholder. That divergence is pre-existing (`load_from_storage`
+        // already logs it as a failed migration), and the load-side resolution
+        // added for #4978 repairs such a row once the index does know it.
         let key = self.bridged_lookup_key(key.id()).unwrap_or(key);
         let parameters = {
             self.state_store

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -150,7 +150,24 @@ where
             }
             container_key
         } else {
-            key
+            // #4978: with no container in hand the caller's code hash is all we
+            // have, and UPDATE is the one verb whose wire type carries a full
+            // `ContractKey` — so a client that built its key from a base58
+            // instance id alone (the TS SDK's `fromInstanceId()`, `fdev
+            // update`'s all-zero placeholder) hands us a code hash that names
+            // no blob, and the `code_blob_stored(key.code_hash())` gate below
+            // rejects the UPDATE with `MissingContract` even though this node
+            // holds the contract. GET and SUBSCRIBE never hit this because they
+            // carry only an instance id and are resolved by `lookup_key`.
+            //
+            // Resolve the same way here. The instance id is derived from the
+            // code hash and the parameters, so the store's instance->code row
+            // is the authoritative answer and a correct caller-supplied hash
+            // resolves to itself. When this node has no row for the instance
+            // (it does not hold the contract) the caller's key is kept
+            // unchanged, so the existing `MissingContract` / auto-fetch
+            // behaviour is untouched.
+            self.bridged_lookup_key(key.id()).unwrap_or(key)
         };
 
         // Opportunistically clean up any stale initializations to prevent resource leaks

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -152,22 +152,53 @@ where
         } else {
             // #4978: with no container in hand the caller's code hash is all we
             // have, and UPDATE is the one verb whose wire type carries a full
-            // `ContractKey` — so a client that built its key from a base58
-            // instance id alone (the TS SDK's `fromInstanceId()`, `fdev
-            // update`'s all-zero placeholder) hands us a code hash that names
-            // no blob, and the `code_blob_stored(key.code_hash())` gate below
-            // rejects the UPDATE with `MissingContract` even though this node
-            // holds the contract. GET and SUBSCRIBE never hit this because they
-            // carry only an instance id and are resolved by `lookup_key`.
+            // `ContractKey` — so a client that can only supply an instance id
+            // hands us a code hash that names no blob, and the
+            // `code_blob_stored(key.code_hash())` gate below rejects the UPDATE
+            // with `MissingContract` even though this node holds the contract.
+            // GET and SUBSCRIBE never hit this because they carry only an
+            // instance id and are resolved by `lookup_key`.
             //
-            // Resolve the same way here. The instance id is derived from the
-            // code hash and the parameters, so the store's instance->code row
-            // is the authoritative answer and a correct caller-supplied hash
-            // resolves to itself. When this node has no row for the instance
-            // (it does not hold the contract) the caller's key is kept
-            // unchanged, so the existing `MissingContract` / auto-fetch
-            // behaviour is untouched.
-            self.bridged_lookup_key(key.id()).unwrap_or(key)
+            // Concretely that is `fdev update`, which fills in an all-zero
+            // `CodeHash` placeholder, and any other client that sends a
+            // well-formed but wrong 32-byte hash. It is NOT yet the TypeScript
+            // SDK's `fromInstanceId()`: that emits a present-but-EMPTY code
+            // vector, which stdlib 0.8.5's `ContractKey::try_decode_fbs`
+            // refuses at the wire boundary, so it never reaches this function.
+            // Relaxing that decode to `Option<CodeHash>` is the stdlib half,
+            // deliberately sequenced after this one — this is the core-side
+            // resolution that makes a `None` answerable.
+            //
+            // Resolve the same way the rest of the store already does
+            // (`ContractStore::fetch_contract`, `prepare_contract_call_inner`):
+            // the instance id is derived from the code hash and the parameters,
+            // so the store's instance->code row is the authoritative answer and
+            // a correct caller-supplied hash resolves to itself. This is also
+            // what keeps a placeholder hash out of the DURABLE hosting-metadata
+            // row, which `storages/redb.rs` and `storages/sqlite.rs` write from
+            // `key.code_hash()` and read back to rebuild the key on restart.
+            //
+            // When this node has no row for the instance (it does not hold the
+            // contract) the caller's key is kept unchanged, so the existing
+            // `MissingContract` / auto-fetch behaviour is untouched.
+            match self.bridged_lookup_key(key.id()) {
+                Some(resolved) => resolved,
+                None => {
+                    // Worth a line: after this change an unresolvable instance
+                    // is the ONLY way to reach the `MissingContract` below with
+                    // a caller-supplied hash, and `ContractKey`'s `Display` is
+                    // instance-only, so nothing else in the log distinguishes
+                    // "no index row for this instance" from "this hash names no
+                    // blob".
+                    tracing::debug!(
+                        contract = %key,
+                        caller_code_hash = ?key.code_hash(),
+                        "update: no instance->code row for this contract; keeping \
+                         the caller's code hash (this node does not hold it)"
+                    );
+                    key
+                }
+            }
         };
 
         // Opportunistically clean up any stale initializations to prevent resource leaks

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -3131,7 +3131,20 @@ impl HostingManager {
                 instance_id_bytes.copy_from_slice(&key_bytes);
                 loaded_instance_ids.insert(instance_id_bytes);
                 let instance_id = ContractInstanceId::new(instance_id_bytes);
-                let code_hash = CodeHash::new(metadata.code_hash);
+                // #4978: prefer the contract store's instance->code row over the
+                // hash persisted in this row. The persisted hash is whatever key
+                // reached `StateStorage::store`, and a pre-fix binary could put a
+                // WRONG one there: local-mode UPDATE wrote the client's key
+                // verbatim, so `fdev update`'s all-zero placeholder landed here.
+                // Restoring that gives a hosting-cache key whose code half is
+                // zeros, and `ContractStore::remove_contract` derives the blob
+                // path from `key.code_hash()` — so eviction never reclaims the
+                // real `.wasm` and the row stays wrong across every subsequent
+                // restart. Resolving here repairs that corpus in place; the
+                // persisted hash remains the fallback for an instance the
+                // contract store has no row for.
+                let code_hash = code_hash_lookup(&instance_id)
+                    .unwrap_or_else(|| CodeHash::new(metadata.code_hash));
                 let key = ContractKey::from_id_and_code(instance_id, code_hash);
 
                 let access_type = match metadata.access_type {
@@ -3293,7 +3306,20 @@ impl HostingManager {
                 instance_id_bytes.copy_from_slice(&key_bytes);
                 loaded_instance_ids.insert(instance_id_bytes);
                 let instance_id = ContractInstanceId::new(instance_id_bytes);
-                let code_hash = CodeHash::new(metadata.code_hash);
+                // #4978: prefer the contract store's instance->code row over the
+                // hash persisted in this row. The persisted hash is whatever key
+                // reached `StateStorage::store`, and a pre-fix binary could put a
+                // WRONG one there: local-mode UPDATE wrote the client's key
+                // verbatim, so `fdev update`'s all-zero placeholder landed here.
+                // Restoring that gives a hosting-cache key whose code half is
+                // zeros, and `ContractStore::remove_contract` derives the blob
+                // path from `key.code_hash()` — so eviction never reclaims the
+                // real `.wasm` and the row stays wrong across every subsequent
+                // restart. Resolving here repairs that corpus in place; the
+                // persisted hash remains the fallback for an instance the
+                // contract store has no row for.
+                let code_hash = code_hash_lookup(&instance_id)
+                    .unwrap_or_else(|| CodeHash::new(metadata.code_hash));
                 let key = ContractKey::from_id_and_code(instance_id, code_hash);
 
                 let access_type = match metadata.access_type {
@@ -7968,6 +7994,101 @@ mod tests {
                 .admit_state_update(&make_contract_key(1), 300 * MIB)
                 .is_err(),
             "growth over budget must still reject"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "redb"))]
+mod restore_code_hash_repair_tests {
+    //! freenet/freenet-core#4978, the durable half.
+    //!
+    //! `StateStorage::store` persists whatever `key.code_hash()` it is handed
+    //! into the hosting-metadata row (`storages/redb.rs`, `storages/sqlite.rs`),
+    //! and `load_from_storage` rebuilds the `ContractKey` from it on restart.
+    //! A pre-fix binary could put a WRONG hash there — local-mode UPDATE wrote
+    //! the client's key verbatim, so `fdev update`'s all-zero placeholder
+    //! landed in the row. Restoring that verbatim gives a hosting-cache key
+    //! whose code half is zeros, and `ContractStore::remove_contract` derives
+    //! the blob path from `key.code_hash()`, so eviction never reclaims the
+    //! real `.wasm` and the bad row survives every subsequent restart.
+    //!
+    //! So the load path must prefer the contract store's instance->code row.
+    //! These tests are the guard for that, and they need no WASM engine: the
+    //! resolver is just the closure `load_from_storage` already takes.
+
+    use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey, WrappedState};
+
+    use super::HostingManager;
+    use crate::contract::storages::Storage;
+    use crate::wasm_runtime::StateStorage;
+
+    const REAL_CODE_HASH: [u8; 32] = [0xAB; 32];
+
+    async fn storage_with_row(dir: &tempfile::TempDir, key: ContractKey) -> Storage {
+        let storage = Storage::new(dir.path()).await.expect("create storage");
+        // Goes through the production write, so the test cannot drift from how
+        // the row is actually produced.
+        storage
+            .store(key, WrappedState::new(vec![1u8; 8]))
+            .await
+            .expect("store state + hosting metadata");
+        storage
+    }
+
+    fn instance() -> ContractInstanceId {
+        ContractInstanceId::new([0x11; 32])
+    }
+
+    /// A row written by a pre-fix binary carries an all-zero code hash. The
+    /// contract store knows the real one, so the load must use it.
+    #[tokio::test]
+    async fn load_prefers_the_contract_index_over_a_placeholder_row() {
+        let dir = crate::util::tests::get_temp_dir();
+        let placeholder = ContractKey::from_id_and_code(instance(), CodeHash::new([0u8; 32]));
+        let storage = storage_with_row(&dir, placeholder).await;
+
+        let manager = HostingManager::new(10_000_000);
+        manager
+            .load_from_storage(&storage, |id| {
+                (*id == instance()).then(|| CodeHash::new(REAL_CODE_HASH))
+            })
+            .expect("load must succeed");
+
+        let restored = manager
+            .hosting_contract_keys()
+            .into_iter()
+            .find(|k| *k.id() == instance())
+            .expect("the row must be restored");
+        assert_eq!(
+            restored.code_hash(),
+            &CodeHash::new(REAL_CODE_HASH),
+            "the persisted placeholder must be repaired from the contract index, \
+             or eviction computes the blob path from zeros and leaks the .wasm"
+        );
+    }
+
+    /// The fallback must survive: an instance the contract store has no row for
+    /// keeps the persisted hash rather than being dropped or zeroed.
+    #[tokio::test]
+    async fn load_falls_back_to_the_persisted_hash_when_unresolvable() {
+        let dir = crate::util::tests::get_temp_dir();
+        let persisted = ContractKey::from_id_and_code(instance(), CodeHash::new(REAL_CODE_HASH));
+        let storage = storage_with_row(&dir, persisted).await;
+
+        let manager = HostingManager::new(10_000_000);
+        manager
+            .load_from_storage(&storage, |_| None)
+            .expect("load must succeed");
+
+        let restored = manager
+            .hosting_contract_keys()
+            .into_iter()
+            .find(|k| *k.id() == instance())
+            .expect("the row must still be restored when nothing resolves it");
+        assert_eq!(
+            restored.code_hash(),
+            &CodeHash::new(REAL_CODE_HASH),
+            "an unresolvable instance must keep its persisted hash"
         );
     }
 }

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4730,10 +4730,15 @@ async fn test_get_after_update_observes_fresh_state_3357(ctx: &mut TestContext) 
 /// `ContractKey`, and its code hash used to be taken at face value and fed to
 /// the executor's `code_blob_stored(key.code_hash())` gate — so every client
 /// that can only supply an instance id got `MissingContract` from a node that
-/// was holding the contract. That is the TypeScript SDK's `fromInstanceId()`
-/// (which emits an empty code vector) and freenet-core's own `fdev update`
-/// (which fills in an all-zero `CodeHash`), reproduced here with the same
-/// all-zero placeholder.
+/// was holding the contract. That is freenet-core's own `fdev update` (which
+/// fills in an all-zero `CodeHash`), reproduced here with the same placeholder.
+///
+/// Not covered, and not coverable here: the TypeScript SDK's `fromInstanceId()`
+/// emits a present-but-EMPTY code vector, which stdlib 0.8.5's
+/// `ContractKey::try_decode_fbs` refuses at the wire boundary — and this test
+/// speaks bincode anyway (`ws_url()` appends `?encodingProtocol=native`), so no
+/// test here touches the FlatBuffers decode. Relaxing that decode is the stdlib
+/// half of freenet/freenet-core#4978.
 ///
 /// This runs in NETWORK mode deliberately. The bug was mode-dependent: local
 /// mode dispatches through `perform_contract_update`, which never reaches that
@@ -4817,9 +4822,23 @@ async fn test_update_contract_by_instance_id_4978(ctx: &mut TestContext) -> Test
             key,
             summary: _,
         }))) => {
+            // Compare INSTANCE IDs explicitly. `ContractKey`'s `PartialEq` is
+            // instance-only, so `assert_eq!(key, contract_key)` would pass on a
+            // zeroed code hash and read as a stronger check than it is.
             assert_eq!(
-                key, contract_key,
-                "Contract key mismatch in UPDATE response"
+                key.id(),
+                contract_key.id(),
+                "Contract instance mismatch in UPDATE response"
+            );
+            // The response echoes the key the client sent: the driver never
+            // rewrites it (only the executor resolves, and it does so on its own
+            // copy), so the placeholder comes back. Asserted so the day someone
+            // normalises the response key, this test says so out loud rather
+            // than quietly continuing to pass.
+            assert_eq!(
+                key.code_hash(),
+                instance_id_only_key.code_hash(),
+                "UPDATE response is expected to echo the client's key unchanged"
             );
         }
         Ok(Ok(other)) => bail!("unexpected response while waiting for update: {other:?}"),

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4857,10 +4857,16 @@ async fn test_update_contract_by_instance_id_4978(ctx: &mut TestContext) -> Test
     for attempt in 1..=MAX_VERSION_POLL_ATTEMPTS {
         let (response_contract, response_state) =
             get_contract(&mut client_api_a, contract_key, &gateway.temp_dir_path).await?;
+        // Instance ids compared explicitly, for the same reason as the UPDATE
+        // response above: `ContractKey`'s `PartialEq` is instance-only.
         assert_eq!(
-            response_contract.key(),
-            contract_key,
-            "Contract key mismatch in GET response"
+            response_contract.key().id(),
+            contract_key.id(),
+            "Contract instance mismatch in GET response"
+        );
+        assert_eq!(
+            response_contract, contract,
+            "Contract content mismatch in GET response"
         );
 
         let list: test_utils::TodoList = serde_json::from_slice(response_state.as_ref())

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4721,3 +4721,156 @@ async fn test_get_after_update_observes_fresh_state_3357(ctx: &mut TestContext) 
 
     Ok(())
 }
+
+/// Regression test for freenet/freenet-core#4978: an UPDATE addressed by
+/// instance id alone must work, exactly as GET and SUBSCRIBE already do.
+///
+/// GET and SUBSCRIBE carry only a `ContractInstanceId` on the wire, so the node
+/// resolves the code hash itself. `ContractRequest::Update` carries a full
+/// `ContractKey`, and its code hash used to be taken at face value and fed to
+/// the executor's `code_blob_stored(key.code_hash())` gate — so every client
+/// that can only supply an instance id got `MissingContract` from a node that
+/// was holding the contract. That is the TypeScript SDK's `fromInstanceId()`
+/// (which emits an empty code vector) and freenet-core's own `fdev update`
+/// (which fills in an all-zero `CodeHash`), reproduced here with the same
+/// all-zero placeholder.
+///
+/// This runs in NETWORK mode deliberately. The bug was mode-dependent: local
+/// mode dispatches through `perform_contract_update`, which never reaches that
+/// gate, so the placeholder key worked against `freenet local` and failed the
+/// moment the same client pointed at the network.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway", "peer-a"],
+    timeout_secs = 300,
+    startup_wait_secs = 30,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_update_contract_by_instance_id_4978(ctx: &mut TestContext) -> TestResult {
+    const TEST_CONTRACT: &str = "test-contract-integration";
+    let contract = test_utils::load_contract(TEST_CONTRACT, vec![].into())?;
+    let contract_key = contract.key();
+
+    let initial_state = test_utils::create_empty_todo_list();
+    let wrapped_state = WrappedState::from(initial_state);
+
+    let peer_a = ctx.node("peer-a")?;
+    let gateway = ctx.node("gateway")?;
+
+    let uri = peer_a.ws_url();
+    let (stream, _) = connect_async(&uri).await?;
+    let mut client_api_a = WebApi::start(stream);
+
+    make_put(
+        &mut client_api_a,
+        wrapped_state.clone(),
+        contract.clone(),
+        false,
+    )
+    .await?;
+
+    match tokio::time::timeout(Duration::from_secs(120), client_api_a.recv()).await {
+        Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+            assert_eq!(key, contract_key, "Contract key mismatch in PUT response");
+        }
+        Ok(Ok(other)) => bail!("unexpected response while waiting for put: {other:?}"),
+        Ok(Err(e)) => bail!("Error receiving put response: {e}"),
+        Err(_) => bail!("Timeout waiting for put response after 120 seconds"),
+    }
+
+    let mut todo_list: test_utils::TodoList = serde_json::from_slice(wrapped_state.as_ref())
+        .unwrap_or_else(|_| test_utils::TodoList {
+            tasks: Vec::new(),
+            version: 0,
+        });
+    todo_list.tasks.push(test_utils::Task {
+        id: 1,
+        title: "Update addressed by instance id".to_string(),
+        description: "Regression coverage for #4978".to_string(),
+        completed: false,
+        priority: 3,
+    });
+    let updated_state = WrappedState::from(serde_json::to_vec(&todo_list).unwrap());
+    let expected_version_after_update = todo_list.version + 1;
+
+    // The whole point of the test: everything about this key is right except the
+    // code hash, which is the all-zero placeholder an instance-id-only client
+    // has to supply.
+    let instance_id_only_key =
+        ContractKey::from_id_and_code(*contract_key.id(), CodeHash::new([0u8; 32]));
+    assert_ne!(
+        instance_id_only_key.code_hash(),
+        contract_key.code_hash(),
+        "the fixture must actually carry a placeholder code hash"
+    );
+
+    make_update(
+        &mut client_api_a,
+        instance_id_only_key,
+        updated_state.clone(),
+    )
+    .await?;
+
+    match tokio::time::timeout(Duration::from_secs(60), client_api_a.recv()).await {
+        Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateResponse {
+            key,
+            summary: _,
+        }))) => {
+            assert_eq!(
+                key, contract_key,
+                "Contract key mismatch in UPDATE response"
+            );
+        }
+        Ok(Ok(other)) => bail!("unexpected response while waiting for update: {other:?}"),
+        // Pre-fix this is where the bug lands: `MissingContract` for a contract
+        // the node just stored and can serve over GET.
+        Ok(Err(e)) => bail!("Error receiving update response: {e}"),
+        Err(_) => bail!("Timeout waiting for update response"),
+    }
+
+    // The response only says the operation was accepted; poll the state until the
+    // merge is observable, as `test_update_contract` does.
+    const MAX_VERSION_POLL_ATTEMPTS: usize = 30;
+    const VERSION_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+    let mut observed: Option<test_utils::TodoList> = None;
+    for attempt in 1..=MAX_VERSION_POLL_ATTEMPTS {
+        let (response_contract, response_state) =
+            get_contract(&mut client_api_a, contract_key, &gateway.temp_dir_path).await?;
+        assert_eq!(
+            response_contract.key(),
+            contract_key,
+            "Contract key mismatch in GET response"
+        );
+
+        let list: test_utils::TodoList = serde_json::from_slice(response_state.as_ref())
+            .expect("Failed to deserialize response state");
+        tracing::info!(
+            "Version poll attempt {attempt}/{MAX_VERSION_POLL_ATTEMPTS}: got version {}, expected {}",
+            list.version,
+            expected_version_after_update
+        );
+        if list.version == expected_version_after_update {
+            observed = Some(list);
+            break;
+        }
+        if attempt < MAX_VERSION_POLL_ATTEMPTS {
+            tokio::time::sleep(VERSION_POLL_INTERVAL).await;
+        }
+    }
+
+    let observed = observed.ok_or_else(|| {
+        anyhow::anyhow!(
+            "an UPDATE addressed by instance id was accepted but never applied: \
+             expected version {expected_version_after_update}, never observed"
+        )
+    })?;
+    assert_eq!(observed.tasks.len(), 1, "Should have one task");
+    assert_eq!(
+        observed.tasks[0].title, "Update addressed by instance id",
+        "Task title should match"
+    );
+
+    Ok(())
+}

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -416,7 +416,10 @@ pub async fn get_contract_id(config: GetContractIdConfig) -> anyhow::Result<()> 
 }
 
 pub async fn update(config: UpdateConfig, other: BaseConfig) -> anyhow::Result<()> {
-    // Create ContractKey with placeholder code hash - the node will look up the actual key
+    // `ContractRequest::Update` carries a full `ContractKey` while the user gave
+    // us only a base58 instance id, so the code hash is a placeholder the node
+    // resolves from its own instance->code index. That resolution is #4978; on a
+    // node older than that fix this placeholder fails with `missing contract`.
     let instance_id = ContractInstanceId::try_from(config.key)?;
     let key = ContractKey::from_id_and_code(instance_id, CodeHash::new([0u8; 32]));
     println!("Updating contract {key}");


### PR DESCRIPTION
## Problem

GET and SUBSCRIBE carry only a `ContractInstanceId` on the wire, so the node resolves the contract's code hash itself (`lookup_key` → `ContractStore::code_hash_from_id`). `ContractRequest::Update` carries a full `ContractKey`, and its code hash was taken at face value all the way down to the executor's gate:

```rust
// contract/executor/runtime/executor_impl.rs
if !self.runtime.code_blob_stored(key.code_hash()) {
```

UPDATE passes `code: None`, so a miss there returned `MissingContract` — *"Contract not in store and no code provided"* — even on a node that is holding the contract and will happily serve it over GET. Reproduced against live nodes in the issue thread (0.2.118 and 0.2.128).

The concrete first-party casualty is **`fdev update`**, which fills in an all-zero `CodeHash` placeholder (`crates/fdev/src/commands.rs`). Its comment claimed the node would look up the real key; that was true for `get` (which sends `*key.id()`) and false for `update`.

The gate also had the sign wrong on the case that matters. A hash naming **another stored contract's** blob *passed* it — the blob is on disk, it just belongs to someone else — and was then carried onward as the key. A hash naming *no* blob (the harmless case) was refused. So it rejected the benign shape and accepted the wrong one.

## Approach

Resolve the code hash from the instance id in the `code.is_none()` branch of `bridged_upsert_contract_state_inner`, and in `perform_contract_update` (local mode).

Why the executor rather than the client edge:

- `bridged_upsert_contract_state_inner` is the **one funnel every network apply passes through** — client-originated local apply, relayed `RequestUpdate`, broadcast fan-out, the deferred related-fetch re-run — so each node resolves for itself and the fix does not depend on which peer originated the request. Fixing only the client edge would have left every relay hop still choking on the forwarded key (raised by @magks in the issue thread).
- The instance id is `BLAKE3(code_hash ‖ params)`, so the store's `instance→code` row is the authoritative answer. A correct caller-supplied hash resolves to itself; a wrong one is corrected rather than trusted. Two adjacent sites already resolve exactly this way and call the wire hash an unverified serde field (`ContractStore::fetch_contract`, `prepare_contract_call_inner`) — the gate was the outlier.
- `code_hash_from_id` is an in-memory `DashMap` read (rehydrated from the DB at store construction), so this is not a hot-path cost.
- No index row for the instance ⇒ the caller's key stands ⇒ the existing `MissingContract` / auto-fetch behaviour is untouched.

**The load path repairs rows that are already wrong.** `HostingManager::load_from_storage` was handed a contract-index resolver but only used it on the legacy-migration branch — the metadata branch rebuilt the key from the persisted hash unconditionally. So a row corrupted by a pre-fix binary (local-mode UPDATE wrote the client's key verbatim, so `fdev update`'s placeholder landed there) came back wrong on *every* restart, and the `.wasm` it should have reclaimed leaked permanently. Both backends' load paths now prefer the index and fall back to the persisted hash. Without this the local-mode hunk only stops new corruption and leaves the existing corpus broken.

**Local mode is included for a different reason.** It never reached that gate, so the UPDATE already succeeded — but `perform_contract_update` → `commit_state_update` → `StateStore::update` → the backend `store()` **durably persists `key.code_hash()`** into the hosting-metadata row used to rebuild the `ContractKey` on restart (`storages/redb.rs`, `storages/sqlite.rs`). A placeholder there yields a hosting-cache key whose code half is zeros, so a later `remove_contract` computes the blob path from zeros and never reclaims the real `.wasm`. This PR also makes `fdev update`'s placeholder more discoverable, so that combination gets likelier, not rarer.

**No wire format change, no protocol enum change, no stdlib change.** `ContractKey`'s `PartialEq`/`Hash`/`as_bytes` are instance-only, so the substituted key is invisible to every map, comparison and route decision. It *is* deliberately visible in two places: the durable hosting-metadata row above, and `Debug`-rendered keys inside errors.

One API fact worth stating plainly: **`ContractKey.code` is now advisory-only on UPDATE.** This was its last observable effect (WASM selection already resolved through the index), and it is the precondition for relaxing the stdlib decoder.

## What this does NOT fix

**The TypeScript SDK's `fromInstanceId()` path is still broken, and this PR cannot fix it.** `fromInstanceId()` emits a present-but-**empty** code vector, and stdlib 0.8.5's `ContractKey::try_decode_fbs` rejects an absent or non-32-byte `code` at the wire boundary — so it fails with a deserialization error and never reaches the executor. Only a well-formed-but-wrong 32-byte hash (`fdev update`, bincode clients) benefits here.

That decode's own error text currently tells users the node "gates an UPDATE on already holding the contract's code blob and probes for it by code hash" — the premise this PR removes. Relaxing it to `Option<CodeHash>` is the stdlib half, deliberately sequenced behind this one per the issue's ordering note, and that guidance should be updated with it.

So this is **`Part of #4978`, not `Closes`** — the issue stays open to track the stdlib half. Two further gaps recorded rather than silently left:

- **The forwarded wire key is not normalised**, and it stays unresolved for the *whole* relay chain, not one hop (`op_ctx_task.rs` rebuilds `RequestUpdate` from the inbound key). New peers resolve it themselves; an old peer refuses it exactly as it does today. That narrows a path which currently fails 100% of the time, and the executor's own broadcast fan-out already carries the resolved key — but the mixed-version window is "any old peer on the route", not "the first target".
  One nuance worth stating plainly: because the driver returns `Ok(UpdateResponse)` after the local apply, the client-visible outcome for exactly the requests this unblocks changes from a clean deterministic failure to "success, with one old hop on the route silently dropping the forwarded request". That is bounded — the old peer writes nothing durable and does not amplify (no backoff record, no resync, no auto-fetch), the executor's broadcast fan-out already carries the resolved key, and InterestSync anti-entropy heals the hop. It converges late, not never.
- **The client-visible response key is not normalised either** — the driver echoes what the client sent. Asserted explicitly in the integration test so a future change to that is noticed.

Threading a resolved key back out of `update_contract` would touch nine `UpdateExecution` sites; happy to do it if reviewers judge either window worth closing now.

## Testing

`crates/core/src/contract/executor/runtime.rs` — new `update_by_instance_id_tests`, driving a real `Executor<Runtime>` (real `ContractStore`, real `StateStore`, no network). A `MockRuntime`-backed test could not have caught this: it keys everything by instance id and has no code-hash probe, so it passes with the fix reverted.

- `update_with_placeholder_code_hash_resolves_from_instance_id` — the same UPDATE twice, once with the all-zero placeholder and once with the full key; asserts neither hits the gate **and that both witness the same resolved key**. The synthetic WASM cannot validate, so both die later in the engine; "refused at the gate" vs. "reached the engine" is what makes it discriminating rather than a blanket "UPDATE fails".
- `update_with_another_contracts_code_hash_resolves_to_its_own` — the direction this change actually narrows, and the one the all-zero fixtures cannot see: a hash naming a *different held contract's* blob. Asserts the resolved key carries A's hash and that B's does not survive.
- `update_for_an_unheld_contract_still_reports_missing_contract` — negative control. With no row to resolve, `MissingContract` must still come back, so the fix cannot pass by having simply stopped rejecting things.

`crates/core/tests/operations.rs` — `test_update_contract_by_instance_id_4978`, a two-node **network-mode** `#[freenet_test]`: PUT, UPDATE with the placeholder key, then poll a GET until the merged version is observable. Covers the chain the unit tests cannot (`client_events` → `start_client_update` → handler → executor). Network mode is deliberate — local mode never hit the gate.

`crates/core/src/ring/hosting.rs` — `restore_code_hash_repair_tests`: a hosting-metadata row written with a placeholder hash is repaired from the contract index on load, and an instance the index cannot resolve keeps its persisted hash. No WASM engine needed — the resolver is the closure `load_from_storage` already takes.

`crates/core/src/contract/executor/runtime.rs` — source pin `update_apply_paths_resolve_code_hash_before_touching_the_state_store`. This exists because the two apply paths are not equally reachable: `perform_contract_update` is `impl Executor<Runtime>` and only reaches the durable write after a real WASM `update_state` succeeds, and nothing else in the tree calls it — so the local-mode resolution could otherwise be deleted with the whole suite green. The pin asserts ORDER, not just presence, since the harm is what the unresolved key writes.

**Mutation-verified**, not just green: with the resolution reverted to `key`, `update_with_placeholder_code_hash_resolves_from_instance_id` fails with exactly the issue's `MissingContract`, and the negative control stays green (as it must).

Part of #4978

[AI-assisted - Claude]
