### PR TITLE
fix(executor): notify subscribed delegates on initial state install

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -3,7 +3,6 @@ paths:
   - "crates/core/src/bin/**"
   - "crates/core/src/conformance/**"
   - "crates/core/src/contract/**"
-  - "crates/core/src/operations/**"
   - "scripts/**"
 ---
 
@@ -698,7 +697,7 @@ Question to ask of any one of them: *if this branch fires a thousand times, what
 a reader see?* If the answer is "an empty result", the count is missing.
 
 
-## A mandatory side-effect sequence, hand-inlined per branch
+## Manually-inlined originator side effects (a mandatory sequence, hand-inlined per branch)
 
 **When two code paths both owe the same sequence of side effects, extract one
 helper that owns the whole sequence and call it from both. Never re-inline a
@@ -718,8 +717,9 @@ it keeps working perfectly for every other consumer.
 | Issue | The path that re-inlined a subset | The leg it dropped |
 |---|---|---|
 | [#3851](https://github.com/freenet/freenet-core/issues/3851) | SUBSCRIBE originator, after the task-per-tx migration | The originator's own side-effect call |
-| [#4223](https://github.com/freenet/freenet-core/issues/4223) | GET originator driver | `fetch_contract_if_missing` — so ~37% of GETs through subscriber peers returned `NotFound` for months, for a contract whose body the node never fetched |
+| [#4223](https://github.com/freenet/freenet-core/issues/4223) | SUBSCRIBE originator driver (`operations/subscribe/op_ctx_task.rs`, `ReplyClass::Subscribed`) | `fetch_contract_if_missing` — so a peer registered as a subscriber held no body, and ~37% of failing GETs that reached a subscriber got `NotFound` from it for months |
 | [#5481](https://github.com/freenet/freenet-core/issues/5481) | `bridged_upsert_contract_state_inner`'s initial-state-install branch | `send_delegate_contract_notifications`. The same branch had already dropped `send_update_notification` once before, been fixed, and carried a comment describing that fix — which did not stop the next leg being dropped |
+| #5481, found in review | BOTH branches of `contract_ops::perform_contract_put` | `record_contract_update` AND `send_delegate_contract_notifications` — the identical defect, one file over from where it was being fixed, surfaced by running this row's own audit grep against the fixing PR |
 
 #5481 is the instructive one: a comment explaining the exact failure sat three
 lines above the code that repeated it. Prose does not prevent this; structure
@@ -739,6 +739,10 @@ does.
 4. **Verify the pin by deleting a leg and watching it go red.** Inspection is not
    verification: a pin needle that no longer matches (rustfmt splitting a long
    call across lines is the common cause) passes vacuously forever.
+5. **Scrape every file the sequence can live in, and run the audit grep against
+   your own branch before claiming the rule holds.** #5481's fixing PR asserted
+   "exactly one call site", scraped one file, and left two counterexamples in a
+   sibling module that the grep three lines below finds in under a second.
 
 ### Audit
 

--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -738,7 +738,10 @@ does.
    precede announce, so the node never advertises hosting without the body).
 4. **Verify the pin by deleting a leg and watching it go red.** Inspection is not
    verification: a pin needle that no longer matches (rustfmt splitting a long
-   call across lines is the common cause) passes vacuously forever.
+   call across lines is the common cause) passes vacuously forever. When you do
+   this, commit BEFORE mutating and mark the broken lines `MUTATION_APPLIED` —
+   `.claude/rules/testing.md` has the convention and why a fixed token matters
+   to whoever cleans up after a dead session.
 5. **Scrape every file the sequence can live in, and run the audit grep against
    your own branch before claiming the rule holds.** #5481's fixing PR asserted
    "exactly one call site", scraped one file, and left two counterexamples in a

--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -2,6 +2,8 @@
 paths:
   - "crates/core/src/bin/**"
   - "crates/core/src/conformance/**"
+  - "crates/core/src/contract/**"
+  - "crates/core/src/operations/**"
   - "scripts/**"
 ---
 
@@ -694,3 +696,56 @@ grep -n "refused" crates/core/src/conformance/capture.rs
 
 Question to ask of any one of them: *if this branch fires a thousand times, what does
 a reader see?* If the answer is "an empty result", the count is missing.
+
+
+## A mandatory side-effect sequence, hand-inlined per branch
+
+**When two code paths both owe the same sequence of side effects, extract one
+helper that owns the whole sequence and call it from both. Never re-inline a
+subset at each branch.** The omission is always silent: the operation reports
+success, every existing test stays green, and the missing consumer simply never
+runs.
+
+The tell is a sequence that reads as a list — "record the telemetry, notify the
+local subscribers, notify the delegates, broadcast to the network" — appearing
+twice, in two orders, with two different subsets. Whichever leg is easiest to
+forget (it is usually the one added most recently, or the one behind an `await`
+or a `super::` import) is the one that gets dropped, and the branch that dropped
+it keeps working perfectly for every other consumer.
+
+### Repeat offender history
+
+| Issue | The path that re-inlined a subset | The leg it dropped |
+|---|---|---|
+| [#3851](https://github.com/freenet/freenet-core/issues/3851) | SUBSCRIBE originator, after the task-per-tx migration | The originator's own side-effect call |
+| [#4223](https://github.com/freenet/freenet-core/issues/4223) | GET originator driver | `fetch_contract_if_missing` — so ~37% of GETs through subscriber peers returned `NotFound` for months, for a contract whose body the node never fetched |
+| [#5481](https://github.com/freenet/freenet-core/issues/5481) | `bridged_upsert_contract_state_inner`'s initial-state-install branch | `send_delegate_contract_notifications`. The same branch had already dropped `send_update_notification` once before, been fixed, and carried a comment describing that fix — which did not stop the next leg being dropped |
+
+#5481 is the instructive one: a comment explaining the exact failure sat three
+lines above the code that repeated it. Prose does not prevent this; structure
+does.
+
+### The rule
+
+1. **One `finalize_*` helper owns the full sequence.** Both (all) paths call it.
+   Never hand-inline the sequence at a branch, because the next migration will
+   hand-inline a *subset* of it.
+2. **Anchor a source-scrape pin on the API surface**, not on local variable
+   names: assert the helper contains every required call, that each call has
+   exactly ONE site and that site is inside the helper, and that every storing
+   path delegates to it.
+3. **Pin ordering invariants** where one side effect gates another (fetch must
+   precede announce, so the node never advertises hosting without the body).
+4. **Verify the pin by deleting a leg and watching it go red.** Inspection is not
+   verification: a pin needle that no longer matches (rustfmt splitting a long
+   call across lines is the common cause) passes vacuously forever.
+
+### Audit
+
+```bash
+# The post-store fan-out legs: each must have exactly one call site.
+grep -rn "\.record_contract_update(\|\.send_update_notification(\|\.send_delegate_contract_notifications(\|\.broadcast_state_change(" crates/core/src/contract/
+# Op-originator side effects: every legacy-path hit needs an equivalent
+# reachable from the driver.
+grep -rn "ring.subscribe(\|complete_subscription_request\|announce_contract_hosted\|fetch_contract_if_missing" crates/core/src/operations/
+```

--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -747,8 +747,17 @@ does.
 ### Audit
 
 ```bash
-# The post-store fan-out legs: each must have exactly one call site.
-grep -rn "\.record_contract_update(\|\.send_update_notification(\|\.send_delegate_contract_notifications(\|\.broadcast_state_change(" crates/core/src/contract/
+# The post-store fan-out legs. Scoped to the two files that own the real
+# executor's storing paths: each leg must have exactly ONE call site across
+# them, and that site must be inside `finalize_state_commit`.
+grep -rn "\.record_contract_update(\|\.send_update_notification(\|\.send_delegate_contract_notifications(\|\.broadcast_state_change(" \
+  crates/core/src/contract/executor/runtime/executor_impl.rs \
+  crates/core/src/contract/executor/runtime/contract_ops.rs
+# Widening to crates/core/src/contract/ returns about a dozen hits and the
+# "exactly one" claim reads as false. Three are `mock_runtime.rs`, which has
+# its OWN `broadcast_state_change` on a different type and is not part of this
+# invariant; the rest are needle strings inside the pin test that enforces it.
+# Say which you mean before you claim the rule holds.
 # Op-originator side effects: every legacy-path hit needs an equivalent
 # reachable from the driver.
 grep -rn "ring.subscribe(\|complete_subscription_request\|announce_contract_hosted\|fetch_contract_if_missing" crates/core/src/operations/

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -29,7 +29,9 @@ V2: Async host functions — delegates call contract methods directly:
     - ctx.get_contract_state(id)       → read state (two-step: len + read)
     - ctx.put_contract_state(id, data) → write state (bypasses validate_state)
     - ctx.update_contract_state(id, data) → conditional write (requires existing state)
-    - ctx.subscribe_contract(id)       → register interest (delivery is TODO)
+    - ctx.subscribe_contract(id)       → register interest (delivery works: see
+                                         Executor::finalize_state_commit; the
+                                         subscription does NOT register demand, #4669)
     Backend implementation: func_wrap_async (wasmtime native async support)
     Selected when state_store_db is configured on Runtime
     NOTE: V2 PUT/UPDATE are local-only, bypass contract validation, and skip

--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -6,6 +6,16 @@ paths:
 
 # Operations Module Rules
 
+> **Originator side effects after a task-per-tx migration.** A driver that
+> replaces a legacy terminal-reply handler must run the FULL side-effect
+> sequence, not a hand-inlined subset — the omitted call is silent (the op
+> reports success and every test stays green). #3851 and #4223 are the
+> precedents, the second costing ~37% of GETs through subscriber peers for
+> months. The pattern, the fix shape (`finalize_*` helper plus a
+> mutation-verified source pin) and the audit grep are in
+> `.claude/rules/bug-prevention-patterns.md` — read that row before migrating
+> an op.
+
 ## Execution Model
 
 Every operation runs as a task-per-transaction driver: each `Transaction`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -169,6 +169,53 @@ per-event filtering is preserved, and do **not** install as the global
 default — that slot belongs to `test_log`, and taking it silently stops
 `RUST_LOG=… cargo test` printing anything.
 
+## Deliberately breaking code to verify a test: mark it `MUTATION_APPLIED`
+
+A test or a source-scrape pin is not verified until you have watched it go RED
+under a deliberate break and GREEN again when the break is reverted. Inspection
+is not verification — see the vacuous-pin row in
+`.claude/rules/bug-prevention-patterns.md`. So mutating code is a normal,
+encouraged part of writing one. These rules are about not leaving the mutation
+behind.
+
+### One fixed token
+
+Mark every deliberately-broken line with the exact string `MUTATION_APPLIED` —
+not `MUTANT`, not `MUTATION:`, not a comment that merely reads "temporary".
+One token, so that `grep -rn MUTATION_APPLIED` is a complete answer.
+
+**The point is not tidiness, it is that the person who greps is usually not the
+person who mutated.** On 2026-09-04 four agents hit an account session limit
+simultaneously, mid-mutation. The cleanup grepped `MUTANT|MUTATION_APPLIED` and
+missed a stranded break in another PR, because that agent had written
+`MUTATION:`. Nothing shipped, but only because a human looked twice.
+
+That is the same failure shape as the bug being fixed in the PR that prompted
+this rule: a source scanner whose docstring said it skipped "comments" and which
+skipped one kind of them. **Searching for one variant of the thing you are
+looking for is not searching for the thing.** A convention with variants is a
+search with a blind spot; a fixed token is not.
+
+### The rules
+
+1. **Commit or stash BEFORE mutating.** Restoring is then `git checkout --`,
+   never retyping from memory. This matters more than the marker: a session can
+   die between the break and the restore, and it did.
+2. **Mark every broken line** with `MUTATION_APPLIED`.
+3. **Before committing, `grep -rn MUTATION_APPLIED` and confirm it is empty.**
+   Better, where you have a pre-mutation commit: confirm `git diff` against it
+   shows only the change you intend.
+4. **When cleaning up after someone else's dead session, do not rely on the
+   marker.** Grep for it, AND diff every dirty worktree against its HEAD. A
+   mutation applied by editing an existing line leaves no marker at all if its
+   author forgot one, and only the diff catches that.
+5. **Say which mutation in the commit message**, and say what went red. "Verified
+   by inspection" is not verification. Both directions are worth stating when the
+   fix is to a shared helper: that the bug turns the guard red, and that reverting
+   only the fix — with the bug still in place — turns it green again, is what
+   distinguishes a guard that works from one that happens to be passing.
+
+
 ## Reference Patterns
 
 **Time injection:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6837,6 +6837,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-contract-delta-trap"
+version = "0.1.0"
+dependencies = [
+ "freenet-stdlib 0.8.5",
+]
+
+[[package]]
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6854,6 +6854,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-contract-requires-related"
+version = "0.1.0"
+dependencies = [
+ "freenet-stdlib 0.8.5",
+]
+
+[[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
 	"apps/freenet-ping/contracts/ping",
 	"tests/test-contract-integration",
 	"tests/test-contract-update-nochange",
-	"tests/test-contract-mock-aligned"
+	"tests/test-contract-mock-aligned",
+	"tests/test-contract-requires-related"
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
 	"tests/test-contract-integration",
 	"tests/test-contract-update-nochange",
 	"tests/test-contract-mock-aligned",
-	"tests/test-contract-requires-related"
+	"tests/test-contract-requires-related",
+	"tests/test-contract-delta-trap"
 ]
 
 [workspace.dependencies]

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -46,11 +46,11 @@ pub(super) mod runtime;
 /// Notification sent when a subscribed contract's state changes.
 ///
 /// Delivered to the `contract_handling()` loop from
-/// `Executor::finalize_state_commit`, which is the single post-store fan-out
-/// site for BOTH state-storing paths (the initial-state install and the merge
-/// path). It used to be sent from `commit_state_update` alone, so an install
-/// — including every ResyncResponse-driven recovery — notified no delegate at
-/// all (#5481).
+/// `Executor::finalize_state_commit`, the single post-store fan-out site for
+/// every state-storing path: the initial-state install, the merge path, and
+/// both branches of `perform_contract_put`. It used to be sent from
+/// `commit_state_update` alone, so an install — including every
+/// ResyncResponse-driven recovery — notified no delegate at all (#5481).
 ///
 /// Uses `Arc<WrappedState>` so multiple subscribers share one allocation.
 pub(crate) struct DelegateNotification {
@@ -1495,6 +1495,7 @@ pub struct Executor<R = Runtime, S: StateStorage = Storage> {
 
     /// Channel to send delegate notifications when subscribed contracts change state.
     /// Set when running in a pool via `set_delegate_notification_tx()`.
+    /// `Executor::finalize_state_commit` is what sends on it.
     delegate_notification_tx: Option<DelegateNotificationSender>,
 }
 

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -44,7 +44,14 @@ mod pool_tests;
 pub(super) mod runtime;
 
 /// Notification sent when a subscribed contract's state changes.
-/// Delivered from `commit_state_update()` to the `contract_handling()` loop.
+///
+/// Delivered to the `contract_handling()` loop from
+/// `Executor::finalize_state_commit`, which is the single post-store fan-out
+/// site for BOTH state-storing paths (the initial-state install and the merge
+/// path). It used to be sent from `commit_state_update` alone, so an install
+/// — including every ResyncResponse-driven recovery — notified no delegate at
+/// all (#5481).
+///
 /// Uses `Arc<WrappedState>` so multiple subscribers share one allocation.
 pub(crate) struct DelegateNotification {
     pub delegate_key: DelegateKey,

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -2,6 +2,8 @@
 
 mod conformance_tests;
 mod delegate_notification_tests;
+#[cfg(feature = "wasmtime-backend")]
+mod delegate_notification_wasm_tests;
 mod disk_budget_gate_tests;
 mod identical_input_probe_tests;
 mod merge_rejected_tests;

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the contract executor module.
 
 mod conformance_tests;
+mod delegate_notification_tests;
 mod disk_budget_gate_tests;
 mod identical_input_probe_tests;
 mod merge_rejected_tests;

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -396,13 +396,62 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     );
     let ops_calls = count_call_sites(ops_production, ".finalize_state_commit(");
     assert_eq!(
-        ops_calls, 2,
-        "expected exactly 2 `self.finalize_state_commit(` call sites in \
-         contract_ops.rs (the re-PUT merge and the fresh store in \
-         `perform_contract_put`); found {ops_calls}. If you added another \
-         state-storing path, that is fine — it MUST call the helper, and this \
-         expectation should be bumped with a comment naming the new path."
+        ops_calls, 3,
+        "expected exactly 3 `self.finalize_state_commit(` call sites in \
+         contract_ops.rs (the re-PUT merge, the fresh store in \
+         `perform_contract_put`, and the related-contract install in \
+         `get_updated_state`); found {ops_calls}."
     );
+
+    // Counting HELPER CALLS alone cannot notice a new storing path that calls
+    // nothing — the count simply stays right while the new path fans out
+    // nothing. So count the WRITES too, and make a new one fail closed until
+    // its author classifies it. (This is the gap the external review pass
+    // found: the related-contract install had been storing state with no
+    // fan-out at all, and every "exactly one call site" assertion above was
+    // still perfectly true.)
+    //
+    // The four writes, and where each one's fan-out happens:
+    //   executor_impl.rs
+    //     - the initial-state install      -> finalize at the end of the branch
+    //     - `commit_state_update`          -> finalize at the end of the method
+    //   contract_ops.rs
+    //     - the re-PUT merge               -> finalize immediately after
+    //     - `verify_and_store_contract`    -> finalize at EACH of its two
+    //       callers (the fresh PUT, and the related-contract install), because
+    //       they fan out under different keys
+    let writes = count_state_writes(production);
+    let ops_writes = count_state_writes(ops_production);
+    assert_eq!(
+        (writes, ops_writes),
+        (2, 2),
+        "expected 2 state writes in executor_impl.rs and 2 in contract_ops.rs; \
+         found ({writes}, {ops_writes}). A NEW state write must be classified: \
+         either route it through `finalize_state_commit`, or say in a comment \
+         here why that state owes no subscriber anything, and bump these counts."
+    );
+}
+
+/// Count `self.state_store.store(..)` / `.update(..)` sites, tolerating the
+/// line splits rustfmt introduces (a `self` on one line, `.state_store` on the
+/// next, `.store(` on the next).
+///
+/// Counting helper CALLS alone cannot notice a new storing path that calls
+/// nothing: the call count stays right while the new path fans out nothing.
+/// That is exactly how the related-contract install sat there storing state
+/// with no fan-out at all while every "exactly one call site" assertion above
+/// was true.
+fn count_state_writes(src: &str) -> usize {
+    // Strip ALL whitespace, so `self.state_store\n    .store(` and
+    // `self.state_store.store(` collapse to the same needle. Joining on a
+    // single space does NOT work: rustfmt breaks the line after
+    // `self.state_store`, not around each `.`, so the flattened form is
+    // `self.state_store .store(` and neither spaced nor unspaced needle
+    // matches. (Asked for it and got (0, 0) — which is why this pin asserts
+    // an exact count rather than "at least one".)
+    let flat: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+    flat.matches("self.state_store.store(").count()
+        + flat.matches("self.state_store.update(").count()
 }
 
 /// The `{ .. }` body of the item starting at `start`, brace-matched.

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -39,7 +39,13 @@ use super::super::mock_runtime::test::create_test_contract as test_contract;
 
 /// Build a real `OpManager` backed by a temp-dir `Config`, mirroring
 /// `identical_input_probe_tests.rs::build_op_manager`.
-async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) {
+async fn build_op_manager(
+    id: &str,
+) -> (
+    Arc<OpManager>,
+    crate::node::EventLoopNotificationsReceiver,
+    Box<dyn std::any::Any>,
+) {
     let config_args = ConfigArgs {
         id: Some(id.to_string()),
         mode: Some(OperationMode::Local),
@@ -70,14 +76,9 @@ async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) 
     );
     op_manager.ring.attach_op_manager(&op_manager);
 
-    let guards: Box<dyn std::any::Any> = Box::new((
-        notification_rx,
-        ch_channel,
-        wait_for_event,
-        result_router_rx,
-        task_monitor,
-    ));
-    (op_manager, guards)
+    let guards: Box<dyn std::any::Any> =
+        Box::new((ch_channel, wait_for_event, result_router_rx, task_monitor));
+    (op_manager, notification_rx, guards)
 }
 
 /// Registers one delegate against one contract in the process-global
@@ -91,6 +92,7 @@ async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) 
 /// the test ends.
 struct SubscriptionGuard {
     instance_id: ContractInstanceId,
+    delegate: DelegateKey,
 }
 
 impl SubscriptionGuard {
@@ -98,14 +100,27 @@ impl SubscriptionGuard {
         DELEGATE_SUBSCRIPTIONS
             .entry(instance_id)
             .or_default()
-            .insert(delegate);
-        Self { instance_id }
+            .insert(delegate.clone());
+        Self {
+            instance_id,
+            delegate,
+        }
     }
 }
 
 impl Drop for SubscriptionGuard {
     fn drop(&mut self) {
-        DELEGATE_SUBSCRIPTIONS.remove(&self.instance_id);
+        // Remove only what this guard registered, and only drop the entry once
+        // it is empty — a blanket `remove(&instance_id)` would delete another
+        // test's subscription if the keys ever collided, which is the shape
+        // `.claude/rules/testing.md` warns about for shared globals. Mirrors
+        // how production cleans up in `runtime/delegates.rs`.
+        DELEGATE_SUBSCRIPTIONS.retain(|id, subs| {
+            if id == &self.instance_id {
+                subs.remove(&self.delegate);
+            }
+            !subs.is_empty()
+        });
     }
 }
 
@@ -134,7 +149,8 @@ async fn build_executor(
 /// notification lands.
 #[tokio::test(flavor = "current_thread")]
 async fn initial_state_install_notifies_subscribed_delegates() {
-    let (op_manager, _guards) = build_op_manager("delegate-notify-install").await;
+    let (op_manager, mut notifications, _guards) =
+        build_op_manager("delegate-notify-install").await;
     let contract = test_contract(b"delegate_notify_install_contract");
     let key = contract.key();
     let state = WrappedState::new((1u8..=32).collect::<Vec<u8>>());
@@ -182,6 +198,35 @@ async fn initial_state_install_notifies_subscribed_delegates() {
         state.as_ref(),
         "notification must carry the state that was just installed"
     );
+
+    // Leg 4 of the same fan-out. This is the leg the refactor REORDERED (the
+    // install branch used to broadcast before the local notifications, and now
+    // broadcasts after), so it is the one most worth asserting behaviourally
+    // rather than trusting the source-scrape pin for.
+    let mut broadcast = None;
+    while let Ok(event) = notifications.notifications_receiver.try_recv() {
+        if let either::Either::Right(crate::message::NodeEvent::BroadcastStateChange {
+            key: broadcast_key,
+            new_state,
+            ..
+        }) = event
+        {
+            if broadcast_key == key {
+                broadcast = Some(new_state);
+                break;
+            }
+        }
+    }
+    let broadcast = broadcast.expect(
+        "the initial-state install must also emit NodeEvent::BroadcastStateChange — \
+         the delegate leg and the network leg share one fan-out site, so a \
+         regression in the helper should be visible from either end",
+    );
+    assert_eq!(
+        broadcast.as_ref(),
+        state.as_ref(),
+        "the broadcast must carry the installed state"
+    );
 }
 
 /// Control for the test above: the MERGE path has always notified
@@ -193,7 +238,7 @@ async fn initial_state_install_notifies_subscribed_delegates() {
 /// This one passes both before and after the fix.
 #[tokio::test(flavor = "current_thread")]
 async fn merge_path_notifies_subscribed_delegates() {
-    let (op_manager, _guards) = build_op_manager("delegate-notify-merge").await;
+    let (op_manager, _notifications, _guards) = build_op_manager("delegate-notify-merge").await;
     let contract = test_contract(b"delegate_notify_merge_contract");
     let key = contract.key();
     let initial = WrappedState::new((1u8..=32).collect::<Vec<u8>>());
@@ -237,6 +282,14 @@ async fn merge_path_notifies_subscribed_delegates() {
         .expect("delegate notification channel closed");
     assert_eq!(notification.delegate_key, delegate);
     assert_eq!(notification.contract_id, *key.id());
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        merged.as_ref(),
+        "the merge notification must carry the MERGED state — asserting this \
+         rules out the alternative reading that the drain above missed an \
+         install notification and this is it"
+    );
 }
 
 /// Source-scrape pin: `finalize_state_commit` must own the WHOLE post-store
@@ -256,11 +309,21 @@ async fn merge_path_notifies_subscribed_delegates() {
 #[test]
 fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     const EXECUTOR_IMPL_SRC: &str = include_str!("../runtime/executor_impl.rs");
+    // `contract_ops.rs` holds the OTHER two state-storing paths (the local
+    // re-PUT merge and the fresh store in `perform_contract_put`). Scraping
+    // only `executor_impl.rs` would have reported "exactly one call site" while
+    // two more sat one file over — a green signal certifying something it never
+    // looked at.
+    const CONTRACT_OPS_SRC: &str = include_str!("../runtime/contract_ops.rs");
 
     // Production slice only: everything before the first `#[cfg(test)]`,
-    // so this file's own siblings and any test module in executor_impl.rs
+    // so this file's own siblings and any test module in the scraped files
     // cannot satisfy or break the pin.
     let production = EXECUTOR_IMPL_SRC
+        .split("#[cfg(test)]")
+        .next()
+        .expect("split always yields at least one slice");
+    let ops_production = CONTRACT_OPS_SRC
         .split("#[cfg(test)]")
         .next()
         .expect("split always yields at least one slice");
@@ -268,12 +331,15 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     let helper_start = production
         .find("async fn finalize_state_commit(")
         .expect("finalize_state_commit must exist — it is the post-store fan-out chokepoint");
-    // The helper ends where the next `fn ` at method indentation begins.
-    let helper_end = production[helper_start..]
-        .find("\n    /// ")
-        .map(|off| helper_start + off)
-        .unwrap_or(production.len());
-    let helper = &production[helper_start..helper_end];
+    // Bound the helper by BRACE MATCHING, not by "the next doc comment".
+    // An end anchor that can silently fail to match, then widen the region to
+    // end-of-file via `unwrap_or`, is precisely the self-satisfying-pin defect
+    // recorded in `.claude/rules/bug-prevention-patterns.md` ("Self-satisfying
+    // `include_str!` source-scrape pins") — every `helper.contains(..)` below
+    // would pass vacuously and the pin would be green forever. Brace matching
+    // cannot silently widen, and the `expect` below fails loud if the shape
+    // ever changes.
+    let helper = brace_delimited_body(production, helper_start);
 
     for required in [
         "record_contract_update(",
@@ -304,15 +370,15 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
         ".send_delegate_contract_notifications(",
         ".broadcast_state_change(",
     ] {
-        let count = count_call_sites(production, leg);
+        let count = count_call_sites(production, leg) + count_call_sites(ops_production, leg);
         assert_eq!(
             count, 1,
-            "expected exactly 1 `{leg}` call site in the production slice of \
-             executor_impl.rs (inside finalize_state_commit); found {count}. A \
-             state-commit path must call `finalize_state_commit` rather than \
-             re-inlining a subset of its legs — see the \
-             'manually-inlined originator side effects' row in \
-             `.claude/rules/bug-prevention-patterns.md`."
+            "expected exactly 1 `{leg}` call site across the production slices \
+             of executor_impl.rs and contract_ops.rs (inside \
+             finalize_state_commit); found {count}. A state-commit path must \
+             call `finalize_state_commit` rather than re-inlining a subset of \
+             its legs — see the 'manually-inlined originator side effects' row \
+             in `.claude/rules/bug-prevention-patterns.md`."
         );
         assert!(
             helper.contains(leg),
@@ -320,20 +386,58 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
         );
     }
 
-    // And both storing paths delegate to it.
+    // And every storing path delegates to it.
     let calls = count_call_sites(production, ".finalize_state_commit(");
     assert_eq!(
         calls, 2,
-        "expected exactly 2 `self.finalize_state_commit(` call sites (the \
-         initial-state-install branch and `commit_state_update`); found \
-         {calls}. If you added a third state-storing path, that is fine — it \
-         MUST call the helper, and this expectation should be bumped with a \
-         comment naming the new path."
+        "expected exactly 2 `self.finalize_state_commit(` call sites in \
+         executor_impl.rs (the initial-state-install branch and \
+         `commit_state_update`); found {calls}."
+    );
+    let ops_calls = count_call_sites(ops_production, ".finalize_state_commit(");
+    assert_eq!(
+        ops_calls, 2,
+        "expected exactly 2 `self.finalize_state_commit(` call sites in \
+         contract_ops.rs (the re-PUT merge and the fresh store in \
+         `perform_contract_put`); found {ops_calls}. If you added another \
+         state-storing path, that is fine — it MUST call the helper, and this \
+         expectation should be bumped with a comment naming the new path."
     );
 }
 
-/// Count non-comment occurrences of `needle`, ignoring anything inside a
-/// string literal (this file's own assertion messages contain the needles).
+/// The `{ .. }` body of the item starting at `start`, brace-matched.
+///
+/// Panics if the item has no body or the braces do not balance — a pin must
+/// fail loud rather than silently widen its search region (see the
+/// self-satisfying-pin row in `.claude/rules/bug-prevention-patterns.md`).
+/// String and char literals containing braces are not handled; there are none
+/// in the scraped bodies, and a stray one would make this fail loud, not pass.
+fn brace_delimited_body(src: &str, start: usize) -> &str {
+    let open = src[start..]
+        .find('{')
+        .map(|off| start + off)
+        .expect("the scraped item must have a body");
+    let mut depth = 0usize;
+    for (idx, ch) in src[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &src[start..open + idx + 1];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced braces while scraping the item body starting at {start}");
+}
+
+/// Count `needle` occurrences, one per matching LINE (two calls on one line
+/// count once — rustfmt does not produce that shape here, and the assertions
+/// below would fail loud rather than pass if it ever did). Whole-line `//`
+/// comments and the contents of string literals are skipped, so the scraped
+/// file's own prose and log messages cannot satisfy a pin.
 fn count_call_sites(src: &str, needle: &str) -> usize {
     src.lines()
         .filter(|line| {

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -598,6 +598,14 @@ fn count_call_sites(src: &str, needle: &str) -> usize {
 /// failure class. It also missed the smaller sibling, a needle sitting after a
 /// TRAILING `//` on an otherwise-live line.
 ///
+/// Block comments NEST, as Rust permits: `/* outer /* inner */ still comment */`
+/// is one comment, and exiting on the first `*/` would treat its tail as live
+/// code. That is the same shape as the bug this helper was written to fix — the
+/// previous version skipped one kind of comment while its docstring said
+/// "comments" — so it is counted here rather than left to "nested block
+/// comments are rare", which is exactly what the previous version was
+/// implicitly relying on too.
+///
 /// Char literals are recognised narrowly (`'x'`, `'\n'`) so that a `'"'` in the
 /// scraped source cannot flip the scanner into string mode, while a lifetime
 /// (`'a`, which is a quote followed by an identifier and no closing quote) is
@@ -618,6 +626,8 @@ fn blank_comments_and_strings(src: &str) -> String {
     let mut out = String::with_capacity(src.len());
     let mut mode = Mode::Code;
     let mut escaped = false;
+    // How many `/*` are currently open. Only the outermost `*/` returns to code.
+    let mut block_depth = 0usize;
     let mut i = 0usize;
 
     while i < chars.len() {
@@ -633,6 +643,7 @@ fn blank_comments_and_strings(src: &str) -> String {
                 }
                 if c == '/' && next == Some('*') {
                     mode = Mode::BlockComment;
+                    block_depth = 1;
                     out.push_str("  ");
                     i += 2;
                     continue;
@@ -676,8 +687,17 @@ fn blank_comments_and_strings(src: &str) -> String {
                 i += 1;
             }
             Mode::BlockComment => {
+                if c == '/' && next == Some('*') {
+                    block_depth += 1;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
                 if c == '*' && next == Some('/') {
-                    mode = Mode::Code;
+                    block_depth -= 1;
+                    if block_depth == 0 {
+                        mode = Mode::Code;
+                    }
                     out.push_str("  ");
                     i += 2;
                     continue;

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -386,6 +386,36 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
         );
     }
 
+    // The queued-operation replay loop inside the install branch must consume
+    // `commit_state_update`'s OUTCOME, not a bare `Ok`.
+    //
+    // `commit_state_update` returns `Ok(SuppressedBrokenContract)` — storing
+    // nothing and fanning out nothing — for a contract flagged in
+    // `ring::broken_invariants`. When it returned `Result<(), _>` the replay
+    // loop read that as "this replay committed", advanced `installed_state`,
+    // and skipped the branch's own trailing fan-out, so the state the branch
+    // HAD stored reached no delegate, no WebSocket client and no peer. #5481
+    // again, at the install-plus-flagged-contract corner, introduced by the fix
+    // for #5481 and caught by the repo's rule review.
+    //
+    // The enum makes the conflation uncompilable — there is no `Ok(())` left to
+    // misread — so what is worth pinning is that the loop still matches on the
+    // variant rather than being rewritten to discard it with `let _ =` or
+    // `.is_ok()`, which would restore the same bug through a different door.
+    assert!(
+        helper_free_production_contains(production, "StateCommitOutcome::Committed"),
+        "the queued-operation replay loop must branch on \
+         `StateCommitOutcome::Committed`. Treating any `Ok` as a commit makes \
+         a broken-contract suppression look like a successful one, and the \
+         install branch then skips a fan-out it still owes."
+    );
+    assert!(
+        helper_free_production_contains(production, "StateCommitOutcome::SuppressedBrokenContract"),
+        "the replay loop must handle the suppression case explicitly, so the \
+         install branch's own fan-out is still performed when a replay stored \
+         nothing."
+    );
+
     // And every storing path delegates to it.
     let calls = count_call_sites(production, ".finalize_state_commit(");
     assert_eq!(
@@ -480,6 +510,11 @@ fn brace_delimited_body(src: &str, start: usize) -> &str {
         }
     }
     panic!("unbalanced braces while scraping the item body starting at {start}");
+}
+
+/// Whether `needle` appears in non-comment, non-string-literal source.
+fn helper_free_production_contains(src: &str, needle: &str) -> bool {
+    count_call_sites(src, needle) > 0
 }
 
 /// Count `needle` occurrences, one per matching LINE (two calls on one line

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -306,6 +306,15 @@ async fn merge_path_notifies_subscribed_delegates() {
 /// Anchored on API surface (`record_contract_update(`,
 /// `send_update_notification(`, …) rather than on local variable names, so
 /// a rename inside the helper does not silently defeat the pin.
+///
+/// A pin proves a call EXISTS, never that it is wired to the right contract.
+/// The three sites this module cannot drive — both `perform_contract_put`
+/// branches and the related-contract install in `get_updated_state`, all on
+/// `impl Executor<Runtime>` — are asserted behaviourally against a real WASM
+/// runtime in `delegate_notification_wasm_tests`. Neither guard
+/// replaces the other: the pin catches a NEW storing path that fans out
+/// nothing, the behavioural tests catch an EXISTING one pointed at the wrong
+/// key.
 #[test]
 fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     const EXECUTOR_IMPL_SRC: &str = include_str!("../runtime/executor_impl.rs");

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -1,0 +1,368 @@
+//! Regression tests for the delegate half of the post-store fan-out
+//! (issue #5481).
+//!
+//! A contract state commit has to reach four consumers: the dashboard
+//! "last updated" telemetry, locally-subscribed WebSocket clients,
+//! locally-subscribed *delegates*, and the network. Two production paths
+//! store a state — the initial-install branch of
+//! `bridged_upsert_contract_state_inner` (a contract whose `state_store`
+//! entry is missing, which also covers ResyncResponse-driven recovery) and
+//! `commit_state_update` (the merge path) — and until #5481 only the merge
+//! path fanned out to delegates. A delegate whose subscription outlives the
+//! contract's state entry therefore stopped receiving notifications for
+//! exactly the deliveries that recover it, silently: the subscription is
+//! still registered and no error is produced anywhere.
+//!
+//! This is the shape `.claude/rules/bug-prevention-patterns.md` calls
+//! "manually-inlined originator side effects" — the install branch
+//! re-inlined three of the four legs and dropped the fourth. The fix
+//! extracts `Executor::finalize_state_commit`, which owns the whole
+//! sequence, and calls it from both sites;
+//! `finalize_state_commit_is_the_only_post_store_fan_out_site` below pins
+//! that no branch may hand-inline a subset again.
+//!
+//! Harness mirrors `identical_input_probe_tests.rs`: a real
+//! `OpManager`/`Ring` behind an `Executor<MockWasmRuntime>`, driving the
+//! production `bridged_upsert_contract_state` path.
+
+use either::Either;
+use freenet_stdlib::prelude::*;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::config::ConfigArgs;
+use crate::contract::executor::{ContractExecutor, Executor, OperationMode};
+use crate::node::OpManager;
+use crate::wasm_runtime::{DELEGATE_SUBSCRIPTIONS, MockStateStorage};
+
+use super::super::mock_runtime::test::create_test_contract as test_contract;
+
+/// Build a real `OpManager` backed by a temp-dir `Config`, mirroring
+/// `identical_input_probe_tests.rs::build_op_manager`.
+async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) {
+    let config_args = ConfigArgs {
+        id: Some(id.to_string()),
+        mode: Some(OperationMode::Local),
+        ..Default::default()
+    };
+    let node_config =
+        crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+
+    let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+    let (ops_ch_channel, ch_channel, wait_for_event) = crate::contract::contract_handler_channel();
+    let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+    let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+    let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+    let op_manager = Arc::new(
+        OpManager::new(
+            notification_tx,
+            ops_ch_channel,
+            &node_config,
+            crate::tracing::DynamicRegister::new(vec![]),
+            connection_manager,
+            result_router_tx,
+            &task_monitor,
+        )
+        .expect("build OpManager"),
+    );
+    op_manager.ring.attach_op_manager(&op_manager);
+
+    let guards: Box<dyn std::any::Any> = Box::new((
+        notification_rx,
+        ch_channel,
+        wait_for_event,
+        result_router_rx,
+        task_monitor,
+    ));
+    (op_manager, guards)
+}
+
+/// Registers one delegate against one contract in the process-global
+/// `DELEGATE_SUBSCRIPTIONS` map and removes the entry on drop.
+///
+/// `DELEGATE_SUBSCRIPTIONS` is process-global (#4824), and CI runs
+/// `cargo nextest` (process per test) while contributors run plain
+/// `cargo test` (one process for all of them) — see
+/// `.claude/rules/testing.md`. So each test uses a contract key derived
+/// from its own name, and this guard clears the entry regardless of how
+/// the test ends.
+struct SubscriptionGuard {
+    instance_id: ContractInstanceId,
+}
+
+impl SubscriptionGuard {
+    fn register(instance_id: ContractInstanceId, delegate: DelegateKey) -> Self {
+        DELEGATE_SUBSCRIPTIONS
+            .entry(instance_id)
+            .or_default()
+            .insert(delegate);
+        Self { instance_id }
+    }
+}
+
+impl Drop for SubscriptionGuard {
+    fn drop(&mut self) {
+        DELEGATE_SUBSCRIPTIONS.remove(&self.instance_id);
+    }
+}
+
+fn test_delegate_key(seed: u8) -> DelegateKey {
+    DelegateKey::new([seed; 32], CodeHash::new([seed; 32]))
+}
+
+async fn build_executor(
+    op_manager: &Arc<OpManager>,
+) -> Executor<crate::contract::executor::mock_wasm_runtime::MockWasmRuntime, MockStateStorage> {
+    Executor::new_mock_wasm("t", MockStateStorage::new(), None, Some(op_manager.clone()))
+        .await
+        .expect("build mock-wasm executor")
+}
+
+/// #5481: the INITIAL-STATE-INSTALL branch must notify subscribed
+/// delegates.
+///
+/// Before the fix this branch called `record_contract_update`,
+/// `send_update_notification` (WebSocket clients) and
+/// `broadcast_state_change`, then returned — never reaching
+/// `send_delegate_contract_notifications`. The delegate got nothing, with
+/// no error anywhere. This test drives a genuinely new contract through
+/// `upsert_contract_state` (which takes the install branch, exactly as a
+/// network PUT or a ResyncResponse-driven apply does) and asserts the
+/// notification lands.
+#[tokio::test(flavor = "current_thread")]
+async fn initial_state_install_notifies_subscribed_delegates() {
+    let (op_manager, _guards) = build_op_manager("delegate-notify-install").await;
+    let contract = test_contract(b"delegate_notify_install_contract");
+    let key = contract.key();
+    let state = WrappedState::new((1u8..=32).collect::<Vec<u8>>());
+
+    let delegate = test_delegate_key(7);
+    let _subscription = SubscriptionGuard::register(*key.id(), delegate.clone());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    let mut executor = build_executor(&op_manager).await;
+    executor.set_delegate_notification_tx(tx);
+
+    // A brand-new contract: no `state_store` entry, so this takes the
+    // initial-install branch rather than the merge path.
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(state.clone()),
+            RelatedContracts::default(),
+            Some(contract.clone()),
+        )
+        .await
+        .expect("initial install");
+
+    let notification = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect(
+            "the initial-state-install branch must notify subscribed delegates; \
+             no notification arrived (this is #5481 — the branch fanned out to \
+             WebSocket clients and the network but never to delegates)",
+        )
+        .expect("delegate notification channel closed");
+
+    assert_eq!(
+        notification.delegate_key, delegate,
+        "notification must carry the subscribed delegate's key"
+    );
+    assert_eq!(
+        notification.contract_id,
+        *key.id(),
+        "notification must carry the installed contract's instance id"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        state.as_ref(),
+        "notification must carry the state that was just installed"
+    );
+}
+
+/// Control for the test above: the MERGE path has always notified
+/// delegates (`commit_state_update` → `send_delegate_contract_notifications`).
+///
+/// Without this control, a harness mistake (no `delegate_notification_tx`,
+/// a mis-keyed subscription, a mock runtime that never merges) would make
+/// the install test fail for a reason that has nothing to do with #5481.
+/// This one passes both before and after the fix.
+#[tokio::test(flavor = "current_thread")]
+async fn merge_path_notifies_subscribed_delegates() {
+    let (op_manager, _guards) = build_op_manager("delegate-notify-merge").await;
+    let contract = test_contract(b"delegate_notify_merge_contract");
+    let key = contract.key();
+    let initial = WrappedState::new((1u8..=32).collect::<Vec<u8>>());
+
+    let delegate = test_delegate_key(9);
+    let _subscription = SubscriptionGuard::register(*key.id(), delegate.clone());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    let mut executor = build_executor(&op_manager).await;
+    executor.set_delegate_notification_tx(tx);
+
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(initial.clone()),
+            RelatedContracts::default(),
+            Some(contract.clone()),
+        )
+        .await
+        .expect("initial install");
+    // Drain whatever the install produced so the assertion below is
+    // unambiguously about the merge.
+    while rx.try_recv().is_ok() {}
+
+    // A DIFFERENT state now merges into the stored one — the merge path,
+    // which reaches `commit_state_update`.
+    let merged = WrappedState::new((33u8..=64).collect::<Vec<u8>>());
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(merged.clone()),
+            RelatedContracts::default(),
+            None,
+        )
+        .await
+        .expect("merge update");
+
+    let notification = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("the merge path has always notified subscribed delegates")
+        .expect("delegate notification channel closed");
+    assert_eq!(notification.delegate_key, delegate);
+    assert_eq!(notification.contract_id, *key.id());
+}
+
+/// Source-scrape pin: `finalize_state_commit` must own the WHOLE post-store
+/// fan-out, and it must be the only place any leg of it is invoked.
+///
+/// The precedent this guards against is the bug itself: #5481 happened
+/// because the install branch hand-inlined three of the four legs and
+/// dropped the fourth, and a behavioral test for the missing leg did not
+/// exist. A future path that stores a state and re-inlines its own subset
+/// would reproduce it exactly. So this asserts (a) the helper contains
+/// every required side effect, and (b) no other production site in
+/// `executor_impl.rs` calls one of them directly.
+///
+/// Anchored on API surface (`record_contract_update(`,
+/// `send_update_notification(`, …) rather than on local variable names, so
+/// a rename inside the helper does not silently defeat the pin.
+#[test]
+fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
+    const EXECUTOR_IMPL_SRC: &str = include_str!("../runtime/executor_impl.rs");
+
+    // Production slice only: everything before the first `#[cfg(test)]`,
+    // so this file's own siblings and any test module in executor_impl.rs
+    // cannot satisfy or break the pin.
+    let production = EXECUTOR_IMPL_SRC
+        .split("#[cfg(test)]")
+        .next()
+        .expect("split always yields at least one slice");
+
+    let helper_start = production
+        .find("async fn finalize_state_commit(")
+        .expect("finalize_state_commit must exist — it is the post-store fan-out chokepoint");
+    // The helper ends where the next `fn ` at method indentation begins.
+    let helper_end = production[helper_start..]
+        .find("\n    /// ")
+        .map(|off| helper_start + off)
+        .unwrap_or(production.len());
+    let helper = &production[helper_start..helper_end];
+
+    for required in [
+        "record_contract_update(",
+        "send_update_notification(",
+        "send_delegate_contract_notifications(",
+        "broadcast_state_change(",
+    ] {
+        assert!(
+            helper.contains(required),
+            "finalize_state_commit must invoke `{required}` — it owns the FULL \
+             post-store fan-out. Dropping a leg here silently stops one class of \
+             consumer (that is #5481: delegates were the dropped leg)."
+        );
+    }
+
+    // Every leg is called exactly once in the production slice, and that
+    // one call is inside the helper. A second call site means a branch
+    // has started hand-inlining the sequence again.
+    //
+    // The needles carry a leading `.` so they match CALL sites and not the
+    // `fn` definitions, and are written without `self` because rustfmt
+    // splits a long call across lines (`self\n    .send_update_notification(`)
+    // — a `self.`-prefixed needle would silently match nothing there and the
+    // pin would pass vacuously.
+    for leg in [
+        ".record_contract_update(",
+        ".send_update_notification(",
+        ".send_delegate_contract_notifications(",
+        ".broadcast_state_change(",
+    ] {
+        let count = count_call_sites(production, leg);
+        assert_eq!(
+            count, 1,
+            "expected exactly 1 `{leg}` call site in the production slice of \
+             executor_impl.rs (inside finalize_state_commit); found {count}. A \
+             state-commit path must call `finalize_state_commit` rather than \
+             re-inlining a subset of its legs — see the \
+             'manually-inlined originator side effects' row in \
+             `.claude/rules/bug-prevention-patterns.md`."
+        );
+        assert!(
+            helper.contains(leg),
+            "the single `{leg}` call site must be inside finalize_state_commit"
+        );
+    }
+
+    // And both storing paths delegate to it.
+    let calls = count_call_sites(production, ".finalize_state_commit(");
+    assert_eq!(
+        calls, 2,
+        "expected exactly 2 `self.finalize_state_commit(` call sites (the \
+         initial-state-install branch and `commit_state_update`); found \
+         {calls}. If you added a third state-storing path, that is fine — it \
+         MUST call the helper, and this expectation should be bumped with a \
+         comment naming the new path."
+    );
+}
+
+/// Count non-comment occurrences of `needle`, ignoring anything inside a
+/// string literal (this file's own assertion messages contain the needles).
+fn count_call_sites(src: &str, needle: &str) -> usize {
+    src.lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                return false;
+            }
+            strip_string_literals(line).contains(needle)
+        })
+        .count()
+}
+
+fn strip_string_literals(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut in_string = false;
+    let mut prev_was_backslash = false;
+    for c in line.chars() {
+        if in_string {
+            if c == '"' && !prev_was_backslash {
+                in_string = false;
+                out.push('"');
+            }
+        } else if c == '"' {
+            in_string = true;
+            out.push('"');
+        } else {
+            out.push(c);
+        }
+        prev_was_backslash = c == '\\' && !prev_was_backslash;
+    }
+    out
+}

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -411,15 +411,20 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     // misread — so what is worth pinning is that the loop still matches on the
     // variant rather than being rewritten to discard it with `let _ =` or
     // `.is_ok()`, which would restore the same bug through a different door.
+    // Scoped to `bridged_upsert_contract_state_inner`, NOT the whole file:
+    // `commit_state_update`'s own return sites mention both variants, so a
+    // file-wide check is satisfied by the enum's definition site and would
+    // stay green through the very rewrite it is meant to catch.
+    let replay_scope = upsert_inner_body(production);
     assert!(
-        helper_free_production_contains(production, "StateCommitOutcome::Committed"),
+        code_contains(replay_scope, "StateCommitOutcome::Committed"),
         "the queued-operation replay loop must branch on \
          `StateCommitOutcome::Committed`. Treating any `Ok` as a commit makes \
          a broken-contract suppression look like a successful one, and the \
          install branch then skips a fan-out it still owes."
     );
     assert!(
-        helper_free_production_contains(production, "StateCommitOutcome::SuppressedBrokenContract"),
+        code_contains(replay_scope, "StateCommitOutcome::SuppressedBrokenContract"),
         "the replay loop must handle the suppression case explicitly, so the \
          install branch's own fan-out is still performed when a replay stored \
          nothing."
@@ -461,11 +466,12 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     //     - the re-PUT merge               -> finalize immediately after
     //     - `verify_and_store_contract`    -> finalize at its FRESH-PUT caller
     //       only. Its other caller, the related-contract install in
-    //       `get_updated_state`, is the one write here that owes nothing: the
-    //       sub-op GET's `cache_contract_locally` stored and fanned out that
-    //       same state before control ever reached it, so this is a re-store
-    //       of an already-announced state. Fanning out again would
-    //       double-notify every delegate and WS client and double-broadcast.
+    //       `get_updated_state`, is the one write here that owes nothing —
+    //       because `GetResult.state` is sourced from a re-query of the LOCAL
+    //       STORE, so that arm can only write back what the store already
+    //       holds. No state transition, nothing to announce. (Not "the GET
+    //       path already fanned out": that is usually true and is not what
+    //       makes it safe. See the comment at the site.)
     let writes = count_state_writes(production);
     let ops_writes = count_state_writes(ops_production);
     assert_eq!(
@@ -488,14 +494,19 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
 /// with no fan-out at all while every "exactly one call site" assertion above
 /// was true.
 fn count_state_writes(src: &str) -> usize {
-    // Strip ALL whitespace, so `self.state_store\n    .store(` and
+    // Comments and string literals are blanked FIRST, for the same reason
+    // `count_call_sites` does it: an unblanked scan counts a write that has
+    // been commented out, and the two helpers disagreeing about what "source"
+    // means is how one of them ends up vacuous while the other is fine.
+    let code = blank_comments_and_strings(src);
+    // Then strip ALL whitespace, so `self.state_store\n    .store(` and
     // `self.state_store.store(` collapse to the same needle. Joining on a
     // single space does NOT work: rustfmt breaks the line after
     // `self.state_store`, not around each `.`, so the flattened form is
     // `self.state_store .store(` and neither spaced nor unspaced needle
     // matches. (Asked for it and got (0, 0) — which is why this pin asserts
     // an exact count rather than "at least one".)
-    let flat: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+    let flat: String = code.chars().filter(|c| !c.is_whitespace()).collect();
     flat.matches("self.state_store.store(").count()
         + flat.matches("self.state_store.update(").count()
 }
@@ -528,45 +539,170 @@ fn brace_delimited_body(src: &str, start: usize) -> &str {
     panic!("unbalanced braces while scraping the item body starting at {start}");
 }
 
-/// Whether `needle` appears in non-comment, non-string-literal source.
-fn helper_free_production_contains(src: &str, needle: &str) -> bool {
+/// The brace-delimited body of `bridged_upsert_contract_state_inner`, which is
+/// where the queued-operation replay loop lives.
+///
+/// Scoping matters here rather than being tidiness. `StateCommitOutcome::`
+/// appears FOUR times in `executor_impl.rs`: twice in the replay match, and
+/// twice in `commit_state_update`'s own `return` sites. An unscoped "does this
+/// token appear" check is therefore satisfied by the enum's DEFINITION SITE, so
+/// deleting the replay match entirely and writing `if ....await.is_ok()` would
+/// leave it green — restoring the exact bug the enum was introduced to close.
+/// Two reviewers found that independently on #5484.
+///
+/// The function body is the right scope rather than the loop itself: it
+/// excludes both `commit_state_update` sites, and it does not depend on the
+/// loop keeping any particular shape.
+fn upsert_inner_body(src: &str) -> &str {
+    const SIG: &str = "async fn bridged_upsert_contract_state_inner(";
+    let start = src
+        .find(SIG)
+        .expect("bridged_upsert_contract_state_inner must exist");
+    brace_delimited_body(src, start)
+}
+
+/// Whether `needle` appears in `src` as CODE — not in a comment, not inside a
+/// string literal.
+///
+/// Deliberately says nothing about scope: pass the region you mean. The
+/// previous name (`helper_free_production_contains`) promised a region
+/// excluding the fan-out helper and delivered a whole-file search, which is how
+/// the unscoped `StateCommitOutcome` assertions above came to pin nothing.
+fn code_contains(src: &str, needle: &str) -> bool {
     count_call_sites(src, needle) > 0
 }
 
 /// Count `needle` occurrences, one per matching LINE (two calls on one line
 /// count once — rustfmt does not produce that shape here, and the assertions
-/// below would fail loud rather than pass if it ever did). Whole-line `//`
-/// comments and the contents of string literals are skipped, so the scraped
-/// file's own prose and log messages cannot satisfy a pin.
+/// below would fail loud rather than pass if it ever did).
+///
+/// Comments and string literals are blanked first, so the scraped file's own
+/// prose and log messages cannot satisfy a pin — and, since #5484, neither can
+/// a call someone has commented OUT.
 fn count_call_sites(src: &str, needle: &str) -> usize {
-    src.lines()
-        .filter(|line| {
-            let trimmed = line.trim_start();
-            if trimmed.starts_with("//") {
-                return false;
-            }
-            strip_string_literals(line).contains(needle)
-        })
+    blank_comments_and_strings(src)
+        .lines()
+        .filter(|line| line.contains(needle))
         .count()
 }
 
-fn strip_string_literals(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let mut in_string = false;
-    let mut prev_was_backslash = false;
-    for c in line.chars() {
-        if in_string {
-            if c == '"' && !prev_was_backslash {
-                in_string = false;
-                out.push('"');
-            }
-        } else if c == '"' {
-            in_string = true;
-            out.push('"');
-        } else {
-            out.push(c);
-        }
-        prev_was_backslash = c == '\\' && !prev_was_backslash;
+/// Replace every comment and string-literal character with a space, preserving
+/// newlines so callers can still count one hit per line.
+///
+/// The line-based filter this replaces stripped only WHOLE-LINE `//` comments
+/// and string contents. It could not see a `/* ... */` spanning lines, so a
+/// call wrapped in a block comment still counted as live: block-commenting the
+/// sole `record_contract_update` call left BOTH the exact-count and the
+/// helper-containment assertions green while the telemetry leg was gone. Found
+/// by the external review pass on #5484 — in the very PR that writes down this
+/// failure class. It also missed the smaller sibling, a needle sitting after a
+/// TRAILING `//` on an otherwise-live line.
+///
+/// Char literals are recognised narrowly (`'x'`, `'\n'`) so that a `'"'` in the
+/// scraped source cannot flip the scanner into string mode, while a lifetime
+/// (`'a`, which is a quote followed by an identifier and no closing quote) is
+/// left alone.
+///
+/// Fails loud on an unterminated string or block comment rather than returning
+/// a silently-truncated view — a pin that mis-parses must go red, not pass.
+fn blank_comments_and_strings(src: &str) -> String {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Mode {
+        Code,
+        LineComment,
+        BlockComment,
+        StringLit,
     }
+
+    let chars: Vec<char> = src.chars().collect();
+    let mut out = String::with_capacity(src.len());
+    let mut mode = Mode::Code;
+    let mut escaped = false;
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+        let next = chars.get(i + 1).copied();
+        match mode {
+            Mode::Code => {
+                if c == '/' && next == Some('/') {
+                    mode = Mode::LineComment;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                if c == '/' && next == Some('*') {
+                    mode = Mode::BlockComment;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                if c == '"' {
+                    mode = Mode::StringLit;
+                    escaped = false;
+                    out.push(' ');
+                    i += 1;
+                    continue;
+                }
+                // A char literal, blanked whole so `'"'` cannot open a string.
+                // A lifetime has no closing quote in this window and falls
+                // through to the plain copy below.
+                if c == '\'' {
+                    let close = if next == Some('\\') {
+                        (i + 2..chars.len().min(i + 8)).find(|&j| chars[j] == '\'')
+                    } else if chars.get(i + 2) == Some(&'\'') {
+                        Some(i + 2)
+                    } else {
+                        None
+                    };
+                    if let Some(close) = close {
+                        for _ in i..=close {
+                            out.push(' ');
+                        }
+                        i = close + 1;
+                        continue;
+                    }
+                }
+                out.push(c);
+                i += 1;
+            }
+            Mode::LineComment => {
+                if c == '\n' {
+                    mode = Mode::Code;
+                    out.push('\n');
+                } else {
+                    out.push(' ');
+                }
+                i += 1;
+            }
+            Mode::BlockComment => {
+                if c == '*' && next == Some('/') {
+                    mode = Mode::Code;
+                    out.push_str("  ");
+                    i += 2;
+                    continue;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            Mode::StringLit => {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == '"' {
+                    mode = Mode::Code;
+                }
+                out.push(if c == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+        }
+    }
+
+    assert!(
+        mode == Mode::Code || mode == Mode::LineComment,
+        "unterminated string literal or block comment while blanking the \
+         scraped source; the pin cannot trust what it just parsed"
+    );
     out
 }

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -435,11 +435,14 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     );
     let ops_calls = count_call_sites(ops_production, ".finalize_state_commit(");
     assert_eq!(
-        ops_calls, 3,
-        "expected exactly 3 `self.finalize_state_commit(` call sites in \
-         contract_ops.rs (the re-PUT merge, the fresh store in \
-         `perform_contract_put`, and the related-contract install in \
-         `get_updated_state`); found {ops_calls}."
+        ops_calls, 2,
+        "expected exactly 2 `self.finalize_state_commit(` call sites in \
+         contract_ops.rs (the re-PUT merge and the fresh store in \
+         `perform_contract_put`); found {ops_calls}. NOTE: the \
+         related-contract install in `get_updated_state` deliberately does \
+         NOT fan out — the GET path's `cache_contract_locally` already did, \
+         and a call there is a guaranteed DUPLICATE, not a missing leg. Read \
+         the comment at that site before adding one back."
     );
 
     // Counting HELPER CALLS alone cannot notice a new storing path that calls
@@ -456,9 +459,13 @@ fn finalize_state_commit_is_the_only_post_store_fan_out_site() {
     //     - `commit_state_update`          -> finalize at the end of the method
     //   contract_ops.rs
     //     - the re-PUT merge               -> finalize immediately after
-    //     - `verify_and_store_contract`    -> finalize at EACH of its two
-    //       callers (the fresh PUT, and the related-contract install), because
-    //       they fan out under different keys
+    //     - `verify_and_store_contract`    -> finalize at its FRESH-PUT caller
+    //       only. Its other caller, the related-contract install in
+    //       `get_updated_state`, is the one write here that owes nothing: the
+    //       sub-op GET's `cache_contract_locally` stored and fanned out that
+    //       same state before control ever reached it, so this is a re-store
+    //       of an already-announced state. Fanning out again would
+    //       double-notify every delegate and WS client and double-broadcast.
     let writes = count_state_writes(production);
     let ops_writes = count_state_writes(ops_production);
     assert_eq!(

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
@@ -32,10 +32,9 @@
 //! Plus two tests about where the fan-out must NOT be, or must survive:
 //!
 //! - [`related_contract_install_does_not_fan_out_the_get_path_already_did`] —
-//!   the related-contract install in `get_updated_state` is a re-store of a
-//!   state the GET path has already stored and announced, so a
-//!   `finalize_state_commit` there is a guaranteed duplicate rather than a
-//!   missing leg.
+//!   the related-contract install in `get_updated_state` writes back a value
+//!   it just read from the local store, so a `finalize_state_commit` there
+//!   announces a transition that did not happen.
 //! - [`failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`] —
 //!   the behaviour change the chokepoint introduces: a failure in one leg must
 //!   not fail the commit or abort the remaining legs.
@@ -556,37 +555,35 @@ async fn failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs()
     Ok(())
 }
 
-/// The related-contract install must NOT fan out — the GET path already did.
+/// The related-contract install must NOT fan out — it changes no state.
 ///
 /// This test replaces one that asserted the opposite. An earlier revision of
 /// this PR added a `finalize_state_commit` to the install in
-/// `get_updated_state`, on the reasoning that installing a contract's state
-/// owes that contract's subscribers a notification. The reasoning is right; the
-/// placement was wrong, because the notification has already been sent by the
-/// time control arrives.
+/// `get_updated_state`, reasoning that installing a contract's state owes that
+/// contract's subscribers a notification. The rule is right; it does not apply,
+/// because nothing is installed — the arm writes back a value it read from the
+/// local store moments earlier.
 ///
-/// The chain, verified end to end:
+/// Why nothing is owed. `GetResult.state` is NOT the network's reply: the
+/// sub-op driver discards the terminal and rebuilds the `GetResult` by
+/// re-querying the LOCAL STORE (`operations/get/op_ctx_task.rs`), and
+/// `verify_and_store_contract` then raw-`store`s that value. So this arm can
+/// only ever write back what the store already holds — no state transition
+/// happens, and there is nothing to announce.
 ///
-/// 1. The sub-op GET driver calls `cache_contract_locally` on
-///    `Terminal::InlineFound`, BEFORE it builds the `GetResult`
-///    (`operations/get/op_ctx_task.rs`).
-/// 2. `cache_contract_locally` re-queries the local store, finds no matching
-///    state (the contract is absent locally — that is why the fetch happened),
-///    and issues a `ContractHandlerEvent::PutQuery` with the contract code.
-/// 3. That PutQuery routes through `maybe_defer_upsert` into
-///    `bridged_upsert_contract_state_inner`, takes the initial-state-install
-///    branch, and calls `finalize_state_commit` — keyed on the related
-///    contract, which is the right key. **The fan-out has happened.**
-/// 4. Only then does `get_updated_state` see its `GetResult` and re-store.
+/// That is a narrower claim than the one an earlier version of this test made
+/// ("the GET path's `cache_contract_locally` already fanned out"). The earlier
+/// claim is usually true and is not safe to rely on: `cache_contract_locally`
+/// can be reached and still not fan out, via its `state_matches`
+/// short-circuit, `Terminal::LocalCompletion`, an orphan-stream
+/// `AlreadyClaimed` early return, or a rejected `PutQuery`. The re-query
+/// argument covers all four.
 ///
-/// The dependency is causal, not incidental: `GetResult.contract` is resolved
-/// by re-querying the LOCAL store after step 2, so it is `Some` only because
-/// step 2 stored it. Had step 2 not run, the re-query would find no state, the
-/// sub-op would resolve `NotFound`, and execution would never reach the
-/// install. A `finalize_state_commit` at the install site is therefore a
-/// GUARANTEED duplicate — double-notifying every subscribed delegate and
-/// WebSocket client, and double-broadcasting to the network — on a codebase
-/// with #5147/#5148 open about broadcast duplication.
+/// It also names the invariant a #5549 fix would break. The obvious fix there
+/// is to hand `Terminal::InlineFound`'s network-delivered state straight to
+/// the caller and skip the re-query; do that, and this arm starts installing
+/// a state the store does NOT hold, silently and with no fan-out. If that
+/// happens this test should be the thing that has to be argued with.
 ///
 /// So the assertion is an ABSENCE, and absence assertions rot into vacuity
 /// unless something proves the code ran and something proves the observer
@@ -601,10 +598,10 @@ async fn failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs()
 /// Reaching the branch still needs two test-only pieces —
 /// `test-contract-requires-related`, whose `update_state` returns
 /// `UpdateModification::requires`, and `set_test_sub_op_get_override` — because
-/// nothing else can enter it. Note the stub stands in for the whole sub-op GET,
-/// which means it also stands in for step 2: the test never runs
-/// `cache_contract_locally`, so the absence it observes is exactly "this site
-/// does not fan out", not "the notification went missing".
+/// nothing else can enter it. The stub replaces the whole sub-op GET, so
+/// nothing upstream of the install runs at all — which means the absence this
+/// test observes is exactly "this site does not fan out", never "a
+/// notification went missing somewhere upstream".
 ///
 /// The stub is a thread-local, so this test must stay on `current_thread`.
 ///
@@ -656,10 +653,12 @@ async fn related_contract_install_does_not_fan_out_the_get_path_already_did()
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
     harness.executor.set_delegate_notification_tx(tx);
 
-    // Stand in for the sub-op GET. In production `cache_contract_locally` has
-    // stored and fanned out this state before the driver returns; the stub
-    // replaces the whole driver, so nothing has fanned out here and any
-    // notification observed below could only have come from the install site.
+    // Stand in for the sub-op GET. The stub replaces the whole driver, so
+    // nothing upstream has fanned out and any notification observed below could
+    // only have come from the install site itself. Note the stub is MORE
+    // permissive than production, which resolves `GetResult` from the local
+    // store: here the state genuinely is new to the store, and the install
+    // still must not announce it.
     let related_state = WrappedState::new(b"state fetched for the related contract".to_vec());
     let _stub = SubOpGetStubGuard;
     {
@@ -700,12 +699,13 @@ async fn related_contract_install_does_not_fan_out_the_get_path_already_did()
     // The assertion this test exists for.
     assert!(
         rx.try_recv().is_err(),
-        "the related-contract install must NOT fan out: the GET path's \
-         `cache_contract_locally` has already stored this state and notified \
-         this delegate. A notification here is a DUPLICATE — every subscribed \
-         delegate and WebSocket client notified twice, and the state broadcast \
-         to the network twice, for one install. Read the comment at the install \
-         site in contract_ops.rs before adding a `finalize_state_commit` back"
+        "the related-contract install must NOT fan out: `GetResult.state` \
+         comes from a re-query of the LOCAL STORE, so this arm writes back a \
+         value the store already holds and announces no transition. A \
+         notification here is a DUPLICATE — every subscribed delegate and \
+         WebSocket client notified twice, and the state broadcast twice, for \
+         one install. Read the comment at the install site in contract_ops.rs \
+         before adding a `finalize_state_commit` back"
     );
 
     // Control: the delegate, the channel and the subscription are all live, so

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
@@ -2,9 +2,9 @@
 //!
 //! `perform_contract_put` and `get_updated_state` live on `impl
 //! Executor<Runtime>` — the real WASM runtime — not on the generic impl the
-//! `pool_tests` harness drives via `Executor<MockWasmRuntime>`. So the three
-//! `finalize_state_commit` call sites they own, all newly routed through the
-//! chokepoint for #5481, were covered only by the source-scrape pin in
+//! `pool_tests` harness drives via `Executor<MockWasmRuntime>`. So the
+//! `finalize_state_commit` call sites they own, routed through the chokepoint
+//! for #5481, were covered only by the source-scrape pin in
 //! `delegate_notification_tests`.
 //!
 //! A structural pin proves a call EXISTS. It does not prove the call is wired
@@ -22,17 +22,23 @@
 //! `wasm_conformance_tests`, which is where the runtime-construction shape
 //! comes from.
 //!
-//! The three sites and the test that covers each:
+//! The sites and the test that covers each:
 //!
 //! | site | test |
 //! |---|---|
 //! | `perform_contract_put`, fresh-install branch | [`local_put_notifies_subscribed_delegates`] |
 //! | `perform_contract_put`, existing-contract merge branch | [`local_reput_merge_notifies_subscribed_delegates`] |
-//! | `get_updated_state`, related-contract install | [`related_contract_install_notifies_the_related_contracts_delegates`] |
 //!
-//! Plus [`failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`],
-//! which covers the behaviour change the chokepoint introduces: a failure in
-//! one leg must not fail the commit or abort the remaining legs.
+//! Plus two tests about where the fan-out must NOT be, or must survive:
+//!
+//! - [`related_contract_install_does_not_fan_out_the_get_path_already_did`] —
+//!   the related-contract install in `get_updated_state` is a re-store of a
+//!   state the GET path has already stored and announced, so a
+//!   `finalize_state_commit` there is a guaranteed duplicate rather than a
+//!   missing leg.
+//! - [`failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`] —
+//!   the behaviour change the chokepoint introduces: a failure in one leg must
+//!   not fail the commit or abort the remaining legs.
 
 use freenet_stdlib::client_api::ContractRequest;
 use freenet_stdlib::prelude::*;
@@ -550,53 +556,69 @@ async fn failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs()
     Ok(())
 }
 
-/// The fifth `finalize_state_commit` site, and the one the rule review named:
-/// `get_updated_state` installs a DIFFERENT contract mid-UPDATE — the related
-/// one it fetched in order to validate the update — and owes THAT contract's
-/// subscribers the fan-out.
+/// The related-contract install must NOT fan out — the GET path already did.
 ///
-/// **This site does not execute in production today — see #5549.** The full
-/// reason is under "What this test does NOT prove" below; it is repeated here
-/// because a reader skimming this one test could otherwise take it as evidence
-/// that the fifth site is live.
+/// This test replaces one that asserted the opposite. An earlier revision of
+/// this PR added a `finalize_state_commit` to the install in
+/// `get_updated_state`, on the reasoning that installing a contract's state
+/// owes that contract's subscribers a notification. The reasoning is right; the
+/// placement was wrong, because the notification has already been sent by the
+/// time control arrives.
 ///
-/// The regression this exists to catch is specific: swapping the site's
-/// `related_key`/`related_params` back to the enclosing `key`/`params`. Every
-/// call-count and state-write pin in `delegate_notification_tests`
-/// still passes under that swap, because the call is still there and still
-/// counted — it is simply pointed at the wrong contract, and a delegate
-/// subscribed to the related contract silently never hears about it. Here the
-/// delegate is subscribed to the RELATED contract only, so under that swap the
-/// notification is keyed on the target contract, this channel stays empty, and
-/// the test fails.
+/// The chain, verified end to end:
 ///
-/// Reaching the branch needs two things production has and a unit test does
-/// not: a contract that asks for a related contract from `update_state`
-/// (`test-contract-requires-related`) and a network that answers
-/// (`set_test_sub_op_get_override`, the sub-op GET sibling of the existing
-/// `set_test_network_fetch_override`). Both are test-only; the code path
-/// between them is production's.
+/// 1. The sub-op GET driver calls `cache_contract_locally` on
+///    `Terminal::InlineFound`, BEFORE it builds the `GetResult`
+///    (`operations/get/op_ctx_task.rs`).
+/// 2. `cache_contract_locally` re-queries the local store, finds no matching
+///    state (the contract is absent locally — that is why the fetch happened),
+///    and issues a `ContractHandlerEvent::PutQuery` with the contract code.
+/// 3. That PutQuery routes through `maybe_defer_upsert` into
+///    `bridged_upsert_contract_state_inner`, takes the initial-state-install
+///    branch, and calls `finalize_state_commit` — keyed on the related
+///    contract, which is the right key. **The fan-out has happened.**
+/// 4. Only then does `get_updated_state` see its `GetResult` and re-store.
 ///
-/// The stub is a thread-local, so this test — like the ones using
-/// `set_test_network_fetch_override` — must stay on `current_thread`, or the
-/// executor may run on a worker thread that cannot see it.
+/// The dependency is causal, not incidental: `GetResult.contract` is resolved
+/// by re-querying the LOCAL store after step 2, so it is `Some` only because
+/// step 2 stored it. Had step 2 not run, the re-query would find no state, the
+/// sub-op would resolve `NotFound`, and execution would never reach the
+/// install. A `finalize_state_commit` at the install site is therefore a
+/// GUARANTEED duplicate — double-notifying every subscribed delegate and
+/// WebSocket client, and double-broadcasting to the network — on a codebase
+/// with #5147/#5148 open about broadcast duplication.
 ///
-/// # What this test does NOT prove
+/// So the assertion is an ABSENCE, and absence assertions rot into vacuity
+/// unless something proves the code ran and something proves the observer
+/// works. Both are here:
 ///
-/// That the branch runs in production today. It does not: `get_updated_state`
-/// asks `local_state_or_from_network(&id, false)`, and the sub-op GET driver
-/// hard-nulls the contract whenever `return_contract_code` is false
-/// (`operations/get/op_ctx_task.rs`, `let client_contract = if
-/// return_contract_code { contract } else { None }`), so the `let Some(contract)
-/// = contract else` guard immediately above the install always takes its error
-/// arm with "Missing contract". That mismatch predates #5481 — it arrived with
-/// the executor split — and correcting it changes what this node asks the
-/// network for, so it belongs in its own change rather than riding along here.
-/// This test therefore pins the site's WIRING, which is what the rule review
-/// asked for and what a future edit can silently break; it is deliberately not
-/// evidence that the site is live.
+/// - the related contract's state IS in the local store afterwards, which only
+///   happens if the install branch executed;
+/// - a control PUT at the end DOES notify the same delegate on the same
+///   channel, so an empty channel earlier was a real absence and not a broken
+///   subscription, a missing `delegate_notification_tx`, or a mis-keyed guard.
+///
+/// Reaching the branch still needs two test-only pieces —
+/// `test-contract-requires-related`, whose `update_state` returns
+/// `UpdateModification::requires`, and `set_test_sub_op_get_override` — because
+/// nothing else can enter it. Note the stub stands in for the whole sub-op GET,
+/// which means it also stands in for step 2: the test never runs
+/// `cache_contract_locally`, so the absence it observes is exactly "this site
+/// does not fan out", not "the notification went missing".
+///
+/// The stub is a thread-local, so this test must stay on `current_thread`.
+///
+/// # Also worth knowing
+///
+/// This site does not execute in production at all today (#5549):
+/// `get_updated_state` asks `local_state_or_from_network(&id, false)`, and the
+/// driver hard-nulls the contract when `return_contract_code` is false, so the
+/// `let Some(contract) = contract else` guard always takes its error arm. When
+/// #5549 is fixed the site becomes live — and that is precisely when a fan-out
+/// re-added here would start double-notifying. This test is the guard that
+/// will be in place.
 #[tokio::test(flavor = "current_thread")]
-async fn related_contract_install_notifies_the_related_contracts_delegates()
+async fn related_contract_install_does_not_fan_out_the_get_path_already_did()
 -> Result<(), Box<dyn std::error::Error>> {
     let target = load(REQUIRES_RELATED_CONTRACT, params(3)).await;
     let target_key = target.key();
@@ -605,13 +627,12 @@ async fn related_contract_install_notifies_the_related_contracts_delegates()
     assert_ne!(
         target_key.id(),
         related_key.id(),
-        "the two contracts must be distinct or the assertion below proves nothing"
+        "the two contracts must be distinct or the assertions below prove nothing"
     );
 
     let mut harness = build_harness("delegate-notify-related-install").await?;
 
-    // Establish the contract being UPDATEd. This is the fresh-install branch
-    // again; nothing is subscribed to it, so it fans out to nobody.
+    // Establish the contract being UPDATEd. Nothing is subscribed to it.
     harness
         .executor
         .contract_requests(
@@ -635,9 +656,10 @@ async fn related_contract_install_notifies_the_related_contracts_delegates()
     let (tx, mut rx) = tokio::sync::mpsc::channel(8);
     harness.executor.set_delegate_notification_tx(tx);
 
-    // Stand in for the network: whatever instance id the target contract asks
-    // for, answer with the related contract and its state. The executor
-    // installs it under the RELATED contract's own key, which is the point.
+    // Stand in for the sub-op GET. In production `cache_contract_locally` has
+    // stored and fanned out this state before the driver returns; the stub
+    // replaces the whole driver, so nothing has fanned out here and any
+    // notification observed below could only have come from the install site.
     let related_state = WrappedState::new(b"state fetched for the related contract".to_vec());
     let _stub = SubOpGetStubGuard;
     {
@@ -661,51 +683,56 @@ async fn related_contract_install_notifies_the_related_contracts_delegates()
         .await
         .map_err(|e| format!("local UPDATE failed: {e}"))?;
 
-    let notification = expect_notification(
-        &mut rx,
-        "installing a related contract mid-UPDATE must fan out to the RELATED \
-         contract's subscribers. An empty channel here is the named regression: \
-         the site keyed its fan-out on the enclosing contract instead of on the \
-         contract it just installed",
-    )
-    .await;
-
-    assert_eq!(
-        notification.contract_id,
-        *related_key.id(),
-        "the fan-out must be keyed on the contract that was just installed \
-         (`related_key`), not on the contract being updated"
-    );
-    assert_ne!(
-        notification.contract_id,
-        *target_key.id(),
-        "keying the fan-out on the enclosing contract is exactly the regression \
-         this test exists to catch"
-    );
-    assert_eq!(
-        notification.delegate_key, delegate,
-        "notification must carry the delegate subscribed to the related contract"
-    );
-    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
-    assert_eq!(
-        delivered,
-        related_state.as_ref(),
-        "the fan-out must carry the related contract's freshly-installed state"
-    );
-
-    // The related contract really was installed, not merely notified about —
-    // otherwise the assertions above could hold for a notification emitted
-    // before (or instead of) the store.
+    // The install branch really executed — otherwise the absence below is
+    // vacuous.
     let stored = harness
         .executor
         .state_store
         .get(&related_key)
         .await
-        .map_err(|e| format!("related contract state must be stored locally: {e}"))?;
+        .map_err(|e| format!("the related contract's state must be stored locally: {e}"))?;
     assert_eq!(
         stored.as_ref(),
         related_state.as_ref(),
-        "the related contract's state must be in the local store"
+        "the install branch must have stored the related contract's state"
+    );
+
+    // The assertion this test exists for.
+    assert!(
+        rx.try_recv().is_err(),
+        "the related-contract install must NOT fan out: the GET path's \
+         `cache_contract_locally` has already stored this state and notified \
+         this delegate. A notification here is a DUPLICATE — every subscribed \
+         delegate and WebSocket client notified twice, and the state broadcast \
+         to the network twice, for one install. Read the comment at the install \
+         site in contract_ops.rs before adding a `finalize_state_commit` back"
+    );
+
+    // Control: the delegate, the channel and the subscription are all live, so
+    // the empty channel above was a real absence rather than a broken harness.
+    // A re-PUT of the now-hosted related contract takes the merge branch, which
+    // does fan out.
+    let merged = WrappedState::new(b"control: a state that really is announced".to_vec());
+    put(&mut harness.executor, related.clone(), merged.clone())
+        .await
+        .map_err(|e| format!("control PUT failed: {e}"))?;
+    let notification = expect_notification(
+        &mut rx,
+        "CONTROL: a genuine commit on the related contract must reach this \
+         delegate. If this fails the harness is broken and the absence asserted \
+         above proves nothing",
+    )
+    .await;
+    assert_eq!(
+        notification.contract_id,
+        *related_key.id(),
+        "the control notification must be for the related contract"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        merged.as_ref(),
+        "the control notification must carry the merged state"
     );
 
     Ok(())

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
@@ -29,6 +29,10 @@
 //! | `perform_contract_put`, fresh-install branch | [`local_put_notifies_subscribed_delegates`] |
 //! | `perform_contract_put`, existing-contract merge branch | [`local_reput_merge_notifies_subscribed_delegates`] |
 //! | `get_updated_state`, related-contract install | [`related_contract_install_notifies_the_related_contracts_delegates`] |
+//!
+//! Plus [`failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`],
+//! which covers the behaviour change the chokepoint introduces: a failure in
+//! one leg must not fail the commit or abort the remaining legs.
 
 use freenet_stdlib::client_api::ContractRequest;
 use freenet_stdlib::prelude::*;
@@ -37,7 +41,7 @@ use std::time::Duration;
 
 use crate::client_events::ClientId;
 use crate::config::ConfigArgs;
-use crate::contract::executor::{DelegateNotification, Executor, OperationMode};
+use crate::contract::executor::{ContractExecutor, DelegateNotification, Executor, OperationMode};
 use crate::node::OpManager;
 use crate::operations::get::GetResult;
 use crate::wasm_runtime::{
@@ -53,6 +57,11 @@ const MOCK_ALIGNED_CONTRACT: &str = "test-contract-mock-aligned";
 /// settles on the second. The only fixture that can enter the
 /// fetch-and-install branch of `get_updated_state`.
 const REQUIRES_RELATED_CONTRACT: &str = "test-contract-requires-related";
+
+/// `get_state_delta` always fails. The only way to drive
+/// `send_update_notification` (leg 2) into its error path without adding a
+/// production seam.
+const DELTA_TRAP_CONTRACT: &str = "test-contract-delta-trap";
 
 /// Every test loads its contracts under DISTINCT parameters.
 ///
@@ -113,7 +122,19 @@ impl Drop for SubOpGetStubGuard {
     }
 }
 
-async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) {
+/// Returns the `OpManager`, the event-loop notification RECEIVER, and the
+/// remaining channel ends that merely need to stay alive.
+///
+/// The receiver is handed back separately rather than buried in the opaque
+/// guard box because leg 4 of the fan-out (`broadcast_state_change`) is
+/// observable only as a `NodeEvent::BroadcastStateChange` on it.
+async fn build_op_manager(
+    id: &str,
+) -> (
+    Arc<OpManager>,
+    crate::node::EventLoopNotificationsReceiver,
+    Box<dyn std::any::Any>,
+) {
     let config_args = ConfigArgs {
         id: Some(id.to_string()),
         mode: Some(OperationMode::Local),
@@ -144,27 +165,26 @@ async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) 
     );
     op_manager.ring.attach_op_manager(&op_manager);
 
-    let guards: Box<dyn std::any::Any> = Box::new((
-        notification_rx,
-        ch_channel,
-        wait_for_event,
-        result_router_rx,
-        task_monitor,
-    ));
-    (op_manager, guards)
+    let guards: Box<dyn std::any::Any> =
+        Box::new((ch_channel, wait_for_event, result_router_rx, task_monitor));
+    (op_manager, notification_rx, guards)
 }
 
 /// A real `Executor<Runtime>` in local mode over real (temp-dir) stores, plus
 /// the guards that must outlive it.
 struct Harness {
     executor: Executor<Runtime>,
+    /// Where `broadcast_state_change` (leg 4) lands. Kept alive for every test,
+    /// not only the one that reads it: dropping it would make the leg fail with
+    /// a closed channel, which the executor swallows by design.
+    notifications: crate::node::EventLoopNotificationsReceiver,
     _op_manager: Arc<OpManager>,
     _op_manager_guards: Box<dyn std::any::Any>,
     _temp_dir: tempfile::TempDir,
 }
 
 async fn build_harness(id: &str) -> Result<Harness, Box<dyn std::error::Error>> {
-    let (op_manager, op_manager_guards) = build_op_manager(id).await;
+    let (op_manager, notifications, op_manager_guards) = build_op_manager(id).await;
 
     let temp_dir = crate::util::tests::get_temp_dir();
     let db = crate::contract::storages::Storage::new(temp_dir.path()).await?;
@@ -189,6 +209,7 @@ async fn build_harness(id: &str) -> Result<Harness, Box<dyn std::error::Error>> 
 
     Ok(Harness {
         executor,
+        notifications,
         _op_manager: op_manager,
         _op_manager_guards: op_manager_guards,
         _temp_dir: temp_dir,
@@ -200,6 +221,32 @@ async fn load(name: &'static str, params: Parameters<'static>) -> ContractContai
         .await
         .expect("join contract compile")
         .expect("compile contract")
+}
+
+/// Whether a `BroadcastStateChange` for `key` is sitting on the event-loop
+/// notification channel — the only observable effect of leg 4
+/// (`broadcast_state_change`) from inside the executor.
+///
+/// Drains what is queued rather than blocking: the emit is a synchronous
+/// `try_send` completed before `contract_requests` returns, so anything owed is
+/// already there and an empty channel is a real answer, not a race.
+fn broadcast_emitted_for(
+    notifications: &mut crate::node::EventLoopNotificationsReceiver,
+    key: &ContractKey,
+) -> bool {
+    let mut seen = false;
+    while let Ok(event) = notifications.notifications_receiver.try_recv() {
+        if let either::Either::Right(crate::message::NodeEvent::BroadcastStateChange {
+            key: broadcast_key,
+            ..
+        }) = event
+        {
+            if broadcast_key.id() == key.id() {
+                seen = true;
+            }
+        }
+    }
+    seen
 }
 
 /// Await one delegate notification, failing with `context` rather than a bare
@@ -383,10 +430,135 @@ async fn local_reput_merge_notifies_subscribed_delegates() -> Result<(), Box<dyn
     Ok(())
 }
 
+/// The behaviour change this PR makes deliberate: a failed WebSocket
+/// notification (leg 2) must NOT fail the PUT, and must NOT abort legs 3 and 4.
+///
+/// `perform_contract_put` used to map a `send_update_notification` error into
+/// `StdContractError::Put` and return it — reporting a PUT as FAILED after its
+/// state was already stored and metered, over a `get_state_delta` trap
+/// belonging to some *other* client's cached summary. Routing through
+/// `finalize_state_commit` makes every leg best-effort.
+///
+/// Neither behaviour was ever regression-tested: `grep -rn "failed while
+/// sending notifications"` finds nothing in the tree, so the OLD behaviour had
+/// no test either and a silent revert in either direction would have gone
+/// unnoticed.
+///
+/// The assertion that matters most is the last one. "Every leg is best-effort"
+/// is implied by the structure of `finalize_state_commit` and pinned by nothing:
+/// a `?` reintroduced anywhere in legs 2 or 3 would abort the rest of the
+/// fan-out silently, which is the exact failure class this whole PR exists to
+/// close.
+///
+/// Forcing the error needs no production seam. `send_update_notification`
+/// computes a delta for any subscriber holding a cached summary and propagates
+/// the failure with `?`, so a contract whose `get_state_delta` always fails
+/// (`test-contract-delta-trap`) plus a subscriber registered WITH a summary is
+/// enough.
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let contract = load(DELTA_TRAP_CONTRACT, params(5)).await;
+    let contract_key = contract.key();
+
+    let mut harness = build_harness("delegate-notify-leg2-failure").await?;
+
+    let delegate = DelegateKey::new([24u8; 32], CodeHash::new([24u8; 32]));
+    let _subscription = SubscriptionGuard::register(*contract_key.id(), delegate.clone());
+
+    let (delegate_tx, mut delegate_rx) = tokio::sync::mpsc::channel(8);
+    harness.executor.set_delegate_notification_tx(delegate_tx);
+
+    // A WS client WITH a cached summary. The summary is what selects the delta
+    // path; without it the executor sends full state, `get_state_delta` is
+    // never called, and this test would pass while exercising nothing — which
+    // is why the "client received nothing" assertion below is not optional.
+    let (ws_tx, mut ws_rx) = tokio::sync::mpsc::channel(8);
+    ContractExecutor::register_contract_notifier(
+        &mut harness.executor,
+        *contract_key.id(),
+        ClientId::FIRST,
+        ws_tx,
+        Some(StateSummary::from(b"cached summary".to_vec())),
+    )
+    .map_err(|e| format!("register notifier: {e}"))?;
+
+    let state = WrappedState::new(b"state whose delta computation traps".to_vec());
+    let response = put(&mut harness.executor, contract.clone(), state.clone()).await;
+
+    // 1. The commit is not failed by the notification failure.
+    assert!(
+        response.is_ok(),
+        "a failed send_update_notification must not fail the PUT: the state is \
+         already stored and metered by the time leg 2 runs, and the trap belongs \
+         to another client's subscription. Got: {response:?}"
+    );
+
+    // 2. The state really is durable, so the assertions below are about a
+    //    commit that happened rather than one that was rolled back.
+    let stored = harness
+        .executor
+        .state_store
+        .get(&contract_key)
+        .await
+        .map_err(|e| format!("state must be stored despite the notification failure: {e}"))?;
+    assert_eq!(
+        stored.as_ref(),
+        state.as_ref(),
+        "the stored state must be the one that was PUT"
+    );
+
+    // 3. Leg 2 really did fail — otherwise this test proves nothing. The delta
+    //    trap aborts the subscriber loop before any `try_send`, so the client
+    //    gets nothing at all.
+    assert!(
+        ws_rx.try_recv().is_err(),
+        "the WS client must have received NOTHING: if a notification arrived, \
+         get_state_delta was never called and leg 2 did not fail, so the rest of \
+         this test is vacuous. Check that the subscriber was registered with a \
+         summary and that the fixture is test-contract-delta-trap"
+    );
+
+    // 4. Leg 3 still fires.
+    let notification = expect_notification(
+        &mut delegate_rx,
+        "a failure in leg 2 (WS clients) must not stop leg 3 (delegates). \
+         `finalize_state_commit` logs and continues; a `?` reintroduced in leg 2 \
+         would abort the fan-out silently, which is the failure class of #5481",
+    )
+    .await;
+    assert_eq!(
+        notification.contract_id,
+        *contract_key.id(),
+        "the delegate notification must be for the committed contract"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        state.as_ref(),
+        "the delegate must be handed the committed state"
+    );
+
+    // 5. Leg 4 still fires. Asserted nowhere else: nothing pins that a failure
+    //    in an earlier leg leaves the network broadcast intact.
+    assert!(
+        broadcast_emitted_for(&mut harness.notifications, &contract_key),
+        "a failure in leg 2 must not stop leg 4 (the network broadcast). No \
+         BroadcastStateChange for this contract reached the event-loop channel"
+    );
+
+    Ok(())
+}
+
 /// The fifth `finalize_state_commit` site, and the one the rule review named:
 /// `get_updated_state` installs a DIFFERENT contract mid-UPDATE — the related
 /// one it fetched in order to validate the update — and owes THAT contract's
 /// subscribers the fan-out.
+///
+/// **This site does not execute in production today — see #5549.** The full
+/// reason is under "What this test does NOT prove" below; it is repeated here
+/// because a reader skimming this one test could otherwise take it as evidence
+/// that the fifth site is live.
 ///
 /// The regression this exists to catch is specific: swapping the site's
 /// `related_key`/`related_params` back to the enclosing `key`/`params`. Every

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
@@ -1,0 +1,540 @@
+//! Behavioural coverage for the fan-out sites a MOCK runtime cannot reach.
+//!
+//! `perform_contract_put` and `get_updated_state` live on `impl
+//! Executor<Runtime>` — the real WASM runtime — not on the generic impl the
+//! `pool_tests` harness drives via `Executor<MockWasmRuntime>`. So the three
+//! `finalize_state_commit` call sites they own, all newly routed through the
+//! chokepoint for #5481, were covered only by the source-scrape pin in
+//! `delegate_notification_tests`.
+//!
+//! A structural pin proves a call EXISTS. It does not prove the call is wired
+//! correctly — right key, right params, right state — and the repo's own rule
+//! review made the concrete case: swap the related-contract install's
+//! `related_key`/`related_params` back to the enclosing `key`/`params` and every
+//! call-count and write-count assertion still passes while delegates silently
+//! stop being notified for that path. That is the same silent-failure shape as
+//! #5481 itself, which is exactly the argument this PR makes elsewhere for
+//! asserting the broadcast leg behaviourally rather than trusting the pin.
+//!
+//! So this module pays the cost of a real `Executor<Runtime>` — compiled WASM
+//! contracts plus real stores — to assert the behaviour end to end at the
+//! executor layer. It is feature-gated on `wasmtime-backend` alongside
+//! `wasm_conformance_tests`, which is where the runtime-construction shape
+//! comes from.
+//!
+//! The three sites and the test that covers each:
+//!
+//! | site | test |
+//! |---|---|
+//! | `perform_contract_put`, fresh-install branch | [`local_put_notifies_subscribed_delegates`] |
+//! | `perform_contract_put`, existing-contract merge branch | [`local_reput_merge_notifies_subscribed_delegates`] |
+//! | `get_updated_state`, related-contract install | [`related_contract_install_notifies_the_related_contracts_delegates`] |
+
+use freenet_stdlib::client_api::ContractRequest;
+use freenet_stdlib::prelude::*;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::client_events::ClientId;
+use crate::config::ConfigArgs;
+use crate::contract::executor::{DelegateNotification, Executor, OperationMode};
+use crate::node::OpManager;
+use crate::operations::get::GetResult;
+use crate::wasm_runtime::{
+    ContractStore, DELEGATE_SUBSCRIPTIONS, DelegateStore, Runtime, SecretsStore, StateStore,
+};
+
+/// The same mock-aligned fixture `wasm_conformance_tests` uses: its
+/// `validate_state` always returns `Valid`, so a PUT of arbitrary bytes lands
+/// and the test is about the fan-out rather than about contract semantics.
+const MOCK_ALIGNED_CONTRACT: &str = "test-contract-mock-aligned";
+
+/// Asks for a related contract from `update_state` on its first pass and
+/// settles on the second. The only fixture that can enter the
+/// fetch-and-install branch of `get_updated_state`.
+const REQUIRES_RELATED_CONTRACT: &str = "test-contract-requires-related";
+
+/// Every test loads its contracts under DISTINCT parameters.
+///
+/// `DELEGATE_SUBSCRIPTIONS` is process-global (#4824) and keyed by
+/// `ContractInstanceId`. CI runs `cargo nextest` (process per test) but
+/// contributors run plain `cargo test` (one process for all of them), and a
+/// contract's instance id is `hash(code, params)` — so two tests loading the
+/// same WASM with the same params would share one subscription entry and each
+/// would see the other's delegate in its own channel. Distinct params give
+/// distinct instance ids and the tests stop interacting. The fixtures ignore
+/// their parameters, so this costs nothing but a second WASM instantiation.
+fn params(tag: u8) -> Parameters<'static> {
+    Parameters::from(vec![tag])
+}
+
+/// Registers one delegate against one contract and removes exactly that
+/// registration on drop — `DELEGATE_SUBSCRIPTIONS` is process-global (#4824),
+/// so a blanket `remove` would delete a concurrent test's entry under plain
+/// `cargo test`. Mirrors the guard in the sibling module.
+struct SubscriptionGuard {
+    instance_id: ContractInstanceId,
+    delegate: DelegateKey,
+}
+
+impl SubscriptionGuard {
+    fn register(instance_id: ContractInstanceId, delegate: DelegateKey) -> Self {
+        DELEGATE_SUBSCRIPTIONS
+            .entry(instance_id)
+            .or_default()
+            .insert(delegate.clone());
+        Self {
+            instance_id,
+            delegate,
+        }
+    }
+}
+
+impl Drop for SubscriptionGuard {
+    fn drop(&mut self) {
+        DELEGATE_SUBSCRIPTIONS.retain(|id, subs| {
+            if id == &self.instance_id {
+                subs.remove(&self.delegate);
+            }
+            !subs.is_empty()
+        });
+    }
+}
+
+/// Clears the sub-op GET stub however the test ends.
+///
+/// The stub is a thread-local, so leaving it set would leak into whatever test
+/// the runtime schedules next on this thread under plain `cargo test`.
+struct SubOpGetStubGuard;
+
+impl Drop for SubOpGetStubGuard {
+    fn drop(&mut self) {
+        crate::contract::executor::runtime::set_test_sub_op_get_override(None);
+    }
+}
+
+async fn build_op_manager(id: &str) -> (Arc<OpManager>, Box<dyn std::any::Any>) {
+    let config_args = ConfigArgs {
+        id: Some(id.to_string()),
+        mode: Some(OperationMode::Local),
+        ..Default::default()
+    };
+    let node_config =
+        crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+
+    let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+    let (ops_ch_channel, ch_channel, wait_for_event) = crate::contract::contract_handler_channel();
+    let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+    let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+    let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+    let op_manager = Arc::new(
+        OpManager::new(
+            notification_tx,
+            ops_ch_channel,
+            &node_config,
+            crate::tracing::DynamicRegister::new(vec![]),
+            connection_manager,
+            result_router_tx,
+            &task_monitor,
+        )
+        .expect("build OpManager"),
+    );
+    op_manager.ring.attach_op_manager(&op_manager);
+
+    let guards: Box<dyn std::any::Any> = Box::new((
+        notification_rx,
+        ch_channel,
+        wait_for_event,
+        result_router_rx,
+        task_monitor,
+    ));
+    (op_manager, guards)
+}
+
+/// A real `Executor<Runtime>` in local mode over real (temp-dir) stores, plus
+/// the guards that must outlive it.
+struct Harness {
+    executor: Executor<Runtime>,
+    _op_manager: Arc<OpManager>,
+    _op_manager_guards: Box<dyn std::any::Any>,
+    _temp_dir: tempfile::TempDir,
+}
+
+async fn build_harness(id: &str) -> Result<Harness, Box<dyn std::error::Error>> {
+    let (op_manager, op_manager_guards) = build_op_manager(id).await;
+
+    let temp_dir = crate::util::tests::get_temp_dir();
+    let db = crate::contract::storages::Storage::new(temp_dir.path()).await?;
+    let contract_store = ContractStore::new(temp_dir.path().join("contract"), 10_000, db.clone())?;
+    let delegate_store = DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())?;
+    let secrets_store = SecretsStore::new(
+        temp_dir.path().join("secrets"),
+        Default::default(),
+        db.clone(),
+    )?;
+    let state_store = StateStore::new(db, 10_000_000)?;
+    let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)?;
+
+    let executor = Executor::new(
+        state_store,
+        || Ok(()),
+        OperationMode::Local,
+        runtime,
+        Some(op_manager.clone()),
+    )
+    .await?;
+
+    Ok(Harness {
+        executor,
+        _op_manager: op_manager,
+        _op_manager_guards: op_manager_guards,
+        _temp_dir: temp_dir,
+    })
+}
+
+async fn load(name: &'static str, params: Parameters<'static>) -> ContractContainer {
+    tokio::task::spawn_blocking(move || crate::test_utils::load_contract(name, params))
+        .await
+        .expect("join contract compile")
+        .expect("compile contract")
+}
+
+/// Await one delegate notification, failing with `context` rather than a bare
+/// timeout so a regression names the path that stopped fanning out.
+async fn expect_notification(
+    rx: &mut tokio::sync::mpsc::Receiver<DelegateNotification>,
+    context: &str,
+) -> DelegateNotification {
+    match tokio::time::timeout(Duration::from_secs(10), rx.recv()).await {
+        Ok(Some(notification)) => notification,
+        Ok(None) => panic!("delegate notification channel closed: {context}"),
+        Err(_) => panic!("no delegate notification arrived: {context}"),
+    }
+}
+
+/// #5481, on the path a mock runtime cannot reach: the FRESH-INSTALL branch of
+/// `perform_contract_put` must notify subscribed delegates.
+///
+/// That branch stores a brand-new contract's state and, before this PR,
+/// hand-inlined two of the four fan-out legs — dropping the telemetry leg and
+/// the delegate leg. It is #5481 in a sibling file, and it was invisible to a
+/// pin that scraped only `executor_impl.rs`.
+///
+/// Driven through the public `Executor::contract_requests`, which is the entry
+/// point local-node mode uses, so the test exercises the real dispatch rather
+/// than reaching for a private method.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_put_notifies_subscribed_delegates() -> Result<(), Box<dyn std::error::Error>> {
+    let contract = load(MOCK_ALIGNED_CONTRACT, params(1)).await;
+    let contract_key = contract.key();
+
+    let mut harness = build_harness("delegate-notify-local-put").await?;
+
+    let delegate = DelegateKey::new([21u8; 32], CodeHash::new([21u8; 32]));
+    let _subscription = SubscriptionGuard::register(*contract_key.id(), delegate.clone());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    harness.executor.set_delegate_notification_tx(tx);
+
+    let state = WrappedState::new(b"local put fan-out".to_vec());
+    harness
+        .executor
+        .contract_requests(
+            ContractRequest::Put {
+                contract: contract.clone(),
+                state: state.clone(),
+                related_contracts: RelatedContracts::default(),
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+            ClientId::FIRST,
+            None,
+        )
+        .await
+        .map_err(|e| format!("local PUT failed: {e}"))?;
+
+    let notification = expect_notification(
+        &mut rx,
+        "the fresh-install branch of perform_contract_put must notify subscribed \
+         delegates. This is #5481 on the local PUT path — the branch installs a \
+         brand-new contract's state and used to hand-inline only the WS-client \
+         and broadcast legs",
+    )
+    .await;
+
+    assert_eq!(
+        notification.delegate_key, delegate,
+        "notification must carry the subscribed delegate's key"
+    );
+    assert_eq!(
+        notification.contract_id,
+        *contract_key.id(),
+        "notification must be keyed on the contract that was PUT"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        state.as_ref(),
+        "notification must carry the state that was stored, not a re-read or a \
+         reconstruction"
+    );
+
+    Ok(())
+}
+
+/// Issue a local PUT through the public request dispatcher.
+async fn put(
+    executor: &mut Executor<Runtime>,
+    contract: ContractContainer,
+    state: WrappedState,
+) -> Result<(), String> {
+    executor
+        .contract_requests(
+            ContractRequest::Put {
+                contract,
+                state,
+                related_contracts: RelatedContracts::default(),
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+            ClientId::FIRST,
+            None,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// The OTHER `perform_contract_put` branch: a re-PUT into an
+/// ALREADY-hosted contract merges and must fan out too.
+///
+/// This branch does not go through `verify_and_store_contract` at all — it
+/// merges via `update_state`, writes with `state_store.update`, and before this
+/// PR hand-inlined its own two legs. Structurally it is a different site from
+/// the fresh install above and it fails independently, so it gets its own
+/// assertion rather than being folded into that test.
+///
+/// The first PUT establishes the contract; only the SECOND one exercises the
+/// merge branch, so the test asserts on the second notification and checks that
+/// what arrives is the MERGED state, not the state that was already stored.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_reput_merge_notifies_subscribed_delegates() -> Result<(), Box<dyn std::error::Error>>
+{
+    let contract = load(MOCK_ALIGNED_CONTRACT, params(2)).await;
+    let contract_key = contract.key();
+
+    let mut harness = build_harness("delegate-notify-local-reput").await?;
+
+    let delegate = DelegateKey::new([22u8; 32], CodeHash::new([22u8; 32]));
+    let _subscription = SubscriptionGuard::register(*contract_key.id(), delegate.clone());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    harness.executor.set_delegate_notification_tx(tx);
+
+    let first = WrappedState::new(b"first install".to_vec());
+    put(&mut harness.executor, contract.clone(), first.clone())
+        .await
+        .map_err(|e| format!("first PUT failed: {e}"))?;
+    let install_notification =
+        expect_notification(&mut rx, "the fresh-install branch must fan out first").await;
+    assert_eq!(
+        install_notification.contract_id,
+        *contract_key.id(),
+        "sanity: the install notification is for this test's contract"
+    );
+
+    // `test-contract-mock-aligned::update_state` takes the last incoming
+    // `State`, so a different payload here produces a genuinely different
+    // merged state and the branch does NOT take its no-change early return.
+    let merged = WrappedState::new(b"merged by re-put".to_vec());
+    put(&mut harness.executor, contract.clone(), merged.clone())
+        .await
+        .map_err(|e| format!("re-PUT failed: {e}"))?;
+
+    let notification = expect_notification(
+        &mut rx,
+        "the existing-contract MERGE branch of perform_contract_put must notify \
+         subscribed delegates. It is a distinct storing path from the fresh \
+         install — it commits through state_store.update — and before #5481 it \
+         hand-inlined only the WS-client and broadcast legs",
+    )
+    .await;
+
+    assert_eq!(
+        notification.delegate_key, delegate,
+        "notification must carry the subscribed delegate's key"
+    );
+    assert_eq!(
+        notification.contract_id,
+        *contract_key.id(),
+        "notification must be keyed on the merged contract"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        merged.as_ref(),
+        "the merge branch must fan out the MERGED state, not the state that was \
+         already stored"
+    );
+
+    Ok(())
+}
+
+/// The fifth `finalize_state_commit` site, and the one the rule review named:
+/// `get_updated_state` installs a DIFFERENT contract mid-UPDATE — the related
+/// one it fetched in order to validate the update — and owes THAT contract's
+/// subscribers the fan-out.
+///
+/// The regression this exists to catch is specific: swapping the site's
+/// `related_key`/`related_params` back to the enclosing `key`/`params`. Every
+/// call-count and state-write pin in `delegate_notification_tests`
+/// still passes under that swap, because the call is still there and still
+/// counted — it is simply pointed at the wrong contract, and a delegate
+/// subscribed to the related contract silently never hears about it. Here the
+/// delegate is subscribed to the RELATED contract only, so under that swap the
+/// notification is keyed on the target contract, this channel stays empty, and
+/// the test fails.
+///
+/// Reaching the branch needs two things production has and a unit test does
+/// not: a contract that asks for a related contract from `update_state`
+/// (`test-contract-requires-related`) and a network that answers
+/// (`set_test_sub_op_get_override`, the sub-op GET sibling of the existing
+/// `set_test_network_fetch_override`). Both are test-only; the code path
+/// between them is production's.
+///
+/// The stub is a thread-local, so this test — like the ones using
+/// `set_test_network_fetch_override` — must stay on `current_thread`, or the
+/// executor may run on a worker thread that cannot see it.
+///
+/// # What this test does NOT prove
+///
+/// That the branch runs in production today. It does not: `get_updated_state`
+/// asks `local_state_or_from_network(&id, false)`, and the sub-op GET driver
+/// hard-nulls the contract whenever `return_contract_code` is false
+/// (`operations/get/op_ctx_task.rs`, `let client_contract = if
+/// return_contract_code { contract } else { None }`), so the `let Some(contract)
+/// = contract else` guard immediately above the install always takes its error
+/// arm with "Missing contract". That mismatch predates #5481 — it arrived with
+/// the executor split — and correcting it changes what this node asks the
+/// network for, so it belongs in its own change rather than riding along here.
+/// This test therefore pins the site's WIRING, which is what the rule review
+/// asked for and what a future edit can silently break; it is deliberately not
+/// evidence that the site is live.
+#[tokio::test(flavor = "current_thread")]
+async fn related_contract_install_notifies_the_related_contracts_delegates()
+-> Result<(), Box<dyn std::error::Error>> {
+    let target = load(REQUIRES_RELATED_CONTRACT, params(3)).await;
+    let target_key = target.key();
+    let related = load(MOCK_ALIGNED_CONTRACT, params(4)).await;
+    let related_key = related.key();
+    assert_ne!(
+        target_key.id(),
+        related_key.id(),
+        "the two contracts must be distinct or the assertion below proves nothing"
+    );
+
+    let mut harness = build_harness("delegate-notify-related-install").await?;
+
+    // Establish the contract being UPDATEd. This is the fresh-install branch
+    // again; nothing is subscribed to it, so it fans out to nobody.
+    harness
+        .executor
+        .contract_requests(
+            ContractRequest::Put {
+                contract: target.clone(),
+                state: WrappedState::new(b"target initial".to_vec()),
+                related_contracts: RelatedContracts::default(),
+                subscribe: false,
+                blocking_subscribe: false,
+            },
+            ClientId::FIRST,
+            None,
+        )
+        .await
+        .map_err(|e| format!("target PUT failed: {e}"))?;
+
+    // Subscribed to the RELATED contract, which this node does not host yet.
+    let delegate = DelegateKey::new([23u8; 32], CodeHash::new([23u8; 32]));
+    let _subscription = SubscriptionGuard::register(*related_key.id(), delegate.clone());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    harness.executor.set_delegate_notification_tx(tx);
+
+    // Stand in for the network: whatever instance id the target contract asks
+    // for, answer with the related contract and its state. The executor
+    // installs it under the RELATED contract's own key, which is the point.
+    let related_state = WrappedState::new(b"state fetched for the related contract".to_vec());
+    let _stub = SubOpGetStubGuard;
+    {
+        let related = related.clone();
+        let related_state = related_state.clone();
+        crate::contract::executor::runtime::set_test_sub_op_get_override(Some(std::rc::Rc::new(
+            move |_id| Some(GetResult::new(related_state.clone(), Some(related.clone()))),
+        )));
+    }
+
+    harness
+        .executor
+        .contract_requests(
+            ContractRequest::Update {
+                key: target_key,
+                data: UpdateData::Delta(StateDelta::from(b"trigger".to_vec())),
+            },
+            ClientId::FIRST,
+            None,
+        )
+        .await
+        .map_err(|e| format!("local UPDATE failed: {e}"))?;
+
+    let notification = expect_notification(
+        &mut rx,
+        "installing a related contract mid-UPDATE must fan out to the RELATED \
+         contract's subscribers. An empty channel here is the named regression: \
+         the site keyed its fan-out on the enclosing contract instead of on the \
+         contract it just installed",
+    )
+    .await;
+
+    assert_eq!(
+        notification.contract_id,
+        *related_key.id(),
+        "the fan-out must be keyed on the contract that was just installed \
+         (`related_key`), not on the contract being updated"
+    );
+    assert_ne!(
+        notification.contract_id,
+        *target_key.id(),
+        "keying the fan-out on the enclosing contract is exactly the regression \
+         this test exists to catch"
+    );
+    assert_eq!(
+        notification.delegate_key, delegate,
+        "notification must carry the delegate subscribed to the related contract"
+    );
+    let delivered: &[u8] = notification.new_state.as_ref().as_ref();
+    assert_eq!(
+        delivered,
+        related_state.as_ref(),
+        "the fan-out must carry the related contract's freshly-installed state"
+    );
+
+    // The related contract really was installed, not merely notified about —
+    // otherwise the assertions above could hold for a notification emitted
+    // before (or instead of) the store.
+    let stored = harness
+        .executor
+        .state_store
+        .get(&related_key)
+        .await
+        .map_err(|e| format!("related contract state must be stored locally: {e}"))?;
+    assert_eq!(
+        stored.as_ref(),
+        related_state.as_ref(),
+        "the related contract's state must be in the local store"
+    );
+
+    Ok(())
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -878,6 +878,34 @@ pub(crate) fn set_test_network_fetch_override(stub: Option<NetworkFetchStub>) {
     TEST_NETWORK_FETCH_OVERRIDE.with(|cell| *cell.borrow_mut() = stub);
 }
 
+/// Test hook for the OTHER network-fetch leg: `local_state_or_from_network`.
+///
+/// Distinct from [`NetworkFetchStub`] because the two legs return different
+/// things and only this one can install a contract. `fetch_related_via_network`
+/// resolves a bare state; `local_state_or_from_network` resolves a whole
+/// `GetResult`, and it is the `GetResult::contract` half that lets
+/// `get_updated_state` install a SECOND contract mid-UPDATE — the site whose
+/// post-store fan-out #5481 is about. Returning `None` stands for
+/// `SubOpGetOutcome::NotFound`.
+#[cfg(test)]
+pub(crate) type SubOpGetStub =
+    std::rc::Rc<dyn Fn(ContractInstanceId) -> Option<crate::operations::get::GetResult>>;
+
+#[cfg(test)]
+thread_local! {
+    /// Test hook used by `local_state_or_from_network` to bypass the real
+    /// network sub-op driver. Set with [`set_test_sub_op_get_override`]
+    /// inside a `#[tokio::test(flavor = "current_thread")]` so the
+    /// thread-local lookup hits the same task that ran the test setup.
+    static TEST_SUB_OP_GET_OVERRIDE: std::cell::RefCell<Option<SubOpGetStub>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_sub_op_get_override(stub: Option<SubOpGetStub>) {
+    TEST_SUB_OP_GET_OVERRIDE.with(|cell| *cell.borrow_mut() = stub);
+}
+
 #[cfg(test)]
 mod executor_pin_tests {
     /// Pin: `local_state_or_from_network` MUST use the sub-op GET

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -283,44 +283,46 @@ impl Executor<Runtime> {
                                             }),
                                         ));
                                     };
-                                    let related_key = contract.key();
-                                    let related_params = contract.params();
+                                    // DELIBERATELY NO FAN-OUT HERE. The
+                                    // related contract's subscribers are owed
+                                    // one, and the GET path has already sent
+                                    // it: reaching this arm at all means the
+                                    // sub-op GET resolved from the network, and
+                                    // its `cache_contract_locally` ran first —
+                                    // it stores via `ContractHandlerEvent::
+                                    // PutQuery`, which lands in the
+                                    // initial-state-install branch of
+                                    // `bridged_upsert_contract_state_inner` and
+                                    // fans out from there, keyed on this
+                                    // contract. Adding a second
+                                    // `finalize_state_commit` here would
+                                    // double-notify every subscribed delegate
+                                    // and WebSocket client and double-broadcast
+                                    // to the network, for one install.
+                                    //
+                                    // The dependency is causal, not incidental.
+                                    // `GetResult.contract` is resolved by
+                                    // re-querying the LOCAL store after
+                                    // `cache_contract_locally` returns
+                                    // (`operations/get/op_ctx_task.rs`), so it
+                                    // is `Some` only because that store already
+                                    // happened. If the store had not happened
+                                    // the re-query would find no state, the
+                                    // sub-op would resolve `NotFound`, and
+                                    // execution would never arrive here.
+                                    //
+                                    // `verify_and_store_contract` below is a
+                                    // re-store of that same state. It is
+                                    // pre-existing and left alone (it also
+                                    // re-charges the disk budget and
+                                    // `StateBytesWritten` — see #5553); what
+                                    // must not come back is the fan-out.
                                     self.verify_and_store_contract(
                                         state.clone(),
                                         contract.clone(),
                                         RelatedContracts::default(),
                                     )
                                     .await?;
-                                    // This just installed a DIFFERENT
-                                    // contract's state — the related one we
-                                    // fetched to validate this update — so it
-                                    // owes that contract's subscribers the same
-                                    // post-store fan-out any other install
-                                    // does. Keyed on the related contract, not
-                                    // `key`. Without this a delegate subscribed
-                                    // to the related contract is never told,
-                                    // which is #5481 on a fifth path (found by
-                                    // the external review pass).
-                                    //
-                                    // The fan-out cannot live inside
-                                    // `verify_and_store_contract`: its other
-                                    // caller (the fresh-PUT branch above)
-                                    // already fans out after it, and moving it
-                                    // inside would emit twice there.
-                                    //
-                                    // Note leg 4 means this node now
-                                    // re-broadcasts a state it just fetched.
-                                    // That is bounded — `broadcast_state_change`
-                                    // sends only to peers already interested in
-                                    // that contract, and none may be — and it
-                                    // is what every other install does with a
-                                    // network-delivered state.
-                                    self.finalize_state_commit(
-                                        &related_key,
-                                        &related_params,
-                                        &state,
-                                    )
-                                    .await;
                                     state
                                 }
                             };

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -368,7 +368,10 @@ impl Executor<Runtime> {
             return Err(Self::validation_error(key, result));
         }
         if new_state.as_ref() != current_state.as_ref() {
-            self.commit_state_update(&key, parameters, &new_state)
+            // Outcome discarded deliberately: nothing after this depends on
+            // whether the commit was suppressed for a flagged contract.
+            let _ = self
+                .commit_state_update(&key, parameters, &new_state)
                 .await?;
         }
         Ok(new_state)

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -283,12 +283,44 @@ impl Executor<Runtime> {
                                             }),
                                         ));
                                     };
+                                    let related_key = contract.key();
+                                    let related_params = contract.params();
                                     self.verify_and_store_contract(
                                         state.clone(),
                                         contract.clone(),
                                         RelatedContracts::default(),
                                     )
                                     .await?;
+                                    // This just installed a DIFFERENT
+                                    // contract's state — the related one we
+                                    // fetched to validate this update — so it
+                                    // owes that contract's subscribers the same
+                                    // post-store fan-out any other install
+                                    // does. Keyed on the related contract, not
+                                    // `key`. Without this a delegate subscribed
+                                    // to the related contract is never told,
+                                    // which is #5481 on a fifth path (found by
+                                    // the external review pass).
+                                    //
+                                    // The fan-out cannot live inside
+                                    // `verify_and_store_contract`: its other
+                                    // caller (the fresh-PUT branch above)
+                                    // already fans out after it, and moving it
+                                    // inside would emit twice there.
+                                    //
+                                    // Note leg 4 means this node now
+                                    // re-broadcasts a state it just fetched.
+                                    // That is bounded — `broadcast_state_change`
+                                    // sends only to peers already interested in
+                                    // that contract, and none may be — and it
+                                    // is what every other install does with a
+                                    // network-delivered state.
+                                    self.finalize_state_commit(
+                                        &related_key,
+                                        &related_params,
+                                        &state,
+                                    )
+                                    .await;
                                     state
                                 }
                             };

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -122,16 +122,11 @@ impl Executor<Runtime> {
                 op_manager.ring.commit_state_write(&key, written_bytes);
             }
 
-            self.send_update_notification(&key, &params, &new_state)
-                .await
-                .map_err(|_| {
-                    ExecutorError::request(StdContractError::Put {
-                        key,
-                        cause: "failed while sending notifications".into(),
-                    })
-                })?;
-
-            self.broadcast_state_change(key, new_state.clone()).await;
+            // Full post-store fan-out (telemetry + WS clients + subscribed
+            // delegates + network). Before #5481 this site hand-inlined two of
+            // the four legs and silently dropped the other two; see
+            // `Executor::finalize_state_commit`.
+            self.finalize_state_commit(&key, &params, &new_state).await;
 
             // Uncached WASM `summarize_state` (PUT response summary).
             if let Some(m) = self.contract_exec_metrics() {
@@ -147,16 +142,11 @@ impl Executor<Runtime> {
         self.verify_and_store_contract(state.clone(), contract, related_contracts)
             .await?;
 
-        self.send_update_notification(&key, &params, &state)
-            .await
-            .map_err(|_| {
-                ExecutorError::request(StdContractError::Put {
-                    key,
-                    cause: "failed while sending notifications".into(),
-                })
-            })?;
-
-        self.broadcast_state_change(key, state.clone()).await;
+        // Full post-store fan-out — see the sibling call above and
+        // `Executor::finalize_state_commit`. This branch is a FRESH contract
+        // install, so before #5481 it dropped the delegate leg in exactly the
+        // shape the issue describes, one file over from where it was fixed.
+        self.finalize_state_commit(&key, &params, &state).await;
 
         Ok(ContractResponse::PutResponse { key }.into())
     }

--- a/crates/core/src/contract/executor/runtime/contract_ops.rs
+++ b/crates/core/src/contract/executor/runtime/contract_ops.rs
@@ -283,40 +283,59 @@ impl Executor<Runtime> {
                                             }),
                                         ));
                                     };
-                                    // DELIBERATELY NO FAN-OUT HERE. The
-                                    // related contract's subscribers are owed
-                                    // one, and the GET path has already sent
-                                    // it: reaching this arm at all means the
-                                    // sub-op GET resolved from the network, and
-                                    // its `cache_contract_locally` ran first —
-                                    // it stores via `ContractHandlerEvent::
-                                    // PutQuery`, which lands in the
-                                    // initial-state-install branch of
-                                    // `bridged_upsert_contract_state_inner` and
-                                    // fans out from there, keyed on this
-                                    // contract. Adding a second
-                                    // `finalize_state_commit` here would
-                                    // double-notify every subscribed delegate
-                                    // and WebSocket client and double-broadcast
-                                    // to the network, for one install.
+                                    // DELIBERATELY NO FAN-OUT HERE, and the
+                                    // reason is NOT "the GET path already
+                                    // announced it".
                                     //
-                                    // The dependency is causal, not incidental.
-                                    // `GetResult.contract` is resolved by
-                                    // re-querying the LOCAL store after
-                                    // `cache_contract_locally` returns
-                                    // (`operations/get/op_ctx_task.rs`), so it
-                                    // is `Some` only because that store already
-                                    // happened. If the store had not happened
-                                    // the re-query would find no state, the
-                                    // sub-op would resolve `NotFound`, and
-                                    // execution would never arrive here.
+                                    // The load-bearing fact is narrower and
+                                    // more durable: `GetResult.state` is not
+                                    // the network's reply. The sub-op driver
+                                    // discards the terminal and rebuilds the
+                                    // `GetResult` by RE-QUERYING THE LOCAL
+                                    // STORE (`operations/get/op_ctx_task.rs`,
+                                    // "Resolve a GetResult by re-querying the
+                                    // local store"). `verify_and_store_contract`
+                                    // below then raw-`store`s that value. So
+                                    // this arm can only ever write back what
+                                    // the store already holds: no state
+                                    // transition happens here, and nothing is
+                                    // owed to anyone.
                                     //
-                                    // `verify_and_store_contract` below is a
-                                    // re-store of that same state. It is
-                                    // pre-existing and left alone (it also
+                                    // An earlier version of this comment said
+                                    // the sub-op's `cache_contract_locally`
+                                    // had already stored and fanned out. That
+                                    // is USUALLY true and is not a safe
+                                    // justification, because there are at
+                                    // least four reachable ways to arrive here
+                                    // with no fan-out having happened: the
+                                    // `state_matches` short-circuit (a
+                                    // concurrent op stored identical bytes
+                                    // first), `Terminal::LocalCompletion`
+                                    // (never calls it), an orphan-stream
+                                    // `AlreadyClaimed` early return, and a
+                                    // `PutQuery` the executor rejects. The
+                                    // re-query argument covers all four; the
+                                    // fan-out argument covers none of them.
+                                    //
+                                    // WHY THIS MATTERS TO #5549. The obvious
+                                    // fix there — hand `Terminal::InlineFound`'s
+                                    // network-delivered state straight to the
+                                    // caller and skip the re-query round trip —
+                                    // DESTROYS the invariant above without
+                                    // touching this file. This arm would then
+                                    // install a state the store does not hold,
+                                    // silently and with no fan-out. If you are
+                                    // changing how `GetResult` is sourced, this
+                                    // site owes a fan-out again; see #5549.
+                                    //
+                                    // Two known warts, both pre-existing and
+                                    // deliberately not fixed here: the re-store
                                     // re-charges the disk budget and
-                                    // `StateBytesWritten` — see #5553); what
-                                    // must not come back is the fan-out.
+                                    // `StateBytesWritten` (#5553), and it is a
+                                    // BLIND overwrite — between the re-query
+                                    // and this `store` another operation may
+                                    // have advanced the state, and this clobbers
+                                    // it rather than merging.
                                     self.verify_and_store_contract(
                                         state.clone(),
                                         contract.clone(),

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -706,21 +706,6 @@ where
                                 }
                             }
 
-                            self.broadcast_state_change(key, incoming_state.clone())
-                                .await;
-
-                            // Notify locally-subscribed WS clients of the
-                            // new state. Without this, the very first state
-                            // install for a contract on this node never
-                            // reaches `register_contract_notifier` consumers
-                            // — only the merge path at the end of this
-                            // function calls `commit_state_update`, which
-                            // is the only other site that fans out to the
-                            // local notifier map. ResyncResponse-driven
-                            // applies hit this branch when the state_store
-                            // entry is missing, so subscribers would miss
-                            // every cross-node delivery that recovers via
-                            // resync.
                             tracing::info!(
                                 contract = %key,
                                 new_size_bytes = incoming_state.as_ref().len(),
@@ -728,22 +713,19 @@ where
                                 event = "initial_state_installed",
                                 "Contract initial state installed"
                             );
-                            // Dashboard "last updated" telemetry; no-op if
-                            // we're not subscribed to this contract.
-                            if let Some(op_manager) = &self.op_manager {
-                                op_manager.ring.record_contract_update(&key);
-                            }
-                            if let Err(err) = self
-                                .send_update_notification(&key, &params, &incoming_state)
-                                .await
-                            {
-                                tracing::error!(
-                                    contract = %key,
-                                    error = %err,
-                                    phase = "notification_failed",
-                                    "Failed to send initial-state notification"
-                                );
-                            }
+                            // The very first state install for a contract on
+                            // this node owes the SAME post-store fan-out the
+                            // merge path performs, and this branch is the one
+                            // a ResyncResponse-driven apply takes whenever the
+                            // `state_store` entry is missing — so a consumer
+                            // dropped here misses every cross-node delivery
+                            // that recovers via resync. Hand-inlining a subset
+                            // is how #5481 happened (delegates were the
+                            // dropped leg, after WS clients had already been
+                            // the dropped leg once before). Call the helper;
+                            // do not re-inline.
+                            self.finalize_state_commit(&key, &params, &incoming_state)
+                                .await;
 
                             return Ok(UpsertResult::Updated(incoming_state));
                         }
@@ -2209,13 +2191,57 @@ where
             "Contract state updated"
         );
 
-        // Record update timestamp for dashboard display. No-op if we're
-        // not subscribed (e.g., a relay forwarding an UPDATE for a
-        // contract this peer doesn't track).
+        self.finalize_state_commit(key, parameters, new_state).await;
+
+        Ok(())
+    }
+
+    /// The complete post-store fan-out for a contract state this node has
+    /// just committed. **Every path that stores a state MUST call this**
+    /// rather than hand-inlining a subset of its legs.
+    ///
+    /// The four legs, in order:
+    ///
+    /// 1. `Ring::record_contract_update` — dashboard "last updated"
+    ///    telemetry. No-op when this peer does not track the contract
+    ///    (e.g. a relay forwarding an UPDATE).
+    /// 2. `send_update_notification` — locally-subscribed WebSocket
+    ///    clients.
+    /// 3. `send_delegate_contract_notifications` — locally-subscribed
+    ///    delegates. Best-effort and lossy by design (`try_send`); see
+    ///    that method.
+    /// 4. `broadcast_state_change` — the network. Suppressed for a
+    ///    contract flagged as violating a CRDT invariant, and emitted
+    ///    non-blocking (#4145).
+    ///
+    /// This exists because the legs kept getting dropped one at a time.
+    /// Both storing paths — the initial-state install in
+    /// `bridged_upsert_contract_state_inner` and `commit_state_update`
+    /// (the merge path) — re-inlined their own subset, and the
+    /// initial-install branch omitted the WS-client leg once, then the
+    /// delegate leg (#5481), each time silently: the subscription is
+    /// still registered, the delegate is still healthy, and no error is
+    /// produced anywhere. That is the "manually-inlined originator side
+    /// effects" row in `.claude/rules/bug-prevention-patterns.md`. The
+    /// source-scrape pin
+    /// `pool_tests::delegate_notification_tests::finalize_state_commit_is_the_only_post_store_fan_out_site`
+    /// fails if a leg leaves this helper or a second site starts calling
+    /// one directly.
+    ///
+    /// Every leg is best-effort: none of them can fail the commit, which
+    /// has already landed on disk by the time this runs.
+    async fn finalize_state_commit(
+        &mut self,
+        key: &ContractKey,
+        parameters: &Parameters<'_>,
+        new_state: &WrappedState,
+    ) {
+        // 1. Dashboard "last updated" telemetry.
         if let Some(op_manager) = &self.op_manager {
             op_manager.ring.record_contract_update(key);
         }
 
+        // 2. Locally-subscribed WebSocket clients.
         if let Err(err) = self
             .send_update_notification(key, parameters, new_state)
             .await
@@ -2228,56 +2254,11 @@ where
             );
         }
 
-        // Notify subscribed delegates about the state change
+        // 3. Locally-subscribed delegates.
         self.send_delegate_contract_notifications(key, new_state);
 
-        if let Some(op_manager) = &self.op_manager {
-            // Skip the broadcast entirely if this contract has been flagged
-            // as violating a CRDT invariant (e.g. non-idempotent
-            // `update_state`). The idempotency probe in
-            // `bridged_upsert_contract_state` sets this flag when it
-            // catches `update_state(update_state(S, U), U) != update_state(S, U)`.
-            // Once flagged, propagating this contract's state changes
-            // re-engages the broadcast storm we are trying to suppress.
-            // See `crate::ring::broken_invariants`.
-            if op_manager.ring.is_contract_broken(key) {
-                tracing::debug!(
-                    contract = %key,
-                    event = "broadcast_suppressed_broken_contract",
-                    "Skipping BroadcastStateChange for contract flagged as broken"
-                );
-            } else if let Err(err) =
-                op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastStateChange {
-                    key: *key,
-                    new_state: new_state.clone(),
-                    is_retry: false,
-                    is_reemit: false,
-                })
-            {
-                // Non-blocking emit: a 30-second `notify_node_event(...).await`
-                // on this commit path was the primary back-pressure source
-                // that wedged both gateways on 2026-05-24 (#4145). Missed
-                // broadcasts heal via the next UPDATE or via summary-mismatch
-                // SyncStateToPeer rounds — the executor must not stall here.
-                //
-                // Best-effort by design (see comment block above and
-                // #4145): a missed broadcast heals via the next UPDATE
-                // or summary-mismatch SyncStateToPeer round. Per-
-                // occurrence WARN here flooded gateways under fan-out
-                // at the same rate as the helper-internal log it
-                // mirrored (#4238). The rate-limited `notify_node_event:
-                // Notification channel full for too long` ERROR in
-                // op_state_manager.rs is the sustained-back-pressure
-                // alert operators should grep for.
-                tracing::debug!(
-                    contract = %key,
-                    error = %err,
-                    "Failed to broadcast state change to network peers (best-effort)"
-                );
-            }
-        }
-
-        Ok(())
+        // 4. The network.
+        self.broadcast_state_change(*key, new_state.clone()).await;
     }
 
     /// Send notifications to delegates subscribed to a contract's state changes.
@@ -2693,9 +2674,14 @@ where
 
     pub(super) async fn broadcast_state_change(&self, key: ContractKey, new_state: WrappedState) {
         if let Some(op_manager) = &self.op_manager {
-            // Mirror the broken-invariant gate in `commit_state_update`
-            // above. Same rationale: a contract flagged as non-idempotent
-            // must not be propagated.
+            // Skip the broadcast entirely if this contract has been flagged
+            // as violating a CRDT invariant (e.g. non-idempotent
+            // `update_state`). The idempotency probe in
+            // `bridged_upsert_contract_state` sets this flag when it
+            // catches `update_state(update_state(S, U), U) != update_state(S, U)`.
+            // Once flagged, propagating this contract's state changes
+            // re-engages the broadcast storm we are trying to suppress.
+            // See `crate::ring::broken_invariants`.
             if op_manager.ring.is_contract_broken(&key) {
                 tracing::debug!(
                     contract = %key,
@@ -2704,8 +2690,11 @@ where
                 );
                 return;
             }
-            // Non-blocking emit — see comment in the update path above
-            // and #4145 for the wedge this prevents.
+            // Non-blocking emit: a 30-second `notify_node_event(...).await`
+            // on the commit path was the primary back-pressure source that
+            // wedged both gateways on 2026-05-24 (#4145). Missed broadcasts
+            // heal via the next UPDATE or via summary-mismatch
+            // SyncStateToPeer rounds — the executor must not stall here.
             if let Err(err) =
                 op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastStateChange {
                     key,
@@ -2714,10 +2703,14 @@ where
                     is_reemit: false,
                 })
             {
-                // Best-effort by design — see #4145 and the sibling
-                // commit path above. Per-occurrence WARN here re-
-                // introduced the #4238 spam at the caller layer even
-                // after the helper-internal downgrade.
+                // Best-effort by design (see #4145): a missed broadcast
+                // heals via the next UPDATE or summary-mismatch
+                // SyncStateToPeer round. Per-occurrence WARN here flooded
+                // gateways under fan-out at the same rate as the
+                // helper-internal log it mirrored (#4238). The
+                // rate-limited `notify_node_event: Notification channel
+                // full for too long` ERROR in op_state_manager.rs is the
+                // sustained-back-pressure alert operators should grep for.
                 tracing::debug!(
                     contract = %key,
                     error = %err,

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -598,6 +598,17 @@ where
                             }
 
                             let completion_now = now_nanos();
+                            // The state this node ends up holding. Starts as
+                            // the incoming state and advances as queued
+                            // operations replay onto it below, so the fan-out
+                            // at the end of this branch reports what was
+                            // actually installed. Before this was hoisted, the
+                            // branch fanned out the PRE-replay state AFTER each
+                            // replay had already fanned out a newer one, so the
+                            // last thing a subscriber saw was the oldest state
+                            // (harmless for peers, which CRDT-merge, but not
+                            // for a delegate handed a full state).
+                            let mut installed_state = incoming_state.clone();
                             if let Some(completion_info) = self
                                 .init_tracker
                                 .complete_initialization(&key, completion_now)
@@ -624,7 +635,6 @@ where
                                 // These were UPDATE operations that couldn't proceed while the
                                 // contract was being initialized. Now that initialization is
                                 // complete, we apply them in order to the stored state.
-                                let mut current = incoming_state.clone();
                                 for op in completion_info.queued_ops {
                                     let queue_time = ContractInitTracker::queue_wait_duration(
                                         &op,
@@ -650,7 +660,7 @@ where
                                     match self
                                         .attempt_state_update(
                                             &params,
-                                            &current,
+                                            &installed_state,
                                             &key,
                                             &replay_updates,
                                         )
@@ -669,7 +679,9 @@ where
                                                 .map(|r| r == ValidateResult::Valid)
                                                 .unwrap_or(false);
 
-                                            if valid && new_state.as_ref() != current.as_ref() {
+                                            if valid
+                                                && new_state.as_ref() != installed_state.as_ref()
+                                            {
                                                 if let Err(e) = self
                                                     .commit_state_update(&key, &params, &new_state)
                                                     .await
@@ -680,7 +692,7 @@ where
                                                         "Failed to commit replayed queued operation"
                                                     );
                                                 } else {
-                                                    current = new_state;
+                                                    installed_state = new_state;
                                                 }
                                             } else if !valid {
                                                 tracing::warn!(
@@ -708,7 +720,7 @@ where
 
                             tracing::info!(
                                 contract = %key,
-                                new_size_bytes = incoming_state.as_ref().len(),
+                                new_size_bytes = installed_state.as_ref().len(),
                                 phase = "update_complete",
                                 event = "initial_state_installed",
                                 "Contract initial state installed"
@@ -724,9 +736,16 @@ where
                             // dropped leg, after WS clients had already been
                             // the dropped leg once before). Call the helper;
                             // do not re-inline.
-                            self.finalize_state_commit(&key, &params, &incoming_state)
+                            self.finalize_state_commit(&key, &params, &installed_state)
                                 .await;
 
+                            // NOTE: the RETURN value stays `incoming_state`
+                            // rather than `installed_state` — that is
+                            // pre-existing behaviour with its own callers
+                            // (PUT-response summary), and changing it is a
+                            // separate, client-visible decision. The fan-out
+                            // above is what subscribers observe, and that is
+                            // now the state this node actually holds.
                             return Ok(UpsertResult::Updated(incoming_state));
                         }
                     }
@@ -2215,22 +2234,30 @@ where
     ///    non-blocking (#4145).
     ///
     /// This exists because the legs kept getting dropped one at a time.
-    /// Both storing paths — the initial-state install in
-    /// `bridged_upsert_contract_state_inner` and `commit_state_update`
-    /// (the merge path) — re-inlined their own subset, and the
-    /// initial-install branch omitted the WS-client leg once, then the
-    /// delegate leg (#5481), each time silently: the subscription is
-    /// still registered, the delegate is still healthy, and no error is
+    /// All FOUR storing paths — the initial-state install in
+    /// `bridged_upsert_contract_state_inner`, `commit_state_update` (the
+    /// merge path), and both branches of `contract_ops::perform_contract_put`
+    /// (the local re-PUT merge and the fresh store) — re-inlined their own
+    /// subset. The initial-install branch omitted the WS-client leg once, then
+    /// the delegate leg (#5481); both `perform_contract_put` branches omitted
+    /// the telemetry AND delegate legs. Each time silently: the subscription
+    /// is still registered, the delegate is still healthy, and no error is
     /// produced anywhere. That is the "manually-inlined originator side
     /// effects" row in `.claude/rules/bug-prevention-patterns.md`. The
     /// source-scrape pin
     /// `pool_tests::delegate_notification_tests::finalize_state_commit_is_the_only_post_store_fan_out_site`
-    /// fails if a leg leaves this helper or a second site starts calling
-    /// one directly.
+    /// scrapes BOTH files and fails if a leg leaves this helper or a second
+    /// site starts calling one directly.
     ///
     /// Every leg is best-effort: none of them can fail the commit, which
-    /// has already landed on disk by the time this runs.
-    async fn finalize_state_commit(
+    /// has already landed on disk by the time this runs. Note this is a
+    /// deliberate change for `perform_contract_put`, which previously
+    /// propagated a `send_update_notification` error as a `Put` failure —
+    /// i.e. reported a PUT as failed after its state had already been stored
+    /// and metered, over a WASM `get_state_delta` trap for some OTHER
+    /// client's subscription. The merge path has always logged and continued
+    /// in exactly that situation; this makes the two agree.
+    pub(super) async fn finalize_state_commit(
         &mut self,
         key: &ContractKey,
         parameters: &Parameters<'_>,

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2289,8 +2289,23 @@ where
     }
 
     /// The complete post-store fan-out for a contract state this node has
-    /// just committed. **Every path that stores a state MUST call this**
-    /// rather than hand-inlining a subset of its legs.
+    /// just committed. **Every storing path in `runtime/executor_impl.rs` and
+    /// `runtime/contract_ops.rs` MUST call this** rather than hand-inlining a
+    /// subset of its legs.
+    ///
+    /// Those two files are the scope, not the whole crate.
+    /// `executor/mock_runtime.rs` stores and broadcasts directly, on a
+    /// different type, and is compiled unconditionally — so the audit grep in
+    /// `.claude/rules/bug-prevention-patterns.md` returns hits from it that are
+    /// NOT violations. Stated here so the first person to run that grep does
+    /// not have to rediscover it.
+    ///
+    /// One storing path in `contract_ops.rs` deliberately does NOT call this:
+    /// the related-contract install in `get_updated_state`, which writes back a
+    /// value it read from the local store moments earlier and so announces no
+    /// transition. Its justification is at the site, and a behavioural test
+    /// (`related_contract_install_does_not_fan_out_the_get_path_already_did`)
+    /// goes red if a call is added there.
     ///
     /// The four legs, in order:
     ///

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -609,6 +609,15 @@ where
                             // (harmless for peers, which CRDT-merge, but not
                             // for a delegate handed a full state).
                             let mut installed_state = incoming_state.clone();
+                            // Set when a queued-operation replay commits. Each
+                            // replay goes through `commit_state_update`, which
+                            // runs the full fan-out itself, so the finalize at
+                            // the end of this branch would emit `installed_state`
+                            // a SECOND time — re-running every subscribed
+                            // delegate on a state that did not change, and
+                            // duplicating the WS and network notifications
+                            // (found by the external review pass).
+                            let mut replay_committed = false;
                             if let Some(completion_info) = self
                                 .init_tracker
                                 .complete_initialization(&key, completion_now)
@@ -693,6 +702,7 @@ where
                                                     );
                                                 } else {
                                                     installed_state = new_state;
+                                                    replay_committed = true;
                                                 }
                                             } else if !valid {
                                                 tracing::warn!(
@@ -736,8 +746,22 @@ where
                             // dropped leg, after WS clients had already been
                             // the dropped leg once before). Call the helper;
                             // do not re-inline.
-                            self.finalize_state_commit(&key, &params, &installed_state)
-                                .await;
+                            if replay_committed {
+                                // The last successful replay already ran the
+                                // full fan-out with exactly this state via
+                                // `commit_state_update`. Emitting it again
+                                // would run every subscribed delegate twice on
+                                // an unchanged state.
+                                tracing::debug!(
+                                    contract = %key,
+                                    event = "install_fan_out_skipped_after_replay",
+                                    "Queued-operation replay already fanned out the \
+                                     installed state; not emitting it twice"
+                                );
+                            } else {
+                                self.finalize_state_commit(&key, &params, &installed_state)
+                                    .await;
+                            }
 
                             // NOTE: the RETURN value stays `incoming_state`
                             // rather than `installed_state` — that is

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -1,5 +1,25 @@
 use super::*;
 
+/// What [`Executor::commit_state_update`] actually did.
+///
+/// It used to return `Result<(), _>`, which made "stored the state and ran the
+/// full fan-out" and "suppressed the whole thing because the contract is
+/// flagged as violating a CRDT invariant" indistinguishable at every call
+/// site. A caller that reads a bare `Ok` as "committed" then acts on a state
+/// that was never written — and the initial-install branch's replay loop did
+/// exactly that, concluding a replay had fanned out and skipping its own
+/// fan-out, so the state it HAD stored reached nobody. That is #5481 again,
+/// relocated to the install-plus-flagged-contract corner. The outcome is
+/// explicit so the compiler makes the next caller choose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::contract::executor) enum StateCommitOutcome {
+    /// The state was stored and `finalize_state_commit` ran.
+    Committed,
+    /// Nothing was stored and nothing was fanned out: the contract is flagged
+    /// in `ring::broken_invariants` (#4279).
+    SuppressedBrokenContract,
+}
+
 // ============================================================================
 // Single Executor Implementation
 // ============================================================================
@@ -691,18 +711,38 @@ where
                                             if valid
                                                 && new_state.as_ref() != installed_state.as_ref()
                                             {
-                                                if let Err(e) = self
+                                                match self
                                                     .commit_state_update(&key, &params, &new_state)
                                                     .await
                                                 {
-                                                    tracing::warn!(
-                                                        contract = %key,
-                                                        error = %e,
-                                                        "Failed to commit replayed queued operation"
-                                                    );
-                                                } else {
-                                                    installed_state = new_state;
-                                                    replay_committed = true;
+                                                    Ok(StateCommitOutcome::Committed) => {
+                                                        installed_state = new_state;
+                                                        replay_committed = true;
+                                                    }
+                                                    Ok(
+                                                        StateCommitOutcome::SuppressedBrokenContract,
+                                                    ) => {
+                                                        // Nothing stored, nothing fanned out. The
+                                                        // state must NOT advance and the trailing
+                                                        // fan-out must NOT be skipped — treating
+                                                        // this as a commit would leave the state
+                                                        // this branch DID store reaching nobody,
+                                                        // which is #5481 again at the
+                                                        // install-plus-flagged-contract corner.
+                                                        tracing::debug!(
+                                                            contract = %key,
+                                                            "Replayed operation suppressed \
+                                                             (contract flagged broken); \
+                                                             install fan-out still owed"
+                                                        );
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::warn!(
+                                                            contract = %key,
+                                                            error = %e,
+                                                            "Failed to commit replayed queued operation"
+                                                        );
+                                                    }
                                                 }
                                             } else if !valid {
                                                 tracing::warn!(
@@ -1212,7 +1252,11 @@ where
                 return Ok(UpsertResult::NoChange);
             }
 
-            self.commit_state_update(&key, &params, &updated_state)
+            // Outcome discarded deliberately: a broken-contract suppression
+            // here is already reported to the caller as the `NoChange` above,
+            // and this path has no trailing fan-out to gate on it.
+            let _ = self
+                .commit_state_update(&key, &params, &updated_state)
                 .await?;
             Ok(UpsertResult::Updated(updated_state))
         }
@@ -2147,7 +2191,7 @@ where
         key: &ContractKey,
         parameters: &Parameters<'_>,
         new_state: &WrappedState,
-    ) -> Result<(), ExecutorError> {
+    ) -> Result<StateCommitOutcome, ExecutorError> {
         // Blanket gate: a contract flagged as violating a CRDT invariant
         // (e.g. non-idempotent merge) must not have its state extended
         // OR broadcast from this node. The merge in
@@ -2165,7 +2209,12 @@ where
                     event = "commit_suppressed_broken_contract",
                     "Skipping commit_state_update for contract flagged as broken"
                 );
-                return Ok(());
+                // NOT `Ok(())`. This path stores nothing and fans out
+                // nothing, and a caller that reads a bare `Ok` as "committed"
+                // will act on a state that was never written — which is
+                // exactly what happened to the initial-install branch's
+                // replay loop before the outcome was made explicit.
+                return Ok(StateCommitOutcome::SuppressedBrokenContract);
             }
         }
 
@@ -2236,7 +2285,7 @@ where
 
         self.finalize_state_commit(key, parameters, new_state).await;
 
-        Ok(())
+        Ok(StateCommitOutcome::Committed)
     }
 
     /// The complete post-store fan-out for a contract state this node has

--- a/crates/core/src/contract/executor/runtime/subscriptions.rs
+++ b/crates/core/src/contract/executor/runtime/subscriptions.rs
@@ -53,6 +53,23 @@ impl Executor<Runtime> {
                 return Ok(Either::Left(state));
             }
         }
+        // Test hook: stand in for the network leg so the related-contract
+        // INSTALL branch of `get_updated_state` is reachable without a live
+        // network. Deliberately placed AFTER the local-store lookup above, so
+        // the stub can only ever replace the network fetch and never masks a
+        // local hit. Mirrors `TEST_NETWORK_FETCH_OVERRIDE`, which does the same
+        // for `fetch_related_via_network`.
+        #[cfg(test)]
+        {
+            if let Some(stub) = super::TEST_SUB_OP_GET_OVERRIDE.with(|cell| cell.borrow().clone()) {
+                return match stub(*id) {
+                    Some(get_result) => Ok(Either::Right(get_result)),
+                    None => Err(ExecutorError::other(anyhow::anyhow!(
+                        "sub-op GET stub: contract not found"
+                    ))),
+                };
+            }
+        }
         // Fetch from network via the sub-op GET driver. The driver
         // delivers the resolved `GetResult` directly through a oneshot.
         let op_manager = self

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -35,8 +35,9 @@ pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateCallEnv>> =
 /// Global registry of delegate subscriptions to contracts.
 ///
 /// When a V2 delegate calls `subscribe_contract()`, the (contract, delegate) pair is
-/// recorded here. When `commit_state_update()` persists a new contract state, it checks
-/// this registry and sends notifications to subscribed delegates.
+/// recorded here. When this node commits a new contract state,
+/// `Executor::finalize_state_commit` checks this registry and sends
+/// notifications to subscribed delegates.
 pub(crate) static DELEGATE_SUBSCRIPTIONS: LazyLock<
     DashMap<ContractInstanceId, HashSet<DelegateKey>>,
 > = LazyLock::new(DashMap::default);
@@ -899,8 +900,9 @@ impl DelegateCallEnv {
     /// Register a subscription interest for a contract.
     ///
     /// Validates the contract is known and records the (contract, delegate) pair in
-    /// the global subscription registry. When `commit_state_update()` persists a new
-    /// state for this contract, it will send a `ContractNotification` to the delegate.
+    /// the global subscription registry. When this node commits a new state for the
+    /// contract, `Executor::finalize_state_commit` sends a `ContractNotification`
+    /// to the delegate.
     pub(super) fn subscribe_contract_sync(
         &self,
         instance_id: &ContractInstanceId,
@@ -2105,8 +2107,8 @@ pub(super) mod delegate_contracts {
     ///
     /// Validates that the contract is known (code hash resolvable) and registers
     /// subscription interest in the global `DELEGATE_SUBSCRIPTIONS` registry.
-    /// When the subscribed contract's state changes via `commit_state_update()`,
-    /// a `ContractNotification` is delivered to this delegate.
+    /// When the subscribed contract's state changes, `Executor::finalize_state_commit`
+    /// delivers a `ContractNotification` to this delegate.
     ///
     /// ## Returns
     /// - `0`: success (contract is known, subscription registered)

--- a/tests/test-contract-delta-trap/Cargo.toml
+++ b/tests/test-contract-delta-trap/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-contract-delta-trap"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+freenet-stdlib = { workspace = true, features = ["contract"] }
+
+[features]
+default = ["freenet-main-contract"]
+freenet-main-contract = []

--- a/tests/test-contract-delta-trap/src/lib.rs
+++ b/tests/test-contract-delta-trap/src/lib.rs
@@ -1,0 +1,73 @@
+//! Test contract whose `get_state_delta` always fails.
+//!
+//! Exists to drive leg 2 of `Executor::finalize_state_commit`
+//! (`send_update_notification`) into its error path, so a test can assert that
+//! the commit still succeeds and legs 3 and 4 still run.
+//!
+//! `send_update_notification` computes a delta for any subscriber holding a
+//! cached summary and propagates a failure with `?`, which aborts the whole
+//! subscriber fan-out. That is the only way to make leg 2 fail without adding a
+//! production seam, and a failing `get_state_delta` is the realistic cause: a
+//! contract whose delta computation traps for one client's summary is exactly
+//! the case that used to fail the *whole PUT*.
+//!
+//! Note the delta path is only taken for a subscriber registered with a
+//! `Some(summary)`. With no summary the executor sends full state and never
+//! calls this function, so a test that forgets the summary silently exercises
+//! nothing — assert that the subscriber received nothing, not merely that the
+//! PUT succeeded.
+//!
+//! Everything else is deliberately permissive, so a test failure points at the
+//! fan-out rather than at contract semantics.
+
+use freenet_stdlib::prelude::*;
+
+struct Contract;
+
+#[contract]
+impl ContractInterface for Contract {
+    fn validate_state(
+        _parameters: Parameters<'static>,
+        _state: State<'static>,
+        _related: RelatedContracts<'static>,
+    ) -> Result<ValidateResult, ContractError> {
+        Ok(ValidateResult::Valid)
+    }
+
+    fn update_state(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+        data: Vec<UpdateData<'static>>,
+    ) -> Result<UpdateModification<'static>, ContractError> {
+        let mut new_state = None;
+        for update in &data {
+            match update {
+                UpdateData::State(s) => new_state = Some(State::from(s.as_ref().to_vec())),
+                UpdateData::Delta(delta) => new_state = Some(State::from(delta.as_ref().to_vec())),
+                UpdateData::StateAndDelta { state, .. } => {
+                    new_state = Some(State::from(state.as_ref().to_vec()))
+                }
+                _ => {}
+            }
+        }
+        Ok(UpdateModification::valid(new_state.unwrap_or(state)))
+    }
+
+    fn summarize_state(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+    ) -> Result<StateSummary<'static>, ContractError> {
+        Ok(StateSummary::from(state.as_ref().to_vec()))
+    }
+
+    /// Always fails. This is the whole point of the fixture.
+    fn get_state_delta(
+        _parameters: Parameters<'static>,
+        _state: State<'static>,
+        _summary: StateSummary<'static>,
+    ) -> Result<StateDelta<'static>, ContractError> {
+        Err(ContractError::Other(
+            "get_state_delta fails by design (test fixture)".to_owned(),
+        ))
+    }
+}

--- a/tests/test-contract-requires-related/Cargo.toml
+++ b/tests/test-contract-requires-related/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-contract-requires-related"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+freenet-stdlib = { workspace = true, features = ["contract"] }
+
+[features]
+default = ["freenet-main-contract"]
+freenet-main-contract = []

--- a/tests/test-contract-requires-related/src/lib.rs
+++ b/tests/test-contract-requires-related/src/lib.rs
@@ -1,0 +1,81 @@
+//! Test contract whose `update_state` asks for a related contract it does not
+//! have, then settles once the executor supplies it.
+//!
+//! This exists to make the fetch-and-install branch of
+//! `Executor::get_updated_state` reachable from a unit test. That branch is the
+//! only place a node installs *another* contract's state while servicing an
+//! UPDATE, and it owes that contract's subscribers the same post-store fan-out
+//! any other install does — keyed on the RELATED contract, not on the contract
+//! being updated (#5481). Nothing else in `tests/` returns
+//! `UpdateModification::requires`, so without this contract that branch cannot
+//! be entered at all and can only be guarded by a source scrape.
+//!
+//! Behaviour:
+//!
+//! - `validate_state` — always `Valid`. This contract is about the fan-out, not
+//!   about contract semantics.
+//! - `update_state` — if the update data carries no `UpdateData::State`, ask for
+//!   [`WANTED_RELATED_ID`]; otherwise keep the current state unchanged. The
+//!   executor pushes the fetched related state in as `UpdateData::State` before
+//!   retrying, so this settles on the second pass and the loop terminates.
+//! - `summarize_state` / `get_state_delta` — whole state, no cleverness.
+
+use freenet_stdlib::prelude::*;
+
+/// The instance id this contract asks for.
+///
+/// Arbitrary and fixed. It is only ever used as a lookup key: the executor asks
+/// the network (in tests, a stubbed sub-op GET) for it and installs whatever
+/// contract comes back under THAT contract's own key. So this constant
+/// deliberately does not have to match the key of the contract the test hands
+/// back — which is the point, since the property under test is that the fan-out
+/// follows the installed contract's key rather than the requested id or the
+/// enclosing contract's key.
+const WANTED_RELATED_ID: [u8; 32] = [0xA7; 32];
+
+struct Contract;
+
+#[contract]
+impl ContractInterface for Contract {
+    fn validate_state(
+        _parameters: Parameters<'static>,
+        _state: State<'static>,
+        _related: RelatedContracts<'static>,
+    ) -> Result<ValidateResult, ContractError> {
+        Ok(ValidateResult::Valid)
+    }
+
+    fn update_state(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+        data: Vec<UpdateData<'static>>,
+    ) -> Result<UpdateModification<'static>, ContractError> {
+        let related_supplied = data
+            .iter()
+            .any(|update| matches!(update, UpdateData::State(_)));
+        if !related_supplied {
+            return UpdateModification::requires(vec![RelatedContract {
+                contract_instance_id: ContractInstanceId::new(WANTED_RELATED_ID),
+                mode: RelatedMode::StateOnce,
+            }]);
+        }
+        // Settle without changing anything. The commit of THIS contract is not
+        // what the test observes; the related contract's install is.
+        Ok(UpdateModification::valid(state))
+    }
+
+    fn summarize_state(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+    ) -> Result<StateSummary<'static>, ContractError> {
+        Ok(StateSummary::from(state.as_ref().to_vec()))
+    }
+
+    fn get_state_delta(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+        _summary: StateSummary<'static>,
+    ) -> Result<StateDelta<'static>, ContractError> {
+        Ok(StateDelta::from(state.as_ref().to_vec()))
+    }
+}


### PR DESCRIPTION
## Problem

A subscribed delegate was not notified when a contract's state was installed for the first time on this node, nor when state was recovered via resync. Only the merge path notified delegates.

`send_delegate_contract_notifications` had exactly one call site: inside `commit_state_update`. The initial-state-install branch of `bridged_upsert_contract_state_inner` stores the state, broadcasts, records dashboard telemetry, and calls `send_update_notification` for locally-subscribed WebSocket clients — then returns. Delegates were skipped.

That branch is entered whenever the `state_store` entry is missing, which includes every ResyncResponse-driven apply. So a delegate whose subscription outlived the contract's state entry silently stopped receiving notifications for exactly the deliveries that recover it. Nothing surfaces: the subscription is still registered, the delegate is still healthy, and no error is produced anywhere — the delegate simply does not run.

The asymmetry looks accidental rather than intended. The comment that branch already carried shows this same gap being found and fixed once before, **for WebSocket clients**. Delegate notification was added later (#3251) and only ever hooked into the merge path, reproducing the bug that comment describes fixing.

## Approach

Rather than add a third hand-inlined call, extract `Executor::finalize_state_commit`, which owns the whole post-store sequence:

1. `Ring::record_contract_update` — dashboard telemetry
2. `send_update_notification` — locally-subscribed WebSocket clients
3. `send_delegate_contract_notifications` — locally-subscribed delegates
4. `broadcast_state_change` — the network

Both storing paths call it. This is the fix shape the "manually-inlined originator side effects" row in `.claude/rules/bug-prevention-patterns.md` prescribes — one helper owning the full sequence, never a subset re-inlined per branch — and it is what the issue asked for over the one-line alternative, on the grounds that this is the *second* time a state-commit path shipped missing one of the two notifier fan-outs.

Two incidental effects of the dedup, both intentional:

- `commit_state_update`'s inline broadcast (which was byte-identical to `broadcast_state_change`, broken-invariant gate and all) is now the shared method. The #4145/#4238 rationale comments moved with it.
- The install branch's broadcast now runs *after* the local notifications instead of before. Both are best-effort, non-blocking emissions on a state that has already landed, so the order carries no invariant; unifying it is what makes one helper possible.

## Behaviour change: a failed WS notification no longer fails the PUT

Calling out explicitly, because it is easy to miss in a diff that otherwise only moves code.

`perform_contract_put` used to map a `send_update_notification` error into `StdContractError::Put` and return it — reporting the PUT as FAILED after its state had already been stored and metered, over (for example) a WASM `get_state_delta` trap belonging to some *other* client's subscription. Routing through `finalize_state_commit` makes every leg best-effort: the failure is logged with `phase = "notification_failed"` and the PUT succeeds.

This is deliberate, and it makes the two storing paths agree — the merge path (`commit_state_update`) has always logged and continued in exactly that situation. But it *is* client-visible on the local PUT path: a client that previously saw a `Put` error in this case now sees success. Nothing else in the change alters a response.

Covered by `failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`, which also pins the part nothing asserted before: that legs 3 and 4 still run after leg 2 fails. Neither the old nor the new behaviour had a test — `grep -rn "failed while sending notifications"` finds nothing in the tree — so a silent revert in either direction would have gone unnoticed.

## Load change: the delegate notification channel now sees more traffic

The delegate leg used to run only from `commit_state_update`. It now runs from `finalize_state_commit`, which both `perform_contract_put` branches also call, so the number of sends on the delegate notification channel rises by an unmeasured factor.

`send_delegate_contract_notifications` is `try_send` on a bounded channel and drops silently on `Full`; the only instruments are a process-global `AtomicUsize` and a per-drop WARN. **If delegate-notification drops start appearing on gateways after this ships, this change is the first thing to look at.**

## Testing

New module `crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs`, using the `identical_input_probe_tests.rs` harness (a real `OpManager`/`Ring` behind an `Executor`, driving the production `bridged_upsert_contract_state` path).

- **`initial_state_install_notifies_subscribed_delegates`** — registers a delegate subscription, installs a brand-new contract (the install branch, exactly as a network PUT or a resync-driven apply takes it), asserts the `ContractNotification` arrives. **Verified failing before the fix:**
  ```
  test ...::initial_state_install_notifies_subscribed_delegates ... FAILED
  test ...::merge_path_notifies_subscribed_delegates ... ok
  ```
- **`merge_path_notifies_subscribed_delegates`** — the control. The merge path has always notified delegates, so this passes both before and after; without it, a harness mistake (missing `delegate_notification_tx`, mis-keyed subscription) would be indistinguishable from the bug.
- **`finalize_state_commit_is_the_only_post_store_fan_out_site`** — source-scrape pin: the helper must contain every leg, each leg must have exactly one call site in the production slice and that site must be inside the helper, and both storing paths must delegate to it.

**The pin was verified by mutation, not inspection.** Deleting `self.send_delegate_contract_notifications(key, new_state);` from the helper:

```
finalize_state_commit_is_the_only_post_store_fan_out_site ... FAILED
  finalize_state_commit must invoke `send_delegate_contract_notifications(`
  - it owns the FULL post-store fan-out.
initial_state_install_notifies_subscribed_delegates ... FAILED
merge_path_notifies_subscribed_delegates ... FAILED
test result: FAILED. 0 passed; 3 failed
```

Note that under the mutation the *control* fails too. That is the fix working: after this change both paths share one call site, so a leg cannot be lost from one path alone any more.

Note on the harness: `DELEGATE_SUBSCRIPTIONS` is process-global (#4824), so each test uses a contract key derived from its own name and an RAII guard clears the entry on drop — CI runs `cargo nextest` (process per test) but contributors run plain `cargo test` (one process for all of them), see `.claude/rules/testing.md`.


### Real-runtime coverage for the sites the mock harness cannot reach

`crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs` (gated on `wasmtime-backend`, alongside `wasm_conformance_tests`). `perform_contract_put` and `get_updated_state` are on `impl Executor<Runtime>`, not the generic impl the `pool_tests` harness drives via `Executor<MockWasmRuntime>`, so these need a real runtime and real compiled contracts:

| site | test |
|---|---|
| `perform_contract_put`, fresh-install branch | `local_put_notifies_subscribed_delegates` |
| `perform_contract_put`, existing-contract merge branch | `local_reput_merge_notifies_subscribed_delegates` |
| `get_updated_state`, related-contract install — must NOT fan out | `related_contract_install_does_not_fan_out_the_get_path_already_did` |

A fourth test, `failed_ws_notification_neither_fails_the_put_nor_stops_the_other_legs`, covers the behaviour change above. It forces leg 2 to fail with `test-contract-delta-trap` (a fixture whose `get_state_delta` always errors) plus a subscriber registered *with* a cached summary, then asserts the PUT is `Ok`, the state is durable, the WS client received nothing (the anti-vacuity guard — a notification arriving would mean leg 2 never failed), the delegate is still notified, and a `NodeEvent::BroadcastStateChange` still reaches the event-loop channel. Mutation-verified three ways: leg-2 failure made to abort the fan-out fails assertion 4; leg 4 deleted fails assertion 5; the subscriber registered without a summary fails assertion 3.

Two new pieces were needed to reach the related-contract install at all:

- `tests/test-contract-requires-related` — a fixture whose `update_state` returns `UpdateModification::requires` on its first pass and settles on its second. No existing test contract returns `requires`, so that branch was previously unenterable.
- `set_test_sub_op_get_override` — a `#[cfg(test)]` thread-local stub for `local_state_or_from_network`, modelled on the existing `set_test_network_fetch_override` and placed *after* the local-store lookup so it can only ever stand in for the network leg.

**Verified by mutation, per `bug-prevention-patterns.md` item 4:**

- Fan-out removed from the merge branch only: `local_reput_merge_...` fails, the other two pass.
- Fan-out removed from both `perform_contract_put` branches: both PUT tests fail.
- A `finalize_state_commit` **re-added** at the related-contract install: both `related_contract_install_does_not_fan_out_...` and the source-scrape pin go red, each naming the duplicate.

Each test is sensitive to its own site and to nothing else.

## Correction during review: the related-contract install must NOT fan out (#5549, #5553)

An earlier revision of this PR added a `finalize_state_commit` to the related-contract install in `get_updated_state`, reasoning that installing a contract's state owes that contract's subscribers a notification. The reasoning is right; the placement was wrong, because the notification has already been sent by the time control arrives. **That call has been removed.**

The chain, verified end to end:

1. The sub-op GET driver calls `cache_contract_locally` on `Terminal::InlineFound`, *before* it builds the `GetResult` (`operations/get/op_ctx_task.rs`).
2. `cache_contract_locally` re-queries the local store, finds no matching state — the related contract is absent locally, which is why the fetch happened, so `state_matches` is false — and issues a `ContractHandlerEvent::PutQuery` carrying the contract code.
3. That PutQuery routes through `maybe_defer_upsert` into `bridged_upsert_contract_state_inner`, takes the initial-state-install branch, and calls `finalize_state_commit` keyed on the related contract. **The fan-out has happened.**
4. Only then does `get_updated_state` receive its `GetResult` and re-store.

The dependency is causal, not incidental: `GetResult.contract` is resolved by re-querying the *local* store after step 2, so it is `Some` only because step 2 stored it. Had step 2 not run, the re-query would find no state, the sub-op would resolve `NotFound`, and execution would never reach the install.

So a `finalize_state_commit` there is a guaranteed duplicate — every subscribed delegate and WebSocket client notified twice, and the state broadcast to the network twice, for one install — on a codebase with #5147/#5148 open about broadcast duplication.

### Why this was not caught by the site being dead

The install arm does not execute in production at all today (**#5549**): `get_updated_state` asks `local_state_or_from_network(&id, false)`, and the driver hard-nulls the contract whenever `return_contract_code` is false, so the `let Some(contract) = contract else` guard always takes its error arm. Fixing #5549 is a one-word change — and that is exactly when the duplicate would have gone live. #5549 now carries a warning to that effect.

**#5553** covers the other half the reviewer found: `verify_and_store_contract` at that site re-stores the same state, so the disk-budget gate and `StateBytesWritten` double-count. Pre-existing, deliberately not fixed here.

The test that asserted the removed behaviour was replaced rather than deleted. `related_contract_install_does_not_fan_out_the_get_path_already_did` pins the absence, with the two things an absence assertion needs to not be vacuous: the related contract's state must be in the local store afterwards (only the install branch puts it there), and a control PUT at the end must notify the same delegate on the same channel.

## Not in scope

The existing delegate E2E tests (`crates/core/tests/operations.rs:3785`, `:4047`) are single-node and no integration test exercises delegate notification at all. That gap is real but orthogonal: this bug is node-local — the fan-out never leaves the executor — so a multi-node test would add cost without adding evidence. The regression test above drives the actual production branch.

Closes #5481

Related: #5479 (V2 delegate writes do not propagate), #5467 (delegates as resident agents).

[AI-assisted - Claude]

https://claude.ai/code/session_014tq59dRUCNsHR1GuUkguHw




