### PR TITLE
fix(delegates): propagate V2 delegate contract writes to the network

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -34,8 +34,16 @@ V2: Async host functions — delegates call contract methods directly:
                                          subscription does NOT register demand, #4669)
     Backend implementation: func_wrap_async (wasmtime native async support)
     Selected when state_store_db is configured on Runtime
-    NOTE: V2 PUT/UPDATE are local-only, bypass contract validation, and skip
-    hosting metadata. Network propagation is separate.
+    NOTE (updated by #5479): V2 PUT/UPDATE now emit BroadcastStateChange, so a
+    content-CHANGING write propagates to peers already interested in the
+    contract. Three caveats remain, and they matter:
+      - the write still bypasses the contract's own validate_state/update_state
+        merge on the writing node (receivers do merge it);
+      - it writes no hosting metadata, so `should_summarize_or_broadcast` drops
+        the broadcast for a contract this node holds ONLY because a delegate
+        wrote it (#4669 — a delegate subscription does not register demand);
+      - it does not reach this node's OWN WebSocket clients or other locally
+        subscribed delegates (#5486).
 ```
 
 ### WASM Call Modes

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -34,9 +34,15 @@ V2: Async host functions — delegates call contract methods directly:
                                          subscription does NOT register demand, #4669)
     Backend implementation: func_wrap_async (wasmtime native async support)
     Selected when state_store_db is configured on Runtime
-    NOTE (updated by #5479): V2 PUT/UPDATE now emit BroadcastStateChange, so a
+    NOTE (updated by #5479): V2 PUT/UPDATE now queue a network fan-out, so a
     content-CHANGING write propagates to peers already interested in the
-    contract. Three caveats remain, and they matter:
+    contract. The queued event (NodeEvent::V2DelegateStateChanged) carries the
+    contract id and NO state; the handler re-reads current state when it drains,
+    so the queue cost does not scale with state size and repeat writes to one
+    contract coalesce into a single fan-out carrying the newest value.
+    Bookkeeping (generation bump, meters, cache invalidation) runs on EVERY
+    committed write; only the fan-out is skipped when the bytes did not change.
+    Three caveats remain, and they matter:
       - the write still bypasses the contract's own validate_state/update_state
         merge on the writing node (receivers do merge it);
       - it writes no hosting metadata, so `should_summarize_or_broadcast` drops

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -216,6 +216,19 @@ search with a blind spot; a fixed token is not.
    distinguishes a guard that works from one that happens to be passing.
 
 
+### Rescued trees have not been through the local gate
+
+When you recover work from a session that died — your own or someone else's —
+run `cargo check`, then `cargo fmt`, then `cargo clippy`, in that order, before
+pushing it. Compiling is not sufficient evidence that it is pushable.
+
+An agent dies wherever it dies, and formatting is the last thing done, not the
+first: a tree can hold finished, correct logic that has never been formatted or
+linted. On 2026-09-04 a rescued commit was verified with `cargo check` alone and
+would have failed both Fmt and Clippy in CI — for hand-edited closure
+signatures and a `#[cfg(test)]` helper left with no caller — neither of which
+had anything to do with the work being rescued.
+
 ## Reference Patterns
 
 **Time injection:**

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -216,19 +216,6 @@ search with a blind spot; a fixed token is not.
    distinguishes a guard that works from one that happens to be passing.
 
 
-### Rescued trees have not been through the local gate
-
-When you recover work from a session that died — your own or someone else's —
-run `cargo check`, then `cargo fmt`, then `cargo clippy`, in that order, before
-pushing it. Compiling is not sufficient evidence that it is pushable.
-
-An agent dies wherever it dies, and formatting is the last thing done, not the
-first: a tree can hold finished, correct logic that has never been formatted or
-linted. On 2026-09-04 a rescued commit was verified with `cargo check` alone and
-would have failed both Fmt and Clippy in CI — for hand-edited closure
-signatures and a `#[cfg(test)]` helper left with no caller — neither of which
-had anything to do with the work being rescued.
-
 ## Reference Patterns
 
 **Time injection:**

--- a/crates/core/src/contract/executor/pool_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests.rs
@@ -13,5 +13,6 @@ mod runtime_pool_tests;
 mod subscriber_limit_tests;
 mod subscriber_stress_tests;
 mod summarize_delta_cache_tests;
+mod v2_delegate_propagation_tests;
 #[cfg(feature = "wasmtime-backend")]
 mod wasm_conformance_tests;

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -94,7 +94,7 @@ fn take_broadcasts(rx: &mut EventLoopNotificationsReceiver) -> Vec<ContractKey> 
     out
 }
 
-/// #5479: the installed V2 write callback must emit `BroadcastStateChange`
+/// #5479: the installed V2 write callback must emit `V2DelegateStateChanged`
 /// carrying the state that was written.
 ///
 /// Before the fix the callback could not have done this even in principle —

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -343,3 +343,43 @@ async fn v2_delegate_failed_enqueue_releases_the_coalescing_marker() {
         "a later write must still attempt its own enqueue after an earlier failure"
     );
 }
+
+/// The `content_changed = false` half of the callback, which nothing else covers.
+///
+/// Every other test in this file passes `true`, so the early return that gates
+/// ONLY the fan-out is invisible to all of them: moving it above
+/// `commit_state_write` — one line — leaves the entire suite green while
+/// re-opening the eviction race that split was made to close. This is the same
+/// function that carried a stranded mutation earlier in this workstream, so it
+/// gets a behavioural assertion rather than trust.
+///
+/// Asserts both halves of the split at once: the generation still advances (the
+/// bookkeeping is owed for a write that committed), and no broadcast is queued
+/// (the fan-out is the one leg an identical rewrite does not need).
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_unchanged_write_meters_but_does_not_queue() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-unchanged").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(21);
+    let written = WrappedState::new(vec![5, 5, 5]);
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+
+    let generation_before = op_manager.ring.state_generation(&key);
+    callback(&key, &written, false);
+
+    assert_ne!(
+        op_manager.ring.state_generation(&key),
+        generation_before,
+        "an unchanged write still COMMITTED to storage, so `commit_state_write` is owed: its \
+         generation bump is what tells a scheduled EvictContract the contract was written \
+         after the eviction was queued. If this is unchanged, the early return has moved \
+         above the bookkeeping and an in-flight eviction can reclaim a just-written contract"
+    );
+    assert!(
+        take_broadcasts(&mut notifications).is_empty(),
+        "an unchanged write must queue NO fan-out — that is the one leg a byte-identical \
+         rewrite does not need, and the whole reason the flag is threaded through"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -110,7 +110,7 @@ async fn v2_delegate_write_callback_queues_a_broadcast() {
 
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
-    callback(&key, &written);
+    callback(&key, &written, true);
 
     let queued = take_broadcasts(&mut notifications);
     assert_eq!(
@@ -142,7 +142,7 @@ async fn v2_delegate_writes_to_one_contract_coalesce_while_undrained() {
 
     // Ten content-changing writes, nothing draining the channel in between.
     for i in 0..10u8 {
-        callback(&key, &WrappedState::new(vec![i, i, i, i]));
+        callback(&key, &WrappedState::new(vec![i, i, i, i]), true);
     }
 
     assert_eq!(
@@ -165,9 +165,9 @@ async fn v2_delegate_broadcast_coalescing_is_per_contract() {
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
     let (a, b) = (test_key(16), test_key(17));
-    callback(&a, &WrappedState::new(vec![1]));
-    callback(&b, &WrappedState::new(vec![2]));
-    callback(&a, &WrappedState::new(vec![3]));
+    callback(&a, &WrappedState::new(vec![1]), true);
+    callback(&b, &WrappedState::new(vec![2]), true);
+    callback(&a, &WrappedState::new(vec![3]), true);
 
     let mut queued = take_broadcasts(&mut notifications);
     queued.sort_by_key(|k| k.id().as_bytes().to_vec());
@@ -194,11 +194,11 @@ async fn v2_delegate_broadcast_requeues_after_drain() {
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
 
-    callback(&key, &WrappedState::new(vec![1]));
+    callback(&key, &WrappedState::new(vec![1]), true);
     assert_eq!(take_broadcasts(&mut notifications), vec![key]);
 
     // Second write while the marker is still set: coalesced away.
-    callback(&key, &WrappedState::new(vec![2]));
+    callback(&key, &WrappedState::new(vec![2]), true);
     assert!(
         take_broadcasts(&mut notifications).is_empty(),
         "still-pending contract must coalesce"
@@ -207,7 +207,7 @@ async fn v2_delegate_broadcast_requeues_after_drain() {
     // The handler clears the marker as it starts draining.
     op_manager.clear_v2_delegate_broadcast_pending(&key);
 
-    callback(&key, &WrappedState::new(vec![3]));
+    callback(&key, &WrappedState::new(vec![3]), true);
     assert_eq!(
         take_broadcasts(&mut notifications),
         vec![key],
@@ -235,7 +235,7 @@ async fn v2_delegate_write_callback_still_meters_and_invalidates() {
 
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
-    callback(&key, &written);
+    callback(&key, &written, true);
 
     assert_eq!(
         state_store.cached_state_hash(&key),
@@ -269,7 +269,7 @@ async fn v2_delegate_write_callback_suppresses_broken_contract_broadcast() {
 
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
-    callback(&key, &written);
+    callback(&key, &written, true);
 
     assert!(
         take_broadcasts(&mut notifications).is_empty(),
@@ -291,7 +291,7 @@ async fn v2_delegate_write_callback_without_op_manager_only_invalidates() {
     state_store.cache_state_hash(key, crate::wasm_runtime::state_hash(&written));
 
     let callback = v2_delegate_state_write_callback(state_store.cache_invalidator(), None);
-    callback(&key, &written);
+    callback(&key, &written, true);
 
     assert_eq!(
         state_store.cached_state_hash(&key),
@@ -326,7 +326,7 @@ async fn v2_delegate_failed_enqueue_releases_the_coalescing_marker() {
     let key = test_key(19);
     let callback =
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
-    callback(&key, &WrappedState::new(vec![1, 2, 3]));
+    callback(&key, &WrappedState::new(vec![1, 2, 3]), true);
 
     assert!(
         !op_manager.v2_delegate_broadcast_pending.contains(key.id()),
@@ -337,7 +337,7 @@ async fn v2_delegate_failed_enqueue_releases_the_coalescing_marker() {
 
     // And the latch must genuinely be absent, not merely unobserved: a second
     // write has to be free to try again rather than be swallowed as a repeat.
-    callback(&key, &WrappedState::new(vec![4, 5, 6]));
+    callback(&key, &WrappedState::new(vec![4, 5, 6]), true);
     assert!(
         !op_manager.v2_delegate_broadcast_pending.contains(key.id()),
         "a later write must still attempt its own enqueue after an earlier failure"

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -300,3 +300,46 @@ async fn v2_delegate_write_callback_without_op_manager_only_invalidates() {
          and a local-only executor still serves reads from these caches"
     );
 }
+
+/// A FAILED enqueue must release the coalescing marker.
+///
+/// This is the error path `queue_v2_delegate_broadcast` calls out as critical,
+/// and it fails in the worst direction available: leaving the marker set turns
+/// a one-off dropped broadcast into a permanent wedge. Every later write to
+/// that contract would coalesce into a queued broadcast that no handler will
+/// ever drain — because none was ever queued — so the contract silently stops
+/// propagating for the lifetime of the process. That is the same
+/// write-returns-success-but-the-network-never-learns shape as #5479, one
+/// layer up, and it would be very hard to diagnose from outside the node.
+///
+/// Dropping the receiver closes the notification channel, so `try_send`
+/// returns `Closed` and the enqueue fails deterministically — no need to push
+/// 2048 messages to fill it.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_failed_enqueue_releases_the_coalescing_marker() {
+    let (op_manager, notifications, _guards) = build_op_manager("v2-prop-enqueue-fail").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    // Close the channel: every subsequent enqueue attempt now fails.
+    drop(notifications);
+
+    let key = test_key(19);
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+    callback(&key, &WrappedState::new(vec![1, 2, 3]));
+
+    assert!(
+        !op_manager.v2_delegate_broadcast_pending.contains(key.id()),
+        "a failed enqueue must release the coalescing marker. Left set, it latches the \
+         contract: every later write coalesces into a broadcast that was never queued and \
+         will never drain, so the contract stops propagating permanently"
+    );
+
+    // And the latch must genuinely be absent, not merely unobserved: a second
+    // write has to be free to try again rather than be swallowed as a repeat.
+    callback(&key, &WrappedState::new(vec![4, 5, 6]));
+    assert!(
+        !op_manager.v2_delegate_broadcast_pending.contains(key.id()),
+        "a later write must still attempt its own enqueue after an earlier failure"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -81,15 +81,17 @@ fn test_key(seed: u8) -> ContractKey {
     ContractKey::from_params_and_code(&params, &code)
 }
 
-/// Drain the notification channel and return the first `BroadcastStateChange`,
-/// or `None` if the channel holds no such event.
-fn take_broadcast(rx: &mut EventLoopNotificationsReceiver) -> Option<(ContractKey, WrappedState)> {
+/// Drain the notification channel and return every queued V2 broadcast, in
+/// order. The event names the contract and carries NO state — the handler
+/// re-reads what is stored when it drains — so there are no bytes to return.
+fn take_broadcasts(rx: &mut EventLoopNotificationsReceiver) -> Vec<ContractKey> {
+    let mut out = Vec::new();
     while let Ok(event) = rx.notifications_receiver.try_recv() {
-        if let Either::Right(NodeEvent::BroadcastStateChange { key, new_state, .. }) = event {
-            return Some((key, new_state));
+        if let Either::Right(NodeEvent::V2DelegateStateChanged { key }) = event {
+            out.push(key);
         }
     }
-    None
+    out
 }
 
 /// #5479: the installed V2 write callback must emit `BroadcastStateChange`
@@ -99,7 +101,7 @@ fn take_broadcast(rx: &mut EventLoopNotificationsReceiver) -> Option<(ContractKe
 /// it received only `(key, state_size)`, so the state to broadcast was not
 /// available to it. The signature change is the fix; this asserts the emission.
 #[tokio::test(flavor = "current_thread")]
-async fn v2_delegate_write_callback_emits_broadcast_state_change() {
+async fn v2_delegate_write_callback_queues_a_broadcast() {
     let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-emit").await;
     let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
 
@@ -110,20 +112,108 @@ async fn v2_delegate_write_callback_emits_broadcast_state_change() {
         v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
     callback(&key, &written);
 
-    let (broadcast_key, broadcast_state) = take_broadcast(&mut notifications).expect(
-        "a V2 delegate write must emit NodeEvent::BroadcastStateChange — without it the \
-         write is invisible to the network even though the host function returned success \
-         (this is #5479)",
-    );
+    let queued = take_broadcasts(&mut notifications);
     assert_eq!(
-        broadcast_key, key,
-        "broadcast must name the written contract"
+        queued,
+        vec![key],
+        "a V2 delegate write must queue exactly one NodeEvent::V2DelegateStateChanged \
+         naming the written contract — without it the write is invisible to the network \
+         even though the host function returned success (this is #5479)"
     );
+}
+
+/// Successive writes to ONE contract must coalesce into a single queued
+/// broadcast while that broadcast is undrained.
+///
+/// This is the property that makes the queue's message-count bound also a
+/// bound on what it retains: the event carries a contract id rather than a
+/// `WrappedState`, and repeats for the same contract add nothing at all. The
+/// single drain re-reads stored state, so it fans out the NEWEST value — the
+/// coalescing loses no information, it only avoids re-announcing the same
+/// contract N times.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_writes_to_one_contract_coalesce_while_undrained() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-coalesce").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(15);
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+
+    // Ten content-changing writes, nothing draining the channel in between.
+    for i in 0..10u8 {
+        callback(&key, &WrappedState::new(vec![i, i, i, i]));
+    }
+
     assert_eq!(
-        broadcast_state.as_ref(),
-        written.as_ref(),
-        "broadcast must carry the bytes that were actually written, not a re-read or a \
-         reconstruction"
+        take_broadcasts(&mut notifications),
+        vec![key],
+        "ten writes to one contract with nothing draining must queue ONE broadcast, not \
+         ten: the marker set by the first write suppresses the rest until a drain clears \
+         it. If this reads ten, the coalescing is gone and the queue again grows one \
+         entry per write"
+    );
+}
+
+/// Coalescing must be PER CONTRACT — a queued broadcast for one contract must
+/// not suppress another contract's.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_broadcast_coalescing_is_per_contract() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-per-key").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+    let (a, b) = (test_key(16), test_key(17));
+    callback(&a, &WrappedState::new(vec![1]));
+    callback(&b, &WrappedState::new(vec![2]));
+    callback(&a, &WrappedState::new(vec![3]));
+
+    let mut queued = take_broadcasts(&mut notifications);
+    queued.sort_by_key(|k| k.id().as_bytes().to_vec());
+    let mut expected = vec![a, b];
+    expected.sort_by_key(|k| k.id().as_bytes().to_vec());
+    assert_eq!(
+        queued, expected,
+        "each contract must get its own queued broadcast; the repeat write to `a` \
+         coalesces into a's pending entry and must not be suppressed by, or suppress, b's"
+    );
+}
+
+/// Once a queued broadcast is DRAINED, the next write must queue a fresh one.
+///
+/// The marker is cleared by the handler when it begins draining, so this pins
+/// that the suppression is a coalescing window and not a latch — a latch would
+/// silently stop a contract propagating for the rest of the process lifetime.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_broadcast_requeues_after_drain() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-requeue").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(18);
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+
+    callback(&key, &WrappedState::new(vec![1]));
+    assert_eq!(take_broadcasts(&mut notifications), vec![key]);
+
+    // Second write while the marker is still set: coalesced away.
+    callback(&key, &WrappedState::new(vec![2]));
+    assert!(
+        take_broadcasts(&mut notifications).is_empty(),
+        "still-pending contract must coalesce"
+    );
+
+    // The handler clears the marker as it starts draining.
+    op_manager.clear_v2_delegate_broadcast_pending(&key);
+
+    callback(&key, &WrappedState::new(vec![3]));
+    assert_eq!(
+        take_broadcasts(&mut notifications),
+        vec![key],
+        "after the pending broadcast is drained, the next write must queue a new one. If \
+         this is empty the marker has become a latch and the contract has stopped \
+         propagating permanently"
     );
 }
 
@@ -182,7 +272,7 @@ async fn v2_delegate_write_callback_suppresses_broken_contract_broadcast() {
     callback(&key, &written);
 
     assert!(
-        take_broadcast(&mut notifications).is_none(),
+        take_broadcasts(&mut notifications).is_empty(),
         "a contract flagged as non-idempotent must not be broadcast from the V2 delegate \
          write path either — otherwise V2 is a hole in the suppression that stops the \
          #4279 storm"

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -383,3 +383,86 @@ async fn v2_delegate_unchanged_write_meters_but_does_not_queue() {
          rewrite does not need, and the whole reason the flag is threaded through"
     );
 }
+
+/// #4549: the drain read must be BOUNDED, and the bound must be its own, not
+/// the contract handler's `CH_EV_RESPONSE_TIME_OUT` (300 s).
+///
+/// This is the test whose absence let a 5x widening of that bound ship. The
+/// mutation lens proved the point rather than argued it: replacing the passed
+/// `timeout` with `Duration::from_secs(300)` inside
+/// `read_state_for_broadcast_drain` SURVIVED the entire 5,440-test suite, as
+/// did replacing the constant with 1 ms. The suite was green for 1 ms, 2 s,
+/// 10 s and 300 s alike, so the rustdoc's central claim — "it is bounded" —
+/// was prose that nothing executed.
+///
+/// Why it matters more than a slow test: this read is awaited INLINE on the
+/// network event loop, so overrunning it stops the node processing UDP and
+/// connection events entirely. And no slow-iteration warning covers it —
+/// `SLOW_EVENT_THRESHOLD` is measured around `process_select_result`, while
+/// this arm runs after that elapsed time is taken. An unbounded await here is
+/// the #4549 wedge that took a gateway network-dead.
+///
+/// The harness never services the contract-handler channel, which is exactly
+/// the condition the bound exists for: a handler that cannot answer.
+///
+/// The ceiling asserted here is ABSOLUTE, not derived from the constant. A
+/// test that scaled with the value it guards would pass for any value — the
+/// self-referential shape that let `MAX_V2_DRAIN_RETRIES` 3 -> 100 survive
+/// elsewhere in this diff.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_drain_read_is_bounded_and_does_not_inherit_the_handler_timeout() {
+    use crate::node::DrainStateRead;
+
+    let (op_manager, _rx, _guards) = build_op_manager("v2-drain-bound").await;
+    let key = test_key(41);
+
+    let started = std::time::Instant::now();
+    let outcome = op_manager
+        .read_state_for_broadcast_drain(&key, std::time::Duration::from_secs(2))
+        .await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        matches!(outcome, DrainStateRead::Unavailable),
+        "a handler that never answers must classify as Unavailable — the arm \
+         that retries — and NOT as NotHeld, which is a correct and final no-op. \
+         Conflating them silently discards a committed write. Got {outcome:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(30),
+        "the drain read must honour its own bound rather than inheriting the \
+         handler's 300 s CH_EV_RESPONSE_TIME_OUT. It ran for {elapsed:?}, which \
+         is the #4549 wedge: that time is spent inline on the network event \
+         loop, processing no packets and emitting no slow-iteration warning."
+    );
+}
+
+/// The drain bound must leave room for a handler that is merely BUSY.
+///
+/// The paired lower bound to the test above, and the two are only meaningful
+/// together. An upper-bound assertion alone is satisfied by a 1 ms timeout —
+/// which the mutation lens confirmed also survives the suite — and a 1 ms bound
+/// would classify every real read as `Unavailable`, so every V2 write would
+/// take the retry path and then be reported dropped. That is the opposite
+/// failure and just as silent.
+///
+/// Asserted against the CONSTANT the production arm actually passes, because
+/// the property under test is a property of that value.
+#[test]
+fn the_drain_bound_leaves_room_for_a_busy_handler() {
+    use crate::node::V2_BROADCAST_DRAIN_READ_TIMEOUT as BOUND;
+
+    assert!(
+        BOUND >= std::time::Duration::from_millis(500),
+        "a bound this tight classifies a merely-busy handler as Unavailable, so \
+         every V2 write takes the retry path and is then reported as a dropped \
+         broadcast. Got {BOUND:?}"
+    );
+    assert!(
+        BOUND <= std::time::Duration::from_secs(5),
+        "this read is awaited INLINE on the network event loop and no \
+         slow-iteration warning covers it, so the bound is a cap on how long \
+         the node stops processing packets. The marker coalesces PER CONTRACT, \
+         so a delegate writing N contracts costs N times this. Got {BOUND:?}"
+    );
+}

--- a/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/v2_delegate_propagation_tests.rs
@@ -1,0 +1,212 @@
+//! Deterministic guards for V2 delegate write propagation (#5479).
+//!
+//! A V2 delegate's `put_contract_state` / `update_contract_state` writes
+//! straight through the raw `Storage`, bypassing the executor's
+//! `state_store.{store,update}` chokepoints. Everything those chokepoints do
+//! has to be re-applied by the callback installed on `Runtime` — and until
+//! #5479 network propagation was the leg nobody had re-applied, so a V2 write
+//! returned success, read back correctly on the writing node, and was never
+//! seen anywhere else.
+//!
+//! The end-to-end proof is
+//! `crates/core/tests/operations.rs::test_v2_delegate_update_propagates_to_second_peer`,
+//! which is the only place the bug is observable by construction (a second
+//! peer). These tests are the cheap, deterministic complement: they drive the
+//! PRODUCTION closure — `v2_delegate_state_write_callback`, the exact value
+//! `install_v2_delegate_state_write_hooks` installs — against a real
+//! `OpManager`/`Ring` and assert what it emits. That keeps the regression
+//! covered in a fast unit run even when the 3-node E2E is not exercised.
+
+use std::sync::Arc;
+
+use either::Either;
+use freenet_stdlib::prelude::*;
+
+use crate::config::ConfigArgs;
+use crate::contract::executor::OperationMode;
+use crate::contract::executor::runtime::v2_delegate_state_write_callback;
+use crate::message::NodeEvent;
+use crate::node::{EventLoopNotificationsReceiver, OpManager};
+use crate::wasm_runtime::{MockStateStorage, StateStore};
+
+/// Build a real `OpManager` and hand back the notification RECEIVER typed, so a
+/// test can read the events the callback emits. (The sibling harness in
+/// `identical_input_probe_tests.rs` buries the receiver in an opaque guard box
+/// because it only needs it kept alive.)
+async fn build_op_manager(
+    id: &str,
+) -> (
+    Arc<OpManager>,
+    EventLoopNotificationsReceiver,
+    Box<dyn std::any::Any>,
+) {
+    let config_args = ConfigArgs {
+        id: Some(id.to_string()),
+        mode: Some(OperationMode::Local),
+        ..Default::default()
+    };
+    let node_config =
+        crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+
+    let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+    let (ops_ch_channel, ch_channel, wait_for_event) = crate::contract::contract_handler_channel();
+    let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+    let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+    let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+    let op_manager = Arc::new(
+        OpManager::new(
+            notification_tx,
+            ops_ch_channel,
+            &node_config,
+            crate::tracing::DynamicRegister::new(vec![]),
+            connection_manager,
+            result_router_tx,
+            &task_monitor,
+        )
+        .expect("build OpManager"),
+    );
+    op_manager.ring.attach_op_manager(&op_manager);
+
+    let guards: Box<dyn std::any::Any> =
+        Box::new((ch_channel, wait_for_event, result_router_rx, task_monitor));
+    (op_manager, notification_rx, guards)
+}
+
+fn test_key(seed: u8) -> ContractKey {
+    let code = ContractCode::from(vec![seed, seed, seed]);
+    let params = Parameters::from(vec![seed]);
+    ContractKey::from_params_and_code(&params, &code)
+}
+
+/// Drain the notification channel and return the first `BroadcastStateChange`,
+/// or `None` if the channel holds no such event.
+fn take_broadcast(rx: &mut EventLoopNotificationsReceiver) -> Option<(ContractKey, WrappedState)> {
+    while let Ok(event) = rx.notifications_receiver.try_recv() {
+        if let Either::Right(NodeEvent::BroadcastStateChange { key, new_state, .. }) = event {
+            return Some((key, new_state));
+        }
+    }
+    None
+}
+
+/// #5479: the installed V2 write callback must emit `BroadcastStateChange`
+/// carrying the state that was written.
+///
+/// Before the fix the callback could not have done this even in principle —
+/// it received only `(key, state_size)`, so the state to broadcast was not
+/// available to it. The signature change is the fix; this asserts the emission.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_write_callback_emits_broadcast_state_change() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-emit").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(11);
+    let written = WrappedState::new(vec![9, 8, 7, 6]);
+
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+    callback(&key, &written);
+
+    let (broadcast_key, broadcast_state) = take_broadcast(&mut notifications).expect(
+        "a V2 delegate write must emit NodeEvent::BroadcastStateChange — without it the \
+         write is invisible to the network even though the host function returned success \
+         (this is #5479)",
+    );
+    assert_eq!(
+        broadcast_key, key,
+        "broadcast must name the written contract"
+    );
+    assert_eq!(
+        broadcast_state.as_ref(),
+        written.as_ref(),
+        "broadcast must carry the bytes that were actually written, not a re-read or a \
+         reconstruction"
+    );
+}
+
+/// The write must still be metered and the caches still invalidated — the legs
+/// that already existed before #5479 must not have been traded for the new one.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_write_callback_still_meters_and_invalidates() {
+    let (op_manager, _notifications, _guards) = build_op_manager("v2-prop-meter").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(12);
+    let written = WrappedState::new(vec![1, 2, 3, 4, 5]);
+
+    // Warm the change-detector, as a prior summarize slow path would.
+    state_store.cache_state_hash(key, crate::wasm_runtime::state_hash(&written));
+    assert!(state_store.cached_state_hash(&key).is_some());
+
+    let generation_before = op_manager.ring.state_generation(&key);
+
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+    callback(&key, &written);
+
+    assert_eq!(
+        state_store.cached_state_hash(&key),
+        None,
+        "the callback must drop StateStore's change-detector entry, or the summarize/delta \
+         fast path serves a stale summary for a state it never saw written"
+    );
+    assert_ne!(
+        op_manager.ring.state_generation(&key),
+        generation_before,
+        "the callback must bump the per-contract state-write generation (the EvictContract \
+         re-host race)"
+    );
+}
+
+/// A contract flagged as violating a CRDT invariant must NOT be broadcast, the
+/// same suppression `Executor::broadcast_state_change` applies. Otherwise the
+/// V2 path becomes a hole in the storm suppression that #4251/#4279 installed.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_write_callback_suppresses_broken_contract_broadcast() {
+    let (op_manager, mut notifications, _guards) = build_op_manager("v2-prop-broken").await;
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+
+    let key = test_key(13);
+    let written = WrappedState::new(vec![4, 4, 4]);
+
+    op_manager
+        .ring
+        .record_broken_invariant(key, crate::ring::BrokenInvariant::NonIdempotent);
+    assert!(op_manager.ring.is_contract_broken(&key));
+
+    let callback =
+        v2_delegate_state_write_callback(state_store.cache_invalidator(), Some(op_manager.clone()));
+    callback(&key, &written);
+
+    assert!(
+        take_broadcast(&mut notifications).is_none(),
+        "a contract flagged as non-idempotent must not be broadcast from the V2 delegate \
+         write path either — otherwise V2 is a hole in the suppression that stops the \
+         #4279 storm"
+    );
+}
+
+/// An executor with no `OpManager` (unit-test and local-only harnesses) has no
+/// ring to meter or broadcast against. The callback must still invalidate the
+/// caches and must not panic.
+#[tokio::test(flavor = "current_thread")]
+async fn v2_delegate_write_callback_without_op_manager_only_invalidates() {
+    let state_store = StateStore::new(MockStateStorage::new(), 10_000_000).unwrap();
+    let key = test_key(14);
+    let written = WrappedState::new(vec![7, 7]);
+
+    state_store.cache_state_hash(key, crate::wasm_runtime::state_hash(&written));
+
+    let callback = v2_delegate_state_write_callback(state_store.cache_invalidator(), None);
+    callback(&key, &written);
+
+    assert_eq!(
+        state_store.cached_state_hash(&key),
+        None,
+        "cache invalidation is unconditional — it is a correctness leg, not a telemetry leg, \
+         and a local-only executor still serves reads from these caches"
+    );
+}

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -456,10 +456,18 @@ fn install_v2_delegate_state_write_hooks(
 ///   next to the write rather than after it, and live in
 ///   `native_api::{state_content_changed, check_state_size}`.
 /// - **Hosting registration.** A V2 write does not make this node a host, so
-///   the emitted broadcast is still dropped by
-///   `should_summarize_or_broadcast` for a contract held only because a
+///   the emitted broadcast is still dropped by `should_broadcast_contract` (the
+///   `should_summarize_or_broadcast` gate, applied at the per-peer send in
+///   `broadcast_queue::broadcast_to_single_peer` — not in
+///   `handle_broadcast_state_change`) for a contract held only because a
 ///   delegate wrote it. That is **#4669** (a delegate subscription must
 ///   register demand), not this fix.
+/// - **Contract validation, and any check on WHICH contract a delegate may
+///   write.** The V1 path reaches the network only after
+///   `bridged_upsert_contract_state` has run the contract's own
+///   `validate_state`/`update_state`; this path does not, and this fix turns
+///   that from a local-disk question into a network one. Tracked separately;
+///   receivers still merge through their own contract, which bounds it.
 pub(super) fn v2_delegate_state_write_callback(
     cache_invalidator: crate::wasm_runtime::StateCacheInvalidator,
     op_manager: Option<Arc<OpManager>>,
@@ -489,11 +497,21 @@ pub(super) fn v2_delegate_state_write_callback(
             // hand-written copies of one decision.
             //
             // KNOWN LIMIT, and it is the case #5467 cares about: the event is
-            // dropped downstream by `handle_broadcast_state_change`'s
-            // `Ring::should_summarize_or_broadcast` gate unless this node is
-            // hosting the contract or it is `contract_in_use` — and a DELEGATE
-            // subscription is neither (`ring::hosting::contract_in_use` counts
-            // client subscriptions and downstream subscribers only). So a
+            // dropped downstream by the `Ring::should_summarize_or_broadcast`
+            // gate unless this node is hosting the contract or it is
+            // `contract_in_use` — and a DELEGATE subscription is neither
+            // (`ring::hosting::contract_in_use` counts client subscriptions and
+            // downstream subscribers only).
+            //
+            // WHERE THAT GATE ACTUALLY IS, because two independent readers have
+            // now looked in the wrong place and concluded it was absent: NOT in
+            // `handle_broadcast_state_change`, which is where this comment used
+            // to send them. It is one layer down, at the per-peer send in
+            // `broadcast_queue::broadcast_to_single_peer`, wrapped in the
+            // one-line `should_broadcast_contract` — so grepping
+            // `broadcast.rs` for the inner name finds only a comment. A
+            // limitation stated where it cannot be verified reads, to the next
+            // reader who checks, as one that was fixed or imagined. So a
             // contract this node holds ONLY because a delegate wrote it still
             // does not propagate. Making a delegate subscription register
             // demand is #4669 and is a hosting-invariants decision, not
@@ -547,7 +565,11 @@ pub(super) fn v2_delegate_state_write_callback(
             // its own marker; the rate-limited `notify_node_event:
             // Notification channel full for too long` ERROR in
             // op_state_manager.rs is the sustained-back-pressure alert.
-            op_manager.queue_v2_delegate_broadcast(*key);
+            // Outcome deliberately discarded: all three are correct here.
+            // `Coalesced` means an undrained broadcast already covers this
+            // write, and `EnqueueFailed` has already been counted and WARNed
+            // inside the call.
+            let _ = op_manager.queue_v2_delegate_broadcast(*key);
         },
     )
 }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2984,42 +2984,99 @@ mod state_write_attribution_pin_tests {
     /// real code — the heuristic is: the line is not a comment AND the
     /// needle does not appear inside a double-quoted string on that line.
     fn count_call_sites(src: &str, needle: &str) -> usize {
-        src.lines()
-            .filter(|line| {
-                let trimmed = line.trim_start();
-                if trimmed.starts_with("//") {
-                    return false;
-                }
-                // Strip everything between matched double quotes so we
-                // don't count needle occurrences inside string literals
-                // (the test's own assertion messages contain the needles).
-                let stripped = strip_string_literals(line);
-                stripped.contains(needle)
-            })
-            .count()
+        let code = strip_comments_and_strings(src);
+        code.lines().filter(|line| line.contains(needle)).count()
     }
 
-    /// Replace the contents of every `"..."` on the line with empty
-    /// quotes so substring searches on the result skip string literals.
-    /// Handles escaped quotes pragmatically (rare in this codebase).
-    fn strip_string_literals(line: &str) -> String {
-        let mut out = String::with_capacity(line.len());
+    /// Blank out every COMMENT and every STRING LITERAL in `src`, preserving
+    /// line structure so line-based counting still works.
+    ///
+    /// # Why this replaced a line-prefix filter
+    ///
+    /// The previous version skipped a line only when its trimmed start was
+    /// `//`, and blanked string literals per line. That left two ways to
+    /// satisfy a pin without the code it guards:
+    ///
+    /// 1. **Block comments.** `/* op_manager.ring.record_contract_update(key); */`
+    ///    does not begin with `//`, so the needle stayed visible and the pin
+    ///    stayed green while the call was inert. A reviewer demonstrated this
+    ///    against `one_v2_delegate_write_callback_shared_by_both_executor_constructors`
+    ///    by block-commenting the call and watching it pass.
+    /// 2. **Trailing comments.** `foo(); // ... .commit_state_write() ...` has
+    ///    real code before the `//`, so the line was scanned in full and the
+    ///    needle inside the comment counted as a call site — which inflates an
+    ///    exact-count pin and can mask a genuine deletion.
+    ///
+    /// Both are the same defect: a scraper that skips SOME comments is not
+    /// skipping comments. That shape has now been found five times in this
+    /// workstream, which is why this is a single scanner rather than another
+    /// filter refinement.
+    ///
+    /// KNOWN LIMIT: raw strings (`r#"..."#`) are not recognised, so a needle
+    /// inside one would still count. None of the scraped sources contains one
+    /// (verified); if that changes, this needs a raw-string state.
+    fn strip_comments_and_strings(src: &str) -> String {
+        let mut out = String::with_capacity(src.len());
+        let mut chars = src.chars().peekable();
         let mut in_string = false;
-        let mut prev_was_backslash = false;
-        for c in line.chars() {
+        let mut in_line_comment = false;
+        let mut in_block_comment = false;
+        let mut prev_backslash = false;
+
+        while let Some(c) = chars.next() {
+            if in_line_comment {
+                if c == '\n' {
+                    in_line_comment = false;
+                    out.push('\n');
+                }
+                continue;
+            }
+            if in_block_comment {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    in_block_comment = false;
+                } else if c == '\n' {
+                    // Keep the newline so a multi-line block comment does not
+                    // splice two code lines into one.
+                    out.push('\n');
+                }
+                continue;
+            }
             if in_string {
-                if c == '"' && !prev_was_backslash {
+                if prev_backslash {
+                    prev_backslash = false;
+                } else if c == '\\' {
+                    prev_backslash = true;
+                } else if c == '"' {
                     in_string = false;
                     out.push('"');
                 }
-                // drop characters inside the string
-            } else if c == '"' {
+                if c == '\n' {
+                    out.push('\n');
+                }
+                continue;
+            }
+            if c == '/' {
+                match chars.peek() {
+                    Some('/') => {
+                        chars.next();
+                        in_line_comment = true;
+                        continue;
+                    }
+                    Some('*') => {
+                        chars.next();
+                        in_block_comment = true;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            if c == '"' {
                 in_string = true;
                 out.push('"');
-            } else {
-                out.push(c);
+                continue;
             }
-            prev_was_backslash = c == '\\' && !prev_was_backslash;
+            out.push(c);
         }
         out
     }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -505,26 +505,30 @@ pub(super) fn v2_delegate_state_write_callback(
                 );
                 return;
             }
-            if let Err(err) =
-                op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastStateChange {
-                    key: *key,
-                    new_state: new_state.clone(),
-                    is_retry: false,
-                    is_reemit: false,
-                })
-            {
-                // Best-effort by design (#4145 / #4231): a missed broadcast
-                // heals via the next UPDATE or a summary-mismatch
-                // SyncStateToPeer round. The rate-limited `notify_node_event:
-                // Notification channel full for too long` ERROR in
-                // op_state_manager.rs is the sustained-back-pressure alert.
-                tracing::debug!(
-                    contract = %key,
-                    error = %err,
-                    "Failed to broadcast V2 delegate state change to network peers \
-                     (best-effort)"
-                );
-            }
+            // Queue the fan-out rather than enqueueing the state itself.
+            //
+            // `NodeEvent::V2DelegateStateChanged` names the contract and
+            // carries no state, and the handler re-reads what is stored when
+            // it drains. Two reasons this is the right shape here, both of
+            // which the state-carrying `BroadcastStateChange` cannot give:
+            //
+            // 1. The event-loop notification channel is bounded by message
+            //    COUNT (`DEFAULT_EVENT_LOOP_CHANNEL_CAPACITY`), and a
+            //    `WrappedState` runs to `MAX_STATE_SIZE`. Queueing ids keeps
+            //    the queue's retained bytes bounded by that count rather than
+            //    by count times the largest state.
+            // 2. Successive writes to one contract coalesce into the single
+            //    queued broadcast, which then carries the NEWEST state rather
+            //    than the oldest — strictly better than the snapshot a
+            //    state-carrying event would have frozen at emit time.
+            //
+            // Best-effort by design (#4145 / #4231): a dropped queue attempt
+            // heals via the next write or a summary-mismatch SyncStateToPeer
+            // round. `queue_v2_delegate_broadcast` logs the drop and releases
+            // its own marker; the rate-limited `notify_node_event:
+            // Notification channel full for too long` ERROR in
+            // op_state_manager.rs is the sustained-back-pressure alert.
+            op_manager.queue_v2_delegate_broadcast(*key);
         },
     )
 }
@@ -3148,18 +3152,27 @@ mod state_write_attribution_pin_tests {
         for required in [
             "cache_invalidator.invalidate(",
             ".commit_state_write(",
-            "NodeEvent::BroadcastStateChange",
+            // The propagation leg. It queues a key-only event rather than
+            // enqueueing the state; see `queue_v2_delegate_broadcast`.
+            "queue_v2_delegate_broadcast(",
             "is_contract_broken(",
         ] {
+            // `count_call_sites`, not `body.contains`: the callback carries a
+            // long comment block that names each of these symbols, and a raw
+            // substring search is satisfied by the COMMENT alone. That is the
+            // vacuous-pin shape `.claude/rules/bug-prevention-patterns.md`
+            // warns about — the pin would keep passing after the call it
+            // guards was deleted, as long as the prose survived.
             assert!(
-                body.contains(required),
-                "the V2 delegate write callback must invoke `{required}`. \
-                 Dropping the invalidation serves stale bytes and stale \
-                 summaries; dropping commit_state_write re-opens the \
-                 EvictContract race and undercounts the meter; dropping \
-                 BroadcastStateChange is #5479 (the write returns success \
-                 and the network never learns of it); dropping the \
-                 broken-contract check re-engages a suppressed storm."
+                count_call_sites(body, required) >= 1,
+                "the V2 delegate write callback must invoke `{required}` as \
+                 real code (not merely mention it in a comment). Dropping the \
+                 invalidation serves stale bytes and stale summaries; dropping \
+                 commit_state_write re-opens the EvictContract race and \
+                 undercounts the meter; dropping the broadcast queue is #5479 \
+                 (the write returns success and the network never learns of \
+                 it); dropping the broken-contract check re-engages a \
+                 suppressed storm."
             );
         }
     }

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -3058,7 +3058,10 @@ mod state_write_attribution_pin_tests {
              {hook_calls}"
         );
         // …and exactly one place that actually invokes the callback.
-        let invocations = count_call_sites(NATIVE_API_SRC, "cb(contract_key, new_state, content_changed)");
+        let invocations = count_call_sites(
+            NATIVE_API_SRC,
+            "cb(contract_key, new_state, content_changed)",
+        );
         assert_eq!(
             invocations, 1,
             "expected exactly 1 callback invocation in native_api.rs (inside \

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -423,7 +423,10 @@ fn install_v2_delegate_state_write_hooks(
 ///    refresh, and the StateBytesWritten meter report. Without it the
 ///    EvictContract re-host race stays open for V2 writes and governance
 ///    scoring undercounts them.
-/// 3. **`NodeEvent::BroadcastStateChange`** — the propagation V1 gets for free
+/// 3. **`Ring::record_contract_update`** — the dashboard "last updated"
+///    timestamp. `commit_state_write` does not do this; the V1 UPDATE path
+///    does it separately, so it has to be here too.
+/// 4. **`NodeEvent::BroadcastStateChange`** — the propagation V1 gets for free
 ///    from `upsert_contract_state` (#5479). Suppressed for a contract flagged
 ///    as violating a CRDT invariant, mirroring
 ///    `Executor::broadcast_state_change`, and emitted NON-BLOCKING: a blocking
@@ -431,8 +434,24 @@ fn install_v2_delegate_state_write_hooks(
 ///    gateways in #4145, and this one runs inside a synchronous WASM host call,
 ///    where blocking would be worse still.
 ///
-/// Legs 2 and 3 need the ring, so they run only when `op_manager` is `Some`
+/// Legs 2-4 need the ring, so they run only when `op_manager` is `Some`
 /// (unit-test and local-only executors have none). Leg 1 always runs.
+///
+/// **What this deliberately does NOT re-apply**, so the next reader does not
+/// have to rediscover it — an explicit list is what stops the fourth omission:
+///
+/// - **Local fan-out** (this node's own WebSocket clients and other subscribed
+///   delegates). Not reachable from here: the `DelegateNotificationSender` is
+///   installed on the executor after this callback is built (`pool.rs`), and
+///   the WS subscriber maps need `&mut Executor`. Tracked as **#5486**.
+/// - **The no-change filter and the `MAX_STATE_SIZE` ceiling.** Both belong
+///   next to the write rather than after it, and live in
+///   `native_api::{state_content_changed, check_state_size}`.
+/// - **Hosting registration.** A V2 write does not make this node a host, so
+///   the emitted broadcast is still dropped by
+///   `should_summarize_or_broadcast` for a contract held only because a
+///   delegate wrote it. That is **#4669** (a delegate subscription must
+///   register demand), not this fix.
 ///
 /// Local fan-out — WebSocket clients and other delegates subscribed on THIS
 /// node — is deliberately NOT here and is not reachable from here: the
@@ -453,8 +472,31 @@ pub(super) fn v2_delegate_state_write_callback(
                 .ring
                 .commit_state_write(key, new_state.as_ref().len());
 
-            // Propagate, exactly as the V1 path does via
-            // `upsert_contract_state` → `Executor::finalize_state_commit`.
+            // Dashboard "last updated" telemetry. The V1 UPDATE path does
+            // this in `Executor::commit_state_update`; `commit_state_write`
+            // does not, so without this line a contract written only by a V2
+            // delegate shows a stale last-update timestamp forever.
+            op_manager.ring.record_contract_update(key);
+
+            // Propagate, mirroring `Executor::broadcast_state_change` (the
+            // helper the V1 commit path uses). Keep the two in step: a gate
+            // added there — the broken-invariant check below is the existing
+            // one — has to be added here as well, because these are two
+            // hand-written copies of one decision.
+            //
+            // KNOWN LIMIT, and it is the case #5467 cares about: the event is
+            // dropped downstream by `handle_broadcast_state_change`'s
+            // `Ring::should_summarize_or_broadcast` gate unless this node is
+            // hosting the contract or it is `contract_in_use` — and a DELEGATE
+            // subscription is neither (`ring::hosting::contract_in_use` counts
+            // client subscriptions and downstream subscribers only). So a
+            // contract this node holds ONLY because a delegate wrote it still
+            // does not propagate. Making a delegate subscription register
+            // demand is #4669 and is a hosting-invariants decision, not
+            // something to smuggle into a propagation fix.
+            //
+            // Not registered with `ring::broadcast_coverage` — see the
+            // residual list in that module, which this path is named in.
             if op_manager.ring.is_contract_broken(key) {
                 tracing::debug!(
                     contract = %key,
@@ -3071,13 +3113,26 @@ mod state_write_attribution_pin_tests {
              {installs}. A second installer is a copy-paste twin waiting to \
              drift — extend the shared one instead."
         );
-        let callers =
-            count_call_sites(RUNTIME_SRC, "install_v2_delegate_state_write_hooks(&mut rt");
+        // Both constructors must call it, AND must pass the op_manager
+        // through. `install_v2_delegate_state_write_hooks(&mut rt, &store,
+        // None)` would compile, disable network propagation on every
+        // production node, and leave every unit test and every pin above
+        // green — only the 3-node E2E would notice. Pin the argument, not
+        // just the call.
+        let callers = count_call_sites(
+            RUNTIME_SRC,
+            "install_v2_delegate_state_write_hooks(&mut rt, &state_store, op_manager.clone())",
+        ) + count_call_sites(
+            RUNTIME_SRC,
+            "install_v2_delegate_state_write_hooks(&mut rt, &shared_state_store, \
+             op_manager.clone())",
+        );
         assert_eq!(
             callers, 2,
             "expected both executor constructors (`from_config` and \
              `from_config_with_shared_modules`) to call \
-             install_v2_delegate_state_write_hooks; found {callers} call sites."
+             install_v2_delegate_state_write_hooks WITH `op_manager.clone()`; \
+             found {callers} matching call sites."
         );
 
         // And the one callback must still do all three legs. Anchored on API

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -452,12 +452,6 @@ fn install_v2_delegate_state_write_hooks(
 ///   `should_summarize_or_broadcast` for a contract held only because a
 ///   delegate wrote it. That is **#4669** (a delegate subscription must
 ///   register demand), not this fix.
-///
-/// Local fan-out — WebSocket clients and other delegates subscribed on THIS
-/// node — is deliberately NOT here and is not reachable from here: the
-/// `DelegateNotificationSender` is installed on the executor after this runs
-/// (`pool.rs`), and the WS subscriber maps need `&mut Executor`. Tracked
-/// separately.
 pub(super) fn v2_delegate_state_write_callback(
     cache_invalidator: crate::wasm_runtime::StateCacheInvalidator,
     op_manager: Option<Arc<OpManager>>,

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -426,13 +426,21 @@ fn install_v2_delegate_state_write_hooks(
 /// 3. **`Ring::record_contract_update`** — the dashboard "last updated"
 ///    timestamp. `commit_state_write` does not do this; the V1 UPDATE path
 ///    does it separately, so it has to be here too.
-/// 4. **`NodeEvent::BroadcastStateChange`** — the propagation V1 gets for free
-///    from `upsert_contract_state` (#5479). Suppressed for a contract flagged
-///    as violating a CRDT invariant, mirroring
-///    `Executor::broadcast_state_change`, and emitted NON-BLOCKING: a blocking
-///    `notify_node_event(...).await` on a commit path is what wedged both
-///    gateways in #4145, and this one runs inside a synchronous WASM host call,
-///    where blocking would be worse still.
+/// 4. **Queueing the network fan-out** via
+///    `OpManager::queue_v2_delegate_broadcast` — the propagation V1 gets for
+///    free from `upsert_contract_state` (#5479). It enqueues a KEY-ONLY
+///    `NodeEvent::V2DelegateStateChanged`; the handler reads current state when
+///    it drains, so the queue holds contract ids rather than states and repeat
+///    writes to one contract coalesce. Suppressed for a contract flagged as
+///    violating a CRDT invariant, mirroring `Executor::broadcast_state_change`,
+///    and enqueued NON-BLOCKING: a blocking `notify_node_event(...).await` on a
+///    commit path is what wedged both gateways in #4145, and this one runs
+///    inside a synchronous WASM host call, where blocking would be worse still.
+///
+///    This leg — and ONLY this leg — is skipped when the write did not change
+///    the stored bytes. Legs 1-3 run for every committed write; see
+///    `native_api::after_state_write` for why skipping them was a data-loss
+///    bug rather than an optimisation.
 ///
 /// Legs 2-4 need the ring, so they run only when `op_manager` is `Some`
 /// (unit-test and local-only executors have none). Leg 1 always runs.

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -3177,6 +3177,10 @@ mod state_write_attribution_pin_tests {
             // The propagation leg. It queues a key-only event rather than
             // enqueueing the state; see `queue_v2_delegate_broadcast`.
             "queue_v2_delegate_broadcast(",
+            // Leg 3 in the rustdoc above. Deleting it was green before this
+            // line existed: the dashboard timestamp for a contract written only
+            // by a V2 delegate would silently stop advancing.
+            ".record_contract_update(",
             "is_contract_broken(",
         ] {
             // `count_call_sites`, not `body.contains`: the callback carries a

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -360,6 +360,133 @@ impl ContractExecutor for Executor<Runtime> {
     }
 }
 
+/// Install the two V2-delegate state-write hooks on `rt`: the pre-write
+/// disk-budget admission gate and the post-write side-effect callback.
+///
+/// **There is exactly one of these on purpose.** V2 delegate writes
+/// (`put_contract_state_sync` / `update_contract_state_sync`) go straight
+/// through the raw `Storage`, bypassing the executor's
+/// `state_store.{store,update}` chokepoints — so everything those chokepoints
+/// do has to be re-applied by these hooks, and until #5479 the installers were
+/// two copy-paste twins (`from_config` and `from_config_with_shared_modules`)
+/// guarded only by a pin test that counted occurrences. That is precisely the
+/// shape the "manually-inlined originator side effects" row in
+/// `.claude/rules/bug-prevention-patterns.md` warns about: the next side effect
+/// added to one twin and not the other is silent. One installer, two callers.
+fn install_v2_delegate_state_write_hooks(
+    rt: &mut Runtime,
+    state_store: &StateStore<Storage>,
+    op_manager: Option<Arc<OpManager>>,
+) {
+    rt.set_state_write_callback(v2_delegate_state_write_callback(
+        state_store.cache_invalidator(),
+        op_manager.clone(),
+    ));
+
+    // Disk-budget admission gate for the V2 delegate write path (#4683,
+    // PR 3): V2 PUT/UPDATE bypass the executor's `state_store` chokepoints
+    // (and hence the gate installed there), so install the same pre-write
+    // gate here. Returns Err(cause) → the native-API method aborts without
+    // writing. No-op admit until the disk tracker is seeded.
+    if let Some(op_manager) = op_manager {
+        rt.set_state_admit_callback(Arc::new(
+            move |key: &ContractKey, state_size: usize, is_update: bool| {
+                // V2 PUT → hard gate; V2 UPDATE → growth-only gate (#4683).
+                // A shrinking/holding V2 UPDATE must never block convergence.
+                let result = if is_update {
+                    op_manager.ring.admit_state_update(key, state_size)
+                } else {
+                    op_manager.ring.admit_state_write(key, state_size)
+                };
+                result.map_err(|over| over.to_string())
+            },
+        ));
+    }
+}
+
+/// The post-write callback `install_v2_delegate_state_write_hooks` installs.
+///
+/// Split out from the installer so a test can drive the PRODUCTION closure
+/// directly and observe what it emits — see
+/// `pool_tests::v2_delegate_propagation_tests`. Building a whole `Runtime`
+/// (contract, delegate and secret stores plus a WASM engine) just to reach the
+/// closure would make that test cost far more than the behaviour it checks.
+///
+/// It does three things:
+///
+/// 1. **Drops `StateStore`'s cached view of the contract — ALWAYS**, whether or
+///    not an `op_manager` is wired. The bypass write touches neither the moka
+///    state-bytes cache nor the change-detector, so without this a later read
+///    serves the OLD bytes and the summarize/delta fast path can serve a STALE
+///    summary/delta → state divergence.
+/// 2. **`Ring::commit_state_write`** — generation bump, hosting-cache snapshot
+///    refresh, and the StateBytesWritten meter report. Without it the
+///    EvictContract re-host race stays open for V2 writes and governance
+///    scoring undercounts them.
+/// 3. **`NodeEvent::BroadcastStateChange`** — the propagation V1 gets for free
+///    from `upsert_contract_state` (#5479). Suppressed for a contract flagged
+///    as violating a CRDT invariant, mirroring
+///    `Executor::broadcast_state_change`, and emitted NON-BLOCKING: a blocking
+///    `notify_node_event(...).await` on a commit path is what wedged both
+///    gateways in #4145, and this one runs inside a synchronous WASM host call,
+///    where blocking would be worse still.
+///
+/// Legs 2 and 3 need the ring, so they run only when `op_manager` is `Some`
+/// (unit-test and local-only executors have none). Leg 1 always runs.
+///
+/// Local fan-out — WebSocket clients and other delegates subscribed on THIS
+/// node — is deliberately NOT here and is not reachable from here: the
+/// `DelegateNotificationSender` is installed on the executor after this runs
+/// (`pool.rs`), and the WS subscriber maps need `&mut Executor`. Tracked
+/// separately.
+pub(super) fn v2_delegate_state_write_callback(
+    cache_invalidator: crate::wasm_runtime::StateCacheInvalidator,
+    op_manager: Option<Arc<OpManager>>,
+) -> crate::wasm_runtime::StateWriteCallback {
+    Arc::new(
+        move |key: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+            cache_invalidator.invalidate(key);
+            let Some(op_manager) = &op_manager else {
+                return;
+            };
+            op_manager
+                .ring
+                .commit_state_write(key, new_state.as_ref().len());
+
+            // Propagate, exactly as the V1 path does via
+            // `upsert_contract_state` → `Executor::finalize_state_commit`.
+            if op_manager.ring.is_contract_broken(key) {
+                tracing::debug!(
+                    contract = %key,
+                    event = "broadcast_suppressed_broken_contract",
+                    "Skipping BroadcastStateChange for contract flagged as broken"
+                );
+                return;
+            }
+            if let Err(err) =
+                op_manager.try_notify_node_event(crate::message::NodeEvent::BroadcastStateChange {
+                    key: *key,
+                    new_state: new_state.clone(),
+                    is_retry: false,
+                    is_reemit: false,
+                })
+            {
+                // Best-effort by design (#4145 / #4231): a missed broadcast
+                // heals via the next UPDATE or a summary-mismatch
+                // SyncStateToPeer round. The rate-limited `notify_node_event:
+                // Notification channel full for too long` ERROR in
+                // op_state_manager.rs is the sustained-back-pressure alert.
+                tracing::debug!(
+                    contract = %key,
+                    error = %err,
+                    "Failed to broadcast V2 delegate state change to network peers \
+                     (best-effort)"
+                );
+            }
+        },
+    )
+}
+
 impl Executor<Runtime> {
     /// Create an Executor for local-only mode (no network operations).
     /// Use this from the binary for local mode execution.
@@ -378,47 +505,10 @@ impl Executor<Runtime> {
         let mut rt = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
         // Enable V2 delegate contract access by providing the state store DB
         rt.set_state_store_db(state_store.storage());
-        // V2 delegate state writes (put/update_contract_state_sync) write
-        // directly through the raw `Storage`, bypassing the executor's
-        // `state_store.{store,update}` chokepoints. The callback restores the
-        // side effects those chokepoints perform on every write:
-        //   1. Drop StateStore's cached view of the contract — ALWAYS. The
-        //      bypass write doesn't touch the moka state-bytes cache OR the
-        //      change-detector, so without this a later read would serve the OLD
-        //      bytes from moka and the summarize/delta fast path could serve a
-        //      STALE summary/delta → state divergence (Codex review).
-        //   2. Bump+refresh+report via `Ring::commit_state_write` — only when an
-        //      op_manager is present (it owns the ring/governance state).
-        //      Without this, V2 PUT/UPDATE would leave the EvictContract re-host
-        //      race open AND undercount StateBytesWritten in the meter.
-        let cache_invalidator = state_store.cache_invalidator();
-        let op_manager_for_cb = op_manager.clone();
-        rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-            cache_invalidator.invalidate(key);
-            if let Some(op_manager) = &op_manager_for_cb {
-                op_manager.ring.commit_state_write(key, state_size);
-            }
-        }));
-        // Disk-budget admission gate for the V2 delegate write path (#4683,
-        // PR 3): V2 PUT/UPDATE bypass the executor's `state_store` chokepoints
-        // (and hence the gate installed there), so install the same pre-write
-        // gate here. Returns Err(cause) → the native-API method aborts without
-        // writing. No-op admit until the disk tracker is seeded.
-        let op_manager_for_admit = op_manager.clone();
-        if let Some(op_manager) = op_manager_for_admit {
-            rt.set_state_admit_callback(Arc::new(
-                move |key: &ContractKey, state_size: usize, is_update: bool| {
-                    // V2 PUT → hard gate; V2 UPDATE → growth-only gate (#4683).
-                    // A shrinking/holding V2 UPDATE must never block convergence.
-                    let result = if is_update {
-                        op_manager.ring.admit_state_update(key, state_size)
-                    } else {
-                        op_manager.ring.admit_state_write(key, state_size)
-                    };
-                    result.map_err(|over| over.to_string())
-                },
-            ));
-        }
+        // V2 delegate state writes bypass the executor chokepoints — one
+        // shared installer restores every side effect they skip, propagation
+        // included. See `install_v2_delegate_state_write_hooks`.
+        install_v2_delegate_state_write_hooks(&mut rt, &state_store, op_manager.clone());
         Executor::new(
             state_store,
             move || {
@@ -533,40 +623,9 @@ impl Executor<Runtime> {
         )
         .unwrap();
         rt.set_state_store_db(db);
-        // V2 delegate state writes bypass the executor chokepoints — install the
-        // callback that (1) ALWAYS drops StateStore's cached view of the contract
-        // (both the moka state-bytes cache and the change-detector; a stale
-        // cached state or detector hash after a V2 write would serve a stale
-        // summary/delta → divergence; Codex review) and (2) mirrors the
-        // bump+refresh+report side effects via `Ring::commit_state_write` when an
-        // op_manager is present. See `from_config` and
-        // `Runtime::set_state_write_callback`.
-        let cache_invalidator = shared_state_store.cache_invalidator();
-        let op_manager_for_cb = op_manager.clone();
-        rt.set_state_write_callback(Arc::new(move |key: &ContractKey, state_size: usize| {
-            cache_invalidator.invalidate(key);
-            if let Some(op_manager) = &op_manager_for_cb {
-                op_manager.ring.commit_state_write(key, state_size);
-            }
-        }));
-        // Disk-budget admission gate for the V2 delegate write path (#4683,
-        // PR 3) — see `from_config` for the rationale. Same gate the executor
-        // chokepoints apply, restored for the V2 bypass.
-        let op_manager_for_admit = op_manager.clone();
-        if let Some(op_manager) = op_manager_for_admit {
-            rt.set_state_admit_callback(Arc::new(
-                move |key: &ContractKey, state_size: usize, is_update: bool| {
-                    // V2 PUT → hard gate; V2 UPDATE → growth-only gate (#4683).
-                    // A shrinking/holding V2 UPDATE must never block convergence.
-                    let result = if is_update {
-                        op_manager.ring.admit_state_update(key, state_size)
-                    } else {
-                        op_manager.ring.admit_state_write(key, state_size)
-                    };
-                    result.map_err(|over| over.to_string())
-                },
-            ));
-        }
+        // Same shared installer as `from_config` — see
+        // `install_v2_delegate_state_write_hooks` for what the V2 bypass owes.
+        install_v2_delegate_state_write_hooks(&mut rt, &shared_state_store, op_manager.clone());
         Executor::new(
             shared_state_store,
             || Ok(()),
@@ -2910,9 +2969,10 @@ mod state_write_attribution_pin_tests {
     #[test]
     fn every_runtime_state_write_chokepoint_goes_through_commit_state_write() {
         // 4 executor-internal chokepoints (PUT-new, UPDATE, re-PUT,
-        // verify_and_store PUT) + 2 V2 delegate callback installers
-        // = 6 total commit_state_write call sites in runtime.rs.
-        const EXPECTED: usize = 6;
+        // verify_and_store PUT) + 1 V2 delegate callback (the two
+        // installers collapsed into `v2_delegate_state_write_callback`
+        // in #5479) = 5 total commit_state_write call sites in runtime.rs.
+        const EXPECTED: usize = 5;
         let count = count_call_sites(RUNTIME_SRC, ".commit_state_write(");
         assert_eq!(
             count, EXPECTED,
@@ -2926,28 +2986,41 @@ mod state_write_attribution_pin_tests {
     }
 
     #[test]
-    fn v2_delegate_state_write_paths_invoke_callback_with_state_size() {
-        // The V2 delegate PUT and UPDATE paths in native_api.rs MUST
-        // capture state.len() BEFORE the move into store_state_sync /
-        // update_state_sync, and pass it to the callback. Otherwise the
-        // governance scoring undercounts every V2 delegate write by the
-        // full state size of that write.
-        let calls = count_call_sites(NATIVE_API_SRC, "cb(&contract_key,");
+    fn v2_delegate_state_write_paths_run_the_shared_post_write_hook() {
+        // Both V2 delegate write paths in native_api.rs (PUT and UPDATE) MUST
+        // go through the one `after_state_write` helper, which is what fires
+        // the installed callback. Hand-inlining the callback invocation at
+        // each path is how a side effect ends up on one path and not the
+        // other — the "manually-inlined originator side effects" row in
+        // `.claude/rules/bug-prevention-patterns.md`.
+        let hook_calls = count_call_sites(NATIVE_API_SRC, "self.after_state_write(");
         assert_eq!(
-            calls, 2,
-            "expected exactly 2 callback invocations passing state_size \
-             in native_api.rs (one for PUT, one for UPDATE); found {calls}"
+            hook_calls, 2,
+            "expected exactly 2 `self.after_state_write(` call sites in \
+             native_api.rs (one for V2 PUT, one for V2 UPDATE); found \
+             {hook_calls}"
         );
-        // And state.len() MUST be captured before the move.
-        let captures = count_call_sites(NATIVE_API_SRC, "let state_size = state.len();");
+        // …and exactly one place that actually invokes the callback.
+        let invocations = count_call_sites(NATIVE_API_SRC, "cb(contract_key, new_state)");
+        assert_eq!(
+            invocations, 1,
+            "expected exactly 1 callback invocation in native_api.rs (inside \
+             after_state_write); found {invocations}. A second one means a \
+             write path has started re-inlining the post-write sequence."
+        );
+        // The state is wrapped ONCE and the same value is admitted, written
+        // and handed to the callback. Reconstructing it for the hook, or
+        // measuring a different value than the one written, is the drift this
+        // catches.
+        let captures = count_call_sites(
+            NATIVE_API_SRC,
+            "let new_state = freenet_stdlib::prelude::WrappedState::new(state);",
+        );
         assert_eq!(
             captures, 2,
-            "expected exactly 2 `let state_size = state.len();` captures \
-             in native_api.rs (one before each state-store move); found \
-             {captures}. The order matters — capturing AFTER the move \
-             into store_state_sync would not compile, but a refactor \
-             that moves state into an intermediate first could regress \
-             this silently."
+            "expected exactly 2 `WrappedState::new(state)` wraps in \
+             native_api.rs (one per V2 write path, before the admission \
+             gate); found {captures}."
         );
     }
 
@@ -2982,23 +3055,58 @@ mod state_write_attribution_pin_tests {
     }
 
     #[test]
-    fn v2_delegate_callback_installers_invalidate_state_caches() {
+    fn one_v2_delegate_write_callback_shared_by_both_executor_constructors() {
         // V2 delegate state writes (put/update_contract_state_sync) bypass
-        // `StateStore::{store,update}`, so both `state_write_callback` installers
-        // (in `from_config` and `from_config_with_shared_modules`) MUST drop
-        // StateStore's cached view of the contract (moka state cache + change
-        // detector). Dropping this would let a V2 write leave a stale cached
-        // state/detector hash and the summarize/delta fast path serve a STALE
-        // summary/delta → state divergence (Codex review).
-        let count = count_call_sites(RUNTIME_SRC, "cache_invalidator.invalidate(");
+        // `StateStore::{store,update}`, so the `state_write_callback` has to
+        // re-apply every side effect those chokepoints perform. Before #5479
+        // that callback was built TWICE — once in `from_config`, once in
+        // `from_config_with_shared_modules` — as copy-paste twins, which is
+        // exactly the shape that lets a side effect be added to one and not
+        // the other. There is now ONE builder and ONE installer.
+        let installs = count_call_sites(RUNTIME_SRC, "rt.set_state_write_callback(");
         assert_eq!(
-            count, 2,
-            "expected exactly 2 `cache_invalidator.invalidate(` calls in \
-             runtime.rs (one per V2 state_write_callback installer); found \
-             {count}. If a callback installer stopped invalidating StateStore's \
-             caches, a V2 delegate state write would leave stale cached state \
-             and the summarize/delta fast path could serve a stale result."
+            installs, 1,
+            "expected exactly 1 `rt.set_state_write_callback(` site in \
+             runtime.rs (inside install_v2_delegate_state_write_hooks); found \
+             {installs}. A second installer is a copy-paste twin waiting to \
+             drift — extend the shared one instead."
         );
+        let callers =
+            count_call_sites(RUNTIME_SRC, "install_v2_delegate_state_write_hooks(&mut rt");
+        assert_eq!(
+            callers, 2,
+            "expected both executor constructors (`from_config` and \
+             `from_config_with_shared_modules`) to call \
+             install_v2_delegate_state_write_hooks; found {callers} call sites."
+        );
+
+        // And the one callback must still do all three legs. Anchored on API
+        // surface, not local names, so a rename inside it cannot pass vacuously.
+        let start = RUNTIME_SRC
+            .find("pub(super) fn v2_delegate_state_write_callback(")
+            .expect("v2_delegate_state_write_callback must exist");
+        let body = &RUNTIME_SRC[start..];
+        let end = body
+            .find("\nimpl Executor<Runtime> {")
+            .expect("the callback builder sits just above impl Executor<Runtime>");
+        let body = &body[..end];
+        for required in [
+            "cache_invalidator.invalidate(",
+            ".commit_state_write(",
+            "NodeEvent::BroadcastStateChange",
+            "is_contract_broken(",
+        ] {
+            assert!(
+                body.contains(required),
+                "the V2 delegate write callback must invoke `{required}`. \
+                 Dropping the invalidation serves stale bytes and stale \
+                 summaries; dropping commit_state_write re-opens the \
+                 EvictContract race and undercounts the meter; dropping \
+                 BroadcastStateChange is #5479 (the write returns success \
+                 and the network never learns of it); dropping the \
+                 broken-contract check re-engages a suppressed storm."
+            );
+        }
     }
 }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -457,7 +457,9 @@ pub(super) fn v2_delegate_state_write_callback(
     op_manager: Option<Arc<OpManager>>,
 ) -> crate::wasm_runtime::StateWriteCallback {
     Arc::new(
-        move |key: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+        move |key: &ContractKey,
+              new_state: &freenet_stdlib::prelude::WrappedState,
+              content_changed: bool| {
             cache_invalidator.invalidate(key);
             let Some(op_manager) = &op_manager else {
                 return;
@@ -491,6 +493,21 @@ pub(super) fn v2_delegate_state_write_callback(
             //
             // Not registered with `ring::broadcast_coverage` — see the
             // residual list in that module, which this path is named in.
+            // Everything above is owed for ANY committed write. Only the
+            // network fan-out below is skipped when the bytes did not change:
+            // it is the one leg an idempotent rewrite genuinely does not need,
+            // and the one whose cost scales with the subscriber set.
+            //
+            // The generation bump inside `commit_state_write` is why the split
+            // is here rather than at the caller: it is what tells a scheduled
+            // `EvictContract` the contract was written after it was queued
+            // (`pool.rs::remove_contract` guard 3). A V2 write has already
+            // committed to storage by the time this runs, so gating the whole
+            // hook on `content_changed` let an in-flight eviction reclaim a
+            // contract that had just been written.
+            if !content_changed {
+                return;
+            }
             if op_manager.ring.is_contract_broken(key) {
                 tracing::debug!(
                     contract = %key,
@@ -3041,7 +3058,7 @@ mod state_write_attribution_pin_tests {
              {hook_calls}"
         );
         // …and exactly one place that actually invokes the callback.
-        let invocations = count_call_sites(NATIVE_API_SRC, "cb(contract_key, new_state)");
+        let invocations = count_call_sites(NATIVE_API_SRC, "cb(contract_key, new_state, content_changed)");
         assert_eq!(
             invocations, 1,
             "expected exactly 1 callback invocation in native_api.rs (inside \

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -994,9 +994,25 @@ pub(crate) enum NodeEvent {
     ///   oldest.
     ///
     /// The re-read costs one contract-handler `GetQuery` per drained
-    /// broadcast, which is why the coalescing matters: the cost is per
-    /// drain, not per write. This mirrors the #4359 deferred-broadcast flush,
-    /// which re-reads for the same stale-state reason.
+    /// broadcast, which is why the coalescing matters: the cost is per drain,
+    /// not per write. It is BOUNDED at the drain site — that read runs inline
+    /// on the network event loop, where an unbounded await is the #4549 wedge.
+    ///
+    /// It shares the PRINCIPLE of the #4359 deferred-broadcast flush — re-read
+    /// rather than carry bytes that may have been superseded — but is not the
+    /// same mechanism, and the differences are the ones a reader would
+    /// otherwise assume away:
+    ///
+    /// * **When the read happens.** #4359 reads at the TRIGGER and
+    ///   synchronously builds a state-carrying event. This path reads at the
+    ///   DRAIN, because the write callback that queues it is synchronous inside
+    ///   a WASM host call and cannot `.await` anything.
+    /// * **What happens when the read fails.** #4359 falls back to the bytes it
+    ///   stashed (`read_current_state().await.unwrap_or(stashed)`), so it always
+    ///   emits something. This path stashes nothing, so a failed read has no
+    ///   fallback: it is reported and dropped, and the state is re-announced by
+    ///   the next write or by anti-entropy. See the `Unavailable` arm at the
+    ///   drain site.
     V2DelegateStateChanged {
         key: ContractKey,
     },

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -971,6 +971,35 @@ pub(crate) enum NodeEvent {
         /// and retry re-emissions.
         is_reemit: bool,
     },
+    /// A V2 delegate wrote contract state; fan the change out to the network.
+    ///
+    /// DISPATCH: this ends in the same all-subscriber fan-out as
+    /// [`Self::BroadcastStateChange`] — the handler resolves the state and
+    /// hands it to `handle_broadcast_state_change`, which sends to EVERY
+    /// advertised co-host of the contract. It is not targeted at one peer.
+    ///
+    /// Carries the contract id and NO state. The handler re-reads the current
+    /// stored state when it drains, which gives two properties the
+    /// state-carrying variant cannot:
+    ///
+    /// * **Queue cost is independent of state size.** A queued event is one
+    ///   contract id, not a `WrappedState` of up to `MAX_STATE_SIZE`, so the
+    ///   channel's message-count bound is also a bound on the bytes these
+    ///   events retain.
+    /// * **Pending broadcasts for one contract coalesce.** While a broadcast
+    ///   is queued for a contract, further writes to it enqueue nothing (see
+    ///   `OpManager::queue_v2_delegate_broadcast`), and the single drain
+    ///   broadcasts whatever is stored by the time it runs — so a burst of
+    ///   writes costs one fan-out, carrying the newest state rather than the
+    ///   oldest.
+    ///
+    /// The re-read costs one contract-handler `GetQuery` per drained
+    /// broadcast, which is why the coalescing matters: the cost is per
+    /// drain, not per write. This mirrors the #4359 deferred-broadcast flush,
+    /// which re-reads for the same stale-state reason.
+    V2DelegateStateChanged {
+        key: ContractKey,
+    },
     /// Send state to a specific peer that reported a stale summary.
     /// Unlike BroadcastStateChange (which fans out to ALL subscribers),
     /// this targets only the peer that needs catching up.
@@ -1120,6 +1149,9 @@ impl Display for NodeEvent {
             }
             NodeEvent::BroadcastStateChange { key, .. } => {
                 write!(f, "BroadcastStateChange (contract: {key})")
+            }
+            NodeEvent::V2DelegateStateChanged { key } => {
+                write!(f, "V2DelegateStateChanged (contract: {key})")
             }
             NodeEvent::SyncStateToPeer { key, target, .. } => {
                 write!(f, "SyncStateToPeer (contract: {key}, target: {target})")

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -89,7 +89,12 @@ pub(crate) use op_state_manager::OpManager;
 // outcome and its bound from outside `node`. Both were untestable from
 // `contract::executor::pool_tests` while these modules were private, which is
 // part of why the drain path had no behavioural coverage at all.
+// `#[cfg(test)]`: both are reached only from `pool_tests`, so an unqualified
+// re-export is an unused import in a non-test build -- and CI runs clippy with
+// `-D warnings`, which turns that into a build failure.
+#[cfg(test)]
 pub(crate) use network_bridge::p2p_protoc::V2_BROADCAST_DRAIN_READ_TIMEOUT;
+#[cfg(test)]
 pub(crate) use op_state_manager::DrainStateRead;
 
 mod network_bridge;

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -85,6 +85,12 @@ pub use network_bridge::{EventLoopExitReason, NetworkStats, reset_channel_id_cou
 use crate::topology::rate::Rate;
 use crate::transport::{TransportKeypair, TransportPublicKey};
 pub(crate) use op_state_manager::OpManager;
+// Re-exported so the V2 propagation tests can assert on the drain read's
+// outcome and its bound from outside `node`. Both were untestable from
+// `contract::executor::pool_tests` while these modules were private, which is
+// part of why the drain path had no behavioural coverage at all.
+pub(crate) use network_bridge::p2p_protoc::V2_BROADCAST_DRAIN_READ_TIMEOUT;
+pub(crate) use op_state_manager::DrainStateRead;
 
 mod network_bridge;
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -53,6 +53,7 @@ mod broadcast;
 mod connection_lifecycle;
 mod dispatch;
 mod migration;
+mod v2_drain;
 
 /// Represents the different ways the event loop can exit.
 ///
@@ -3036,147 +3037,28 @@ impl P2pConnManager {
                                 .await;
                             }
                             NodeEvent::V2DelegateStateChanged { key } => {
-                                // Clear the coalescing marker BEFORE the read.
-                                // A write landing during the read then queues a
-                                // fresh event instead of being folded into this
-                                // one, which is already past the point where it
-                                // could observe it. Clearing after the read
-                                // would drop that write's fan-out.
+                                // Extracted so it is reachable from a test —
+                                // see `v2_drain`, and the mutation results that
+                                // motivated it. Inline in this `select!` arm,
+                                // deleting the fan-out left the whole suite
+                                // green.
                                 //
-                                // The marker also stays clear for the whole
-                                // fan-out below, so a write landing mid-fan-out
-                                // queues a fresh event and re-sends bytes
-                                // already going out. Correct but wasteful, on
-                                // the sink #5147/#5153 exist to shrink.
-                                // Deliberate: holding the marker until the
-                                // fan-out completes would trade a duplicate
-                                // send for a DROPPED one, and a drop here is
-                                // unrecoverable until the next write.
-                                op_manager.clear_v2_delegate_broadcast_pending(&key);
-                                // The event carries no state; read what is
-                                // stored now. BOUNDED (#4549 — this runs inline
-                                // on the event loop) and three-way, because
-                                // "we do not hold it" and "the read failed"
-                                // need opposite handling.
-                                match op_manager
-                                    .read_state_for_broadcast_drain(
-                                        &key,
-                                        V2_BROADCAST_DRAIN_READ_TIMEOUT,
-                                    )
-                                    .await
-                                {
-                                    crate::node::op_state_manager::DrainStateRead::Found(
-                                        new_state,
-                                    ) => {
-                                        ctx.v2_drain_retries.remove(&key);
-                                        ctx.handle_broadcast_state_change(
-                                            &op_manager,
-                                            key,
-                                            new_state,
-                                            false,
-                                            false,
-                                        )
-                                        .await;
-                                    }
-                                    crate::node::op_state_manager::DrainStateRead::NotHeld => {
-                                        // Definitive: retrying cannot change it.
-                                        ctx.v2_drain_retries.remove(&key);
-                                        tracing::debug!(
-                                            contract = %key,
-                                            "V2 delegate broadcast drained for a contract we \
-                                             do not hold; nothing to send"
-                                        );
-                                    }
-                                    crate::node::op_state_manager::DrainStateRead::Unavailable => {
-                                        // The read is a GetQuery to the serial
-                                        // contract-handling loop, and the event
-                                        // being drained was queued by a delegate
-                                        // write that ran ON that loop — so this
-                                        // read waits for the delegate that
-                                        // caused it. A bounded retry recovers a
-                                        // delegate that was merely busy.
-                                        //
-                                        // Re-queueing is safe: the marker was
-                                        // cleared before the read, so a fresh
-                                        // write is free to queue its own event
-                                        // and at worst we fan out twice.
-                                        let attempt = ctx.v2_drain_retries.entry(key).or_insert(0);
-                                        // Linear backoff with +/-20% jitter so a
-                                        // burst of contracts failing together
-                                        // does not retry in lockstep against the
-                                        // one serial loop that was already too
-                                        // busy to answer (`code-style.md`).
-                                        let jitter_pct: u64 =
-                                            crate::config::GlobalRng::random_range(80u64..=120u64);
-                                        if let Some(delay) =
-                                            Self::plan_v2_drain_retry(*attempt, jitter_pct)
-                                        {
-                                            *attempt += 1;
-                                            let op_mgr = op_manager.clone();
-                                            let shutdown = op_manager.ring.shutdown_token();
-                                            tokio::spawn(async move {
-                                                // Interruptible: a >=1s plain
-                                                // sleep in a retry loop would
-                                                // keep this task alive past
-                                                // shutdown (`code-style.md`).
-                                                tokio::select! {
-                                                    _ = shutdown.cancelled() => return,
-                                                    _ = tokio::time::sleep(delay) => {}
-                                                }
-                                                // Through the marker-respecting
-                                                // API, not a raw emit: if a
-                                                // fresh write has already queued
-                                                // its own drain for this
-                                                // contract, this retry coalesces
-                                                // into it instead of adding a
-                                                // second event.
-                                                // NOTHING IS COUNTED HERE.
-                                                // This site used to count every
-                                                // non-`Queued` outcome as a
-                                                // dropped broadcast, which was
-                                                // wrong in both directions — see
-                                                // the arms. The drop WARN fires
-                                                // at powers of two, so inflating
-                                                // the counter with benign
-                                                // coalesces pushes the next
-                                                // milestone exponentially out of
-                                                // reach and a genuine drop then
-                                                // logs nothing at all.
-                                                match op_mgr.queue_v2_delegate_broadcast(key) {
-                                                    // The retry did its job.
-                                                    crate::node::op_state_manager::V2BroadcastQueued::Queued => {}
-                                                    // A fresh write queued its
-                                                    // own drain while we slept.
-                                                    // That drain re-reads stored
-                                                    // state, so this write is
-                                                    // announced by it. Nothing
-                                                    // was lost and nothing is
-                                                    // counted.
-                                                    crate::node::op_state_manager::V2BroadcastQueued::Coalesced => {}
-                                                    // A real drop, but already
-                                                    // counted and WARNed inside
-                                                    // the call. Counting it here
-                                                    // too would report one event
-                                                    // twice across two separate
-                                                    // counters.
-                                                    crate::node::op_state_manager::V2BroadcastQueued::EnqueueFailed => {}
-                                                }
-                                            });
-                                        } else {
-                                            // Retries exhausted. A write that
-                                            // already committed and already
-                                            // returned success to the delegate
-                                            // now goes unannounced.
-                                            //
-                                            // WARN, not debug: `release_max_level_info`
-                                            // compiles debug out, and a drop that
-                                            // leaves no evidence in a release build
-                                            // is the #4981 shape.
-                                            ctx.v2_drain_retries.remove(&key);
-                                            note_v2_broadcast_drain_dropped(&key);
-                                        }
-                                    }
-                                }
+                                // Linear backoff with +/-20% jitter so a burst
+                                // of contracts failing together does not retry
+                                // in lockstep against the one serial loop that
+                                // was already too busy to answer
+                                // (`code-style.md`). Drawn here, not inside, so
+                                // the retry arithmetic is deterministic under
+                                // test.
+                                let jitter_pct: u64 =
+                                    crate::config::GlobalRng::random_range(80u64..=120u64);
+                                v2_drain::handle_v2_delegate_state_changed(
+                                    &mut ctx,
+                                    &op_manager,
+                                    key,
+                                    jitter_pct,
+                                )
+                                .await;
                             }
                             NodeEvent::SyncStateToPeer {
                                 key,
@@ -5606,103 +5488,6 @@ pub(crate) mod tests {
                 "jitter must stay within the documented +/-20% band at attempt {attempts}"
             );
         }
-    }
-
-    /// Every terminal outcome of the V2 drain must drop its retry entry.
-    ///
-    /// `v2_drain_retries` is keyed by contract and bounded only by removal
-    /// discipline — there is no size cap (matching the neighbouring
-    /// `broadcast_retries`). So an arm that forgets to remove leaks one entry
-    /// per contract that ever hit it, and nothing else in the tree would catch
-    /// it: the map is not observable from any behavioural test of this loop.
-    ///
-    /// All three arms are terminal for the retry: `Found` sent it, `NotHeld` is
-    /// definitive, and the exhausted branch has given up. Only the still-retrying
-    /// branch may leave an entry in place.
-    #[test]
-    fn v2_drain_retry_entries_are_dropped_on_every_terminal_outcome() {
-        const SOURCE: &str = include_str!("p2p_protoc.rs");
-
-        let arm_anchor = "NodeEvent::V2DelegateStateChanged { key } => {";
-        let arm_start = SOURCE
-            .find(arm_anchor)
-            .expect("the V2DelegateStateChanged dispatch arm is gone — update this pin");
-        let after = &SOURCE[arm_start..];
-        let arm_end = after
-            .find("NodeEvent::SyncStateToPeer {")
-            .map(|p| arm_start + p)
-            .unwrap_or(SOURCE.len());
-        let arm = &SOURCE[arm_start..arm_end];
-
-        let removals = arm.matches("v2_drain_retries.remove(&key)").count();
-        assert_eq!(
-            removals, 3,
-            "expected exactly 3 `v2_drain_retries.remove(&key)` sites in the V2 drain arm \
-             (Found, NotHeld, and retries-exhausted); found {removals}. Fewer means a \
-             terminal outcome leaks one map entry per contract that reaches it, and the map \
-             has no size cap. More means a still-retrying path is dropping its own counter, \
-             which makes the retry unbounded."
-        );
-    }
-
-    /// The V2 drain must clear the coalescing marker BEFORE it reads state.
-    ///
-    /// This ordering is the whole lost-write story and nothing else pins it.
-    /// The behavioural tests in `v2_delegate_propagation_tests` drive the write
-    /// callback and call `clear_v2_delegate_broadcast_pending` THEMSELVES to
-    /// simulate the handler, so they never observe this site at all: moving the
-    /// clear below the read — the single edit that reopens the window — leaves
-    /// every one of them green.
-    ///
-    /// Why the order matters: between the read and the fan-out, a delegate may
-    /// write again. If the marker is still set at that moment the new write
-    /// coalesces into THIS drain, which has already read and cannot see it, and
-    /// its fan-out never happens. Clearing first means such a write queues a
-    /// fresh event instead. The cost is a possible duplicate fan-out; the
-    /// alternative is a silently dropped one, which is #5479 again.
-    #[test]
-    fn v2_drain_clears_marker_before_reading_state() {
-        const SOURCE: &str = include_str!("p2p_protoc.rs");
-
-        let arm_anchor = "NodeEvent::V2DelegateStateChanged { key } => {";
-        let arm_start = SOURCE
-            .find(arm_anchor)
-            .expect("the V2DelegateStateChanged dispatch arm is gone — update this pin");
-        // Bound at the next dispatch arm so a later arm's text cannot satisfy
-        // the assertion.
-        let after = &SOURCE[arm_start..];
-        // Bounded, and it must FAIL rather than fall through: an
-        // `unwrap_or(SOURCE.len())` would absorb the rest of the file including
-        // this test's own `expect` strings, which contain both needles in the
-        // passing order — a vacuous pass triggered by nothing worse than the
-        // arms being reordered.
-        let arm_end = arm_start
-            + after.find("NodeEvent::SyncStateToPeer {").expect(
-                "SyncStateToPeer arm no longer follows the V2 drain arm — this pin \
-                         bounds its search on it, and without a bound it would scan its own \
-                         assertion text and pass vacuously. Re-anchor it.",
-            );
-        // Strip line comments before searching: `arm.find(..)` matches inside a
-        // comment, so COMMENTING OUT the clear left this pin green. The call it
-        // guards is the whole lost-write story.
-        let arm: String = SOURCE[arm_start..arm_end]
-            .lines()
-            .filter(|l| !l.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let arm = arm.as_str();
-
-        let clear_pos = arm.find("clear_v2_delegate_broadcast_pending(").expect(
-            "the V2 drain no longer clears the coalescing marker. Without the clear the              marker latches: every later write to this contract coalesces into a              broadcast that has already drained, and the contract stops propagating",
-        );
-        let read_pos = arm
-            .find("read_state_for_broadcast_drain(")
-            .expect("the V2 drain no longer reads state — update this pin");
-
-        assert!(
-            clear_pos < read_pos,
-            "the V2 drain must clear the coalescing marker (offset {clear_pos}) BEFORE              reading state (offset {read_pos}). Clearing afterwards means a write that              lands during the read coalesces into a drain that has already read past it,              and that write is never announced. Arm:\n{arm}"
-        );
     }
 
     /// Phase 7 egress self-block pin (#4300). `handle_broadcast_state_change`

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2971,6 +2971,16 @@ impl P2pConnManager {
                                 // one, which is already past the point where it
                                 // could observe it. Clearing after the read
                                 // would drop that write's fan-out.
+                                //
+                                // The marker also stays clear for the whole
+                                // fan-out below, so a write landing mid-fan-out
+                                // queues a fresh event and re-sends bytes
+                                // already going out. Correct but wasteful, on
+                                // the sink #5147/#5153 exist to shrink.
+                                // Deliberate: holding the marker until the
+                                // fan-out completes would trade a duplicate
+                                // send for a DROPPED one, and a drop here is
+                                // unrecoverable until the next write.
                                 op_manager.clear_v2_delegate_broadcast_pending(&key);
                                 // The event carries no state; read what is
                                 // stored now. BOUNDED (#4549 — this runs inline
@@ -5395,6 +5405,51 @@ pub(crate) mod tests {
              fan-out and names peers that fan-out never touched — \
              over-suppression. Every queue test passes an empty fanout, so no \
              behavioural test distinguishes the two."
+        );
+    }
+
+    /// The V2 drain must clear the coalescing marker BEFORE it reads state.
+    ///
+    /// This ordering is the whole lost-write story and nothing else pins it.
+    /// The behavioural tests in `v2_delegate_propagation_tests` drive the write
+    /// callback and call `clear_v2_delegate_broadcast_pending` THEMSELVES to
+    /// simulate the handler, so they never observe this site at all: moving the
+    /// clear below the read — the single edit that reopens the window — leaves
+    /// every one of them green.
+    ///
+    /// Why the order matters: between the read and the fan-out, a delegate may
+    /// write again. If the marker is still set at that moment the new write
+    /// coalesces into THIS drain, which has already read and cannot see it, and
+    /// its fan-out never happens. Clearing first means such a write queues a
+    /// fresh event instead. The cost is a possible duplicate fan-out; the
+    /// alternative is a silently dropped one, which is #5479 again.
+    #[test]
+    fn v2_drain_clears_marker_before_reading_state() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let arm_anchor = "NodeEvent::V2DelegateStateChanged { key } => {";
+        let arm_start = SOURCE
+            .find(arm_anchor)
+            .expect("the V2DelegateStateChanged dispatch arm is gone — update this pin");
+        // Bound at the next dispatch arm so a later arm's text cannot satisfy
+        // the assertion.
+        let after = &SOURCE[arm_start..];
+        let arm_end = after
+            .find("NodeEvent::SyncStateToPeer {")
+            .map(|p| arm_start + p)
+            .unwrap_or(SOURCE.len());
+        let arm = &SOURCE[arm_start..arm_end];
+
+        let clear_pos = arm.find("clear_v2_delegate_broadcast_pending(").expect(
+            "the V2 drain no longer clears the coalescing marker. Without the clear the              marker latches: every later write to this contract coalesces into a              broadcast that has already drained, and the contract stops propagating",
+        );
+        let read_pos = arm
+            .find("read_state_for_broadcast_drain(")
+            .expect("the V2 drain no longer reads state — update this pin");
+
+        assert!(
+            clear_pos < read_pos,
+            "the V2 drain must clear the coalescing marker (offset {clear_pos}) BEFORE              reading state (offset {read_pos}). Clearing afterwards means a write that              lands during the read coalesces into a drain that has already read past it,              and that write is never announced. Arm:\n{arm}"
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -154,8 +154,10 @@ fn note_v2_broadcast_drain_dropped(key: &freenet_stdlib::prelude::ContractKey) {
              loop being held by the delegate that made this write — a delegate awaiting user \
              input holds it for a human-scale time and will not be recovered by retries \
              (#5544/#5554 remove that precondition). The write is committed locally; a peer \
-             hosting or using this contract re-learns it within one anti-entropy round \
-             (INTEREST_HEARTBEAT_INTERVAL, 300s), or sooner on the delegate's next write. \
+             hosting or using this contract re-learns it within about one anti-entropy \
+             round — up to INTEREST_HEARTBEAT_INTERVAL (300s), and STAGGERED rather than \
+             swept, since the heartbeat spreads its sends across the interval — or sooner \
+             on the delegate's next write. \
              Logged at power-of-two milestones (#4238)."
         );
     }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2935,6 +2935,36 @@ impl P2pConnManager {
                                 )
                                 .await;
                             }
+                            NodeEvent::V2DelegateStateChanged { key } => {
+                                // Clear the coalescing marker BEFORE the read.
+                                // A write landing during the read then queues a
+                                // fresh event instead of being folded into this
+                                // one, which is already past the point where it
+                                // could observe it. Clearing after the read
+                                // would drop that write's fan-out.
+                                op_manager.clear_v2_delegate_broadcast_pending(&key);
+                                // The event carries no state; read what is
+                                // stored now. A contract we no longer hold
+                                // reads as None and is simply not broadcast.
+                                if let Some(new_state) =
+                                    op_manager.read_current_contract_state(&key).await
+                                {
+                                    ctx.handle_broadcast_state_change(
+                                        &op_manager,
+                                        key,
+                                        new_state,
+                                        false,
+                                        false,
+                                    )
+                                    .await;
+                                } else {
+                                    tracing::debug!(
+                                        contract = %key,
+                                        "V2 delegate broadcast drained but no local state to \
+                                         send; skipping fan-out"
+                                    );
+                                }
+                            }
                             NodeEvent::SyncStateToPeer {
                                 key,
                                 new_state,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -118,12 +118,6 @@ const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
 static V2_BROADCAST_DRAINS_DROPPED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-/// Read [`V2_BROADCAST_DRAINS_DROPPED`]. Test/diagnostics accessor.
-#[cfg(test)]
-pub(crate) fn v2_broadcast_drains_dropped() -> u64 {
-    V2_BROADCAST_DRAINS_DROPPED.load(std::sync::atomic::Ordering::Relaxed)
-}
-
 /// Best-effort, bounded query to the contract handler for application-level
 /// subscriptions, used by the diagnostics arms of the network event loop (#4549).
 ///
@@ -2990,7 +2984,9 @@ impl P2pConnManager {
                                     )
                                     .await
                                 {
-                                    crate::node::op_state_manager::DrainStateRead::Found(new_state) => {
+                                    crate::node::op_state_manager::DrainStateRead::Found(
+                                        new_state,
+                                    ) => {
                                         ctx.handle_broadcast_state_change(
                                             &op_manager,
                                             key,

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -89,6 +89,41 @@ impl std::error::Error for EventLoopExitReason {}
 /// result on timeout rather than freezing (or, previously, killing) the listener.
 const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Bound on the state read the V2 delegate broadcast drain performs.
+///
+/// Same hazard and same remedy as [`QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT`]: the
+/// read runs INLINE on the network event loop, and the handler's own timeout is
+/// `CH_EV_RESPONSE_TIME_OUT` (300 s), so an unbounded await here is the #4549
+/// wedge — a saturated contract handler stalls, then kills, the listener.
+///
+/// Shorter than the diagnostics bound (5 s) on purpose. That one serves an
+/// operator poll where a slow answer still beats none; this one only decides
+/// whether a broadcast goes out now or waits for the next write, and the loop
+/// it blocks warns at 100 ms of iteration time. Failing fast and letting
+/// anti-entropy heal is the better trade here, so the cap is the smallest that
+/// still clears a normally-loaded handler rather than the largest that is
+/// tolerable.
+const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Count of V2 delegate broadcasts dropped because the drain could not read
+/// local state.
+///
+/// A counter, not only a log line: `crates/core/Cargo.toml` enables tracing's
+/// `release_max_level_info`, so anything logged below INFO does not exist in a
+/// release binary. The accompanying message is therefore WARN, and this counter
+/// gives the same fact a form an operator can poll and graph rather than grep.
+/// `.claude/rules/code-style.md` requires exactly this of a drop that is
+/// invisible on the happy path — a refusal that is not counted renders as a
+/// clean zero.
+static V2_BROADCAST_DRAINS_DROPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Read [`V2_BROADCAST_DRAINS_DROPPED`]. Test/diagnostics accessor.
+#[cfg(test)]
+pub(crate) fn v2_broadcast_drains_dropped() -> u64 {
+    V2_BROADCAST_DRAINS_DROPPED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Best-effort, bounded query to the contract handler for application-level
 /// subscriptions, used by the diagnostics arms of the network event loop (#4549).
 ///
@@ -2944,25 +2979,56 @@ impl P2pConnManager {
                                 // would drop that write's fan-out.
                                 op_manager.clear_v2_delegate_broadcast_pending(&key);
                                 // The event carries no state; read what is
-                                // stored now. A contract we no longer hold
-                                // reads as None and is simply not broadcast.
-                                if let Some(new_state) =
-                                    op_manager.read_current_contract_state(&key).await
-                                {
-                                    ctx.handle_broadcast_state_change(
-                                        &op_manager,
-                                        key,
-                                        new_state,
-                                        false,
-                                        false,
+                                // stored now. BOUNDED (#4549 — this runs inline
+                                // on the event loop) and three-way, because
+                                // "we do not hold it" and "the read failed"
+                                // need opposite handling.
+                                match op_manager
+                                    .read_state_for_broadcast_drain(
+                                        &key,
+                                        V2_BROADCAST_DRAIN_READ_TIMEOUT,
                                     )
-                                    .await;
-                                } else {
-                                    tracing::debug!(
-                                        contract = %key,
-                                        "V2 delegate broadcast drained but no local state to \
-                                         send; skipping fan-out"
-                                    );
+                                    .await
+                                {
+                                    crate::node::op_state_manager::DrainStateRead::Found(new_state) => {
+                                        ctx.handle_broadcast_state_change(
+                                            &op_manager,
+                                            key,
+                                            new_state,
+                                            false,
+                                            false,
+                                        )
+                                        .await;
+                                    }
+                                    crate::node::op_state_manager::DrainStateRead::NotHeld => {
+                                        tracing::debug!(
+                                            contract = %key,
+                                            "V2 delegate broadcast drained for a contract we \
+                                             do not hold; nothing to send"
+                                        );
+                                    }
+                                    crate::node::op_state_manager::DrainStateRead::Unavailable => {
+                                        // A write that already committed and
+                                        // already returned success to the
+                                        // delegate now goes unannounced. WARN,
+                                        // not debug: `release_max_level_info`
+                                        // compiles debug out, and a drop that
+                                        // leaves no evidence in a release build
+                                        // is the #4981 shape.
+                                        let dropped = V2_BROADCAST_DRAINS_DROPPED
+                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                            + 1;
+                                        tracing::warn!(
+                                            contract = %key,
+                                            dropped_total = dropped,
+                                            timeout_secs =
+                                                V2_BROADCAST_DRAIN_READ_TIMEOUT.as_secs(),
+                                            "V2 delegate broadcast dropped: could not read \
+                                             local state to announce. The write is committed \
+                                             locally; the network learns of it on the next \
+                                             write or via anti-entropy"
+                                        );
+                                    }
                                 }
                             }
                             NodeEvent::SyncStateToPeer {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -780,6 +780,15 @@ pub(in crate::node) struct P2pConnManager {
     blocked_addresses: Option<HashSet<SocketAddr>>,
     /// Per-contract retry count for broadcasts that found no targets yet.
     broadcast_retries: HashMap<freenet_stdlib::prelude::ContractKey, u8>,
+    /// Per-contract retry count for a V2 delegate broadcast drain whose state
+    /// read came back `Unavailable`.
+    ///
+    /// Separate from `broadcast_retries`, which counts a different failure (a
+    /// fan-out that resolved no targets). This one counts "we could not read
+    /// what to send". Bounded by [`Self::MAX_V2_DRAIN_RETRIES`]; the entry is
+    /// removed on success, on a definitive `NotHeld`, and on exhaustion, so it
+    /// cannot accumulate per contract.
+    v2_drain_retries: HashMap<freenet_stdlib::prelude::ContractKey, u8>,
     /// Tracks how many consecutive broadcast cycles found zero targets per contract.
     /// Used to suppress repetitive WARN logs after the first few failures.
     /// Bounded to MAX_BROADCAST_STREAK_ENTRIES to prevent unbounded growth from
@@ -1351,6 +1360,7 @@ impl P2pConnManager {
             congestion_config: config.config.network_api.build_congestion_config(),
             blocked_addresses: config.blocked_addresses.clone(),
             broadcast_retries: HashMap::new(),
+            v2_drain_retries: HashMap::new(),
             broadcast_no_target_streak: HashMap::new(),
             #[cfg(not(feature = "simulation_tests"))]
             broadcast_queue: super::broadcast_queue::BroadcastQueue::new(),
@@ -1419,6 +1429,7 @@ impl P2pConnManager {
             ack_version_floor_override,
             blocked_addresses,
             broadcast_retries,
+            v2_drain_retries,
             broadcast_no_target_streak,
             #[cfg(not(feature = "simulation_tests"))]
             broadcast_queue,
@@ -1514,6 +1525,7 @@ impl P2pConnManager {
             ack_version_floor_override,
             blocked_addresses,
             broadcast_retries,
+            v2_drain_retries,
             broadcast_no_target_streak,
             #[cfg(not(feature = "simulation_tests"))]
             broadcast_queue: broadcast_queue.clone(),
@@ -2997,6 +3009,7 @@ impl P2pConnManager {
                                     crate::node::op_state_manager::DrainStateRead::Found(
                                         new_state,
                                     ) => {
+                                        ctx.v2_drain_retries.remove(&key);
                                         ctx.handle_broadcast_state_change(
                                             &op_manager,
                                             key,
@@ -3007,6 +3020,8 @@ impl P2pConnManager {
                                         .await;
                                     }
                                     crate::node::op_state_manager::DrainStateRead::NotHeld => {
+                                        // Definitive: retrying cannot change it.
+                                        ctx.v2_drain_retries.remove(&key);
                                         tracing::debug!(
                                             contract = %key,
                                             "V2 delegate broadcast drained for a contract we \
@@ -3014,26 +3029,92 @@ impl P2pConnManager {
                                         );
                                     }
                                     crate::node::op_state_manager::DrainStateRead::Unavailable => {
-                                        // A write that already committed and
-                                        // already returned success to the
-                                        // delegate now goes unannounced. WARN,
-                                        // not debug: `release_max_level_info`
-                                        // compiles debug out, and a drop that
-                                        // leaves no evidence in a release build
-                                        // is the #4981 shape.
-                                        let dropped = V2_BROADCAST_DRAINS_DROPPED
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                                            + 1;
-                                        tracing::warn!(
-                                            contract = %key,
-                                            dropped_total = dropped,
-                                            timeout_secs =
-                                                V2_BROADCAST_DRAIN_READ_TIMEOUT.as_secs(),
-                                            "V2 delegate broadcast dropped: could not read \
-                                             local state to announce. The write is committed \
-                                             locally; the network learns of it on the next \
-                                             write or via anti-entropy"
-                                        );
+                                        // The read is a GetQuery to the serial
+                                        // contract-handling loop, and the event
+                                        // being drained was queued by a delegate
+                                        // write that ran ON that loop — so this
+                                        // read waits for the delegate that
+                                        // caused it. A bounded retry recovers a
+                                        // delegate that was merely busy.
+                                        //
+                                        // Re-queueing is safe: the marker was
+                                        // cleared before the read, so a fresh
+                                        // write is free to queue its own event
+                                        // and at worst we fan out twice.
+                                        let attempt = ctx.v2_drain_retries.entry(key).or_insert(0);
+                                        if *attempt < Self::MAX_V2_DRAIN_RETRIES {
+                                            *attempt += 1;
+                                            let delay = Self::V2_DRAIN_RETRY_BASE_DELAY
+                                                * u32::from(*attempt);
+                                            let op_mgr = op_manager.clone();
+                                            tokio::spawn(async move {
+                                                tokio::time::sleep(delay).await;
+                                                if op_mgr
+                                                    .try_notify_node_event(
+                                                        crate::message::NodeEvent::
+                                                            V2DelegateStateChanged { key },
+                                                    )
+                                                    .is_err()
+                                                {
+                                                    // The retry never got queued,
+                                                    // so the outcome is the same
+                                                    // as exhausting them: this
+                                                    // write goes unannounced.
+                                                    // Counted and WARNed for that
+                                                    // reason rather than dropped
+                                                    // quietly.
+                                                    let dropped =
+                                                        V2_BROADCAST_DRAINS_DROPPED.fetch_add(
+                                                            1,
+                                                            std::sync::atomic::Ordering::Relaxed,
+                                                        ) + 1;
+                                                    tracing::warn!(
+                                                        contract = %key,
+                                                        dropped_total = dropped,
+                                                        "V2 delegate broadcast dropped: the \
+                                                         drain retry could not be re-queued. \
+                                                         The write is committed locally; a \
+                                                         peer hosting or using this contract \
+                                                         re-learns it within one anti-entropy \
+                                                         round (300s), or sooner on the \
+                                                         delegate's next write"
+                                                    );
+                                                }
+                                            });
+                                        } else {
+                                            // Retries exhausted. A write that
+                                            // already committed and already
+                                            // returned success to the delegate
+                                            // now goes unannounced.
+                                            //
+                                            // WARN, not debug: `release_max_level_info`
+                                            // compiles debug out, and a drop that
+                                            // leaves no evidence in a release build
+                                            // is the #4981 shape.
+                                            ctx.v2_drain_retries.remove(&key);
+                                            let dropped = V2_BROADCAST_DRAINS_DROPPED
+                                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                                + 1;
+                                            tracing::warn!(
+                                                contract = %key,
+                                                dropped_total = dropped,
+                                                retries = Self::MAX_V2_DRAIN_RETRIES,
+                                                timeout_secs =
+                                                    V2_BROADCAST_DRAIN_READ_TIMEOUT.as_secs(),
+                                                "V2 delegate broadcast dropped after retries: \
+                                                 could not read local state to announce. The \
+                                                 usual cause is the contract-handling loop \
+                                                 being held by the delegate that made this \
+                                                 write — a delegate awaiting user input holds \
+                                                 it for a human-scale time and will not be \
+                                                 recovered by retries (#5544/#5554 remove \
+                                                 that precondition). The write is committed \
+                                                 locally; a peer that is hosting or has this \
+                                                 contract in use re-learns it within one \
+                                                 anti-entropy round (INTEREST_HEARTBEAT_INTERVAL, \
+                                                 300s), or sooner on the delegate's next write"
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -5405,6 +5486,43 @@ pub(crate) mod tests {
              fan-out and names peers that fan-out never touched — \
              over-suppression. Every queue test passes an empty fanout, so no \
              behavioural test distinguishes the two."
+        );
+    }
+
+    /// Every terminal outcome of the V2 drain must drop its retry entry.
+    ///
+    /// `v2_drain_retries` is keyed by contract and bounded only by removal
+    /// discipline — there is no size cap (matching the neighbouring
+    /// `broadcast_retries`). So an arm that forgets to remove leaks one entry
+    /// per contract that ever hit it, and nothing else in the tree would catch
+    /// it: the map is not observable from any behavioural test of this loop.
+    ///
+    /// All three arms are terminal for the retry: `Found` sent it, `NotHeld` is
+    /// definitive, and the exhausted branch has given up. Only the still-retrying
+    /// branch may leave an entry in place.
+    #[test]
+    fn v2_drain_retry_entries_are_dropped_on_every_terminal_outcome() {
+        const SOURCE: &str = include_str!("p2p_protoc.rs");
+
+        let arm_anchor = "NodeEvent::V2DelegateStateChanged { key } => {";
+        let arm_start = SOURCE
+            .find(arm_anchor)
+            .expect("the V2DelegateStateChanged dispatch arm is gone — update this pin");
+        let after = &SOURCE[arm_start..];
+        let arm_end = after
+            .find("NodeEvent::SyncStateToPeer {")
+            .map(|p| arm_start + p)
+            .unwrap_or(SOURCE.len());
+        let arm = &SOURCE[arm_start..arm_end];
+
+        let removals = arm.matches("v2_drain_retries.remove(&key)").count();
+        assert_eq!(
+            removals, 3,
+            "expected exactly 3 `v2_drain_retries.remove(&key)` sites in the V2 drain arm \
+             (Found, NotHeld, and retries-exhausted); found {removals}. Fewer means a \
+             terminal outcome leaks one map entry per contract that reaches it, and the map \
+             has no size cap. More means a still-retrying path is dropping its own counter, \
+             which makes the retry unbounded."
         );
     }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -96,24 +96,36 @@ const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
 /// `CH_EV_RESPONSE_TIME_OUT` (300 s), so an unbounded await here is the #4549
 /// wedge — a saturated contract handler stalls, then kills, the listener.
 ///
-/// Deliberately the SAME bound as the contract-handler round trips
-/// `handle_broadcast_state_change` makes three lines later on this very arm
-/// (`ring::interest::BROADCAST_CH_TIMEOUT`). An earlier version of this
-/// constant was 2 s, justified as "failing fast to protect the loop" — which
-/// was wrong twice over. The arm is already willing to spend `BROADCAST_CH_TIMEOUT`
-/// per target immediately afterwards, so a tighter cap here protected nothing;
-/// and it was the only one of the two whose expiry LOSES DATA, since it decides
-/// whether a committed write is announced at all. A cap 5x tighter than the
-/// call that follows it, on the only step that can drop a write, is the wrong
-/// way round.
+/// TIGHT ON PURPOSE, and it was briefly widened to `BROADCAST_CH_TIMEOUT`
+/// (10 s) on reasoning that does not hold. Recorded because the reasoning was
+/// plausible and will be re-invented otherwise.
 ///
-/// It also claimed the loop "warns at 100 ms of iteration time", which is not
-/// true of this await: `SLOW_EVENT_THRESHOLD` is measured around
-/// `process_select_result`, and the `NodeAction` dispatch that contains this
-/// arm runs after that elapsed time is taken. A stall here produces no slow-
-/// iteration warning at all, so nothing was observing the cost the tight bound
-/// was supposedly buying.
-const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = crate::ring::interest::BROADCAST_CH_TIMEOUT;
+/// The widening argued that `handle_broadcast_state_change`, called three lines
+/// later on this same arm, already spends `BROADCAST_CH_TIMEOUT` per target, so
+/// a tighter cap here protected nothing. **That is false in a production
+/// build.** In production the handler resolves targets in memory and hands off
+/// to `BroadcastQueue::enqueue`, a mutex-guarded push; every
+/// `BROADCAST_CH_TIMEOUT` round trip lives in `broadcast_to_single_peer`, which
+/// runs inside the spawned `drain_lane` workers, OFF this loop. The function
+/// that does await per target inline, `broadcast_state_to_peers`, is
+/// `#[cfg(feature = "simulation_tests")]`. So the comparison was against a path
+/// the shipped binary does not take.
+///
+/// The second argument was that a stall here produces no slow-iteration warning
+/// — `SLOW_EVENT_THRESHOLD` is measured around `process_select_result`, and the
+/// `NodeAction` dispatch containing this arm runs after that elapsed time is
+/// taken. That part is TRUE, and it argues the opposite way: an unobserved
+/// stall needs a tighter bound, not a looser one, because nothing will tell an
+/// operator it happened.
+///
+/// What the bound trades. Expiry drops one broadcast, which is recoverable —
+/// the next write to the contract re-announces it, and anti-entropy repairs it
+/// otherwise. Overrunning starves the network event loop, which processes no
+/// UDP and no connection events while it waits, and that is not recoverable.
+/// The asymmetry matters more than it looks because the coalescing marker is
+/// PER CONTRACT: a delegate writing across N contracts queues N distinct
+/// drains, so the worst case is N times this bound of dead loop, not one.
+const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Count of V2 delegate broadcasts dropped because the drain could not read
 /// local state.
@@ -154,10 +166,12 @@ fn note_v2_broadcast_drain_dropped(key: &freenet_stdlib::prelude::ContractKey) {
              loop being held by the delegate that made this write — a delegate awaiting user \
              input holds it for a human-scale time and will not be recovered by retries \
              (#5544/#5554 remove that precondition). The write is committed locally; a peer \
-             hosting or using this contract re-learns it within about one anti-entropy \
-             round — up to INTEREST_HEARTBEAT_INTERVAL (300s), and STAGGERED rather than \
-             swept, since the heartbeat spreads its sends across the interval — or sooner \
-             on the delegate's next write. \
+             hosting or using this contract re-learns it EVENTUALLY via anti-entropy, \
+             or sooner on the delegate's next write. Eventually is the honest word: \
+             INTEREST_HEARTBEAT_INTERVAL (300s) is the heartbeat PERIOD, not a recovery \
+             bound — each exchange carries at most MAX_SUMMARY_ENTRIES_PER_MESSAGE \
+             entries, chosen by RANDOM ROTATION when a peer shares more contracts than \
+             that, so a busy node needs several rounds and the count is probabilistic. \
              Logged at power-of-two milestones (#4238)."
         );
     }
@@ -3116,15 +3130,36 @@ impl P2pConnManager {
                                                 // contract, this retry coalesces
                                                 // into it instead of adding a
                                                 // second event.
-                                                if !op_mgr.queue_v2_delegate_broadcast(key) {
-                                                    // The retry never got queued,
-                                                    // so the outcome is the same
-                                                    // as exhausting them: this
-                                                    // write goes unannounced.
-                                                    // Counted and WARNed for that
-                                                    // reason rather than dropped
-                                                    // quietly.
-                                                    note_v2_broadcast_drain_dropped(&key);
+                                                // NOTHING IS COUNTED HERE.
+                                                // This site used to count every
+                                                // non-`Queued` outcome as a
+                                                // dropped broadcast, which was
+                                                // wrong in both directions — see
+                                                // the arms. The drop WARN fires
+                                                // at powers of two, so inflating
+                                                // the counter with benign
+                                                // coalesces pushes the next
+                                                // milestone exponentially out of
+                                                // reach and a genuine drop then
+                                                // logs nothing at all.
+                                                match op_mgr.queue_v2_delegate_broadcast(key) {
+                                                    // The retry did its job.
+                                                    crate::node::op_state_manager::V2BroadcastQueued::Queued => {}
+                                                    // A fresh write queued its
+                                                    // own drain while we slept.
+                                                    // That drain re-reads stored
+                                                    // state, so this write is
+                                                    // announced by it. Nothing
+                                                    // was lost and nothing is
+                                                    // counted.
+                                                    crate::node::op_state_manager::V2BroadcastQueued::Coalesced => {}
+                                                    // A real drop, but already
+                                                    // counted and WARNed inside
+                                                    // the call. Counting it here
+                                                    // too would report one event
+                                                    // twice across two separate
+                                                    // counters.
+                                                    crate::node::op_state_manager::V2BroadcastQueued::EnqueueFailed => {}
                                                 }
                                             });
                                         } else {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3044,11 +3044,28 @@ impl P2pConnManager {
                                         let attempt = ctx.v2_drain_retries.entry(key).or_insert(0);
                                         if *attempt < Self::MAX_V2_DRAIN_RETRIES {
                                             *attempt += 1;
-                                            let delay = Self::V2_DRAIN_RETRY_BASE_DELAY
+                                            // Linear backoff with +/-20% jitter
+                                            // so a burst of contracts failing
+                                            // together does not retry in
+                                            // lockstep (`code-style.md`).
+                                            let base = Self::V2_DRAIN_RETRY_BASE_DELAY
                                                 * u32::from(*attempt);
+                                            let jitter_pct: u64 =
+                                                crate::config::GlobalRng::random_range(
+                                                    80u64..=120u64,
+                                                );
+                                            let delay = base.mul_f64(jitter_pct as f64 / 100.0);
                                             let op_mgr = op_manager.clone();
+                                            let shutdown = op_manager.ring.shutdown_token();
                                             tokio::spawn(async move {
-                                                tokio::time::sleep(delay).await;
+                                                // Interruptible: a >=1s plain
+                                                // sleep in a retry loop would
+                                                // keep this task alive past
+                                                // shutdown (`code-style.md`).
+                                                tokio::select! {
+                                                    _ = shutdown.cancelled() => return,
+                                                    _ = tokio::time::sleep(delay) => {}
+                                                }
                                                 if op_mgr
                                                     .try_notify_node_event(
                                                         crate::message::NodeEvent::

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -125,7 +125,7 @@ const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
 /// The asymmetry matters more than it looks because the coalescing marker is
 /// PER CONTRACT: a delegate writing across N contracts queues N distinct
 /// drains, so the worst case is N times this bound of dead loop, not one.
-const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Count of V2 delegate broadcasts dropped because the drain could not read
 /// local state.

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -96,14 +96,24 @@ const QUERY_SUBSCRIPTIONS_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
 /// `CH_EV_RESPONSE_TIME_OUT` (300 s), so an unbounded await here is the #4549
 /// wedge — a saturated contract handler stalls, then kills, the listener.
 ///
-/// Shorter than the diagnostics bound (5 s) on purpose. That one serves an
-/// operator poll where a slow answer still beats none; this one only decides
-/// whether a broadcast goes out now or waits for the next write, and the loop
-/// it blocks warns at 100 ms of iteration time. Failing fast and letting
-/// anti-entropy heal is the better trade here, so the cap is the smallest that
-/// still clears a normally-loaded handler rather than the largest that is
-/// tolerable.
-const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
+/// Deliberately the SAME bound as the contract-handler round trips
+/// `handle_broadcast_state_change` makes three lines later on this very arm
+/// (`ring::interest::BROADCAST_CH_TIMEOUT`). An earlier version of this
+/// constant was 2 s, justified as "failing fast to protect the loop" — which
+/// was wrong twice over. The arm is already willing to spend `BROADCAST_CH_TIMEOUT`
+/// per target immediately afterwards, so a tighter cap here protected nothing;
+/// and it was the only one of the two whose expiry LOSES DATA, since it decides
+/// whether a committed write is announced at all. A cap 5x tighter than the
+/// call that follows it, on the only step that can drop a write, is the wrong
+/// way round.
+///
+/// It also claimed the loop "warns at 100 ms of iteration time", which is not
+/// true of this await: `SLOW_EVENT_THRESHOLD` is measured around
+/// `process_select_result`, and the `NodeAction` dispatch that contains this
+/// arm runs after that elapsed time is taken. A stall here produces no slow-
+/// iteration warning at all, so nothing was observing the cost the tight bound
+/// was supposedly buying.
+const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = crate::ring::interest::BROADCAST_CH_TIMEOUT;
 
 /// Count of V2 delegate broadcasts dropped because the drain could not read
 /// local state.
@@ -117,6 +127,39 @@ const V2_BROADCAST_DRAIN_READ_TIMEOUT: Duration = Duration::from_secs(2);
 /// clean zero.
 static V2_BROADCAST_DRAINS_DROPPED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
+
+/// Count a dropped V2 broadcast drain, and WARN at power-of-two milestones.
+///
+/// RATE-LIMITED on purpose, and the reason is a production incident rather than
+/// taste. `try_notify_node_event_on` logs its `Full` arm at `debug!` with the
+/// note that a per-occurrence WARN there flooded production gateways after the
+/// HN spike (#4238) at 8-14 MB/hour. This path is reached under exactly that
+/// condition — a saturated node — and once per V2 write, so an unconditional
+/// WARN here would re-create the same flood by a different door.
+///
+/// `release_max_level_info` still rules out `debug!` (the drop would leave no
+/// evidence in a release build, the #4981 shape), so the answer is neither
+/// every occurrence nor none: count all, warn at 1, 2, 4, 8, ... exactly as
+/// `tracing::register::note_dropped_event_log` does for the same trade.
+fn note_v2_broadcast_drain_dropped(key: &freenet_stdlib::prelude::ContractKey) {
+    let dropped =
+        V2_BROADCAST_DRAINS_DROPPED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    if dropped.is_power_of_two() {
+        tracing::warn!(
+            contract = %key,
+            dropped_total = dropped,
+            timeout_secs = V2_BROADCAST_DRAIN_READ_TIMEOUT.as_secs(),
+            "V2 delegate broadcast dropped: could not read local state to announce, and \
+             the bounded retry did not recover it. The usual cause is the contract-handling \
+             loop being held by the delegate that made this write — a delegate awaiting user \
+             input holds it for a human-scale time and will not be recovered by retries \
+             (#5544/#5554 remove that precondition). The write is committed locally; a peer \
+             hosting or using this contract re-learns it within one anti-entropy round \
+             (INTEREST_HEARTBEAT_INTERVAL, 300s), or sooner on the delegate's next write. \
+             Logged at power-of-two milestones (#4238)."
+        );
+    }
+}
 
 /// Best-effort, bounded query to the contract handler for application-level
 /// subscriptions, used by the diagnostics arms of the network event loop (#4549).
@@ -3042,19 +3085,17 @@ impl P2pConnManager {
                                         // write is free to queue its own event
                                         // and at worst we fan out twice.
                                         let attempt = ctx.v2_drain_retries.entry(key).or_insert(0);
-                                        if *attempt < Self::MAX_V2_DRAIN_RETRIES {
+                                        // Linear backoff with +/-20% jitter so a
+                                        // burst of contracts failing together
+                                        // does not retry in lockstep against the
+                                        // one serial loop that was already too
+                                        // busy to answer (`code-style.md`).
+                                        let jitter_pct: u64 =
+                                            crate::config::GlobalRng::random_range(80u64..=120u64);
+                                        if let Some(delay) =
+                                            Self::plan_v2_drain_retry(*attempt, jitter_pct)
+                                        {
                                             *attempt += 1;
-                                            // Linear backoff with +/-20% jitter
-                                            // so a burst of contracts failing
-                                            // together does not retry in
-                                            // lockstep (`code-style.md`).
-                                            let base = Self::V2_DRAIN_RETRY_BASE_DELAY
-                                                * u32::from(*attempt);
-                                            let jitter_pct: u64 =
-                                                crate::config::GlobalRng::random_range(
-                                                    80u64..=120u64,
-                                                );
-                                            let delay = base.mul_f64(jitter_pct as f64 / 100.0);
                                             let op_mgr = op_manager.clone();
                                             let shutdown = op_manager.ring.shutdown_token();
                                             tokio::spawn(async move {
@@ -3066,13 +3107,14 @@ impl P2pConnManager {
                                                     _ = shutdown.cancelled() => return,
                                                     _ = tokio::time::sleep(delay) => {}
                                                 }
-                                                if op_mgr
-                                                    .try_notify_node_event(
-                                                        crate::message::NodeEvent::
-                                                            V2DelegateStateChanged { key },
-                                                    )
-                                                    .is_err()
-                                                {
+                                                // Through the marker-respecting
+                                                // API, not a raw emit: if a
+                                                // fresh write has already queued
+                                                // its own drain for this
+                                                // contract, this retry coalesces
+                                                // into it instead of adding a
+                                                // second event.
+                                                if !op_mgr.queue_v2_delegate_broadcast(key) {
                                                     // The retry never got queued,
                                                     // so the outcome is the same
                                                     // as exhausting them: this
@@ -3080,22 +3122,7 @@ impl P2pConnManager {
                                                     // Counted and WARNed for that
                                                     // reason rather than dropped
                                                     // quietly.
-                                                    let dropped =
-                                                        V2_BROADCAST_DRAINS_DROPPED.fetch_add(
-                                                            1,
-                                                            std::sync::atomic::Ordering::Relaxed,
-                                                        ) + 1;
-                                                    tracing::warn!(
-                                                        contract = %key,
-                                                        dropped_total = dropped,
-                                                        "V2 delegate broadcast dropped: the \
-                                                         drain retry could not be re-queued. \
-                                                         The write is committed locally; a \
-                                                         peer hosting or using this contract \
-                                                         re-learns it within one anti-entropy \
-                                                         round (300s), or sooner on the \
-                                                         delegate's next write"
-                                                    );
+                                                    note_v2_broadcast_drain_dropped(&key);
                                                 }
                                             });
                                         } else {
@@ -3109,28 +3136,7 @@ impl P2pConnManager {
                                             // leaves no evidence in a release build
                                             // is the #4981 shape.
                                             ctx.v2_drain_retries.remove(&key);
-                                            let dropped = V2_BROADCAST_DRAINS_DROPPED
-                                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                                                + 1;
-                                            tracing::warn!(
-                                                contract = %key,
-                                                dropped_total = dropped,
-                                                retries = Self::MAX_V2_DRAIN_RETRIES,
-                                                timeout_secs =
-                                                    V2_BROADCAST_DRAIN_READ_TIMEOUT.as_secs(),
-                                                "V2 delegate broadcast dropped after retries: \
-                                                 could not read local state to announce. The \
-                                                 usual cause is the contract-handling loop \
-                                                 being held by the delegate that made this \
-                                                 write — a delegate awaiting user input holds \
-                                                 it for a human-scale time and will not be \
-                                                 recovered by retries (#5544/#5554 remove \
-                                                 that precondition). The write is committed \
-                                                 locally; a peer that is hosting or has this \
-                                                 contract in use re-learns it within one \
-                                                 anti-entropy round (INTEREST_HEARTBEAT_INTERVAL, \
-                                                 300s), or sooner on the delegate's next write"
-                                            );
+                                            note_v2_broadcast_drain_dropped(&key);
                                         }
                                     }
                                 }
@@ -5506,6 +5512,65 @@ pub(crate) mod tests {
         );
     }
 
+    /// The V2 drain retry POLICY, which the source-order pins cannot reach.
+    ///
+    /// The pins assert the shape of the dispatch arm; they cannot tell you that
+    /// retries stop at the cap or that the jitter stays inside its documented
+    /// band. Both matter here for a specific reason: the drops are CORRELATED —
+    /// the read fails because it is queued behind a delegate notification
+    /// batch, so one busy batch drops many contracts at once. Un-jittered
+    /// backoff would then re-queue all of them in lockstep against the same
+    /// serial loop that was already too busy, making the retry amplify the
+    /// congestion it exists to recover from.
+    #[test]
+    fn v2_drain_retry_policy_is_bounded_and_jittered() {
+        use super::P2pConnManager;
+
+        // Stops exactly at the cap, and the cap is what gives up.
+        for attempts in 0..P2pConnManager::MAX_V2_DRAIN_RETRIES {
+            assert!(
+                P2pConnManager::plan_v2_drain_retry(attempts, 100).is_some(),
+                "attempt {attempts} is below MAX_V2_DRAIN_RETRIES and must still retry"
+            );
+        }
+        assert!(
+            P2pConnManager::plan_v2_drain_retry(P2pConnManager::MAX_V2_DRAIN_RETRIES, 100)
+                .is_none(),
+            "at MAX_V2_DRAIN_RETRIES the drain must give up rather than retry forever — an \
+             unbounded retry here is a loop against the contract handler that is already \
+             saturated"
+        );
+        assert!(
+            P2pConnManager::plan_v2_drain_retry(u8::MAX, 100).is_none(),
+            "any count past the cap must also give up"
+        );
+
+        // Linear growth at the neutral factor.
+        let base = P2pConnManager::V2_DRAIN_RETRY_BASE_DELAY;
+        assert_eq!(P2pConnManager::plan_v2_drain_retry(0, 100), Some(base));
+        assert_eq!(P2pConnManager::plan_v2_drain_retry(1, 100), Some(base * 2));
+        assert_eq!(P2pConnManager::plan_v2_drain_retry(2, 100), Some(base * 3));
+
+        // Jitter band: +/-20% of the linear delay at each attempt, and the
+        // extremes must actually MOVE the delay — a jitter that silently
+        // collapsed to 1.0 would pass a bounds-only check.
+        for attempts in 0..P2pConnManager::MAX_V2_DRAIN_RETRIES {
+            let linear = base * u32::from(attempts + 1);
+            let low = P2pConnManager::plan_v2_drain_retry(attempts, 80).unwrap();
+            let high = P2pConnManager::plan_v2_drain_retry(attempts, 120).unwrap();
+            assert!(
+                low < linear && high > linear,
+                "jitter must actually spread attempt {attempts}: got low={low:?}, \
+                 linear={linear:?}, high={high:?}. If low == high == linear the jitter \
+                 factor is being ignored and correlated drops will retry in lockstep"
+            );
+            assert!(
+                low >= linear.mul_f64(0.8) && high <= linear.mul_f64(1.2),
+                "jitter must stay within the documented +/-20% band at attempt {attempts}"
+            );
+        }
+    }
+
     /// Every terminal outcome of the V2 drain must drop its retry entry.
     ///
     /// `v2_drain_retries` is keyed by contract and bounded only by removal
@@ -5569,11 +5634,26 @@ pub(crate) mod tests {
         // Bound at the next dispatch arm so a later arm's text cannot satisfy
         // the assertion.
         let after = &SOURCE[arm_start..];
-        let arm_end = after
-            .find("NodeEvent::SyncStateToPeer {")
-            .map(|p| arm_start + p)
-            .unwrap_or(SOURCE.len());
-        let arm = &SOURCE[arm_start..arm_end];
+        // Bounded, and it must FAIL rather than fall through: an
+        // `unwrap_or(SOURCE.len())` would absorb the rest of the file including
+        // this test's own `expect` strings, which contain both needles in the
+        // passing order — a vacuous pass triggered by nothing worse than the
+        // arms being reordered.
+        let arm_end = arm_start
+            + after.find("NodeEvent::SyncStateToPeer {").expect(
+                "SyncStateToPeer arm no longer follows the V2 drain arm — this pin \
+                         bounds its search on it, and without a bound it would scan its own \
+                         assertion text and pass vacuously. Re-anchor it.",
+            );
+        // Strip line comments before searching: `arm.find(..)` matches inside a
+        // comment, so COMMENTING OUT the clear left this pin green. The call it
+        // guards is the whole lost-write story.
+        let arm: String = SOURCE[arm_start..arm_end]
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let arm = arm.as_str();
 
         let clear_pos = arm.find("clear_v2_delegate_broadcast_pending(").expect(
             "the V2 drain no longer clears the coalescing marker. Without the clear the              marker latches: every later write to this contract coalesces into a              broadcast that has already drained, and the contract stops propagating",

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -184,6 +184,30 @@ impl P2pConnManager {
     /// Base delay between V2 drain retries, scaled by attempt number.
     pub(super) const V2_DRAIN_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
+    /// Decide whether a V2 drain retry happens, and after how long.
+    ///
+    /// Split out from the dispatch arm for the same reason `classify_drain_read`
+    /// was split out of the read: the policy is the part with a decision in it,
+    /// and inline in a `match` arm of the select loop it is unreachable from any
+    /// test. Source-order pins can assert the shape of that arm; only this can
+    /// assert that retries actually stop at the cap and that the jitter stays in
+    /// its documented band.
+    ///
+    /// `jitter_pct` is a parameter rather than a `GlobalRng` call inside, so the
+    /// arithmetic is deterministic under test while production still supplies a
+    /// random factor.
+    ///
+    /// Returns `None` once `attempts_so_far` has reached
+    /// [`Self::MAX_V2_DRAIN_RETRIES`], i.e. the caller must give up.
+    pub(super) fn plan_v2_drain_retry(attempts_so_far: u8, jitter_pct: u64) -> Option<Duration> {
+        if attempts_so_far >= Self::MAX_V2_DRAIN_RETRIES {
+            return None;
+        }
+        let attempt = attempts_so_far + 1;
+        let base = Self::V2_DRAIN_RETRY_BASE_DELAY * u32::from(attempt);
+        Some(base.mul_f64(jitter_pct as f64 / 100.0))
+    }
+
     /// Maximum entries in the no-target streak tracker. Prevents unbounded growth
     /// from network-influenced contract keys.
     const MAX_BROADCAST_STREAK_ENTRIES: usize = 256;

--- a/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs
@@ -164,6 +164,26 @@ impl P2pConnManager {
     /// Base delay between broadcast retries (scaled by attempt number for linear backoff).
     const BROADCAST_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
+    /// Maximum retry attempts when a V2 delegate broadcast drain cannot read
+    /// the state it was going to send.
+    ///
+    /// Deliberately small, and deliberately NOT a fix for the whole failure.
+    /// The read is a `GetQuery` to the serial `contract_handling` loop, and the
+    /// event being drained was queued by a delegate write that ran ON that
+    /// loop — so the read waits for the delegate that caused it. Retrying
+    /// recovers a delegate that was merely busy for a few seconds.
+    ///
+    /// It does NOT recover a delegate that requests user input:
+    /// `handle_delegate_with_contract_requests` awaits `prompter.prompt(..)`
+    /// inline on that loop, so the hold is human-scale and three retries over a
+    /// few seconds cannot outlast it. That case is not retried into
+    /// submission — it is reported, counted, and healed by anti-entropy.
+    /// #5544/#5554 remove the precondition by parking delegates off the loop.
+    pub(super) const MAX_V2_DRAIN_RETRIES: u8 = 3;
+
+    /// Base delay between V2 drain retries, scaled by attempt number.
+    pub(super) const V2_DRAIN_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+
     /// Maximum entries in the no-target streak tracker. Prevents unbounded growth
     /// from network-influenced contract keys.
     const MAX_BROADCAST_STREAK_ENTRIES: usize = 256;

--- a/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
@@ -1,0 +1,705 @@
+//! The V2 delegate broadcast drain (#5479), lifted out of the network event
+//! loop's `select!` so that it is reachable from a test.
+//!
+//! # Why this is a module and not a `match` arm
+//!
+//! This PR already applied exactly this refactor twice, and said why each
+//! time: `classify_drain_read` was split out of `read_state_for_broadcast_drain`
+//! because "the mapping can be tested exhaustively without a live contract
+//! handler", and `plan_v2_drain_retry` was split out of the dispatch arm
+//! because "inline in a `match` arm of the select loop it is unreachable from
+//! any test".
+//!
+//! Both observations were right and neither went far enough. What remained in
+//! the arm was the part that decides whether a committed write is announced at
+//! all, and a mutation-testing pass over `4ef5823c0` found that region had NO
+//! behavioural coverage whatsoever: six separate mutations to it — including
+//! deleting the fan-out call outright, which reinstates #5479 in full — each
+//! left the entire 5440-test suite green. The three source-order pins written
+//! to compensate all passed while the call each one guards was commented out.
+//!
+//! Source-order pins can assert that a call appears in a block. They cannot
+//! assert that it runs, that it runs for the right read outcome, or that it
+//! runs at all when the line is commented rather than deleted. That is the gap
+//! this module closes.
+//!
+//! # The seam
+//!
+//! [`V2DrainCtx`] is the whole trick. The drain's *decisions* live in
+//! [`handle_v2_delegate_state_changed`]; its three *side effects* — touching
+//! the retry map, fanning out, scheduling a retry — go through the trait. The
+//! production implementor is `P2pConnManager`; the tests use a recording
+//! double, so they observe what the drain decided to do without standing up a
+//! transport, a bridge, or an event register.
+//!
+//! The retry body is [`run_v2_drain_retry`], a free function rather than an
+//! inline `tokio::spawn` closure, for the same reason: a closure inside a
+//! spawn inside a match arm is not addressable, and the thing it does — re-queue
+//! through the marker-respecting API rather than a raw emit — is load-bearing.
+
+use super::*;
+use crate::node::op_state_manager::{DrainStateRead, V2BroadcastQueued};
+use freenet_stdlib::prelude::{ContractKey, WrappedState};
+use std::collections::HashMap;
+
+/// The side effects the V2 drain performs, behind a trait so the drain's
+/// control flow can be driven by a test.
+///
+/// Deliberately narrow: three methods, each one an effect the drain must
+/// perform for exactly one read outcome. A test double implementing these
+/// records which were called and with what, which is what turns "the fan-out
+/// call is present in the source" into "the fan-out happened, for `Found`, with
+/// the state that was read".
+///
+/// The retry map is reached through the trait rather than passed as a separate
+/// `&mut` argument on purpose: `P2pConnManager` owns both the map and the
+/// fan-out, so two independent `&mut` borrows of it would not type-check at the
+/// call site. One receiver, three methods.
+pub(super) trait V2DrainCtx {
+    /// Per-contract retry counter for drains whose state read came back
+    /// `Unavailable`. Cleared on every terminal outcome.
+    fn v2_drain_retries_mut(&mut self) -> &mut HashMap<ContractKey, u8>;
+
+    /// Announce `new_state` for `key` to every advertised co-host.
+    ///
+    /// This is the leg whose absence IS #5479: without it a V2 delegate write
+    /// commits locally, returns success to the delegate, and is never seen off
+    /// this node.
+    fn fan_out(
+        &mut self,
+        op_manager: &Arc<OpManager>,
+        key: ContractKey,
+        new_state: WrappedState,
+    ) -> impl std::future::Future<Output = ()> + Send;
+
+    /// Re-attempt the drain for `key` after `delay`.
+    fn schedule_retry(&mut self, op_manager: &Arc<OpManager>, key: ContractKey, delay: Duration);
+}
+
+/// Drain one `NodeEvent::V2DelegateStateChanged`.
+///
+/// `jitter_pct` is a parameter rather than a `GlobalRng` call inside, matching
+/// `plan_v2_drain_retry`, so the retry arithmetic is deterministic under test
+/// while production still supplies a random factor.
+///
+/// # The marker is cleared BEFORE the read, and that ordering is the fix
+///
+/// A write landing during the read then queues a fresh event instead of being
+/// folded into this drain, which is already past the point where it could
+/// observe it. Clearing afterwards would drop that write's fan-out — #5479
+/// again, one layer up.
+///
+/// The marker also stays clear for the whole fan-out, so a write landing
+/// mid-fan-out queues a fresh event and re-sends bytes already going out.
+/// Correct but wasteful, on the sink #5147/#5153 exist to shrink. Deliberate:
+/// holding the marker until the fan-out completed would trade a duplicate send
+/// for a DROPPED one, and a drop here is unrecoverable until the next write.
+pub(super) async fn handle_v2_delegate_state_changed<C: V2DrainCtx>(
+    ctx: &mut C,
+    op_manager: &Arc<OpManager>,
+    key: ContractKey,
+    jitter_pct: u64,
+) {
+    op_manager.clear_v2_delegate_broadcast_pending(&key);
+
+    // The event carries no state; read what is stored now. BOUNDED (#4549 —
+    // this runs inline on the event loop) and three-way, because "we do not
+    // hold it" and "the read failed" need opposite handling.
+    match op_manager
+        .read_state_for_broadcast_drain(&key, V2_BROADCAST_DRAIN_READ_TIMEOUT)
+        .await
+    {
+        DrainStateRead::Found(new_state) => {
+            ctx.v2_drain_retries_mut().remove(&key);
+            ctx.fan_out(op_manager, key, new_state).await;
+        }
+        DrainStateRead::NotHeld => {
+            // Definitive: retrying cannot change it.
+            ctx.v2_drain_retries_mut().remove(&key);
+            tracing::debug!(
+                contract = %key,
+                "V2 delegate broadcast drained for a contract we do not hold; nothing to send"
+            );
+        }
+        DrainStateRead::Unavailable => {
+            // The read is a `GetQuery` to the serial `contract_handling` loop,
+            // and the event being drained was queued by a delegate write that
+            // ran ON that loop — so this read waits for the delegate that
+            // caused it. A bounded retry recovers a delegate that was merely
+            // busy.
+            //
+            // Re-queueing is safe: the marker was cleared before the read, so a
+            // fresh write is free to queue its own event and at worst we fan
+            // out twice.
+            let attempts_so_far = *ctx.v2_drain_retries_mut().entry(key).or_insert(0);
+            if let Some(delay) = P2pConnManager::plan_v2_drain_retry(attempts_so_far, jitter_pct) {
+                *ctx.v2_drain_retries_mut().entry(key).or_insert(0) += 1;
+                ctx.schedule_retry(op_manager, key, delay);
+            } else {
+                // Retries exhausted. A write that already committed and already
+                // returned success to the delegate now goes unannounced.
+                //
+                // WARN, not debug: `release_max_level_info` compiles debug out,
+                // and a drop that leaves no evidence in a release build is the
+                // #4981 shape.
+                ctx.v2_drain_retries_mut().remove(&key);
+                note_v2_broadcast_drain_dropped(&key);
+            }
+        }
+    }
+}
+
+/// The body of a scheduled V2 drain retry.
+///
+/// A free function rather than an inline `tokio::spawn` closure so a test can
+/// call it with a zero delay and observe the re-queue.
+///
+/// Interruptible: a >=1s plain sleep in a retry loop would keep this task alive
+/// past shutdown (`code-style.md`).
+pub(super) async fn run_v2_drain_retry(
+    op_manager: Arc<OpManager>,
+    key: ContractKey,
+    delay: Duration,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    tokio::select! {
+        _ = shutdown.cancelled() => return,
+        _ = tokio::time::sleep(delay) => {}
+    }
+    // Through the marker-respecting API, not a raw emit: if a fresh write has
+    // already queued its own drain for this contract, this retry coalesces into
+    // it instead of adding a second event.
+    //
+    // NOTHING IS COUNTED HERE. This site used to count every non-`Queued`
+    // outcome as a dropped broadcast, which was wrong in both directions — see
+    // the arms. The drop WARN fires at powers of two, so inflating the counter
+    // with benign coalesces pushes the next milestone exponentially out of
+    // reach and a genuine drop then logs nothing at all.
+    match op_manager.queue_v2_delegate_broadcast(key) {
+        // The retry did its job.
+        V2BroadcastQueued::Queued => {}
+        // A fresh write queued its own drain while we slept. That drain
+        // re-reads stored state, so this write is announced by it. Nothing was
+        // lost and nothing is counted.
+        V2BroadcastQueued::Coalesced => {}
+        // A real drop, but already counted and WARNed inside the call. Counting
+        // it here too would report one event twice across two separate
+        // counters.
+        V2BroadcastQueued::EnqueueFailed => {}
+    }
+}
+
+impl V2DrainCtx for P2pConnManager {
+    fn v2_drain_retries_mut(&mut self) -> &mut HashMap<ContractKey, u8> {
+        &mut self.v2_drain_retries
+    }
+
+    async fn fan_out(
+        &mut self,
+        op_manager: &Arc<OpManager>,
+        key: ContractKey,
+        new_state: WrappedState,
+    ) {
+        self.handle_broadcast_state_change(op_manager, key, new_state, false, false)
+            .await;
+    }
+
+    fn schedule_retry(&mut self, op_manager: &Arc<OpManager>, key: ContractKey, delay: Duration) {
+        let op_mgr = op_manager.clone();
+        let shutdown = op_manager.ring.shutdown_token();
+        tokio::spawn(run_v2_drain_retry(op_mgr, key, delay, shutdown));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Behavioural coverage for the V2 drain.
+    //!
+    //! Every test here was written against a mutation that survived the full
+    //! 5440-test suite on `4ef5823c0`, and each is verified by re-applying that
+    //! mutation and watching this test fail. A test that has only been watched
+    //! to pass is not a verified test — that is the finding this module exists
+    //! to answer, so it would be incoherent not to hold these to it.
+    //!
+    //! The mutation each test kills is named in its doc comment.
+
+    use super::*;
+    use crate::config::ConfigArgs;
+    use crate::contract::{ContractHandlerEvent, OperationMode, StoreResponse};
+    use crate::message::NodeEvent;
+    use crate::node::EventLoopNotificationsReceiver;
+    use freenet_stdlib::prelude::{ContractCode, Parameters};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// What the stub contract handler answers a drain's `GetQuery` with.
+    #[derive(Clone, Copy)]
+    enum StubReply {
+        /// State present → `DrainStateRead::Found`.
+        Found(&'static [u8]),
+        /// Answered, no state → `DrainStateRead::NotHeld`.
+        NoState,
+        /// Executor error → `DrainStateRead::Unavailable`.
+        ///
+        /// Used in preference to simply not answering: a silent handler would
+        /// make every `Unavailable` test wait out the full
+        /// `V2_BROADCAST_DRAIN_READ_TIMEOUT`, and the bound already has its own
+        /// dedicated test in `pool_tests`. Here we want the classification, not
+        /// the timeout.
+        ExecutorError,
+    }
+
+    /// Records what the drain decided to do, in place of performing it.
+    ///
+    /// This is the seam that makes the drain testable: production wires these
+    /// three methods to `P2pConnManager`, and the assertions below read them
+    /// back.
+    #[derive(Default)]
+    struct RecordingCtx {
+        retries: HashMap<ContractKey, u8>,
+        fanned_out: Vec<(ContractKey, Vec<u8>)>,
+        retries_scheduled: Vec<(ContractKey, Duration)>,
+    }
+
+    impl V2DrainCtx for RecordingCtx {
+        fn v2_drain_retries_mut(&mut self) -> &mut HashMap<ContractKey, u8> {
+            &mut self.retries
+        }
+
+        async fn fan_out(
+            &mut self,
+            _op_manager: &Arc<OpManager>,
+            key: ContractKey,
+            new_state: WrappedState,
+        ) {
+            self.fanned_out.push((key, new_state.as_ref().to_vec()));
+        }
+
+        fn schedule_retry(
+            &mut self,
+            _op_manager: &Arc<OpManager>,
+            key: ContractKey,
+            delay: Duration,
+        ) {
+            self.retries_scheduled.push((key, delay));
+        }
+    }
+
+    /// Return `src` between `start` with all COMMENTS stripped — both `//` line
+    /// comments and `/* */` block comments.
+    ///
+    /// Stripping BOTH is the point. The pins this replaces stripped only lines
+    /// whose trimmed start was `//`, and a reviewer defeated all three of them
+    /// by block-commenting the guarded call: the needle stayed in the text, the
+    /// pin stayed green, and the call was inert. A scraper that skips one kind
+    /// of comment is not skipping comments.
+    fn strip_comments(src: &str) -> String {
+        let mut out = String::with_capacity(src.len());
+        let mut rest = src;
+        loop {
+            let (idx, is_line) = match (rest.find("//"), rest.find("/*")) {
+                (None, None) => {
+                    out.push_str(rest);
+                    return out;
+                }
+                (Some(l), None) => (l, true),
+                (None, Some(b)) => (b, false),
+                (Some(l), Some(b)) => {
+                    if l < b {
+                        (l, true)
+                    } else {
+                        (b, false)
+                    }
+                }
+            };
+            out.push_str(&rest[..idx]);
+            let tail = &rest[idx..];
+            if is_line {
+                match tail.find('\n') {
+                    Some(nl) => rest = &tail[nl..],
+                    None => return out,
+                }
+            } else {
+                match tail.find("*/") {
+                    Some(e) => rest = &tail[e + 2..],
+                    None => return out,
+                }
+            }
+        }
+    }
+
+    /// The body of `handle_v2_delegate_state_changed`, comments stripped.
+    ///
+    /// Bounded with `.expect(..)` rather than `unwrap_or(SOURCE.len())`. The
+    /// pin this replaces used the latter, so losing its end anchor silently
+    /// widened the window to the whole file — including the pin's own assertion
+    /// prose, which contained the needle twice. Measured on `4ef5823c0`: the
+    /// bounded window saw 3 occurrences and the unbounded one saw 5. Failing
+    /// loudly on a moved anchor is the only safe behaviour.
+    fn drain_fn_body() -> String {
+        const SOURCE: &str = include_str!("v2_drain.rs");
+        let start = SOURCE
+            .find("pub(super) async fn handle_v2_delegate_state_changed")
+            .expect("handle_v2_delegate_state_changed must exist — re-anchor this pin");
+        let rest = &SOURCE[start..];
+        let end = rest
+            .find("\n/// The body of a scheduled V2 drain retry.")
+            .expect(
+                "the retry-body fn no longer follows the drain fn — this pin bounds its \
+                 search on it, and without a bound it would scan its own assertion text \
+                 and pass vacuously. Re-anchor it.",
+            );
+        strip_comments(&rest[..end])
+    }
+
+    /// Every terminal outcome must drop its retry-map entry.
+    ///
+    /// `v2_drain_retries` has no size cap, so an arm that forgets to remove
+    /// leaks one entry per contract that reaches it. The three behavioural
+    /// tests above each assert this for their own outcome; this is the cheap
+    /// structural backstop that also catches a FOURTH terminal arm being added
+    /// without one.
+    #[test]
+    fn every_terminal_outcome_drops_its_retry_entry() {
+        let body = drain_fn_body();
+        let removals = body.matches("v2_drain_retries_mut().remove(&key)").count();
+        assert_eq!(
+            removals, 3,
+            "expected exactly 3 `v2_drain_retries_mut().remove(&key)` sites in the drain \
+             (Found, NotHeld, retries-exhausted); found {removals}. Fewer means a terminal \
+             outcome leaks a map entry; more means a still-retrying path drops its own \
+             counter, making the retry unbounded."
+        );
+    }
+
+    /// The marker clear must precede the state read, in source order too.
+    ///
+    /// `drain_clears_the_coalescing_marker_before_reading_state` above asserts
+    /// this BEHAVIOURALLY and is the real guard. This is kept as a second,
+    /// cheaper lens that also fails if the clear is deleted outright — and,
+    /// unlike its predecessor, it cannot be satisfied by a comment.
+    #[test]
+    fn marker_clear_precedes_the_read_in_source_order() {
+        let body = drain_fn_body();
+        let clear = body
+            .find("clear_v2_delegate_broadcast_pending(")
+            .expect("the drain no longer clears the coalescing marker");
+        let read = body
+            .find("read_state_for_broadcast_drain(")
+            .expect("the drain no longer reads state — re-anchor this pin");
+        assert!(
+            clear < read,
+            "the marker must be cleared BEFORE the read. Clearing afterwards means a write \
+             landing during the read coalesces into a drain that has already read past it, \
+             and that write is never announced."
+        );
+    }
+
+    fn test_key(seed: u8) -> ContractKey {
+        ContractKey::from_params_and_code(
+            &Parameters::from(vec![seed]),
+            &ContractCode::from(vec![seed, seed, seed]),
+        )
+    }
+
+    /// Build a real `OpManager` plus a stub contract handler that answers every
+    /// `GetQuery` with `reply`.
+    ///
+    /// `marker_set_at_read` records whether the coalescing marker was still set
+    /// at the moment the handler saw the read — which is how
+    /// `drain_clears_the_marker_before_reading_state` checks an ORDERING that
+    /// the source-order pin can only scrape.
+    async fn harness(
+        id: &str,
+        reply: StubReply,
+    ) -> (
+        Arc<OpManager>,
+        EventLoopNotificationsReceiver,
+        Arc<AtomicBool>,
+        Box<dyn std::any::Any>,
+    ) {
+        let config_args = ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, mut ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+        let op_manager = Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+
+        let marker_set_at_read = Arc::new(AtomicBool::new(false));
+        let marker_probe = marker_set_at_read.clone();
+        let op_for_stub = op_manager.clone();
+
+        // The stub handler. Answers GetQuery per `reply`, and snapshots the
+        // coalescing marker as it does so.
+        tokio::spawn(async move {
+            while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
+                if let ContractHandlerEvent::GetQuery { instance_id, .. } = ev {
+                    marker_probe.store(
+                        op_for_stub
+                            .v2_delegate_broadcast_pending
+                            .contains(&instance_id),
+                        Ordering::SeqCst,
+                    );
+                    let response = match reply {
+                        StubReply::Found(bytes) => Ok(StoreResponse {
+                            state: Some(WrappedState::new(bytes.to_vec())),
+                            contract: None,
+                        }),
+                        StubReply::NoState => Ok(StoreResponse {
+                            state: None,
+                            contract: None,
+                        }),
+                        StubReply::ExecutorError => Err(crate::contract::ExecutorError::other(
+                            anyhow::anyhow!("stub executor failure"),
+                        )),
+                    };
+                    let _ = ch_channel
+                        .send_to_sender(
+                            id,
+                            ContractHandlerEvent::GetResponse {
+                                key: None,
+                                response,
+                            },
+                        )
+                        .await;
+                }
+            }
+        });
+
+        let guards: Box<dyn std::any::Any> =
+            Box::new((wait_for_event, result_router_rx, task_monitor));
+        (op_manager, notification_rx, marker_set_at_read, guards)
+    }
+
+    /// `Found` must fan the state out. KILLS MUTATION S1.
+    ///
+    /// S1 deleted `ctx.handle_broadcast_state_change(...)` from the dispatch
+    /// arm and the entire suite stayed green — #5479 reintroduced in full, with
+    /// no detector anywhere in `--lib`. This is that detector.
+    #[tokio::test(flavor = "current_thread")]
+    async fn found_fans_out_the_state_that_was_read() {
+        let (op_manager, _rx, _probe, _guards) =
+            harness("v2drain-found", StubReply::Found(&[7, 7, 7])).await;
+        let key = test_key(31);
+        let mut ctx = RecordingCtx::default();
+
+        handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
+
+        assert_eq!(
+            ctx.fanned_out,
+            vec![(key, vec![7, 7, 7])],
+            "a drain that reads state MUST fan it out; without this the write is \
+             committed locally, reported successful to the delegate, and never seen \
+             off this node — which is #5479 itself"
+        );
+        assert!(
+            ctx.retries_scheduled.is_empty(),
+            "a successful drain must not also schedule a retry"
+        );
+        assert!(
+            !ctx.retries.contains_key(&key),
+            "a successful drain is terminal and must drop its retry-map entry"
+        );
+    }
+
+    /// `NotHeld` is final: nothing sent, nothing retried. KILLS MUTATION S7.
+    ///
+    /// S7 swapped the `NotHeld` and `Unavailable` arms. `classify_drain_read`
+    /// has a good exhaustive test of the MAPPING; nothing tested the CONSUMER
+    /// of that mapping, so the swap survived. Treating `NotHeld` as retryable
+    /// spins forever against a contract we will never hold.
+    #[tokio::test(flavor = "current_thread")]
+    async fn not_held_sends_nothing_and_does_not_retry() {
+        let (op_manager, _rx, _probe, _guards) =
+            harness("v2drain-notheld", StubReply::NoState).await;
+        let key = test_key(32);
+        let mut ctx = RecordingCtx::default();
+        ctx.retries.insert(key, 1);
+
+        handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
+
+        assert!(
+            ctx.fanned_out.is_empty(),
+            "we hold no state for this contract; there is nothing to broadcast"
+        );
+        assert!(
+            ctx.retries_scheduled.is_empty(),
+            "NotHeld is DEFINITIVE — retrying cannot change it, and a retry here is an \
+             unbounded spin against a contract this node will never hold"
+        );
+        assert!(
+            !ctx.retries.contains_key(&key),
+            "NotHeld is terminal and must drop its retry-map entry; the map has no size \
+             cap, so a terminal arm that forgets leaks one entry per contract"
+        );
+    }
+
+    /// `Unavailable` retries, and the attempt counter advances.
+    /// KILLS MUTATIONS S7 AND S8.
+    ///
+    /// S8 deleted `*attempt += 1`, making the retry loop unbounded against a
+    /// contract handler that was already too busy to answer — the retry then
+    /// amplifies the congestion it exists to recover from. The counter is only
+    /// observable across successive drains, which is why one call is not enough.
+    #[tokio::test(flavor = "current_thread")]
+    async fn unavailable_schedules_a_retry_and_advances_the_attempt_counter() {
+        let (op_manager, _rx, _probe, _guards) =
+            harness("v2drain-unavail", StubReply::ExecutorError).await;
+        let key = test_key(33);
+        let mut ctx = RecordingCtx::default();
+
+        for expected_attempts in 1..=P2pConnManager::MAX_V2_DRAIN_RETRIES {
+            handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
+            assert_eq!(
+                ctx.retries.get(&key).copied(),
+                Some(expected_attempts),
+                "each Unavailable drain must ADVANCE the attempt counter. If this stays \
+                 at 1 the counter is not incrementing and the retry is unbounded"
+            );
+        }
+        assert_eq!(
+            ctx.retries_scheduled.len() as u8,
+            P2pConnManager::MAX_V2_DRAIN_RETRIES,
+            "every attempt below the cap must schedule exactly one retry"
+        );
+        assert!(
+            ctx.fanned_out.is_empty(),
+            "a failed read has nothing to fan out — broadcasting here would put \
+             whatever was last in hand on the wire"
+        );
+
+        // One more: the cap is reached, so this must GIVE UP rather than retry.
+        handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
+        assert_eq!(
+            ctx.retries_scheduled.len() as u8,
+            P2pConnManager::MAX_V2_DRAIN_RETRIES,
+            "at the cap the drain must stop retrying"
+        );
+        assert!(
+            !ctx.retries.contains_key(&key),
+            "giving up is terminal and must drop its retry-map entry"
+        );
+    }
+
+    /// The retry body must re-queue through the marker-respecting API.
+    /// KILLS MUTATION S10.
+    ///
+    /// S10 made the spawned retry sleep and then do nothing. Retries fired,
+    /// cost a task spawn each, and never re-queued — and the suite stayed
+    /// green because the body was an anonymous closure inside a `tokio::spawn`
+    /// inside a `match` arm, addressable by nothing.
+    #[tokio::test(flavor = "current_thread")]
+    async fn retry_body_requeues_through_the_marker_respecting_api() {
+        let (op_manager, mut rx, _probe, _guards) =
+            harness("v2drain-retrybody", StubReply::NoState).await;
+        let key = test_key(34);
+
+        run_v2_drain_retry(
+            op_manager.clone(),
+            key,
+            Duration::ZERO,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+        let mut queued = Vec::new();
+        while let Ok(event) = rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::V2DelegateStateChanged { key }) = event {
+                queued.push(key);
+            }
+        }
+        assert_eq!(
+            queued,
+            vec![key],
+            "the retry must actually re-queue the drain. If this is empty the retry is a \
+             sleep that does nothing, and the committed write is never announced"
+        );
+    }
+
+    /// A cancelled shutdown token must abandon the retry.
+    ///
+    /// The `select!` is why the sleep is interruptible at all: a >=1s plain
+    /// sleep in a retry loop keeps the task alive past shutdown.
+    #[tokio::test(flavor = "current_thread")]
+    async fn retry_body_abandons_on_shutdown() {
+        let (op_manager, mut rx, _probe, _guards) =
+            harness("v2drain-retrycancel", StubReply::NoState).await;
+        let key = test_key(35);
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        shutdown.cancel();
+
+        run_v2_drain_retry(op_manager.clone(), key, Duration::from_secs(3600), shutdown).await;
+
+        let mut queued = 0;
+        while let Ok(event) = rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::V2DelegateStateChanged { .. }) = event {
+                queued += 1;
+            }
+        }
+        assert_eq!(
+            queued, 0,
+            "a cancelled retry must not re-queue; it must also not have waited out the \
+             3600s delay, which is what this test finishing at all demonstrates"
+        );
+    }
+
+    /// The marker is cleared BEFORE the read — asserted behaviourally.
+    ///
+    /// `v2_drain_clears_marker_before_reading_state` scrapes source order for
+    /// this, and a reviewer defeated it with a block comment: the needle stayed
+    /// present, the pin stayed green, and the marker latched permanently. This
+    /// checks the actual ordering instead, by having the stub handler snapshot
+    /// the marker at the instant it serves the read.
+    ///
+    /// Why the order matters: between the read and the fan-out a delegate may
+    /// write again. If the marker were still set, that write would coalesce
+    /// into THIS drain — which has already read and cannot see it — and its
+    /// fan-out would never happen.
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_clears_the_coalescing_marker_before_reading_state() {
+        let (op_manager, _rx, marker_set_at_read, _guards) =
+            harness("v2drain-order", StubReply::Found(&[1])).await;
+        let key = test_key(36);
+
+        // Put the marker in the state a queued broadcast leaves it in.
+        op_manager.v2_delegate_broadcast_pending.insert(*key.id());
+        assert!(op_manager.v2_delegate_broadcast_pending.contains(key.id()));
+
+        let mut ctx = RecordingCtx::default();
+        handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
+
+        assert!(
+            !marker_set_at_read.load(Ordering::SeqCst),
+            "the coalescing marker must already be CLEAR when the state read is served. \
+             If it is still set, a write landing during the read coalesces into a drain \
+             that has already read past it, and that write is never announced (#5479)"
+        );
+        assert!(
+            !op_manager.v2_delegate_broadcast_pending.contains(key.id()),
+            "and it must stay clear through the fan-out"
+        );
+    }
+}

--- a/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
@@ -396,8 +396,8 @@ mod tests {
 
     fn test_key(seed: u8) -> ContractKey {
         ContractKey::from_params_and_code(
-            &Parameters::from(vec![seed]),
-            &ContractCode::from(vec![seed, seed, seed]),
+            Parameters::from(vec![seed]),
+            ContractCode::from(vec![seed, seed, seed]),
         )
     }
 
@@ -476,7 +476,9 @@ mod tests {
                             anyhow::anyhow!("stub executor failure"),
                         )),
                     };
-                    let _ = ch_channel
+                    // The drain may already have timed out and stopped waiting; a
+                    // failed reply is expected in that case and is not the stub's problem.
+                    let _reply_sent = ch_channel
                         .send_to_sender(
                             id,
                             ContractHandlerEvent::GetResponse {

--- a/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
@@ -229,7 +229,7 @@ mod tests {
     use crate::message::NodeEvent;
     use crate::node::EventLoopNotificationsReceiver;
     use freenet_stdlib::prelude::{ContractCode, Parameters};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
 
     /// What the stub contract handler answers a drain's `GetQuery` with.
     #[derive(Clone, Copy)]
@@ -404,17 +404,26 @@ mod tests {
     /// Build a real `OpManager` plus a stub contract handler that answers every
     /// `GetQuery` with `reply`.
     ///
-    /// `marker_set_at_read` records whether the coalescing marker was still set
-    /// at the moment the handler saw the read — which is how
-    /// `drain_clears_the_marker_before_reading_state` checks an ORDERING that
-    /// the source-order pin can only scrape.
+    /// The returned `Mutex<Option<bool>>` records whether the coalescing marker
+    /// was still set at the moment the handler served the read — which is how
+    /// `drain_clears_the_coalescing_marker_before_reading_state` checks an
+    /// ORDERING that the source-order pin can only scrape.
+    ///
+    /// It is THREE-valued on purpose. `None` means the read never reached the
+    /// handler at all, and that case must be distinguishable from "the read
+    /// happened and the marker was clear". With a plain `AtomicBool` starting
+    /// `false`, a drain that stopped reading entirely would leave the probe
+    /// `false` and satisfy an assertion of "the marker was clear at the read" —
+    /// passing because the event it describes never occurred. A guard asserting
+    /// the ABSENCE of something must also assert that the thing EXISTS to be
+    /// absent from.
     async fn harness(
         id: &str,
         reply: StubReply,
     ) -> (
         Arc<OpManager>,
         EventLoopNotificationsReceiver,
-        Arc<AtomicBool>,
+        Arc<Mutex<Option<bool>>>,
         Box<dyn std::any::Any>,
     ) {
         let config_args = ConfigArgs {
@@ -448,8 +457,8 @@ mod tests {
         );
         op_manager.ring.attach_op_manager(&op_manager);
 
-        let marker_set_at_read = Arc::new(AtomicBool::new(false));
-        let marker_probe = marker_set_at_read.clone();
+        let marker_at_read: Arc<Mutex<Option<bool>>> = Arc::new(Mutex::new(None));
+        let marker_probe = marker_at_read.clone();
         let op_for_stub = op_manager.clone();
 
         // The stub handler. Answers GetQuery per `reply`, and snapshots the
@@ -457,11 +466,10 @@ mod tests {
         tokio::spawn(async move {
             while let Ok((id, ev, _priority)) = ch_channel.recv_from_sender().await {
                 if let ContractHandlerEvent::GetQuery { instance_id, .. } = ev {
-                    marker_probe.store(
+                    *marker_probe.lock().unwrap() = Some(
                         op_for_stub
                             .v2_delegate_broadcast_pending
                             .contains(&instance_id),
-                        Ordering::SeqCst,
                     );
                     let response = match reply {
                         StubReply::Found(bytes) => Ok(StoreResponse {
@@ -493,7 +501,7 @@ mod tests {
 
         let guards: Box<dyn std::any::Any> =
             Box::new((wait_for_event, result_router_rx, task_monitor));
-        (op_manager, notification_rx, marker_set_at_read, guards)
+        (op_manager, notification_rx, marker_at_read, guards)
     }
 
     /// `Found` must fan the state out. KILLS MUTATION S1.
@@ -666,6 +674,32 @@ mod tests {
             "a cancelled retry must not re-queue; it must also not have waited out the \
              3600s delay, which is what this test finishing at all demonstrates"
         );
+
+        // THE POSITIVE HALF. Everything above is an assertion of absence, and an
+        // absence is satisfied by a harness that could never have observed the
+        // thing: a broken notification channel, a receiver already drained, a
+        // key that never matches. So prove the observation was POSSIBLE by
+        // running the same call with a live token and watching it queue.
+        run_v2_drain_retry(
+            op_manager.clone(),
+            key,
+            Duration::ZERO,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+        let mut queued_after = 0;
+        while let Ok(event) = rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::V2DelegateStateChanged { .. }) = event {
+                queued_after += 1;
+            }
+        }
+        assert_eq!(
+            queued_after, 1,
+            "an UNCANCELLED retry through the same harness must queue exactly one event. \
+             If this is 0 the harness cannot observe a re-queue at all, and the \
+             assertion above passed because nothing could ever have been seen — not \
+             because cancellation worked"
+        );
     }
 
     /// The marker is cleared BEFORE the read — asserted behaviourally.
@@ -682,7 +716,7 @@ mod tests {
     /// fan-out would never happen.
     #[tokio::test(flavor = "current_thread")]
     async fn drain_clears_the_coalescing_marker_before_reading_state() {
-        let (op_manager, _rx, marker_set_at_read, _guards) =
+        let (op_manager, _rx, marker_at_read, _guards) =
             harness("v2drain-order", StubReply::Found(&[1])).await;
         let key = test_key(36);
 
@@ -693,11 +727,19 @@ mod tests {
         let mut ctx = RecordingCtx::default();
         handle_v2_delegate_state_changed(&mut ctx, &op_manager, key, 100).await;
 
-        assert!(
-            !marker_set_at_read.load(Ordering::SeqCst),
-            "the coalescing marker must already be CLEAR when the state read is served. \
-             If it is still set, a write landing during the read coalesces into a drain \
-             that has already read past it, and that write is never announced (#5479)"
+        // Some(false) = the read WAS served, and the marker was already clear.
+        // None would mean the read never happened, in which case this test proves
+        // nothing about ordering — the positive half of the assertion.
+        assert_eq!(
+            *marker_at_read.lock().unwrap(),
+            Some(false),
+            "expected the read to be SERVED (not None) and the coalescing marker to be \
+             already CLEAR when it was. None means the drain never issued the read, so \
+             the ordering this test exists to check did not occur and a bare \
+             'marker was not set' assertion would have passed vacuously. Some(true) \
+             means the marker was still set at the read: a write landing during the read \
+             then coalesces into a drain that has already read past it, and that write is \
+             never announced (#5479)"
         );
         assert!(
             !op_manager.v2_delegate_broadcast_pending.contains(key.id()),

--- a/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
@@ -189,6 +189,44 @@ pub(super) async fn run_v2_drain_retry(
     }
 }
 
+/// Spawn a V2 drain retry for `key` after `delay`.
+///
+/// A free function rather than an inline body in
+/// `<P2pConnManager as V2DrainCtx>::schedule_retry`, so that the WIRING — the
+/// `OpManager` clone, the shutdown token taken from the ring, and the spawn
+/// itself — is reachable from a test. Emptying `schedule_retry`'s body was the
+/// one mutation the recording-double tests could not see, because they replace
+/// the very impl that holds it.
+pub(super) fn spawn_v2_drain_retry(op_manager: &Arc<OpManager>, key: ContractKey, delay: Duration) {
+    let op_mgr = op_manager.clone();
+    let shutdown = op_manager.ring.shutdown_token();
+    tokio::spawn(run_v2_drain_retry(op_mgr, key, delay, shutdown));
+}
+
+/// The PRODUCTION side effects.
+///
+/// # What tests can and cannot reach here
+///
+/// The nine behavioural tests drive `RecordingCtx`, which REPLACES this impl —
+/// so they say nothing about it. That is the seam's cost, and it is the same
+/// shape as the mutation that started this work: emptying `schedule_retry` to
+/// `{}` stops every `Unavailable` drain retrying while every test stays green.
+///
+/// Two mitigations, and the honest limit:
+///
+/// * Each method is now a ONE-LINE delegation to something that is itself
+///   tested — `spawn_v2_drain_retry` behaviourally, `handle_broadcast_state_change`
+///   by its own suite. There is no logic left in here to get wrong.
+/// * `production_drain_ctx_delegates_rather_than_reimplementing` pins those
+///   three delegations as REAL CODE through the comment-stripping scanner, so
+///   an emptied body or a commented-out call fails.
+///
+/// LIMIT, stated rather than implied: that pin is a source scrape, and this
+/// file's own history is why that is worth distrusting. Genuinely executing
+/// this impl needs a constructed `P2pConnManager` — 25 fields including a
+/// transport, a bridge and an event register — and, worse, `fan_out` would
+/// still need a populated ring before a broadcast attempt were observable. That
+/// fixture is a larger piece of work than this change and is NOT done here.
 impl V2DrainCtx for P2pConnManager {
     fn v2_drain_retries_mut(&mut self) -> &mut HashMap<ContractKey, u8> {
         &mut self.v2_drain_retries
@@ -205,9 +243,7 @@ impl V2DrainCtx for P2pConnManager {
     }
 
     fn schedule_retry(&mut self, op_manager: &Arc<OpManager>, key: ContractKey, delay: Duration) {
-        let op_mgr = op_manager.clone();
-        let shutdown = op_manager.ring.shutdown_token();
-        tokio::spawn(run_v2_drain_retry(op_mgr, key, delay, shutdown));
+        spawn_v2_drain_retry(op_manager, key, delay);
     }
 }
 
@@ -369,6 +405,101 @@ mod tests {
              outcome leaks a map entry; more means a still-retrying path drops its own \
              counter, making the retry unbounded."
         );
+    }
+
+    /// The production `schedule_retry` wiring, driven for real.
+    ///
+    /// KILLS the seam review's Medium at one remove: `schedule_retry`'s body is
+    /// now a single call to this, and this is exercised end-to-end — the
+    /// `OpManager` clone, the shutdown token pulled from the ring, the spawn,
+    /// and the re-queue the spawned task performs.
+    ///
+    /// The recording double cannot reach any of that, because it REPLACES the
+    /// impl that holds it. This is the closest a test gets without constructing
+    /// a whole `P2pConnManager`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_v2_drain_retry_requeues_after_the_delay() {
+        let (op_manager, mut rx, _probe, _guards) =
+            harness("v2drain-spawnwire", StubReply::NoState).await;
+        let key = test_key(37);
+
+        spawn_v2_drain_retry(&op_manager, key, Duration::ZERO);
+
+        // Let the spawned task run. `current_thread` means it cannot progress
+        // until we yield.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut queued = Vec::new();
+        while let Ok(event) = rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::V2DelegateStateChanged { key }) = event {
+                queued.push(key);
+            }
+        }
+        assert_eq!(
+            queued,
+            vec![key],
+            "spawning a drain retry must actually re-queue the drain. If this is empty the \
+             spawn wiring is broken -- the clone, the shutdown token, or the spawn itself \
+             -- and every Unavailable drain silently stops retrying while the \
+             RecordingCtx tests stay green"
+        );
+    }
+
+    /// The production `V2DrainCtx` impl must DELEGATE, not reimplement.
+    ///
+    /// The nine behavioural tests drive `RecordingCtx`, which replaces this
+    /// impl, so none of them can see it. The seam review found exactly that:
+    /// empty `schedule_retry`'s body to `{}` and every `Unavailable` drain
+    /// stops retrying with the whole suite green.
+    ///
+    /// So each method is reduced to one delegation, and this asserts those
+    /// delegations exist AS REAL CODE — through the comment-stripping scanner,
+    /// because a `//`-only filter is what let four earlier pins in this
+    /// workstream pass against commented-out calls.
+    ///
+    /// This is a source scrape and is therefore the weaker half. It is here
+    /// because the alternative -- constructing a `P2pConnManager` and a
+    /// populated ring so `fan_out` is observable -- is a bigger piece of work
+    /// than this change. See the impl's own rustdoc for that limit.
+    #[test]
+    fn production_drain_ctx_delegates_rather_than_reimplementing() {
+        const SOURCE: &str = include_str!("v2_drain.rs");
+        let start = SOURCE
+            .find("impl V2DrainCtx for P2pConnManager {")
+            .expect("the production V2DrainCtx impl is gone — re-anchor this pin");
+        let rest = &SOURCE[start..];
+        let end = rest.find("\n#[cfg(test)]").expect(
+            "the test module no longer follows the impl — this pin bounds its scan \
+                     on it, and unbounded it would read its own assertion text and pass \
+                     vacuously. Re-anchor it.",
+        );
+        let body = strip_comments(&rest[..end]);
+
+        for (needle, why) in [
+            (
+                "&mut self.v2_drain_retries",
+                "the retry map must be the manager's own field; a fresh map per call makes \
+                 every drain look like a first attempt and the retry never bounds",
+            ),
+            (
+                "self.handle_broadcast_state_change(op_manager, key, new_state, false, false)",
+                "fan_out must hand the read state to the real fan-out with the same five \
+                 arguments the pre-extraction arm used; this is the leg whose absence is \
+                 #5479",
+            ),
+            (
+                "spawn_v2_drain_retry(op_manager, key, delay)",
+                "schedule_retry must actually spawn the retry. An empty body here stops \
+                 every Unavailable drain retrying, and no RecordingCtx test can see it \
+                 because the double replaces this impl",
+            ),
+        ] {
+            assert!(
+                body.contains(needle),
+                "the production V2DrainCtx impl must contain `{needle}` as real code \
+                 (not commented out, not in a string): {why}"
+            );
+        }
     }
 
     /// The marker clear must precede the state read, in source order too.

--- a/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/v2_drain.rs
@@ -407,6 +407,86 @@ mod tests {
         );
     }
 
+    /// All THREE `V2BroadcastQueued` outcomes must be distinguishable.
+    ///
+    /// KILLS MUTATION N6. Returning `Coalesced` where `EnqueueFailed` belongs
+    /// survived the full suite: nothing anywhere observed the difference, so a
+    /// two-valued signal was replaced by a three-valued one that no test could
+    /// tell apart. The arms are not cosmetic -- `run_v2_drain_retry` branches on
+    /// them, and the branch exists because conflating them mis-counts drops:
+    /// `Coalesced` is benign (a fresh write queued its own drain, so this write
+    /// IS announced) while `EnqueueFailed` is a real lost broadcast. Counting a
+    /// coalesce as a drop pushes the power-of-two WARN milestone exponentially
+    /// out of reach, so a genuine drop then logs nothing at all.
+    ///
+    /// Each arm is checked together with its marker side effect, because the
+    /// return value and the marker have to agree: a `Coalesced` that released
+    /// the marker, or an `EnqueueFailed` that held it, is the latch bug.
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_v2_delegate_broadcast_distinguishes_its_three_outcomes() {
+        let (op_manager, rx, _probe, _guards) =
+            harness("v2drain-queue-outcomes", StubReply::NoState).await;
+        let first = test_key(41);
+
+        // 1. Nothing queued for this contract yet -> Queued, marker taken.
+        assert!(
+            matches!(
+                op_manager.queue_v2_delegate_broadcast(first),
+                V2BroadcastQueued::Queued
+            ),
+            "the first write for a contract must report Queued"
+        );
+        assert!(
+            op_manager
+                .v2_delegate_broadcast_pending
+                .contains(first.id()),
+            "a Queued broadcast must hold the coalescing marker until the drain clears it"
+        );
+
+        // 2. Same contract, still undrained -> Coalesced. NOT a drop: the
+        //    outstanding drain re-reads stored state, so this write is announced
+        //    by it.
+        assert!(
+            matches!(
+                op_manager.queue_v2_delegate_broadcast(first),
+                V2BroadcastQueued::Coalesced
+            ),
+            "a repeat write while a broadcast is undrained must report Coalesced, not \
+             Queued and not EnqueueFailed -- it is benign and must not be counted as a \
+             dropped broadcast"
+        );
+        assert!(
+            op_manager
+                .v2_delegate_broadcast_pending
+                .contains(first.id()),
+            "coalescing must LEAVE the marker set; releasing it here would let the next \
+             write queue a second event for a broadcast that has not drained"
+        );
+
+        // 3. Channel closed -> EnqueueFailed, marker released. A fresh contract,
+        //    so the insert succeeds and the failure is genuinely the enqueue.
+        drop(rx);
+        let second = test_key(42);
+        assert!(
+            matches!(
+                op_manager.queue_v2_delegate_broadcast(second),
+                V2BroadcastQueued::EnqueueFailed
+            ),
+            "a failed enqueue must report EnqueueFailed and NOT Coalesced. Reporting a \
+             real lost broadcast as a benign coalesce is mutation N6: the drop goes \
+             uncounted, and because the WARN fires at powers of two, an inflated or \
+             deflated counter means a genuine drop logs nothing at all"
+        );
+        assert!(
+            !op_manager
+                .v2_delegate_broadcast_pending
+                .contains(second.id()),
+            "a failed enqueue must RELEASE the marker. Left set it latches the contract: \
+             every later write coalesces into a broadcast that was never queued and will \
+             never drain, so the contract stops propagating for the process lifetime"
+        );
+    }
+
     /// The production `schedule_retry` wiring, driven for real.
     ///
     /// KILLS the seam review's Medium at one remove: `schedule_retry`'s body is

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -460,6 +460,33 @@ pub(crate) enum DrainStateRead {
 static V2_BROADCAST_ENQUEUE_DROPPED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+/// Count a dropped V2 broadcast enqueue, warning only at power-of-two milestones.
+///
+/// RATE-LIMITED deliberately. This fires exactly when the notification channel
+/// is `Full`, and `try_notify_node_event_on` logs that same condition at
+/// `debug!` precisely because a per-occurrence WARN on it flooded production
+/// gateways after the HN spike (#4238) at 8-14 MB/hour. The marker is released
+/// on failure, so every subsequent write to the contract retries and would log
+/// again — an unconditional WARN here is that incident by another door.
+/// `release_max_level_info` still rules out `debug!` (the drop would leave no
+/// evidence in a release build, the #4981 shape), so the resolution is the one
+/// `tracing::register::note_dropped_event_log` already uses for this exact
+/// trade: count every occurrence, warn at 1, 2, 4, 8, ...
+fn note_v2_broadcast_enqueue_dropped(key: &ContractKey, err: &OpError) {
+    let dropped =
+        V2_BROADCAST_ENQUEUE_DROPPED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    if dropped.is_power_of_two() {
+        tracing::warn!(
+            contract = %key,
+            error = %err,
+            dropped_total = dropped,
+            "V2 delegate state-change broadcast dropped: notification channel would block. \
+             The write is committed locally; the network learns of it on the next write or \
+             within one anti-entropy round (300s). Logged at power-of-two milestones (#4238)."
+        );
+    }
+}
+
 /// Map a contract-handler reply onto a [`DrainStateRead`].
 ///
 /// Split out from [`OpManager::read_state_for_broadcast_drain`] so the mapping
@@ -1059,19 +1086,7 @@ impl OpManager {
             // the contract would silently stop propagating for the process
             // lifetime.
             self.v2_delegate_broadcast_pending.remove(key.id());
-            let dropped =
-                V2_BROADCAST_ENQUEUE_DROPPED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-            // WARN, not debug: `release_max_level_info` compiles debug out, so
-            // a debug-only line here would make this drop invisible in exactly
-            // the builds that matter. Same reasoning as the drain-read drop.
-            tracing::warn!(
-                contract = %key,
-                error = %err,
-                dropped_total = dropped,
-                "V2 delegate state-change broadcast dropped: notification channel would \
-                 block. The write is committed locally; the network learns of it on the \
-                 next write or via anti-entropy"
-            );
+            note_v2_broadcast_enqueue_dropped(&key, &err);
             return false;
         }
         true
@@ -1145,13 +1160,14 @@ impl OpManager {
 
     /// Read the current local state for `key` from the contract handler, or
     /// `None` if we don't host it / the read fails. Used by the #4359 deferred
-    /// re-broadcast flush to avoid re-emitting superseded give-up-time bytes,
-    /// and by the V2 delegate broadcast drain, which carries no state of its
-    /// own and reads what is stored at drain time.
-    pub(crate) async fn read_current_contract_state(
-        &self,
-        key: &ContractKey,
-    ) -> Option<WrappedState> {
+    /// re-broadcast flush to avoid re-emitting superseded give-up-time bytes.
+    ///
+    /// NOT used by the V2 delegate broadcast drain, which needs a bounded read
+    /// that distinguishes a failure from "not held" and therefore has its own
+    /// [`Self::read_state_for_broadcast_drain`]. An earlier version of this
+    /// comment claimed the drain as a caller and widened the visibility for it;
+    /// both were wrong, and the visibility is back to private.
+    async fn read_current_contract_state(&self, key: &ContractKey) -> Option<WrappedState> {
         use crate::contract::ContractHandlerEvent;
         match self
             .notify_contract_handler(ContractHandlerEvent::GetQuery {

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -482,7 +482,8 @@ fn note_v2_broadcast_enqueue_dropped(key: &ContractKey, err: &OpError) {
             dropped_total = dropped,
             "V2 delegate state-change broadcast dropped: notification channel would block. \
              The write is committed locally; the network learns of it on the next write or \
-             within one anti-entropy round (300s). Logged at power-of-two milestones (#4238)."
+             within about one anti-entropy round (up to 300s, staggered across peers rather \
+             than swept). Logged at power-of-two milestones (#4238)."
         );
     }
 }
@@ -1125,10 +1126,25 @@ impl OpManager {
     ///
     /// That case is bounded, not silent: it is counted and WARNed at the drain
     /// site, and a peer hosting or actively using the contract re-learns the
-    /// state within one anti-entropy round (`INTEREST_HEARTBEAT_INTERVAL`,
-    /// 300 s), because the heartbeat summarize and the broadcast fan-out are
-    /// gated on the SAME `should_summarize_or_broadcast` predicate — see
+    /// state within about one anti-entropy round — up to
+    /// `INTEREST_HEARTBEAT_INTERVAL` (300 s), staggered rather than swept,
+    /// since the heartbeat spreads its sends across the interval
+    /// (`spread_delay = INTEREST_HEARTBEAT_INTERVAL / num_peers`).
+    ///
+    /// That recovery covers the right PEERS, not merely the right contracts,
+    /// and the two are not the same claim. The heartbeat enumerates every
+    /// CONNECTED peer (`get_connections_by_location`), while a broadcast target
+    /// must be an advertised co-host resolved through the same connection
+    /// table — so the heartbeat's peer set is a strict SUPERSET of the
+    /// broadcast's, and no peer that would have received the fan-out is
+    /// missed. The contract-level gate matches too: the heartbeat summarize and
+    /// the broadcast fan-out share the one `should_summarize_or_broadcast`
+    /// predicate, deliberately, so they cannot drift — see
     /// `broadcast_queue::should_broadcast_contract`, which says so explicitly.
+    /// The comparison that drives the repair reads FACT on both sides (our real
+    /// summary against the peer's real digest, never our cached belief about
+    /// that peer), which is what makes it a repair rather than a re-assertion
+    /// of the same stale view.
     /// The real fix is #5544/#5554, which parks delegates off this loop and
     /// removes the precondition entirely.
     pub(crate) async fn read_state_for_broadcast_drain(

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -216,6 +216,21 @@ pub(crate) struct OpManager {
     /// network instead of landing locally-hosted only (issue #4359).
     pub(crate) pending_broadcasts:
         Arc<crate::operations::update::pending_broadcast::PendingBroadcastStore>,
+    /// Contracts with a V2 delegate state-change broadcast already queued and
+    /// not yet drained.
+    ///
+    /// The queued event names the contract and carries no state; the handler
+    /// re-reads the current stored state when it drains. So the queue holds a
+    /// contract id per pending broadcast rather than a `WrappedState`, and its
+    /// cost does not scale with state size. This set is what makes the queued
+    /// broadcasts coalesce: while one is outstanding for a contract, further
+    /// writes to that contract add nothing to the queue, and the single drain
+    /// broadcasts whatever is stored by the time it runs.
+    ///
+    /// Membership is cleared by the handler BEFORE it re-reads, so a write
+    /// landing during the read queues a fresh event rather than being folded
+    /// into one already in flight.
+    pub(crate) v2_delegate_broadcast_pending: Arc<dashmap::DashSet<ContractInstanceId>>,
     /// Request router for client request deduplication.
     ///
     /// This is initialized lazily from `client_event_handling` because the router is only
@@ -344,6 +359,7 @@ impl Clone for OpManager {
             broadcast_coverage: self.broadcast_coverage.clone(),
             update_propagation_stats: self.update_propagation_stats.clone(),
             pending_broadcasts: self.pending_broadcasts.clone(),
+            v2_delegate_broadcast_pending: self.v2_delegate_broadcast_pending.clone(),
             request_router: self.request_router.clone(),
             orphan_stream_registry: self.orphan_stream_registry.clone(),
             stream_progress_registry: self.stream_progress_registry.clone(),
@@ -558,6 +574,7 @@ impl OpManager {
             pending_broadcasts: Arc::new(
                 crate::operations::update::pending_broadcast::PendingBroadcastStore::new(),
             ),
+            v2_delegate_broadcast_pending: Arc::new(dashmap::DashSet::new()),
             request_router,
             orphan_stream_registry,
             stream_progress_registry: Arc::new(StreamProgressRegistry::new()),
@@ -943,10 +960,59 @@ impl OpManager {
         .await;
     }
 
+    /// Queue a V2 delegate state-change broadcast for `key`, coalescing with
+    /// any broadcast already queued for the same contract.
+    ///
+    /// Returns `true` when an event was actually enqueued. A `false` return is
+    /// the normal coalesced case — a broadcast for this contract is already
+    /// outstanding and will pick up this write when it drains, because it
+    /// re-reads the stored state rather than carrying a snapshot.
+    ///
+    /// Synchronous and non-blocking on purpose: the only caller runs inside a
+    /// WASM host call on the V2 delegate write path, where blocking would be
+    /// worse than a dropped broadcast. A drop is recoverable — the next write
+    /// or a summary-mismatch resync re-announces the state.
+    pub(crate) fn queue_v2_delegate_broadcast(&self, key: ContractKey) -> bool {
+        // `insert` returns false when the id was already present, i.e. a
+        // broadcast is queued and undrained: coalesce into it and enqueue
+        // nothing.
+        if !self.v2_delegate_broadcast_pending.insert(*key.id()) {
+            return false;
+        }
+        if let Err(err) =
+            self.try_notify_node_event(crate::message::NodeEvent::V2DelegateStateChanged { key })
+        {
+            // Release the marker. Leaving it set after a failed enqueue would
+            // latch this contract permanently: every later write would see a
+            // broadcast "already queued" that no handler will ever drain, and
+            // the contract would silently stop propagating for the process
+            // lifetime.
+            self.v2_delegate_broadcast_pending.remove(key.id());
+            tracing::debug!(
+                contract = %key,
+                error = %err,
+                "Failed to queue V2 delegate state-change broadcast (best-effort)"
+            );
+            return false;
+        }
+        true
+    }
+
+    /// Clear the queued-broadcast marker for `key`, called by the handler when
+    /// it begins draining. See [`Self::queue_v2_delegate_broadcast`].
+    pub(crate) fn clear_v2_delegate_broadcast_pending(&self, key: &ContractKey) {
+        self.v2_delegate_broadcast_pending.remove(key.id());
+    }
+
     /// Read the current local state for `key` from the contract handler, or
     /// `None` if we don't host it / the read fails. Used by the #4359 deferred
-    /// re-broadcast flush to avoid re-emitting superseded give-up-time bytes.
-    async fn read_current_contract_state(&self, key: &ContractKey) -> Option<WrappedState> {
+    /// re-broadcast flush to avoid re-emitting superseded give-up-time bytes,
+    /// and by the V2 delegate broadcast drain, which carries no state of its
+    /// own and reads what is stored at drain time.
+    pub(crate) async fn read_current_contract_state(
+        &self,
+        key: &ContractKey,
+    ) -> Option<WrappedState> {
         use crate::contract::ContractHandlerEvent;
         match self
             .notify_contract_handler(ContractHandlerEvent::GetQuery {

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -231,6 +231,9 @@ pub(crate) struct OpManager {
     /// landing during the read queues a fresh event rather than being folded
     /// into one already in flight.
     pub(crate) v2_delegate_broadcast_pending: Arc<dashmap::DashSet<ContractInstanceId>>,
+    /// Serialises the marker insert / enqueue / rollback triple in
+    /// [`OpManager::queue_v2_delegate_broadcast`]. See that function.
+    v2_delegate_broadcast_queue_lock: Arc<Mutex<()>>,
     /// Request router for client request deduplication.
     ///
     /// This is initialized lazily from `client_event_handling` because the router is only
@@ -360,6 +363,7 @@ impl Clone for OpManager {
             update_propagation_stats: self.update_propagation_stats.clone(),
             pending_broadcasts: self.pending_broadcasts.clone(),
             v2_delegate_broadcast_pending: self.v2_delegate_broadcast_pending.clone(),
+            v2_delegate_broadcast_queue_lock: self.v2_delegate_broadcast_queue_lock.clone(),
             request_router: self.request_router.clone(),
             orphan_stream_registry: self.orphan_stream_registry.clone(),
             stream_progress_registry: self.stream_progress_registry.clone(),
@@ -418,6 +422,32 @@ impl Drop for ClientOpGuard {
         // the drain notices counter==0.
         self.counter.fetch_sub(1, Ordering::Relaxed);
     }
+}
+
+/// Outcome of [`OpManager::queue_v2_delegate_broadcast`].
+///
+/// Three outcomes, not two, because a `bool` conflated the one case where
+/// NOTHING WENT WRONG with the one case where a write goes unannounced — and
+/// the caller then counted both as drops. Coalescing is the common, healthy
+/// path on any node whose delegate writes the same contract twice in quick
+/// succession, so counting it poisoned the very signal that exists to make a
+/// real drop visible: the drop WARN fires at powers of two, so inflating the
+/// counter with non-events pushes the next milestone exponentially further out
+/// and a genuine drop then logs nothing at all (#4981's shape, arrived at from
+/// the opposite direction).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum V2BroadcastQueued {
+    /// An event was enqueued; a drain will run for this contract.
+    Queued,
+    /// A drain was already outstanding for this contract and had not yet run.
+    /// **Nothing was lost:** the drain re-reads stored state rather than
+    /// carrying a snapshot, so it announces this write too.
+    Coalesced,
+    /// The notification channel would have blocked, and the marker was
+    /// released. This write goes unannounced. Already counted and WARNed by
+    /// `note_v2_broadcast_enqueue_dropped` inside the call, so a caller must
+    /// NOT count it a second time.
+    EnqueueFailed,
 }
 
 /// Outcome of a bounded state read on the V2 broadcast drain path.
@@ -481,9 +511,10 @@ fn note_v2_broadcast_enqueue_dropped(key: &ContractKey, err: &OpError) {
             error = %err,
             dropped_total = dropped,
             "V2 delegate state-change broadcast dropped: notification channel would block. \
-             The write is committed locally; the network learns of it on the next write or \
-             within about one anti-entropy round (up to 300s, staggered across peers rather \
-             than swept). Logged at power-of-two milestones (#4238)."
+             The write is committed locally; the network learns of it on the next write, \
+             or eventually via anti-entropy — 300s is the heartbeat PERIOD, not a \
+             recovery bound, since each exchange is capped and randomly sampled. \
+             Logged at power-of-two milestones (#4238)."
         );
     }
 }
@@ -674,6 +705,7 @@ impl OpManager {
                 crate::operations::update::pending_broadcast::PendingBroadcastStore::new(),
             ),
             v2_delegate_broadcast_pending: Arc::new(dashmap::DashSet::new()),
+            v2_delegate_broadcast_queue_lock: Arc::new(Mutex::new(())),
             request_router,
             orphan_stream_registry,
             stream_progress_registry: Arc::new(StreamProgressRegistry::new()),
@@ -1072,39 +1104,59 @@ impl OpManager {
     /// worse than a dropped broadcast. A drop is recoverable — the next write
     /// or a summary-mismatch resync re-announces the state.
     ///
-    /// # The marker insert and the enqueue are not atomic
+    /// # The marker insert and the enqueue are made atomic by a lock
     ///
-    /// `insert` and `try_notify_node_event` are two steps, and the rollback
-    /// below reads the marker a third time. Nothing here is a transaction, so
-    /// this is safe only because the write path is SERIAL: the sole caller is a
-    /// WASM host call executing on `contract_handling`, one delegate at a time.
+    /// `insert`, `try_notify_node_event` and the rollback below are three
+    /// operations, and the coalescing contract depends on another caller never
+    /// observing the marker between them. A short mutex supplies that.
     ///
-    /// Recorded because that is the THIRD safety argument on this path resting
-    /// on the same serial loop — the other two are the drain's bounded read and
-    /// the coalescing contract — and #5544/#5554 are actively removing the loop
-    /// as a stall point. Parking does NOT remove the serialisation (one
-    /// `process()` still runs at a time, and the parked task holds no
-    /// `ContractHandler`, which the borrow checker enforces), so the argument
-    /// survives that change. It would not survive a genuinely concurrent
-    /// writer, and the failure would be silent rather than loud:
+    /// IT USED TO SAY THE SERIAL LOOP SUPPLIED IT, AND THAT WAS FALSE — the
+    /// comment asserted "the sole caller is a WASM host call executing on
+    /// `contract_handling`", and this very PR added a second caller: the drain
+    /// retry in `p2p_protoc`, which runs inside `tokio::spawn` on the
+    /// multi-threaded runtime. So the PR shipped the concurrent writer its own
+    /// safety argument said the protocol could not survive. Two reviewers found
+    /// it independently; it is recorded here rather than quietly corrected
+    /// because the shape is the one worth recognising — a true claim ("the
+    /// write path is serial") about the wrong set (the write path was, the
+    /// caller set was not).
     ///
-    /// * writer A inserts the marker and is preempted before its enqueue;
-    /// * writer B sees the id present, coalesces, and returns `false` — the
-    ///   correct answer only if A's broadcast actually happens;
-    /// * A's enqueue then fails, so A clears the marker and logs ONE drop.
+    /// The sequence it made reachable, all of it silent:
     ///
-    /// B's write is now unannounced with nothing recorded about it, and the
-    /// drop counter under-reports by exactly the number of coalesced writers.
-    /// Anyone making this path concurrent must replace the pair with a single
-    /// atomic transition (e.g. keep the marker owned by the enqueuer and clear
-    /// it only at the drain, per `clear_v2_delegate_broadcast_pending`), not
-    /// add a lock around the two steps as they stand.
-    pub(crate) fn queue_v2_delegate_broadcast(&self, key: ContractKey) -> bool {
+    /// * retry task R inserts the marker and is preempted before its enqueue;
+    /// * delegate write W, on the loop, sees the marker present, coalesces, and
+    ///   returns `Coalesced` — correct only if R's broadcast actually happens;
+    /// * R's enqueue fails, so R rolls the marker back and counts ONE drop.
+    ///
+    /// No event exists, so no drain runs and no retry is scheduled for either.
+    /// W's committed write is never announced, the delegate was told it
+    /// succeeded, and the counter reports one loss where there were at least
+    /// two. Reachability needs the notification channel full during the
+    /// interleave — which is precisely the condition the retry exists for.
+    ///
+    /// With the lock held across all three steps, a caller sees either no
+    /// marker, or a marker whose enqueue has already succeeded. It never sees
+    /// one that is about to be rolled back, so a coalesce is always a real
+    /// promise. The lock is uncontended in the common case and covers no
+    /// `.await`.
+    ///
+    /// An earlier version of this comment claimed a lock here would be the
+    /// wrong fix and that only "marker owned by the enqueuer, cleared at the
+    /// drain" would do. That was also wrong: the drain deliberately clears the
+    /// marker BEFORE its read, so that a write landing during the read is not
+    /// swallowed, and moving the clear to after the read would trade this bug
+    /// for that one.
+    pub(crate) fn queue_v2_delegate_broadcast(&self, key: ContractKey) -> V2BroadcastQueued {
+        // Held across insert, enqueue and rollback. See this function's docs:
+        // without it, a caller can coalesce into a marker that is about to be
+        // rolled back, and its write is then never announced.
+        let _serialise = self.v2_delegate_broadcast_queue_lock.lock();
+
         // `insert` returns false when the id was already present, i.e. a
         // broadcast is queued and undrained: coalesce into it and enqueue
         // nothing.
         if !self.v2_delegate_broadcast_pending.insert(*key.id()) {
-            return false;
+            return V2BroadcastQueued::Coalesced;
         }
         if let Err(err) =
             self.try_notify_node_event(crate::message::NodeEvent::V2DelegateStateChanged { key })
@@ -1116,9 +1168,9 @@ impl OpManager {
             // lifetime.
             self.v2_delegate_broadcast_pending.remove(key.id());
             note_v2_broadcast_enqueue_dropped(&key, &err);
-            return false;
+            return V2BroadcastQueued::EnqueueFailed;
         }
-        true
+        V2BroadcastQueued::Queued
     }
 
     /// Read the current stored state for `key` for a V2 broadcast drain,
@@ -1154,10 +1206,33 @@ impl OpManager {
     ///
     /// That case is bounded, not silent: it is counted and WARNed at the drain
     /// site, and a peer hosting or actively using the contract re-learns the
-    /// state within about one anti-entropy round — up to
-    /// `INTEREST_HEARTBEAT_INTERVAL` (300 s), staggered rather than swept,
-    /// since the heartbeat spreads its sends across the interval
-    /// (`spread_delay = INTEREST_HEARTBEAT_INTERVAL / num_peers`).
+    /// state EVENTUALLY, and "eventually" is the strongest word available here.
+    /// An earlier version of this comment said "within one anti-entropy round
+    /// (300 s)", and a later one softened it to "up to 300 s, staggered". Both
+    /// were wrong in the same way: `INTEREST_HEARTBEAT_INTERVAL` is the PERIOD
+    /// at which the heartbeat fires, not a bound on when a given contract is
+    /// repaired.
+    ///
+    /// Two things break the bound, neither visible from this file:
+    ///
+    /// * **The exchange is capped and randomly sampled.** A summary reply
+    ///   carries at most `MAX_SUMMARY_ENTRIES_PER_MESSAGE` entries; when a peer
+    ///   shares more contracts than that, the list is rotated by a RANDOM
+    ///   offset and truncated (`node.rs`, the `Summaries` arm). So a node with
+    ///   many contracts covers them across several rounds, and the number of
+    ///   rounds is probabilistic rather than `ceil(N / cap)`.
+    /// * **The repair needs local interest too.** The exchange only reaches
+    ///   contracts in the interest-hash intersection that pass
+    ///   `has_local_interest`. The live broadcast path has no such condition —
+    ///   since #4642 step 9 it is advertised-co-hosts-only. The two sets are
+    ///   related through the interest index rather than identical, so the peer
+    ///   superset argument below is about PEERS while the quantity that
+    ///   actually matters is the (peer, contract) pair.
+    ///
+    /// This matters because this paragraph is the entire justification for
+    /// dropping a write that already committed and already returned success to
+    /// the delegate. An operator reading "300 s" will wait five minutes for a
+    /// self-heal that may take considerably longer.
     ///
     /// That recovery covers the right PEERS, not merely the right contracts,
     /// and the two are not the same claim. The heartbeat enumerates every
@@ -1181,13 +1256,26 @@ impl OpManager {
         timeout: std::time::Duration,
     ) -> DrainStateRead {
         use crate::contract::ContractHandlerEvent;
+        // BACKGROUND, not the `NetworkRelay` default (#4534). This read is
+        // best-effort by construction — its whole failure story is "the write
+        // goes unannounced and anti-entropy repairs it" — so under queue
+        // pressure it must be shed BEFORE genuine relayed peer operations, not
+        // compete with them. `NetworkRelay` is not shed first; only
+        // `ClientLocal` gets the reserve.
+        //
+        // The sibling this path is otherwise modelled on, the periodic interest
+        // -sync summarize, already uses `Background` for exactly this reason.
+        // And the pressure is self-inflicted if it is not: the coalescing
+        // marker is per contract, so a delegate writing N contracts issues N
+        // of these at an already-saturated handler.
         match self
-            .notify_contract_handler_with_timeout(
+            .notify_contract_handler_with_timeout_prioritized(
                 ContractHandlerEvent::GetQuery {
                     instance_id: *key.id(),
                     return_contract_code: false,
                 },
                 timeout,
+                crate::contract::Priority::Background,
             )
             .await
         {
@@ -1726,6 +1814,23 @@ impl OpManager {
     ) -> Result<ContractHandlerEvent, ContractError> {
         self.ch_outbound
             .send_to_handler_with_timeout(msg, timeout, crate::contract::Priority::DEFAULT)
+            .await
+    }
+
+    /// As [`Self::notify_contract_handler_with_timeout`], but at an explicit
+    /// priority class (#4534).
+    ///
+    /// Exists because `Priority::DEFAULT` is `NetworkRelay`, which the fair
+    /// queue does NOT shed first — correct for relayed peer operations, wrong
+    /// for best-effort maintenance work that is explicitly allowed to fail.
+    pub async fn notify_contract_handler_with_timeout_prioritized(
+        &self,
+        msg: ContractHandlerEvent,
+        timeout: std::time::Duration,
+        priority: crate::contract::Priority,
+    ) -> Result<ContractHandlerEvent, ContractError> {
+        self.ch_outbound
+            .send_to_handler_with_timeout(msg, timeout, priority)
             .await
     }
 
@@ -2914,6 +3019,64 @@ mod tests {
     /// is GONE — the collapse DECISION now DRIVES one level up
     /// (`reconcile_wants_collapse` at the callers), so the function must no longer
     /// build a reconcile snapshot or run the action-set comparator here.
+    /// PIN: the marker triple in `queue_v2_delegate_broadcast` is serialised.
+    ///
+    /// The function inserts a marker, enqueues an event, and rolls the marker
+    /// back if the enqueue fails. A caller that observes the marker BETWEEN the
+    /// insert and a failed enqueue coalesces into a promise that will not be
+    /// kept, and its committed write is never announced — silently, and with
+    /// the drop counter under-reporting by exactly the number of coalescers.
+    ///
+    /// This is not hypothetical. The function's doc used to assert the triple
+    /// was safe because "the sole caller is a WASM host call executing on
+    /// `contract_handling`", while this same PR added a second caller inside a
+    /// `tokio::spawn` on the multi-threaded runtime. The claim was true of the
+    /// WRITE PATH and false of the CALLER SET.
+    ///
+    /// Pinned from source because the race needs two threads interleaving at a
+    /// specific instruction with a full notification channel — reliably
+    /// unreproducible in a unit test. What IS checkable is that the lock is
+    /// still taken, and taken BEFORE the insert.
+    ///
+    /// FALSIFY: delete the `lock()` line, or move it below the `insert`.
+    /// Verified both fail.
+    #[test]
+    fn queue_v2_delegate_broadcast_serialises_its_marker_triple() {
+        const SRC: &str = include_str!("op_state_manager.rs");
+        let start = SRC
+            .find("pub(crate) fn queue_v2_delegate_broadcast(")
+            .expect("queue_v2_delegate_broadcast must exist");
+        let rest = &SRC[start + 1..];
+        let end = rest
+            .find("\n    pub")
+            .map(|e| start + 1 + e)
+            .unwrap_or(SRC.len());
+        // Strip line comments: every needle below also appears in this
+        // function's own prose, and a scrape that counted those would report a
+        // true fact about the wrong text.
+        let body: String = SRC[start..end]
+            .lines()
+            .map(|l| match l.find("//") {
+                Some(i) => &l[..i],
+                None => l,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let lock = body.find("v2_delegate_broadcast_queue_lock.lock()").expect(
+            "the marker triple must be serialised by the queue lock; without it a \
+             concurrent caller can coalesce into a marker that is then rolled back",
+        );
+        let insert = body
+            .find("v2_delegate_broadcast_pending.insert(")
+            .expect("the marker insert must still exist");
+        assert!(
+            lock < insert,
+            "the lock must be acquired BEFORE the marker insert, or the window \
+             it exists to close is still open"
+        );
+    }
+
     #[test]
     fn send_unsubscribe_upstream_drives_off_stored_upstream_after_flip() {
         const SRC: &str = include_str!("op_state_manager.rs");

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1071,6 +1071,34 @@ impl OpManager {
     /// WASM host call on the V2 delegate write path, where blocking would be
     /// worse than a dropped broadcast. A drop is recoverable — the next write
     /// or a summary-mismatch resync re-announces the state.
+    ///
+    /// # The marker insert and the enqueue are not atomic
+    ///
+    /// `insert` and `try_notify_node_event` are two steps, and the rollback
+    /// below reads the marker a third time. Nothing here is a transaction, so
+    /// this is safe only because the write path is SERIAL: the sole caller is a
+    /// WASM host call executing on `contract_handling`, one delegate at a time.
+    ///
+    /// Recorded because that is the THIRD safety argument on this path resting
+    /// on the same serial loop — the other two are the drain's bounded read and
+    /// the coalescing contract — and #5544/#5554 are actively removing the loop
+    /// as a stall point. Parking does NOT remove the serialisation (one
+    /// `process()` still runs at a time, and the parked task holds no
+    /// `ContractHandler`, which the borrow checker enforces), so the argument
+    /// survives that change. It would not survive a genuinely concurrent
+    /// writer, and the failure would be silent rather than loud:
+    ///
+    /// * writer A inserts the marker and is preempted before its enqueue;
+    /// * writer B sees the id present, coalesces, and returns `false` — the
+    ///   correct answer only if A's broadcast actually happens;
+    /// * A's enqueue then fails, so A clears the marker and logs ONE drop.
+    ///
+    /// B's write is now unannounced with nothing recorded about it, and the
+    /// drop counter under-reports by exactly the number of coalesced writers.
+    /// Anyone making this path concurrent must replace the pair with a single
+    /// atomic transition (e.g. keep the marker owned by the enqueuer and clear
+    /// it only at the drain, per `clear_v2_delegate_broadcast_pending`), not
+    /// add a lock around the two steps as they stand.
     pub(crate) fn queue_v2_delegate_broadcast(&self, key: ContractKey) -> bool {
         // `insert` returns false when the id was already present, i.e. a
         // broadcast is queued and undrained: coalesce into it and enqueue

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1093,6 +1093,29 @@ impl OpManager {
     ///   `None`, which the caller cannot tell from "we do not hold this
     ///   contract". For a drain those need opposite handling: not held is a
     ///   correct no-op, a failed read means a committed write goes unannounced.
+    ///
+    /// # Why this read can time out, and what that costs
+    ///
+    /// The read is a `GetQuery` to the SERIAL `contract_handling` loop, and the
+    /// event being drained was queued by a V2 delegate write that executed ON
+    /// that loop. So the read cannot be served until that delegate returns.
+    ///
+    /// For a delegate that merely computes, that is microseconds and the
+    /// bounded retry at the drain site covers any transient overrun. For a
+    /// delegate that requests USER INPUT it is not: `prompter.prompt(..)` is
+    /// awaited inline inside `handle_delegate_with_contract_requests`, which
+    /// `contract_handling` awaits in turn, so the loop is held for as long as a
+    /// human takes to answer. Such a write is committed, reported successful to
+    /// the delegate, and its broadcast dropped — retries cannot outlast a human.
+    ///
+    /// That case is bounded, not silent: it is counted and WARNed at the drain
+    /// site, and a peer hosting or actively using the contract re-learns the
+    /// state within one anti-entropy round (`INTEREST_HEARTBEAT_INTERVAL`,
+    /// 300 s), because the heartbeat summarize and the broadcast fan-out are
+    /// gated on the SAME `should_summarize_or_broadcast` predicate — see
+    /// `broadcast_queue::should_broadcast_contract`, which says so explicitly.
+    /// The real fix is #5544/#5554, which parks delegates off this loop and
+    /// removes the precondition entirely.
     pub(crate) async fn read_state_for_broadcast_drain(
         &self,
         key: &ContractKey,

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -420,6 +420,26 @@ impl Drop for ClientOpGuard {
     }
 }
 
+/// Outcome of a bounded state read on the V2 broadcast drain path.
+///
+/// Three-way on purpose: collapsing `NotHeld` and `Unavailable` into one
+/// `None` is what let a transient read failure silently discard a write that
+/// had already committed and already returned success to the delegate — the
+/// #5479 shape, reintroduced inside its own fix. See
+/// [`OpManager::read_state_for_broadcast_drain`].
+#[derive(Debug)]
+pub(crate) enum DrainStateRead {
+    /// State read successfully; broadcast it.
+    Found(WrappedState),
+    /// We genuinely do not hold this contract. Not broadcasting is correct
+    /// and final — there is nothing to send.
+    NotHeld,
+    /// The read failed or timed out. We may or may not hold the contract; the
+    /// write it would have announced has already committed. NOT the same as
+    /// `NotHeld`, and must not be silent.
+    Unavailable,
+}
+
 impl OpManager {
     // `pub(crate)` (widened from `pub(super)`) so in-crate unit tests outside
     // `crate::node` can stand up a real `OpManager` — specifically the
@@ -996,6 +1016,50 @@ impl OpManager {
             return false;
         }
         true
+    }
+
+    /// Read the current stored state for `key` for a V2 broadcast drain,
+    /// BOUNDED and distinguishing "not held" from "could not read".
+    ///
+    /// Two things this does not share with
+    /// [`Self::read_current_contract_state`], both because this one runs INLINE
+    /// on the network event loop rather than in a spawned task:
+    ///
+    /// * **It is bounded.** The plain read inherits the handler's own
+    ///   `CH_EV_RESPONSE_TIME_OUT` (300 s). A bare `.await` of that on this loop
+    ///   is the #4549 wedge — see this file's `query_app_subscriptions_bounded`,
+    ///   whose comment records a saturated handler killing the network event
+    ///   listener and taking a gateway network-dead. Same remedy, same reason.
+    /// * **It reports the failure.** The plain read maps every failure to
+    ///   `None`, which the caller cannot tell from "we do not hold this
+    ///   contract". For a drain those need opposite handling: not held is a
+    ///   correct no-op, a failed read means a committed write goes unannounced.
+    pub(crate) async fn read_state_for_broadcast_drain(
+        &self,
+        key: &ContractKey,
+        timeout: std::time::Duration,
+    ) -> DrainStateRead {
+        use crate::contract::ContractHandlerEvent;
+        match self
+            .notify_contract_handler_with_timeout(
+                ContractHandlerEvent::GetQuery {
+                    instance_id: *key.id(),
+                    return_contract_code: false,
+                },
+                timeout,
+            )
+            .await
+        {
+            Ok(ContractHandlerEvent::GetResponse {
+                response: Ok(store_response),
+                ..
+            }) => match store_response.state {
+                Some(state) => DrainStateRead::Found(state),
+                None => DrainStateRead::NotHeld,
+            },
+            Ok(_) => DrainStateRead::Unavailable,
+            Err(_) => DrainStateRead::Unavailable,
+        }
     }
 
     /// Clear the queued-broadcast marker for `key`, called by the handler when

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3067,6 +3067,39 @@ mod tests {
             "the marker triple must be serialised by the queue lock; without it a \
              concurrent caller can coalesce into a marker that is then rolled back",
         );
+
+        // THE GUARD MUST BE BOUND TO A LIVE NAME, not taken and dropped.
+        //
+        // Found by a reviewer defeating the first version of this pin: writing
+        //
+        //     drop(self.v2_delegate_broadcast_queue_lock.lock());
+        //
+        // leaves the needle present and still before the insert, so the pin
+        // passed while the lock was released immediately and the serialisation
+        // it exists to enforce was gone. `let _ = ...` does the same thing, and
+        // differs from the correct `let _serialise = ...` by one character --
+        // a known Rust footgun and exactly the edit an "unused variable"
+        // cleanup suggests.
+        let line_start = body[..lock].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let line = body[line_start..].lines().next().unwrap_or("").trim();
+        assert!(
+            !line.starts_with("drop("),
+            "the lock must be BOUND, not taken and dropped on the spot: a \
+             temporary guard is released at the end of the statement, so the \
+             insert and the enqueue below run unserialised. Found: {line:?}"
+        );
+        let binding = line
+            .strip_prefix("let ")
+            .and_then(|rest| rest.split('=').next())
+            .map(str::trim)
+            .unwrap_or("");
+        assert!(
+            binding != "_" && !binding.is_empty(),
+            "the lock guard must bind to a NAMED variable that lives to the end \
+             of the function. `let _ = ..` drops it immediately, which is the \
+             same defect as `drop(..)` and one character from correct. \
+             Found binding: {binding:?} in {line:?}"
+        );
         let insert = body
             .find("v2_delegate_broadcast_pending.insert(")
             .expect("the marker insert must still exist");

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -440,6 +440,57 @@ pub(crate) enum DrainStateRead {
     Unavailable,
 }
 
+/// Count of V2 delegate broadcasts dropped because the notification channel
+/// would have blocked.
+///
+/// A counter as well as a log line, for the reason `.claude/rules/code-style.md`
+/// gives: a refusal that is not counted renders as a clean zero. The paired
+/// message is WARN because `crates/core/Cargo.toml` enables tracing's
+/// `release_max_level_info` — anything below INFO does not exist in a release
+/// binary, which is how #4981 discarded legitimate traffic with no greppable
+/// evidence.
+///
+/// KNOWN LIMIT: this drop heals on the delegate's NEXT write, which is prompt
+/// for a chatty writer and not prompt at all for an infrequent one. A delegate
+/// that writes once a day and loses that write to a full channel stays
+/// unpropagated until the following day, and the anti-entropy heartbeat only
+/// helps peers already interested in the contract. Re-attempting from the loop
+/// instead of dropping needs a bounded sweep of the pending set with its own
+/// TTL — a design change, not a tweak — and is tracked separately.
+static V2_BROADCAST_ENQUEUE_DROPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Map a contract-handler reply onto a [`DrainStateRead`].
+///
+/// Split out from [`OpManager::read_state_for_broadcast_drain`] so the mapping
+/// can be tested exhaustively without a live contract handler. The async
+/// wrapper is then only the round trip; this is the part with the decision in
+/// it, and the decision is the one that regressed before: collapsing a failed
+/// read into the same answer as "we do not hold it" is what silently discarded
+/// an already-committed write.
+pub(crate) fn classify_drain_read(
+    reply: Result<crate::contract::ContractHandlerEvent, ContractError>,
+) -> DrainStateRead {
+    use crate::contract::ContractHandlerEvent;
+    match reply {
+        // The handler answered and it holds state for the contract.
+        Ok(ContractHandlerEvent::GetResponse {
+            response: Ok(store_response),
+            ..
+        }) => match store_response.state {
+            Some(state) => DrainStateRead::Found(state),
+            // Answered, and we genuinely hold no state. Final: nothing to send.
+            None => DrainStateRead::NotHeld,
+        },
+        // The handler answered with an executor error, or answered something
+        // that is not a GetResponse at all. Either way we learned nothing about
+        // whether we hold the contract, so this is NOT `NotHeld`.
+        Ok(_) => DrainStateRead::Unavailable,
+        // Timed out, channel closed, or the handler is gone.
+        Err(_) => DrainStateRead::Unavailable,
+    }
+}
+
 impl OpManager {
     // `pub(crate)` (widened from `pub(super)`) so in-crate unit tests outside
     // `crate::node` can stand up a real `OpManager` — specifically the
@@ -1008,10 +1059,18 @@ impl OpManager {
             // the contract would silently stop propagating for the process
             // lifetime.
             self.v2_delegate_broadcast_pending.remove(key.id());
-            tracing::debug!(
+            let dropped =
+                V2_BROADCAST_ENQUEUE_DROPPED.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            // WARN, not debug: `release_max_level_info` compiles debug out, so
+            // a debug-only line here would make this drop invisible in exactly
+            // the builds that matter. Same reasoning as the drain-read drop.
+            tracing::warn!(
                 contract = %key,
                 error = %err,
-                "Failed to queue V2 delegate state-change broadcast (best-effort)"
+                dropped_total = dropped,
+                "V2 delegate state-change broadcast dropped: notification channel would \
+                 block. The write is committed locally; the network learns of it on the \
+                 next write or via anti-entropy"
             );
             return false;
         }
@@ -1050,15 +1109,8 @@ impl OpManager {
             )
             .await
         {
-            Ok(ContractHandlerEvent::GetResponse {
-                response: Ok(store_response),
-                ..
-            }) => match store_response.state {
-                Some(state) => DrainStateRead::Found(state),
-                None => DrainStateRead::NotHeld,
-            },
-            Ok(_) => DrainStateRead::Unavailable,
-            Err(_) => DrainStateRead::Unavailable,
+            Ok(ev) => classify_drain_read(Ok(ev)),
+            Err(e) => classify_drain_read(Err(e)),
         }
     }
 
@@ -5815,6 +5867,78 @@ mod tests {
             "NetworkContractHandler::build must call rehydrate_local_hosting_interest \
              after load_hosting_cache so restored hosted contracts serve locally and \
              rejoin anti-entropy (#4780)",
+        );
+    }
+
+    /// `classify_drain_read` must keep "we hold no state" and "the read failed"
+    /// APART. Collapsing them is what let a transient GetQuery failure silently
+    /// discard a write that had already committed and already returned success
+    /// to the delegate — #5479's own shape, reappearing inside its fix.
+    ///
+    /// Exhaustive over the four reply shapes on purpose: three of them are
+    /// error-ish and only ONE of those three is safe to treat as final.
+    #[test]
+    fn classify_drain_read_separates_not_held_from_unavailable() {
+        use crate::contract::ContractHandlerEvent;
+        use crate::contract::StoreResponse;
+        use freenet_stdlib::prelude::WrappedState;
+
+        // 1. Answered, state present → broadcast it.
+        let found = classify_drain_read(Ok(ContractHandlerEvent::GetResponse {
+            key: None,
+            response: Ok(StoreResponse {
+                state: Some(WrappedState::new(vec![1, 2, 3])),
+                contract: None,
+            }),
+        }));
+        match found {
+            DrainStateRead::Found(state) => assert_eq!(state.as_ref(), &[1, 2, 3]),
+            other @ DrainStateRead::NotHeld | other @ DrainStateRead::Unavailable => {
+                panic!("state present must map to Found, got {other:?}")
+            }
+        }
+
+        // 2. Answered, no state → we genuinely do not hold it. Final, silent.
+        assert!(
+            matches!(
+                classify_drain_read(Ok(ContractHandlerEvent::GetResponse {
+                    key: None,
+                    response: Ok(StoreResponse {
+                        state: None,
+                        contract: None,
+                    }),
+                })),
+                DrainStateRead::NotHeld
+            ),
+            "an answered read with no state means we do not hold the contract; not \
+             broadcasting is correct and there is nothing to warn about"
+        );
+
+        // 3. Answered with an executor error → we learned NOTHING about whether
+        //    we hold it, so this must NOT be NotHeld.
+        assert!(
+            matches!(
+                classify_drain_read(Ok(ContractHandlerEvent::GetResponse {
+                    key: None,
+                    response: Err(crate::contract::ExecutorError::other(anyhow::anyhow!(
+                        "executor failure"
+                    ))),
+                })),
+                DrainStateRead::Unavailable
+            ),
+            "an executor error tells us nothing about whether we hold the contract, so \
+             it must be Unavailable — treating it as NotHeld silently drops a committed \
+             write's announcement"
+        );
+
+        // 4. Transport failure (timeout, closed channel, dead handler).
+        assert!(
+            matches!(
+                classify_drain_read(Err(ContractError::NoEvHandlerResponse)),
+                DrainStateRead::Unavailable
+            ),
+            "a failed round trip must be Unavailable, never NotHeld — this is the \
+             timeout case the bounded read exists to produce"
         );
     }
 }

--- a/crates/core/src/ring/broadcast_coverage.rs
+++ b/crates/core/src/ring/broadcast_coverage.rs
@@ -325,6 +325,13 @@ fn peer_hash(tx: &Transaction, pub_key: &TransportPublicKey) -> PeerHash {
 ///   the state it re-drives is by definition one that reached NOBODY, so
 ///   suppressing its fan-out against someone else's claim withholds content
 ///   that has never propagated at all.
+/// * The V2 delegate write callback
+///   (`contract::executor::runtime::v2_delegate_state_write_callback`, #5479).
+///   A delegate writing state while a relayed update for the same contract is
+///   in flight takes that apply's claim. Rarer than the others — it needs a
+///   delegate write concurrent with a relay apply of the same contract — and
+///   healed the same way. Listed here rather than left out, because this
+///   block's own argument is that a partial list is worse than none.
 ///
 /// Each needs a same-contract emission concurrent with a relayed update inside
 /// one contract-handler round trip. All are bounded by [`COVERAGE_TTL`] and

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -337,7 +337,7 @@ impl Drop for ResyncRetrySlot {
 /// Timeout for contract handler queries in the broadcast path (summary and
 /// delta computation). Much shorter than the default 300s to prevent spawned
 /// broadcast tasks from accumulating when the contract handler is slow.
-const BROADCAST_CH_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const BROADCAST_CH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Identifies a peer for interest tracking purposes.
 ///

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -95,7 +95,7 @@ pub(crate) use native_api::time::override_contract_clock;
 pub(crate) use native_api::InheritedOriginsEntry;
 pub use runtime::{ContractExecError, Runtime};
 pub(crate) use runtime::{
-    RuntimeConfig, SharedModuleCache, default_wasmtime_cache_size_bytes_for_dir,
+    RuntimeConfig, SharedModuleCache, StateWriteCallback, default_wasmtime_cache_size_bytes_for_dir,
 };
 pub use secrets_store::{
     DEFAULT_LAST_SEEN_DEBOUNCE_SECS, DEFAULT_PER_USER_INACTIVE_TTL_SECS,
@@ -111,7 +111,7 @@ pub use state_store::StateStore;
 // `MAX_STATE_SIZE` is `pub` (not `pub(crate)`) so it can be re-exported from the
 // crate root as `dev_tool::MAX_CONTRACT_STATE_SIZE` for fdev's client-side check.
 pub use state_store::MAX_STATE_SIZE;
-pub(crate) use state_store::{StateStorage, StateStoreError, state_hash};
+pub(crate) use state_store::{StateCacheInvalidator, StateStorage, StateStoreError, state_hash};
 
 /// Rename a code-hash-named WASM file from the legacy all-lowercase Base58
 /// name to the canonical mixed-case name (issue #4214).

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -476,6 +476,43 @@ mod tests {
             }
         }
 
+        /// Create a DelegateCallEnv wired with BOTH the post-write callback and
+        /// the pre-write admission gate.
+        ///
+        /// The single-hook builders above cannot express a test that observes
+        /// how the two INTERACT — which of them runs first, and whether one
+        /// short-circuiting suppresses the other. See
+        /// `test_env_unchanged_rewrite_still_consults_the_disk_budget_gate`.
+        ///
+        /// # Safety
+        /// Caller must ensure the returned env does not outlive `self`.
+        unsafe fn make_env_with_callback_and_admit(
+            &mut self,
+            cb: super::super::runtime::StateWriteCallback,
+            admit: super::super::runtime::StateAdmitCallback,
+        ) -> DelegateCallEnv {
+            let delegate_key = DelegateKey::new([0u8; 32], CodeHash::new([0u8; 32]));
+            // SAFETY: The caller guarantees the returned env does not outlive `self`,
+            // which keeps the borrowed `secret_store` and `contract_store` alive.
+            unsafe {
+                DelegateCallEnv::new(
+                    vec![],
+                    &mut self.secret_store,
+                    &self.contract_store,
+                    Some(self.db.clone()),
+                    Some(cb),
+                    Some(admit),
+                    delegate_key,
+                    &mut self.delegate_store,
+                    0,
+                    vec![],
+                    None,
+                    self.created_delegates_count.clone(),
+                    self.inherited_origins.clone(),
+                )
+            }
+        }
+
         /// Create a DelegateCallEnv with attested contracts for testing attestation inheritance.
         ///
         /// # Safety
@@ -998,6 +1035,107 @@ mod tests {
             "a rejected oversized V2 PUT must leave the previously-stored state \
              untouched — the check runs before the raw `Storage` write, so \
              nothing should have landed"
+        );
+
+        // The delegate-visible outcome, not just the Rust error. An oversized
+        // state is a CALLER error, so it maps to ERR_INVALID_PARAM rather than
+        // the ERR_STORE_ERROR the disk-budget rejection uses — a delegate
+        // branching on the code must be able to tell "you sent me something
+        // impossible" from "my disk is full".
+        assert_eq!(
+            super::super::native_api::delegate_contracts::delegate_env_error_to_code(
+                &DelegateEnvError::StateTooLarge {
+                    size: super::super::MAX_STATE_SIZE + 1,
+                    limit: super::super::MAX_STATE_SIZE,
+                }
+            ),
+            contract_error_codes::ERR_INVALID_PARAM as i64,
+        );
+    }
+
+    /// Gate interaction: a content-UNCHANGED rewrite must still be admitted by
+    /// the disk-budget gate, and suppressing the post-write hook must not
+    /// suppress the gate.
+    ///
+    /// `put_contract_state_sync` runs five sequenced steps — wrap,
+    /// `check_state_size`, `state_content_changed` (a DB read), the
+    /// disk-budget admit callback, `store_state_sync`, then the conditional
+    /// `after_state_write`. Each is covered on its own; nothing pins the
+    /// ORDER, so a reorder that moved the admit gate behind the no-change
+    /// short-circuit would silently stop metering identical rewrites and no
+    /// existing test would notice.
+    #[tokio::test]
+    async fn test_env_unchanged_rewrite_still_consults_the_disk_budget_gate() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(124, &[1, 2, 3]).await;
+
+        let admit_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let admit_calls_for_cb = admit_calls.clone();
+        let admit: super::super::runtime::StateAdmitCallback =
+            std::sync::Arc::new(move |_k: &ContractKey, _size: usize, _is_update: bool| {
+                admit_calls_for_cb.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            });
+
+        let write_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let write_calls_for_cb = write_calls.clone();
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState| {
+                write_calls_for_cb.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            },
+        );
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback_and_admit(cb, admit) };
+
+        // Rewrite the seeded bytes verbatim: unchanged content, so the
+        // post-write hook is suppressed — but the write still happens.
+        env.put_contract_state_sync(&contract_id, vec![1, 2, 3])
+            .expect("an unchanged V2 PUT should still succeed");
+
+        assert_eq!(
+            admit_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the disk-budget gate must run even for a content-unchanged \
+             rewrite: the raw `Storage` write still happens, so the write \
+             the gate exists to admit is still being made. A reorder that \
+             skipped it here would stop metering identical rewrites"
+        );
+        assert_eq!(
+            write_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the post-write hook must still be suppressed for unchanged \
+             content — the admit gate running does not re-enable it"
+        );
+    }
+
+    /// Gate interaction: a state of EXACTLY `MAX_STATE_SIZE` must be admitted.
+    ///
+    /// `check_state_size` rejects `size > MAX_STATE_SIZE`, so the boundary
+    /// value itself is legal. An off-by-one to `>=` would be invisible to the
+    /// oversized test above, which uses `MAX_STATE_SIZE + 1`.
+    #[tokio::test]
+    async fn test_env_state_at_exactly_max_size_is_admitted() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(125, &[1, 2, 3]).await;
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env() };
+
+        let at_limit = vec![0u8; super::super::MAX_STATE_SIZE];
+        let result = env.put_contract_state_sync(&contract_id, at_limit);
+        assert!(
+            result.is_ok(),
+            "a state of exactly MAX_STATE_SIZE is within the ceiling and must \
+             be accepted — `check_state_size` rejects `> MAX_STATE_SIZE`, not \
+             `>=`. Got {result:?}"
+        );
+        assert_eq!(
+            env.get_contract_state_sync(&contract_id)
+                .unwrap()
+                .map(|s| s.len()),
+            Some(super::super::MAX_STATE_SIZE),
+            "the boundary-size state must actually have landed"
         );
     }
 

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -868,6 +868,139 @@ mod tests {
         );
     }
 
+    /// #5479: a byte-identical rewrite must NOT fire the post-write hook.
+    ///
+    /// `DelegateCallEnv::state_content_changed` is the only thing standing
+    /// between the ordinary delegate shape — *on each application message,
+    /// recompute my contract state and store it*, idempotent, writing the same
+    /// bytes most of the time — and one full network fan-out per message. V1
+    /// gets this for free from `bridged_upsert_contract_state_inner`'s
+    /// `UpsertResult::NoChange` short-circuit; the V2 bypass has to re-apply it,
+    /// and `ring::broadcast_coverage` records that no-change applies are ~97% of
+    /// received contract bytes, so the filter is load-bearing rather than an
+    /// optimisation.
+    ///
+    /// Every OTHER V2 test in this module writes each contract exactly once, and
+    /// `state_content_changed` returns `true` when no prior state exists — so
+    /// before this test the whole suite stayed green with the filter gutted to
+    /// `true`. Two writes of the same bytes is the smallest shape that observes
+    /// it at all.
+    #[tokio::test]
+    async fn test_env_identical_rewrite_does_not_fire_write_callback() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(122, &[1, 2, 3]).await;
+
+        let observed =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
+        let observed_for_cb = observed.clone();
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+                observed_for_cb
+                    .lock()
+                    .unwrap()
+                    .push((*k, new_state.as_ref().to_vec()));
+            },
+        );
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback(cb) };
+
+        // First write: no stored state yet, so this one is genuinely a change.
+        env.put_contract_state_sync(&contract_id, vec![7, 8, 9])
+            .expect("first V2 PUT should succeed");
+        assert_eq!(
+            observed.lock().unwrap().len(),
+            1,
+            "the first write stores new content and must fire the hook"
+        );
+
+        // Second write, same bytes. The write itself still succeeds — the
+        // filter suppresses the SIDE EFFECTS, it does not reject the call.
+        env.put_contract_state_sync(&contract_id, vec![7, 8, 9])
+            .expect("a byte-identical V2 PUT must still report success");
+        assert_eq!(
+            observed.lock().unwrap().len(),
+            1,
+            "a byte-identical V2 PUT must NOT fire the post-write hook a second \
+             time: the hook emits BroadcastStateChange, so firing it here turns \
+             an idempotent delegate into one full network fan-out per message \
+             (#5479). If this assertion reads 2, `state_content_changed` has \
+             been gutted or bypassed."
+        );
+
+        // A genuine change after the no-op must still get through — the filter
+        // must suppress, not latch.
+        env.put_contract_state_sync(&contract_id, vec![7, 8, 10])
+            .expect("a changing V2 PUT after a no-op should succeed");
+        let calls = observed.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            2,
+            "a real change following a no-op must fire the hook — the filter \
+             suppresses identical writes, it does not disable the path"
+        );
+        assert_eq!(
+            calls[1].1,
+            vec![7, 8, 10],
+            "the second firing must carry the newly-written bytes"
+        );
+    }
+
+    /// #5479: a V2 write above `MAX_STATE_SIZE` must be rejected, and nothing
+    /// may land.
+    ///
+    /// `StateStore::{store,update}` enforce this ceiling and the V1 commit path
+    /// enforces it again before broadcasting, but the V2 bypass writes through
+    /// the raw `Storage`, which does not. Before #5479 an oversized V2 write was
+    /// a local-disk problem; now the same uncapped `WrappedState` would be cloned
+    /// into a `BroadcastStateChange` and put on the wire, where every recipient
+    /// rejects it at its own guard AFTER paying for the transfer.
+    #[tokio::test]
+    async fn test_env_oversized_state_is_rejected_and_nothing_is_written() {
+        let mut env_holder = TestEnv::new().await;
+        let contract_id = env_holder.store_contract(123, &[1, 2, 3]).await;
+
+        // A callback that would panic if it ever ran: an oversized write must be
+        // refused BEFORE any post-write side effect, so this is unreachable.
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState| {
+                panic!(
+                    "the post-write hook must not run for a state rejected by \
+                     check_state_size — the broadcast it emits is exactly what \
+                     the size ceiling exists to keep off the wire"
+                );
+            },
+        );
+
+        // SAFETY: `env_holder` is alive for the duration of this test.
+        let env = unsafe { env_holder.make_env_with_callback(cb) };
+
+        let oversized = vec![0u8; super::super::MAX_STATE_SIZE + 1];
+        let result = env.put_contract_state_sync(&contract_id, oversized);
+
+        match result {
+            Err(DelegateEnvError::StateTooLarge { size, limit }) => {
+                assert_eq!(size, super::super::MAX_STATE_SIZE + 1);
+                assert_eq!(limit, super::super::MAX_STATE_SIZE);
+            }
+            other => {
+                panic!("a V2 PUT over MAX_STATE_SIZE must fail with StateTooLarge, got {other:?}")
+            }
+        }
+
+        // `TestEnv::store_contract` seeded this contract with `[1, 2, 3]`, so
+        // asserting that exact value back is stronger than asserting `None`: it
+        // proves the rejected write did not partially overwrite existing state,
+        // not merely that it failed to create new state.
+        assert_eq!(
+            env.get_contract_state_sync(&contract_id).unwrap(),
+            Some(vec![1, 2, 3]),
+            "a rejected oversized V2 PUT must leave the previously-stored state \
+             untouched — the check runs before the raw `Storage` write, so \
+             nothing should have landed"
+        );
+    }
+
     /// #4683 finding #2 regression: a V2 delegate PUT that the admit callback
     /// REJECTS (disk over budget) must return `DiskBudgetExceeded`, map to
     /// `ERR_STORE_ERROR`, and leave the write un-landed (state unchanged). This

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -828,7 +828,9 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
+            move |k: &ContractKey,
+                  new_state: &freenet_stdlib::prelude::WrappedState,
+                  _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()
@@ -874,7 +876,9 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
+            move |k: &ContractKey,
+                  new_state: &freenet_stdlib::prelude::WrappedState,
+                  _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()
@@ -1273,7 +1277,9 @@ mod tests {
         // in `Executor::from_config` / `from_config_with_shared_modules`.
         let invalidator = state_store.cache_invalidator();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
+            move |k: &ContractKey,
+                  _new_state: &freenet_stdlib::prelude::WrappedState,
+                  _changed: bool| {
                 invalidator.invalidate(k);
             },
         );
@@ -1329,7 +1335,9 @@ mod tests {
 
         let invalidator = state_store.cache_invalidator();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
+            move |k: &ContractKey,
+                  _new_state: &freenet_stdlib::prelude::WrappedState,
+                  _changed: bool| {
                 invalidator.invalidate(k);
             },
         );
@@ -1371,7 +1379,9 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
+            move |k: &ContractKey,
+                  new_state: &freenet_stdlib::prelude::WrappedState,
+                  _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -788,12 +788,16 @@ mod tests {
         let contract_id = env_holder.store_contract(120, &[1, 2, 3]).await;
 
         let observed =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, usize)>::new()));
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
-        let cb: super::super::runtime::StateWriteCallback =
-            std::sync::Arc::new(move |k: &ContractKey, state_size: usize| {
-                observed_for_cb.lock().unwrap().push((*k, state_size));
-            });
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+                observed_for_cb
+                    .lock()
+                    .unwrap()
+                    .push((*k, new_state.as_ref().to_vec()));
+            },
+        );
 
         // SAFETY: `env_holder` is alive for the duration of this test.
         let env = unsafe { env_holder.make_env_with_callback(cb) };
@@ -812,10 +816,12 @@ mod tests {
             "callback must receive the written contract key"
         );
         assert_eq!(
-            calls[0].1, 3,
-            "callback must receive the on-disk state byte count (vec![4, 5, 6] = 3 bytes) — \
-             this pins the StateBytesWritten attribution to the actual write size and would \
-             catch a refactor that hardcodes the size or passes a stale length"
+            calls[0].1,
+            vec![4, 5, 6],
+            "callback must receive the state that was actually written. This pins BOTH the \
+             StateBytesWritten attribution (derived from its length) and the payload of the \
+             BroadcastStateChange the production callback emits (#5479), so a refactor that \
+             reconstructs or re-reads the state instead of passing the written one fails here"
         );
     }
 
@@ -828,12 +834,16 @@ mod tests {
         let contract_id = env_holder.store_contract(121, &[10, 20, 30]).await;
 
         let observed =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, usize)>::new()));
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
-        let cb: super::super::runtime::StateWriteCallback =
-            std::sync::Arc::new(move |k: &ContractKey, state_size: usize| {
-                observed_for_cb.lock().unwrap().push((*k, state_size));
-            });
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+                observed_for_cb
+                    .lock()
+                    .unwrap()
+                    .push((*k, new_state.as_ref().to_vec()));
+            },
+        );
 
         // SAFETY: `env_holder` is alive for the duration of this test.
         let env = unsafe { env_holder.make_env_with_callback(cb) };
@@ -852,8 +862,9 @@ mod tests {
             "callback must receive the updated contract key"
         );
         assert_eq!(
-            calls[0].1, 3,
-            "callback must receive the on-disk state byte count (vec![40, 50, 60] = 3 bytes)"
+            calls[0].1,
+            vec![40, 50, 60],
+            "callback must receive the state that was actually written — see the PUT sibling"
         );
     }
 
@@ -986,10 +997,11 @@ mod tests {
         // Wire the PRODUCTION invalidator as the callback — the exact shape used
         // in `Executor::from_config` / `from_config_with_shared_modules`.
         let invalidator = state_store.cache_invalidator();
-        let cb: super::super::runtime::StateWriteCallback =
-            std::sync::Arc::new(move |k: &ContractKey, _size: usize| {
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState| {
                 invalidator.invalidate(k);
-            });
+            },
+        );
 
         {
             // SAFETY: `env_holder` is alive for the duration of this test. The
@@ -1041,10 +1053,11 @@ mod tests {
         assert!(state_store.cached_state_hash(&key).is_some());
 
         let invalidator = state_store.cache_invalidator();
-        let cb: super::super::runtime::StateWriteCallback =
-            std::sync::Arc::new(move |k: &ContractKey, _size: usize| {
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState| {
                 invalidator.invalidate(k);
-            });
+            },
+        );
 
         {
             // SAFETY: see the PUT sibling test above (scoped to drop before the
@@ -1080,12 +1093,16 @@ mod tests {
         env_holder.contract_store.ensure_key_indexed(&key).unwrap();
 
         let observed =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, usize)>::new()));
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
-        let cb: super::super::runtime::StateWriteCallback =
-            std::sync::Arc::new(move |k: &ContractKey, state_size: usize| {
-                observed_for_cb.lock().unwrap().push((*k, state_size));
-            });
+        let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+                observed_for_cb
+                    .lock()
+                    .unwrap()
+                    .push((*k, new_state.as_ref().to_vec()));
+            },
+        );
 
         // SAFETY: `env_holder` is alive for the duration of this test.
         let env = unsafe { env_holder.make_env_with_callback(cb) };

--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -828,7 +828,7 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()
@@ -874,7 +874,7 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()
@@ -905,81 +905,83 @@ mod tests {
         );
     }
 
-    /// #5479: a byte-identical rewrite must NOT fire the post-write hook.
+    /// #5479: a byte-identical rewrite must report `content_changed = false`,
+    /// which is what suppresses the network fan-out.
     ///
-    /// `DelegateCallEnv::state_content_changed` is the only thing standing
-    /// between the ordinary delegate shape — *on each application message,
-    /// recompute my contract state and store it*, idempotent, writing the same
-    /// bytes most of the time — and one full network fan-out per message. V1
-    /// gets this for free from `bridged_upsert_contract_state_inner`'s
-    /// `UpsertResult::NoChange` short-circuit; the V2 bypass has to re-apply it,
-    /// and `ring::broadcast_coverage` records that no-change applies are ~97% of
-    /// received contract bytes, so the filter is load-bearing rather than an
-    /// optimisation.
+    /// The hook itself still RUNS — that is deliberate and is the fix for the
+    /// eviction race. A V2 write commits to the raw `Storage` before the hook,
+    /// so the bookkeeping legs (notably `Ring::commit_state_write`, whose
+    /// generation bump tells a scheduled `EvictContract` the contract was
+    /// written after it was queued) are owed for a byte-identical rewrite too.
+    /// Only the fan-out is skipped, and the flag is how the hook knows.
     ///
-    /// Every OTHER V2 test in this module writes each contract exactly once, and
-    /// `state_content_changed` returns `true` when no prior state exists — so
-    /// before this test the whole suite stayed green with the filter gutted to
-    /// `true`. Two writes of the same bytes is the smallest shape that observes
-    /// it at all.
+    /// The V1 `UpsertResult::NoChange` short-circuit is not a precedent for
+    /// skipping the hook: V1 short-circuits BEFORE writing, so nothing
+    /// committed and nothing is owed.
+    ///
+    /// Every OTHER V2 test in this module writes each contract exactly once,
+    /// and `state_content_changed` returns `true` when no prior state exists —
+    /// so with the filter gutted to `true` the whole suite stayed green. Two
+    /// writes of the same bytes is the smallest shape that observes it.
     #[tokio::test]
-    async fn test_env_identical_rewrite_does_not_fire_write_callback() {
+    async fn test_env_identical_rewrite_reports_no_content_change() {
         let mut env_holder = TestEnv::new().await;
         let contract_id = env_holder.store_contract(122, &[1, 2, 3]).await;
 
-        let observed =
-            std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
+        // Record (bytes, content_changed) per invocation.
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(Vec<u8>, bool)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |_k: &ContractKey,
+                  new_state: &freenet_stdlib::prelude::WrappedState,
+                  content_changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()
-                    .push((*k, new_state.as_ref().to_vec()));
+                    .push((new_state.as_ref().to_vec(), content_changed));
             },
         );
 
         // SAFETY: `env_holder` is alive for the duration of this test.
         let env = unsafe { env_holder.make_env_with_callback(cb) };
 
-        // First write: no stored state yet, so this one is genuinely a change.
+        // First write: no stored state matches, so this is a real change.
         env.put_contract_state_sync(&contract_id, vec![7, 8, 9])
             .expect("first V2 PUT should succeed");
-        assert_eq!(
-            observed.lock().unwrap().len(),
-            1,
-            "the first write stores new content and must fire the hook"
-        );
-
-        // Second write, same bytes. The write itself still succeeds — the
-        // filter suppresses the SIDE EFFECTS, it does not reject the call.
+        // Second write, same bytes.
         env.put_contract_state_sync(&contract_id, vec![7, 8, 9])
             .expect("a byte-identical V2 PUT must still report success");
-        assert_eq!(
-            observed.lock().unwrap().len(),
-            1,
-            "a byte-identical V2 PUT must NOT fire the post-write hook a second \
-             time: the hook emits BroadcastStateChange, so firing it here turns \
-             an idempotent delegate into one full network fan-out per message \
-             (#5479). If this assertion reads 2, `state_content_changed` has \
-             been gutted or bypassed."
-        );
-
-        // A genuine change after the no-op must still get through — the filter
-        // must suppress, not latch.
+        // Third write, changed again — the flag must not latch.
         env.put_contract_state_sync(&contract_id, vec![7, 8, 10])
             .expect("a changing V2 PUT after a no-op should succeed");
+
         let calls = observed.lock().unwrap();
         assert_eq!(
             calls.len(),
-            2,
-            "a real change following a no-op must fire the hook — the filter \
-             suppresses identical writes, it does not disable the path"
+            3,
+            "the post-write hook must run for EVERY committed write, including a \
+             byte-identical one: the write has already landed in storage, so the \
+             generation bump that guards against an in-flight EvictContract reclaiming \
+             it is owed regardless of whether the content changed"
         );
         assert_eq!(
-            calls[1].1,
-            vec![7, 8, 10],
-            "the second firing must carry the newly-written bytes"
+            calls[0],
+            (vec![7, 8, 9], true),
+            "a first write of new content is a change"
+        );
+        assert_eq!(
+            calls[1],
+            (vec![7, 8, 9], false),
+            "a byte-identical rewrite must report content_changed = false — this is what \
+             suppresses the fan-out, and without it an idempotent delegate becomes one \
+             full network fan-out per message (#5479). If this reads true, \
+             `state_content_changed` has been gutted or bypassed"
+        );
+        assert_eq!(
+            calls[2],
+            (vec![7, 8, 10], true),
+            "a real change following a no-op must report true again — the filter \
+             suppresses, it does not latch"
         );
     }
 
@@ -1000,7 +1002,7 @@ mod tests {
         // A callback that would panic if it ever ran: an oversized write must be
         // refused BEFORE any post-write side effect, so this is unreachable.
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState| {
+            |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 panic!(
                     "the post-write hook must not run for a state rejected by \
                      check_state_size — the broadcast it emits is exactly what \
@@ -1080,7 +1082,7 @@ mod tests {
         let write_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let write_calls_for_cb = write_calls.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState| {
+            move |_k: &ContractKey, _s: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 write_calls_for_cb.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             },
         );
@@ -1103,9 +1105,11 @@ mod tests {
         );
         assert_eq!(
             write_calls.load(std::sync::atomic::Ordering::SeqCst),
-            0,
-            "the post-write hook must still be suppressed for unchanged \
-             content — the admit gate running does not re-enable it"
+            1,
+            "the post-write hook must still RUN for unchanged content — the write \
+             committed, so its bookkeeping is owed. What the unchanged case skips is \
+             the fan-out, and the hook decides that from its `content_changed` \
+             argument; see test_env_identical_rewrite_reports_no_content_change"
         );
     }
 
@@ -1269,7 +1273,7 @@ mod tests {
         // in `Executor::from_config` / `from_config_with_shared_modules`.
         let invalidator = state_store.cache_invalidator();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 invalidator.invalidate(k);
             },
         );
@@ -1325,7 +1329,7 @@ mod tests {
 
         let invalidator = state_store.cache_invalidator();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |k: &ContractKey, _new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 invalidator.invalidate(k);
             },
         );
@@ -1367,7 +1371,7 @@ mod tests {
             std::sync::Arc::new(std::sync::Mutex::new(Vec::<(ContractKey, Vec<u8>)>::new()));
         let observed_for_cb = observed.clone();
         let cb: super::super::runtime::StateWriteCallback = std::sync::Arc::new(
-            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState| {
+            move |k: &ContractKey, new_state: &freenet_stdlib::prelude::WrappedState, _changed: bool| {
                 observed_for_cb
                     .lock()
                     .unwrap()

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -535,14 +535,16 @@ pub(super) struct DelegateCallEnv {
     /// contract state synchronously via host functions. ReDb is Arc<Database>
     /// internally, so cloning is cheap.
     state_store_db: Option<Storage>,
-    /// Optional callback invoked AFTER a successful V2 delegate state write
-    /// (`put_contract_state_sync` / `update_contract_state_sync`). Closes the
-    /// EvictContract re-host race for the V2 delegate write path by bumping
-    /// the per-contract generation token and refreshing the hosting-cache
-    /// snapshot — the V2 path bypasses the executor `state_store.{store,update}`
-    /// chokepoints where the four executor-side bump+refresh sites live, so
-    /// without this hook the V2 path leaves the race open. See
-    /// `super::runtime::StateWriteCallback`.
+    /// Optional callback invoked AFTER a successful, content-CHANGING V2
+    /// delegate state write (`put_contract_state_sync` /
+    /// `update_contract_state_sync`). The V2 path bypasses the executor's
+    /// `state_store.{store,update}` chokepoints, so this hook re-applies what
+    /// they do: it invalidates `StateStore`'s caches, bumps the per-contract
+    /// generation and refreshes the hosting-cache snapshot (closing the
+    /// EvictContract re-host race), reports StateBytesWritten, records the
+    /// contract-update timestamp, and emits the `BroadcastStateChange` that
+    /// propagates the write (#5479). See `super::runtime::StateWriteCallback`
+    /// and `after_state_write`.
     state_write_callback: Option<super::runtime::StateWriteCallback>,
     /// Pre-write disk-budget admission gate for V2 delegate writes (#4683,
     /// PR 3). Runs BEFORE the raw `Storage` write in
@@ -662,6 +664,9 @@ pub(super) enum DelegateEnvError {
     StorageError(String),
     /// Pre-write disk-budget admission gate rejected the V2 write (#4683).
     DiskBudgetExceeded(String),
+    /// The state exceeds `MAX_STATE_SIZE`. Enforced here because the V2 path
+    /// bypasses `StateStore::{store,update}`, where the ceiling normally lives.
+    StateTooLarge { size: usize, limit: usize },
 }
 
 /// Errors that can occur during delegate creation via `create_delegate_sync`.
@@ -1007,6 +1012,66 @@ impl DelegateCallEnv {
         }
     }
 
+    /// Reject a V2 delegate write whose state exceeds `MAX_STATE_SIZE`.
+    ///
+    /// `StateStore::{store,update}` enforce this ceiling, and the V1 commit
+    /// path enforces it again before broadcasting. The V2 bypass writes
+    /// through the raw `Storage`, which does not — so before #5479 an
+    /// oversized V2 write was a local-disk problem, and after it the same
+    /// uncapped `WrappedState` would be cloned into a `BroadcastStateChange`
+    /// and put on the wire, where every recipient rejects it at its own guard
+    /// AFTER paying for the transfer. Enforcing it here, next to the
+    /// disk-budget gate, keeps the ceiling where the write is.
+    fn check_state_size(state_size: usize) -> Result<(), DelegateEnvError> {
+        if state_size > crate::wasm_runtime::MAX_STATE_SIZE {
+            return Err(DelegateEnvError::StateTooLarge {
+                size: state_size,
+                limit: crate::wasm_runtime::MAX_STATE_SIZE,
+            });
+        }
+        Ok(())
+    }
+
+    /// Whether `new_state` differs from what is already stored for `key`.
+    ///
+    /// The V1 path never reaches commit-or-broadcast for a byte-identical
+    /// apply — `bridged_upsert_contract_state_inner` short-circuits to
+    /// `UpsertResult::NoChange`, and that filter is load-bearing rather than
+    /// incidental (`ring::broadcast_coverage` records that no-change applies
+    /// are ~97% of received contract bytes). Without the same filter here, the
+    /// ordinary delegate shape "on each message, recompute my state and store
+    /// it" — idempotent, writing identical bytes most of the time — would go
+    /// from zero network fan-out to one full fan-out per message. That is a
+    /// self-inflicted storm needing no attacker, so it is checked, at the cost
+    /// of one ReDb read per V2 write (the V1 path reads the current state
+    /// too).
+    ///
+    /// A read error is reported as CHANGED: failing towards an extra
+    /// broadcast is recoverable, failing towards a silent drop is the bug
+    /// #5479 is about.
+    fn state_content_changed(
+        &self,
+        contract_key: &ContractKey,
+        new_state: &freenet_stdlib::prelude::WrappedState,
+    ) -> bool {
+        let Some(ref db) = self.state_store_db else {
+            return true;
+        };
+        match db.get_state_sync(contract_key) {
+            Ok(Some(existing)) => existing.as_ref() != new_state.as_ref(),
+            Ok(None) => true,
+            Err(e) => {
+                tracing::debug!(
+                    contract = %contract_key,
+                    error = %e,
+                    "could not read the stored state to test for a no-op V2 write; \
+                     treating it as changed"
+                );
+                true
+            }
+        }
+    }
+
     /// The post-write sequence every V2 delegate state write owes, in one
     /// place.
     ///
@@ -1031,7 +1096,21 @@ impl DelegateCallEnv {
         &self,
         contract_key: &ContractKey,
         new_state: &freenet_stdlib::prelude::WrappedState,
+        content_changed: bool,
     ) {
+        if !content_changed {
+            // Byte-identical rewrite: the cached view is still accurate, the
+            // generation does not need bumping, nothing was really written to
+            // meter, and there is nothing for the network to learn. This is
+            // what the V1 path's `UpsertResult::NoChange` short-circuit
+            // achieves; see `state_content_changed`.
+            tracing::debug!(
+                contract = %contract_key,
+                event = "v2_delegate_write_no_content_change",
+                "V2 delegate rewrote identical state; no fan-out"
+            );
+            return;
+        }
         if let Some(cb) = &self.state_write_callback {
             cb(contract_key, new_state);
         }
@@ -1063,6 +1142,8 @@ impl DelegateCallEnv {
         // instead of passing the written one is how these paths drift.
         let new_state = freenet_stdlib::prelude::WrappedState::new(state);
         let state_size = new_state.as_ref().len();
+        Self::check_state_size(state_size)?;
+        let content_changed = self.state_content_changed(&contract_key, &new_state);
 
         // Disk-budget admission gate (#4683): the V2 path bypasses the executor
         // `state_store` chokepoint where the gate normally runs, so apply it here
@@ -1079,7 +1160,7 @@ impl DelegateCallEnv {
         db.store_state_sync(&contract_key, new_state.clone())
             .map_err(|e| DelegateEnvError::StorageError(e.to_string()))?;
 
-        self.after_state_write(&contract_key, &new_state);
+        self.after_state_write(&contract_key, &new_state, content_changed);
 
         Ok(())
     }
@@ -1101,6 +1182,8 @@ impl DelegateCallEnv {
         // Wrap before the admission gate — see `put_contract_state_sync`.
         let new_state = freenet_stdlib::prelude::WrappedState::new(state);
         let state_size = new_state.as_ref().len();
+        Self::check_state_size(state_size)?;
+        let content_changed = self.state_content_changed(&contract_key, &new_state);
 
         // Disk-budget admission gate (#4683): apply the executor-chokepoint gate
         // that the V2 path bypasses, BEFORE the raw write. This is a V2 UPDATE —
@@ -1118,7 +1201,7 @@ impl DelegateCallEnv {
         // Atomic check-and-write in a single ReDb write transaction.
         match db.update_state_sync(&contract_key, new_state.clone()) {
             Ok(true) => {
-                self.after_state_write(&contract_key, &new_state);
+                self.after_state_write(&contract_key, &new_state, content_changed);
                 Ok(())
             }
             Ok(false) => Err(DelegateEnvError::NoExistingState),
@@ -2249,6 +2332,20 @@ pub(super) mod delegate_contracts {
             // A disk-budget rejection is a store-capacity failure from the
             // delegate's perspective — map to the generic store-error code.
             DelegateEnvError::DiskBudgetExceeded(_) => contract_error_codes::ERR_STORE_ERROR as i64,
+            // The delegate handed us a state larger than the protocol allows.
+            // That is a caller error, not a store failure, so it maps to
+            // ERR_INVALID_PARAM rather than ERR_STORE_ERROR — and to an
+            // EXISTING code rather than a new one, because a new negative
+            // return value is a wire-visible change to the V2 delegate API
+            // that a delegate branching on codes would not expect.
+            DelegateEnvError::StateTooLarge { size, limit } => {
+                tracing::warn!(
+                    state_size = size,
+                    limit,
+                    "V2 delegate write rejected: state exceeds MAX_STATE_SIZE"
+                );
+                contract_error_codes::ERR_INVALID_PARAM as i64
+            }
         }
     }
 

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1054,27 +1054,49 @@ impl DelegateCallEnv {
     ///
     /// The comparison happens here; the write happens further down
     /// `put_contract_state_sync` / `update_contract_state_sync`. Nothing holds
-    /// a lock across the two. **Correctness currently depends on delegate
-    /// handling being serialized by the contract-handling loop** — both entry
-    /// points (`contract.rs`) `await` `handle_delegate_with_contract_requests`
-    /// inline on that single loop with no spawn, so two V2 delegate writes to
-    /// one contract cannot interleave on a node today.
+    /// a lock across the two, and this code owns nothing that makes the pair
+    /// safe. **Correctness depends on delegate `process()` being GLOBALLY
+    /// serialized by the contract-handling loop** — `execute_delegate_request`
+    /// is reached only from `handle_delegate_with_contract_requests`, whose
+    /// call sites all `await` it inline on that single-task loop with no
+    /// spawn, so two V2 delegate writes cannot run concurrently on a node.
     ///
-    /// If that serialization is removed, this gate can suppress a REAL change.
-    /// The interleaving is not the symmetric one it looks like: writer A whose
-    /// own bytes happen to equal what it reads decides "no change" and will
+    /// Were that to change, this gate could suppress a REAL change. The
+    /// interleaving is not the symmetric one it looks like: writer A whose own
+    /// bytes happen to equal what it reads decides "no change" and will
     /// suppress; writer B then commits and broadcasts different bytes; A then
     /// writes its own bytes and stays silent. Local state ends at A's value
     /// while the network last heard B's, and nothing re-announces it until the
-    /// next write or the anti-entropy heartbeat. Note that this is precisely
-    /// the idempotent-rewrite workload the gate exists to catch, so the racy
-    /// case is the common case rather than an exotic one.
+    /// next write or the anti-entropy heartbeat. That is precisely the
+    /// idempotent-rewrite workload this gate exists to catch, so the racy case
+    /// would be the common case rather than an exotic one.
     ///
-    /// **#5544 removes that serialization** to fix a node-wide stall. Whoever
-    /// lands it owns this: the gate is not self-sufficient, and the fix is to
-    /// make the compare-and-write atomic (fold the comparison into the same
-    /// ReDb write transaction as the store, the way `update_state_sync`
-    /// already does its check-and-write) rather than to rely on the loop.
+    /// # Per-delegate exclusion would NOT be enough
+    ///
+    /// Read this before concluding some newer delegate-concurrency mechanism
+    /// already covers this gate. **The racing pair is two DIFFERENT delegates
+    /// writing the same contract**, so an exclusion that serializes each
+    /// delegate against itself leaves the race fully intact. Only GLOBAL
+    /// serialization of delegate execution — or an atomic compare-and-write
+    /// here — closes it.
+    ///
+    /// #5544 (implemented by #5554) removes a node-wide stall by moving work
+    /// off this loop, and **preserves the global serialization above**: the
+    /// off-loop task captures neither a `ContractHandler` nor an executor, so
+    /// it structurally cannot invoke a delegate — its jobs (awaiting a human,
+    /// driving a sub-op GET) need neither, and a resumed `process()` always
+    /// runs back on the loop. Parking therefore opens a window in which a
+    /// different delegate may START, not one in which two may RUN. The gate
+    /// stays safe across that change.
+    ///
+    /// # The durable fix
+    ///
+    /// The guarantee above is an unenforced property of the contract-handling
+    /// loop, not an invariant this code holds. Nothing here fails if a future
+    /// change breaks it. The durable fix is to make the compare-and-write
+    /// atomic — fold the comparison into the same ReDb write transaction as
+    /// the store, the way `update_state_sync` already does its check-and-write
+    /// — so this gate stops depending on a caller-side property at all.
     fn state_content_changed(
         &self,
         contract_key: &ContractKey,

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1147,20 +1147,28 @@ impl DelegateCallEnv {
         content_changed: bool,
     ) {
         if !content_changed {
-            // Byte-identical rewrite: the cached view is still accurate, the
-            // generation does not need bumping, nothing was really written to
-            // meter, and there is nothing for the network to learn. This is
-            // what the V1 path's `UpsertResult::NoChange` short-circuit
-            // achieves; see `state_content_changed`.
             tracing::debug!(
                 contract = %contract_key,
                 event = "v2_delegate_write_no_content_change",
                 "V2 delegate rewrote identical state; no fan-out"
             );
-            return;
         }
+        // ALWAYS invoked, including for a byte-identical rewrite — the hook
+        // decides for itself what the unchanged case skips.
+        //
+        // The V1 `UpsertResult::NoChange` short-circuit is NOT a precedent for
+        // returning early here, and the difference is the whole point: V1
+        // short-circuits BEFORE writing, so nothing committed and there is
+        // nothing to record. The V2 path has already written to the raw
+        // `Storage` by the time this runs, so the bookkeeping the hook performs
+        // — in particular `Ring::commit_state_write`, whose generation bump is
+        // what tells a scheduled `EvictContract` that the contract was written
+        // after it was queued (`pool.rs::remove_contract` guard 3) — is owed
+        // whether or not the CONTENT changed. Skipping it left a committed
+        // write invisible to that guard, so an in-flight eviction could reclaim
+        // a contract that had just been written.
         if let Some(cb) = &self.state_write_callback {
-            cb(contract_key, new_state);
+            cb(contract_key, new_state, content_changed);
         }
     }
 

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -542,9 +542,10 @@ pub(super) struct DelegateCallEnv {
     /// they do: it invalidates `StateStore`'s caches, bumps the per-contract
     /// generation and refreshes the hosting-cache snapshot (closing the
     /// EvictContract re-host race), reports StateBytesWritten, records the
-    /// contract-update timestamp, and emits the `BroadcastStateChange` that
-    /// propagates the write (#5479). See `super::runtime::StateWriteCallback`
-    /// and `after_state_write`.
+    /// contract-update timestamp, and — for a write that CHANGED the stored
+    /// bytes — queues the key-only `NodeEvent::V2DelegateStateChanged` that
+    /// propagates it (#5479). See `super::runtime::StateWriteCallback` and
+    /// `after_state_write`.
     state_write_callback: Option<super::runtime::StateWriteCallback>,
     /// Pre-write disk-budget admission gate for V2 delegate writes (#4683,
     /// PR 3). Runs BEFORE the raw `Storage` write in
@@ -1018,10 +1019,12 @@ impl DelegateCallEnv {
     /// path enforces it again before broadcasting. The V2 bypass writes
     /// through the raw `Storage`, which does not — so before #5479 an
     /// oversized V2 write was a local-disk problem, and after it the same
-    /// uncapped `WrappedState` would be cloned into a `BroadcastStateChange`
-    /// and put on the wire, where every recipient rejects it at its own guard
-    /// AFTER paying for the transfer. Enforcing it here, next to the
-    /// disk-budget gate, keeps the ceiling where the write is.
+    /// uncapped `WrappedState` would reach the fan-out and go on the wire,
+    /// where every recipient rejects it at its own guard AFTER paying for the
+    /// transfer. Enforcing it here, next to the disk-budget gate, keeps the
+    /// ceiling where the write is. (The queued event itself carries no state,
+    /// but the drain reads this value back and broadcasts it, so the ceiling is
+    /// still what keeps an oversized state off the wire.)
     fn check_state_size(state_size: usize) -> Result<(), DelegateEnvError> {
         if state_size > crate::wasm_runtime::MAX_STATE_SIZE {
             return Err(DelegateEnvError::StateTooLarge {
@@ -1139,7 +1142,8 @@ impl DelegateCallEnv {
     /// (see `super::runtime::StateWriteCallback` and
     /// `contract::executor::runtime::v2_delegate_state_write_callback`)
     /// invalidates the `StateStore` caches, runs `Ring::commit_state_write`,
-    /// and emits the `BroadcastStateChange` that propagates the write.
+    /// and — only when `content_changed` — queues the fan-out that propagates
+    /// the write.
     fn after_state_write(
         &self,
         contract_key: &ContractKey,

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1049,6 +1049,32 @@ impl DelegateCallEnv {
     /// A read error is reported as CHANGED: failing towards an extra
     /// broadcast is recoverable, failing towards a silent drop is the bug
     /// #5479 is about.
+    ///
+    /// # This read and the write that follows it are NOT atomic
+    ///
+    /// The comparison happens here; the write happens further down
+    /// `put_contract_state_sync` / `update_contract_state_sync`. Nothing holds
+    /// a lock across the two. **Correctness currently depends on delegate
+    /// handling being serialized by the contract-handling loop** — both entry
+    /// points (`contract.rs`) `await` `handle_delegate_with_contract_requests`
+    /// inline on that single loop with no spawn, so two V2 delegate writes to
+    /// one contract cannot interleave on a node today.
+    ///
+    /// If that serialization is removed, this gate can suppress a REAL change.
+    /// The interleaving is not the symmetric one it looks like: writer A whose
+    /// own bytes happen to equal what it reads decides "no change" and will
+    /// suppress; writer B then commits and broadcasts different bytes; A then
+    /// writes its own bytes and stays silent. Local state ends at A's value
+    /// while the network last heard B's, and nothing re-announces it until the
+    /// next write or the anti-entropy heartbeat. Note that this is precisely
+    /// the idempotent-rewrite workload the gate exists to catch, so the racy
+    /// case is the common case rather than an exotic one.
+    ///
+    /// **#5544 removes that serialization** to fix a node-wide stall. Whoever
+    /// lands it owns this: the gate is not self-sufficient, and the fix is to
+    /// make the compare-and-write atomic (fold the comparison into the same
+    /// ReDb write transaction as the store, the way `update_state_sync`
+    /// already does its check-and-write) rather than to rely on the loop.
     fn state_content_changed(
         &self,
         contract_key: &ContractKey,

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1007,6 +1007,36 @@ impl DelegateCallEnv {
         }
     }
 
+    /// The post-write sequence every V2 delegate state write owes, in one
+    /// place.
+    ///
+    /// A V2 write goes straight through the raw `Storage`, bypassing the
+    /// executor's `state_store.{store,update}` chokepoints — so every side
+    /// effect those chokepoints perform has to be re-applied here, and the
+    /// one that gets forgotten is silent. That has already happened twice:
+    /// the disk-budget admission gate (#4683) and network propagation
+    /// (#5479, where a V2 write returned success and the network never
+    /// learned of it). Hence one helper called from both write paths rather
+    /// than the sequence hand-inlined at each — the "manually-inlined
+    /// originator side effects" row in
+    /// `.claude/rules/bug-prevention-patterns.md`.
+    ///
+    /// Everything here is best-effort: the write has already committed, and
+    /// nothing below is worth rolling it back for. The installed callback
+    /// (see `super::runtime::StateWriteCallback` and
+    /// `contract::executor::runtime::v2_delegate_state_write_callback`)
+    /// invalidates the `StateStore` caches, runs `Ring::commit_state_write`,
+    /// and emits the `BroadcastStateChange` that propagates the write.
+    fn after_state_write(
+        &self,
+        contract_key: &ContractKey,
+        new_state: &freenet_stdlib::prelude::WrappedState,
+    ) {
+        if let Some(cb) = &self.state_write_callback {
+            cb(contract_key, new_state);
+        }
+    }
+
     /// Store (PUT) contract state by instance ID.
     ///
     /// The contract's code hash must already be registered in the ContractStore
@@ -1024,13 +1054,15 @@ impl DelegateCallEnv {
         };
 
         let contract_key = self.resolve_contract_key(instance_id)?;
-        // Capture the byte count BEFORE the move into store_state_sync —
-        // the callback needs it for governance attribution. The
-        // bug-prevention-patterns rule about "Manually-inlined originator
-        // side effects after a task-per-tx migration" applies here too:
-        // a future refactor that drops state_size from the callback path
-        // would silently undercount StateBytesWritten for V2 delegate PUT.
-        let state_size = state.len();
+        // Wrap BEFORE the admission gate so exactly one value is admitted,
+        // written, and handed to the post-write hook — `WrappedState` is
+        // `Arc<Vec<u8>>`, so the clone into `store_state_sync` below is a
+        // refcount bump, not a state copy. The "manually-inlined originator
+        // side effects" row in `.claude/rules/bug-prevention-patterns.md`
+        // applies here: a refactor that reconstructs the state for the hook
+        // instead of passing the written one is how these paths drift.
+        let new_state = freenet_stdlib::prelude::WrappedState::new(state);
+        let state_size = new_state.as_ref().len();
 
         // Disk-budget admission gate (#4683): the V2 path bypasses the executor
         // `state_store` chokepoint where the gate normally runs, so apply it here
@@ -1044,21 +1076,10 @@ impl DelegateCallEnv {
             }
         }
 
-        db.store_state_sync(
-            &contract_key,
-            freenet_stdlib::prelude::WrappedState::new(state),
-        )
-        .map_err(|e| DelegateEnvError::StorageError(e.to_string()))?;
+        db.store_state_sync(&contract_key, new_state.clone())
+            .map_err(|e| DelegateEnvError::StorageError(e.to_string()))?;
 
-        // V2 delegate write chokepoint: this path bypasses the executor's
-        // `state_store.store` call site where the bump+refresh+report
-        // happen. The callback (when wired) mirrors those side effects
-        // via `Ring::commit_state_write`. Failure here is best-effort —
-        // the write has already committed and we don't want to roll it
-        // back over a counter bump.
-        if let Some(cb) = &self.state_write_callback {
-            cb(&contract_key, state_size);
-        }
+        self.after_state_write(&contract_key, &new_state);
 
         Ok(())
     }
@@ -1077,9 +1098,9 @@ impl DelegateCallEnv {
         };
 
         let contract_key = self.resolve_contract_key(instance_id)?;
-        // Capture byte count BEFORE the move — same reason as
-        // put_contract_state_sync above.
-        let state_size = state.len();
+        // Wrap before the admission gate — see `put_contract_state_sync`.
+        let new_state = freenet_stdlib::prelude::WrappedState::new(state);
+        let state_size = new_state.as_ref().len();
 
         // Disk-budget admission gate (#4683): apply the executor-chokepoint gate
         // that the V2 path bypasses, BEFORE the raw write. This is a V2 UPDATE —
@@ -1095,18 +1116,9 @@ impl DelegateCallEnv {
         }
 
         // Atomic check-and-write in a single ReDb write transaction.
-        match db.update_state_sync(
-            &contract_key,
-            freenet_stdlib::prelude::WrappedState::new(state),
-        ) {
+        match db.update_state_sync(&contract_key, new_state.clone()) {
             Ok(true) => {
-                // V2 delegate write chokepoint: mirror the executor's
-                // `state_store.update` bump+refresh+report side effects
-                // via `Ring::commit_state_write`. See
-                // `put_contract_state_sync` for the rationale.
-                if let Some(cb) = &self.state_write_callback {
-                    cb(&contract_key, state_size);
-                }
+                self.after_state_write(&contract_key, &new_state);
                 Ok(())
             }
             Ok(false) => Err(DelegateEnvError::NoExistingState),

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -964,21 +964,31 @@ impl Default for RuntimeConfig {
 ///
 /// V2 delegate writes go through `db.store_state_sync` / `db.update_state_sync`
 /// directly and bypass the executor's `state_store.{store,update}` chokepoints
-/// where the bump+refresh+report sites live. Without this callback those
-/// three side effects never fire on a V2 delegate write, leaving the
-/// EvictContract re-host race open AND undercounting StateBytesWritten in
-/// the topology meter for that path. The wiring lives outside `wasm_runtime/`
-/// (Ring lives in `crates/core/src/ring.rs`) so the callback is plumbed via
-/// a trait object owned by `Runtime` to keep `wasm_runtime` independent of
-/// the ring.
+/// where the bump+refresh+report sites live — and, until #5479, where the
+/// NETWORK PROPAGATION happened. Without this callback those side effects never
+/// fire on a V2 delegate write: the EvictContract re-host race stays open,
+/// StateBytesWritten is undercounted in the topology meter, and the write is
+/// never seen off this node even though the host function returned success. The
+/// wiring lives outside `wasm_runtime/` (Ring lives in `crates/core/src/ring.rs`)
+/// so the callback is plumbed via a trait object owned by `Runtime` to keep
+/// `wasm_runtime` independent of the ring.
 ///
-/// The closure SHOULD delegate to `Ring::commit_state_write(key, state_size)`
-/// — see `RuntimePool::contract_state_write_callback` for the production
-/// wiring. The `state_size` argument is the on-disk byte count of the
-/// newly-written state and is fed into the StateBytesWritten meter axis
-/// for governance scoring.
-pub type StateWriteCallback =
-    Arc<dyn Fn(&freenet_stdlib::prelude::ContractKey, usize) + Send + Sync + 'static>;
+/// The closure receives the newly-written state itself, not merely its length,
+/// because the production installer needs BOTH: the byte count for
+/// `Ring::commit_state_write(key, state_size)` (the StateBytesWritten meter axis
+/// that feeds governance scoring), and the state VALUE for the
+/// `NodeEvent::BroadcastStateChange` that gives V2 the same propagation V1 gets
+/// from `upsert_contract_state` (#5479). `WrappedState` is `Arc<Vec<u8>>`
+/// internally, so passing and cloning it is a refcount bump, not a state copy.
+///
+/// See `contract::executor::runtime::install_v2_delegate_state_write_hooks` for
+/// the single production installer.
+pub type StateWriteCallback = Arc<
+    dyn Fn(&freenet_stdlib::prelude::ContractKey, &freenet_stdlib::prelude::WrappedState)
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Pre-write admission gate for V2 delegate state writes (#4683, PR 3).
 ///
@@ -1044,10 +1054,11 @@ pub struct Runtime {
     /// Optional state storage backend for V2 delegate contract access.
     pub(crate) state_store_db: Option<crate::contract::storages::Storage>,
 
-    /// Optional callback invoked after a successful V2 delegate state write,
-    /// used to bump the per-contract generation token and refresh the
-    /// hosting-cache snapshot from the V2 path (which bypasses the executor
-    /// chokepoints). See `StateWriteCallback`.
+    /// Optional callback invoked after a successful V2 delegate state write.
+    /// Bumps the per-contract generation token, refreshes the hosting-cache
+    /// snapshot, and propagates the write to the network — all of which the
+    /// V2 path would otherwise skip, because it bypasses the executor
+    /// chokepoints where they normally happen. See `StateWriteCallback`.
     pub(crate) state_write_callback: Option<StateWriteCallback>,
 
     /// Optional pre-write disk-budget admission gate for V2 delegate state
@@ -1075,8 +1086,9 @@ impl Runtime {
 
     /// Install a callback invoked after each successful V2 delegate state
     /// write. See `StateWriteCallback`. Without this, V2 PUT/UPDATE bypass
-    /// the executor's bump+refresh chokepoints and the EvictContract
-    /// re-host race stays open for V2 delegate writes.
+    /// the executor's bump+refresh chokepoints — the EvictContract re-host
+    /// race stays open, and the write never propagates to the network
+    /// (#5479).
     pub fn set_state_write_callback(&mut self, cb: StateWriteCallback) {
         self.state_write_callback = Some(cb);
     }

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -973,18 +973,32 @@ impl Default for RuntimeConfig {
 /// so the callback is plumbed via a trait object owned by `Runtime` to keep
 /// `wasm_runtime` independent of the ring.
 ///
-/// The closure receives the newly-written state itself, not merely its length,
-/// because the production installer needs BOTH: the byte count for
-/// `Ring::commit_state_write(key, state_size)` (the StateBytesWritten meter axis
-/// that feeds governance scoring), and the state VALUE for the
-/// `NodeEvent::BroadcastStateChange` that gives V2 the same propagation V1 gets
-/// from `upsert_contract_state` (#5479). `WrappedState` is `Arc<Vec<u8>>`
-/// internally, so passing and cloning it is a refcount bump, not a state copy.
+/// The closure receives the newly-written state itself rather than a separately
+/// computed length, so the byte count it meters is measured from the value that
+/// was ACTUALLY written. A `usize` parameter can drift from the write it
+/// describes under refactoring — the failure mode `.claude/rules/
+/// bug-prevention-patterns.md` calls "manually-inlined originator side effects"
+/// — and that drift is silent, because an undercounted meter looks like light
+/// traffic. `WrappedState` is `Arc<Vec<u8>>` internally, so passing it is a
+/// refcount bump, not a state copy. The pins in `delegate_api.rs` assert the
+/// callback receives the exact bytes written, which is what makes this
+/// enforceable rather than merely intended.
+///
+/// (An earlier version of this note justified the wider parameter by the state
+/// VALUE being needed for the emitted `BroadcastStateChange`. That stopped
+/// being true when the propagation event became key-only; the reason above is
+/// the one that still holds.)
+///
+/// The `bool` is `content_changed`: whether the write altered the stored bytes.
+/// The callback runs on EVERY successful write, changed or not — a V2 write
+/// commits to storage before this hook, so the bookkeeping legs are owed
+/// regardless — and uses the flag to skip only the network fan-out, which is
+/// the one leg an idempotent rewrite genuinely does not need.
 ///
 /// See `contract::executor::runtime::install_v2_delegate_state_write_hooks` for
 /// the single production installer.
 pub type StateWriteCallback = Arc<
-    dyn Fn(&freenet_stdlib::prelude::ContractKey, &freenet_stdlib::prelude::WrappedState)
+    dyn Fn(&freenet_stdlib::prelude::ContractKey, &freenet_stdlib::prelude::WrappedState, bool)
         + Send
         + Sync
         + 'static,

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -202,7 +202,7 @@ pub struct StateStore<S: StateStorage> {
     ///     `Storage`, BYPASSING `StateStore`, so they invalidate this entry (and
     ///     the moka state-bytes cache) via a [`StateCacheInvalidator`] handle
     ///     wired into the runtime's `state_write_callback` (see
-    ///     `Runtime::set_state_write_callback` and the callback installers in
+    ///     `Runtime::set_state_write_callback` and the single callback installer in
     ///     `executor/runtime.rs`). Without this a V2 write would leave a stale
     ///     detector hash → stale summary/delta → divergence (caught by Codex
     ///     review).

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4188,6 +4188,321 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
     Ok(())
 }
 
+// ============================================================================
+// #5479: a V2 delegate's contract write must reach the network
+// ============================================================================
+
+/// Application-message types for the `test-delegate-v2-contracts` fixture.
+///
+/// These MUST stay byte-compatible with the fixture's own definitions in
+/// `tests/test-delegate-v2-contracts/src/lib.rs` — they are bincode'd across
+/// the WASM boundary, so a field reorder here silently mis-deserializes.
+mod v2_delegate_messages {
+    use super::*;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum InboundAppMessage {
+        GetContractState {
+            contract_id: [u8; 32],
+        },
+        PutContractState {
+            contract_id: [u8; 32],
+            state: Vec<u8>,
+        },
+        UpdateContractState {
+            contract_id: [u8; 32],
+            state: Vec<u8>,
+        },
+        SubscribeContract {
+            contract_id: [u8; 32],
+        },
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum OutboundAppMessage {
+        ContractState {
+            contract_id: [u8; 32],
+            state: Vec<u8>,
+        },
+        ContractNotFound {
+            contract_id: [u8; 32],
+            error_code: i64,
+        },
+        Success {
+            contract_id: [u8; 32],
+        },
+        Failed {
+            contract_id: [u8; 32],
+            error_code: i64,
+        },
+    }
+}
+
+/// Regression test for #5479: a V2 delegate UPDATE is observed on a SECOND
+/// peer.
+///
+/// The V1 and V2 delegate contract APIs expose the same operations under the
+/// same names, but only V1 routed writes through `upsert_contract_state`,
+/// which emits `NodeEvent::BroadcastStateChange`. The V2 host functions
+/// (`put_contract_state` / `update_contract_state`) wrote straight to ReDb:
+/// the local read-back succeeded, the host function returned success, and the
+/// network never learned anything. Silent write loss.
+///
+/// **This test cannot be single-node.** The two pre-existing delegate E2E
+/// tests (`test_delegate_contract_put_and_update`,
+/// `test_delegate_contract_get`) run `nodes = ["gateway"]`, so they observe
+/// only the local store — where the buggy path looks perfectly healthy. The
+/// assertion that distinguishes the bug is on a peer that did NOT perform the
+/// write.
+///
+/// Shape:
+///   1. node-a PUTs the contract (initial state, version 0) and subscribes.
+///   2. node-b GETs it with `subscribe = true`, so it holds the contract and
+///      is registered as an interested co-host.
+///   3. **Quiesce.** Drain node-b until it has been silent for
+///      `QUIET_PERIOD`. This is load-bearing — see below.
+///   4. node-a registers the V2 delegate and asks it to
+///      `update_contract_state` with a version-1 state.
+///   5. node-b must receive an `UpdateNotification` carrying that state.
+///
+/// **Why step 3 is not optional.** The first version of this test omitted it
+/// and PASSED against unfixed main. The debug log showed node-a emitting only
+/// the PUT's own 24-byte `BroadcastStateChange` (twice — the initial emission
+/// found no targets and was retried) and never one carrying the delegate's
+/// 114-byte state, so the bug was real. But node-b acquired that state anyway,
+/// about a second later, through `SyncStateToPeer` / `ResyncResponse`
+/// anti-entropy fired by the interest exchange that the GET+subscribe had just
+/// set up. "node-b saw the state" was true and did not establish "the write
+/// propagated" — the assertion was measuring the wrong thing.
+///
+/// Once interests are exchanged and summaries agree, anti-entropy does not fire
+/// again until `INTEREST_HEARTBEAT_INTERVAL` (300s,
+/// `crates/core/src/ring/interest.rs:73`). Quiescing first and asserting well
+/// inside that window leaves the write's own broadcast as the only route by
+/// which node-b can learn the new state.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway", "node-a", "node-b"],
+    timeout_secs = 600,
+    startup_wait_secs = 40,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext) -> TestResult {
+    use v2_delegate_messages::{InboundAppMessage, OutboundAppMessage};
+
+    const TEST_DELEGATE: &str = "test-delegate-v2-contracts";
+    const TEST_CONTRACT: &str = "test-contract-integration";
+
+    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
+    let contract_key = contract.key();
+    let contract_id = *contract_key.id();
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    let node_a = ctx.node("node-a")?;
+    let node_b = ctx.node("node-b")?;
+
+    let (stream_a, _) = connect_async(&node_a.ws_url()).await?;
+    let mut client_a = WebApi::start(stream_a);
+    let (stream_b, _) = connect_async(&node_b.ws_url()).await?;
+    let mut client_b = WebApi::start(stream_b);
+
+    // --- 1. node-a installs the contract and subscribes -------------------
+    let initial_state = WrappedState::from(test_utils::create_empty_todo_list());
+    make_put(&mut client_a, initial_state.clone(), contract.clone(), true).await?;
+
+    let mut put_ok = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while !put_ok && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_a.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+                ensure!(key == contract_key, "PUT response for the wrong contract");
+                put_ok = true;
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting PUT"),
+            Ok(Err(e)) => bail!("node-a: websocket error awaiting PUT: {e}"),
+            Err(_) => {}
+        }
+    }
+    ensure!(put_ok, "node-a: no PutResponse within 60s");
+
+    // --- 2. node-b fetches it and subscribes ------------------------------
+    // Retried: under CI resource pressure the first GET can be lost before
+    // the mesh settles (see issue #2682 and the sibling tests in this file).
+    let mut get_ok = false;
+    for attempt in 1..=3u32 {
+        make_get(&mut client_b, contract_key, true, true).await?;
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while !get_ok && std::time::Instant::now() < deadline {
+            match timeout(Duration::from_secs(5), client_b.recv()).await {
+                Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
+                    key,
+                    ..
+                }))) => {
+                    ensure!(key == contract_key, "GET response for the wrong contract");
+                    get_ok = true;
+                }
+                Ok(Ok(other)) => tracing::debug!(?other, "node-b: ignoring while awaiting GET"),
+                Ok(Err(e)) => bail!("node-b: websocket error awaiting GET: {e}"),
+                Err(_) => {}
+            }
+        }
+        if get_ok {
+            break;
+        }
+        tracing::warn!(attempt, "node-b: GET attempt timed out, retrying");
+    }
+    ensure!(get_ok, "node-b: no GetResponse after 3 attempts");
+
+    // --- 3. quiesce -------------------------------------------------------
+    // Wait until node-b has been silent for QUIET_PERIOD, so the interest
+    // exchange and any anti-entropy heal triggered by step 2 have finished and
+    // been discarded. Everything node-b receives after this point is caused by
+    // step 4. See the doc comment: without this, the anti-entropy heal supplies
+    // the state and the test passes against the unfixed code.
+    const QUIET_PERIOD: Duration = Duration::from_secs(8);
+    const QUIESCE_CAP: Duration = Duration::from_secs(60);
+    let quiesce_start = std::time::Instant::now();
+    let mut last_message = std::time::Instant::now();
+    while last_message.elapsed() < QUIET_PERIOD && quiesce_start.elapsed() < QUIESCE_CAP {
+        match timeout(Duration::from_secs(1), client_b.recv()).await {
+            Ok(Ok(msg)) => {
+                tracing::debug!(?msg, "node-b: draining pre-write traffic");
+                last_message = std::time::Instant::now();
+            }
+            Ok(Err(e)) => bail!("node-b: websocket error while quiescing: {e}"),
+            Err(_) => {}
+        }
+    }
+    ensure!(
+        last_message.elapsed() >= QUIET_PERIOD,
+        "node-b never went quiet within {QUIESCE_CAP:?}; the test cannot \
+         distinguish the write's own broadcast from background anti-entropy \
+         while traffic is still flowing, so it would pass for the wrong reason"
+    );
+    tracing::info!(
+        quiesced_after_ms = quiesce_start.elapsed().as_millis(),
+        "node-b quiet; anything it receives from here is caused by the delegate write"
+    );
+
+    // --- 4. node-a registers the V2 delegate and drives the write ---------
+    client_a
+        .send(ClientRequest::DelegateOp(
+            freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
+                delegate: delegate.clone(),
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
+            },
+        ))
+        .await?;
+    match timeout(Duration::from_secs(30), client_a.recv()).await?? {
+        HostResponse::DelegateResponse { key, .. } => {
+            ensure!(key == delegate_key, "delegate key mismatch on register");
+        }
+        other => bail!("unexpected register response: {other:?}"),
+    }
+
+    let contract_id_bytes: [u8; 32] = contract_id
+        .as_bytes()
+        .try_into()
+        .expect("a ContractInstanceId is 32 bytes");
+    let updated_state = test_utils::create_todo_list_with_item("V2 delegate propagation");
+    let command = InboundAppMessage::UpdateContractState {
+        contract_id: contract_id_bytes,
+        state: updated_state.clone(),
+    };
+    client_a
+        .send(ClientRequest::DelegateOp(
+            freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(bincode::serialize(&command)?),
+                )],
+            },
+        ))
+        .await?;
+
+    match timeout(Duration::from_secs(60), client_a.recv()).await?? {
+        HostResponse::DelegateResponse { key, values } => {
+            ensure!(key == delegate_key, "delegate key mismatch on UPDATE");
+            let outcome = values
+                .iter()
+                .find_map(|v| {
+                    if let OutboundDelegateMsg::ApplicationMessage(msg) = v {
+                        bincode::deserialize::<OutboundAppMessage>(&msg.payload).ok()
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| anyhow::anyhow!("no ApplicationMessage in delegate response"))?;
+            match outcome {
+                OutboundAppMessage::Success { .. } => {}
+                other => bail!("V2 delegate update_contract_state failed: {other:?}"),
+            }
+        }
+        other => bail!("unexpected delegate UPDATE response: {other:?}"),
+    }
+
+    // --- 5. THE ASSERTION: node-b sees the write --------------------------
+    // Everything above passes with or without the fix. This is the only step
+    // that distinguishes a write the network learned about from one it did
+    // not — and it only does so because of the quiescence in step 3.
+    //
+    // The window is deliberately far shorter than INTEREST_HEARTBEAT_INTERVAL
+    // (300s): if it were longer, the periodic anti-entropy round could supply
+    // the state and the assertion would stop measuring propagation again.
+    let expected: test_utils::TodoList = serde_json::from_slice(&updated_state)?;
+    let mut notified = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(45);
+    while !notified && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_b.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateNotification {
+                key,
+                update,
+            }))) => {
+                ensure!(
+                    key == contract_key,
+                    "UpdateNotification for the wrong contract"
+                );
+                if let UpdateData::State(state) = update {
+                    let got: test_utils::TodoList = serde_json::from_slice(state.as_ref())?;
+                    if got.tasks.len() == expected.tasks.len()
+                        && got.tasks.first().map(|t| t.title.as_str())
+                            == expected.tasks.first().map(|t| t.title.as_str())
+                    {
+                        notified = true;
+                    } else {
+                        tracing::debug!(
+                            tasks = got.tasks.len(),
+                            "node-b: notification did not yet carry the delegate's state"
+                        );
+                    }
+                }
+            }
+            Ok(Ok(other)) => {
+                tracing::debug!(?other, "node-b: ignoring while awaiting UpdateNotification")
+            }
+            Ok(Err(e)) => bail!("node-b: websocket error awaiting notification: {e}"),
+            Err(_) => {}
+        }
+    }
+
+    ensure!(
+        notified,
+        "node-b never observed the V2 delegate's contract write. The delegate's \
+         update_contract_state returned success and the state is readable on \
+         node-a, but nothing was pushed — this is #5479. V1 delegates propagate \
+         here because they route through upsert_contract_state, which emits \
+         BroadcastStateChange. Note the state may still reach node-b eventually \
+         via the 300s anti-entropy heartbeat; this test asserts the write's own \
+         propagation, which is what the API's success return implies."
+    );
+
+    Ok(())
+}
+
 /// Test that disconnecting a subscribed client does NOT trigger an *immediate*
 /// upstream Unsubscribe when the contract was recently read (demand-gated collapse).
 ///

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4275,11 +4275,20 @@ mod v2_delegate_messages {
 /// set up. "node-b saw the state" was true and did not establish "the write
 /// propagated" — the assertion was measuring the wrong thing.
 ///
-/// Once interests are exchanged and summaries agree, anti-entropy does not fire
-/// again until `INTEREST_HEARTBEAT_INTERVAL` (300s,
-/// `crates/core/src/ring/interest.rs:73`). Quiescing first and asserting well
-/// inside that window leaves the write's own broadcast as the only route by
-/// which node-b can learn the new state.
+/// Quiescing first removes the heal that step 2 triggers, which is what made
+/// the earlier version pass. It does NOT make the isolation absolute, and the
+/// first wording of this comment claimed it did. The interest heartbeat is a
+/// FREE-RUNNING periodic timer with a random phase (`ring.rs`: a 15-45s initial
+/// delay, then `interval(INTEREST_HEARTBEAT_INTERVAL)` = 300s), not a timer the
+/// interest exchange restarts — so quiescence establishes that node-b is
+/// currently silent, not that the next periodic round is far away. A round
+/// landing inside the assertion window would heal node-b and the test would
+/// pass on unfixed code again.
+///
+/// So the window is kept SHORT rather than merely shorter than 300s: the fixed
+/// path delivers in about a second, so a 15s deadline costs nothing and leaves
+/// only a small residual chance of overlapping a periodic round. That residual
+/// is stated rather than denied.
 #[freenet_test(
     health_check_readiness = true,
     nodes = ["gateway", "node-a", "node-b"],
@@ -4396,15 +4405,27 @@ async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext
             },
         ))
         .await?;
-    match timeout(Duration::from_secs(30), client_a.recv()).await?? {
-        HostResponse::DelegateResponse { key, .. } => {
-            ensure!(key == delegate_key, "delegate key mismatch on register");
+    // Drain-and-ignore, like every other phase of this test. `client_a` did
+    // `make_put(.., subscribe = true)`, so it holds a client subscription and
+    // can be handed an `UpdateNotification` at any point; a strict single
+    // `recv()` here would bail on one with a message blaming the register.
+    let mut registered = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while !registered && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_a.recv()).await {
+            Ok(Ok(HostResponse::DelegateResponse { key, .. })) => {
+                ensure!(key == delegate_key, "delegate key mismatch on register");
+                registered = true;
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while registering"),
+            Ok(Err(e)) => bail!("node-a: websocket error awaiting register: {e}"),
+            Err(_) => {}
         }
-        other @ HostResponse::ContractResponse(_)
-        | other @ HostResponse::QueryResponse(_)
-        | other @ HostResponse::Ok
-        | other => bail!("unexpected register response: {other:?}"),
     }
+    ensure!(
+        registered,
+        "node-a: no DelegateResponse to RegisterDelegate in 30s"
+    );
 
     let contract_id_bytes: [u8; 32] = contract_id
         .as_bytes()
@@ -4427,32 +4448,39 @@ async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext
         ))
         .await?;
 
-    match timeout(Duration::from_secs(60), client_a.recv()).await?? {
-        HostResponse::DelegateResponse { key, values } => {
-            ensure!(key == delegate_key, "delegate key mismatch on UPDATE");
-            let outcome = values
-                .iter()
-                .find_map(|v| {
-                    if let OutboundDelegateMsg::ApplicationMessage(msg) = v {
-                        bincode::deserialize::<OutboundAppMessage>(&msg.payload).ok()
-                    } else {
-                        None
-                    }
-                })
-                .ok_or_else(|| anyhow::anyhow!("no ApplicationMessage in delegate response"))?;
-            match outcome {
-                OutboundAppMessage::Success { .. } => {}
-                other @ OutboundAppMessage::ContractState { .. }
-                | other @ OutboundAppMessage::ContractNotFound { .. }
-                | other @ OutboundAppMessage::Failed { .. } => {
-                    bail!("V2 delegate update_contract_state failed: {other:?}")
-                }
+    // Drain-and-ignore, for the same reason as the register step above.
+    let mut delegate_values = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while delegate_values.is_none() && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_a.recv()).await {
+            Ok(Ok(HostResponse::DelegateResponse { key, values })) => {
+                ensure!(key == delegate_key, "delegate key mismatch on UPDATE");
+                delegate_values = Some(values);
             }
+            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting delegate"),
+            Ok(Err(e)) => bail!("node-a: websocket error awaiting delegate response: {e}"),
+            Err(_) => {}
         }
-        other @ HostResponse::ContractResponse(_)
-        | other @ HostResponse::QueryResponse(_)
-        | other @ HostResponse::Ok
-        | other => bail!("unexpected delegate UPDATE response: {other:?}"),
+    }
+    let values =
+        delegate_values.ok_or_else(|| anyhow::anyhow!("no delegate UPDATE response in 60s"))?;
+    let outcome = values
+        .iter()
+        .find_map(|v| {
+            if let OutboundDelegateMsg::ApplicationMessage(msg) = v {
+                bincode::deserialize::<OutboundAppMessage>(&msg.payload).ok()
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("no ApplicationMessage in delegate response"))?;
+    match outcome {
+        OutboundAppMessage::Success { .. } => {}
+        other @ OutboundAppMessage::ContractState { .. }
+        | other @ OutboundAppMessage::ContractNotFound { .. }
+        | other @ OutboundAppMessage::Failed { .. } => {
+            bail!("V2 delegate update_contract_state failed: {other:?}")
+        }
     }
 
     // --- 5. THE ASSERTION: node-b sees the write --------------------------
@@ -4460,12 +4488,14 @@ async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext
     // that distinguishes a write the network learned about from one it did
     // not — and it only does so because of the quiescence in step 3.
     //
-    // The window is deliberately far shorter than INTEREST_HEARTBEAT_INTERVAL
-    // (300s): if it were longer, the periodic anti-entropy round could supply
-    // the state and the assertion would stop measuring propagation again.
+    // Kept SHORT on purpose. The fixed path delivers in about a second; a
+    // longer window buys nothing and only widens the chance of overlapping a
+    // free-running interest-heartbeat round, which would heal node-b and make
+    // this pass on unfixed code — the exact failure the quiescence above is
+    // there to remove. See the doc comment.
     let expected: test_utils::TodoList = serde_json::from_slice(&updated_state)?;
     let mut notified = false;
-    let deadline = std::time::Instant::now() + Duration::from_secs(45);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
     while !notified && std::time::Instant::now() < deadline {
         match timeout(Duration::from_secs(5), client_b.recv()).await {
             Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateNotification {

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4400,7 +4400,10 @@ async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext
         HostResponse::DelegateResponse { key, .. } => {
             ensure!(key == delegate_key, "delegate key mismatch on register");
         }
-        other => bail!("unexpected register response: {other:?}"),
+        other @ HostResponse::ContractResponse(_)
+        | other @ HostResponse::QueryResponse(_)
+        | other @ HostResponse::Ok
+        | other => bail!("unexpected register response: {other:?}"),
     }
 
     let contract_id_bytes: [u8; 32] = contract_id
@@ -4439,10 +4442,17 @@ async fn test_v2_delegate_update_propagates_to_second_peer(ctx: &mut TestContext
                 .ok_or_else(|| anyhow::anyhow!("no ApplicationMessage in delegate response"))?;
             match outcome {
                 OutboundAppMessage::Success { .. } => {}
-                other => bail!("V2 delegate update_contract_state failed: {other:?}"),
+                other @ OutboundAppMessage::ContractState { .. }
+                | other @ OutboundAppMessage::ContractNotFound { .. }
+                | other @ OutboundAppMessage::Failed { .. } => {
+                    bail!("V2 delegate update_contract_state failed: {other:?}")
+                }
             }
         }
-        other => bail!("unexpected delegate UPDATE response: {other:?}"),
+        other @ HostResponse::ContractResponse(_)
+        | other @ HostResponse::QueryResponse(_)
+        | other @ HostResponse::Ok
+        | other => bail!("unexpected delegate UPDATE response: {other:?}"),
     }
 
     // --- 5. THE ASSERTION: node-b sees the write --------------------------


### PR DESCRIPTION
## Problem

The V1 and V2 delegate contract APIs expose the same operations under the same names, but only V1 propagates writes to the network. A V2 delegate calling `ctx.put_contract_state(..)` or `ctx.update_contract_state(..)` writes to local ReDb and the network never learns. The host function returns success and the local read-back is correct, so nothing reports a problem anywhere.

V1 routes through `upsert_contract_state`, which emits `NodeEvent::BroadcastStateChange`. V2's host functions (`put_contract_state_sync`, `update_contract_state_sync`) write straight through the raw `Storage`, bypassing the executor's `state_store.{store,update}` chokepoints — so every side effect those chokepoints perform has to be re-applied by hand next to the write, and the one nobody had re-applied was propagation.

This is the third side effect that bypass has cost: the disk-budget admission gate (#4683) and the generation/cache-invalidation/metering bump were each added only after being noticed missing. It is the "manually-inlined originator side effects" shape.

## Approach

The issue's preferred fix — route V2 through `upsert_contract_state` — cannot be written as a **direct, in-place, synchronous call**, and I verified this rather than taking it on report:

- **Re-entrancy.** `Executor::delegate_request` (`runtime/delegates.rs:225`) takes `&mut self` and calls `self.runtime.inbound_app_message(..)` at `:486`, which drives the WASM `process()`. The host functions run inside that call. `upsert_contract_state` also needs `&mut Executor` — the same object, already mutably borrowed for the whole invocation.
- **Sync context.** `delegate_request` is a plain `fn`, and the host-function bodies are synchronous. `upsert_contract_state` is `async`. There is no place to await it.
- The host functions have no handle to the executor at all: `DelegateCallEnv` carries raw pointers to the stores, reached through a process-global map, deliberately so `wasm_runtime` does not depend on `contract::executor`.

A representable form does exist: buffer the writes and replay them through the chokepoint after `process()` returns — which *is* routing through `upsert_contract_state`, just not from inside the borrow. It changes error semantics (a write rejected downstream could no longer be reported to the delegate synchronously), so it is designed in **#5485** rather than smuggled into a bug fix.

So this takes the fallback the issue names, and takes the opportunity to remove the duplication that made the gap possible:

- **`StateWriteCallback` carries the written state**, not just its length, so the byte count it meters is measured from the value actually written rather than from a separately-passed number that can drift under refactoring. It also carries `content_changed`. `WrappedState` is `Arc<Vec<u8>>` internally, so passing it is a refcount bump, not a state copy.
- **The two copy-paste callback installers collapse into one.** `Executor::from_config` and `from_config_with_shared_modules` each built the callback separately, guarded only by a pin that counted occurrences — precisely the shape that lets the next side effect be added to one twin and not the other. There is now one `install_v2_delegate_state_write_hooks`, called from both.
- The callback is split out as `v2_delegate_state_write_callback` so a test can drive the **production closure** instead of building a whole `Runtime` (contract, delegate and secret stores plus a WASM engine) to reach it.
- Both V2 write host functions call one `after_state_write` helper.
- The broadcast is **suppressed for a contract flagged as violating a CRDT invariant**, mirroring `Executor::broadcast_state_change`, and is emitted **non-blocking**: this runs inside a synchronous WASM host call, where a blocking `notify_node_event` would be worse than the #4145 gateway wedge.
- Two guards that sit next to the V1 broadcast are mirrored too, because the review round found that mirroring one leg without auditing its neighbours is the same defect one level up. A **byte-identical rewrite does not fan out** (V1's `UpsertResult::NoChange` short-circuit; without it, the ordinary "recompute and store on every message" delegate went from zero fan-out to one per message) — though only the fan-out is skipped, never the bookkeeping; see the update below. **`MAX_STATE_SIZE` is enforced at the write** (previously a local-disk problem; propagation would have put the uncapped state on the wire).
- `Ring::record_contract_update` is mirrored as well — without it a contract written only by a V2 delegate showed a stale dashboard timestamp forever.

### What this does NOT do, stated rather than implied

**A contract this node holds only because a delegate wrote it still does not propagate.** The gate is `Ring::should_summarize_or_broadcast` = `(is_hosting_contract || contract_in_use) && contract_state_present`. Note *where* it is applied, because two independent readers have now looked for it in the wrong place and concluded it was absent: it is **not** in `handle_broadcast_state_change`. It is reached one layer down, at the per-peer send in `broadcast_queue::broadcast_to_single_peer`, wrapped in the one-line `should_broadcast_contract` — so grepping `broadcast.rs` for the inner name finds only a comment. A V2 write adds nothing to the hosting cache, and `contract_in_use` counts client subscriptions and downstream subscribers only — a **delegate** subscription is neither. So the event is emitted and then dropped for exactly the case #5467 cares about.

Making a delegate subscription register demand is **#4669**, and `hosting-invariants.md` invariant 2 makes it a design decision rather than a detail. It does not belong inside a propagation fix. The limit is recorded in the callback rustdoc, in `.claude/rules/contracts.md`, and here.

Also unchanged: a **V2 PUT** of a contract no peer already tracks emits a broadcast that finds no targets and depends on the #4359 stash-and-flush, so it gains a broadcast but not placement parity with a client PUT.

## Testing

### The multi-node test, and the first version of it that was wrong

`tests/operations.rs::test_v2_delegate_update_propagates_to_second_peer`. The bug is only observable from a peer that did not perform the write — the two existing delegate E2E tests run `nodes = ["gateway"]`, a single node, where the buggy path reads back correctly and reports success.

**The first version of this test passed against unfixed main**, and it is worth saying why rather than quietly fixing it. It PUT on node-a, did a GET-with-subscribe on node-b, then did the delegate write and asserted node-b saw it. The debug log showed node-a emitting only the PUT's own 24-byte `BroadcastStateChange` (twice — the first found no targets and was retried) and never one carrying the delegate's 114-byte state, so the bug was real. But node-b acquired that state anyway, about a second later, through `SyncStateToPeer` / `ResyncResponse` anti-entropy fired by the interest exchange the GET+subscribe had just set up.

"node-b saw the state" was **true**, and did not establish "the write propagated". The assertion was measuring the wrong thing.

The fix is a quiescence phase: drain node-b until it has been silent for 8s, so the interest exchange and any heal it triggered are finished, then do the write and assert.

**And that argument was also wrong the first time it was written**, which the review round caught: the comment claimed a 45s window was "far inside `INTEREST_HEARTBEAT_INTERVAL` (300s)" and therefore safe. The heartbeat is a **free-running periodic timer with a random phase** (a 15-45s initial delay, then `interval(300s)`), not one the interest exchange restarts — so quiescence establishes that node-b is currently silent, not that the next round is far away. The window is now **15s**: the fixed path delivers in about a second, so it costs nothing, and the comment states the residual chance instead of denying it.

```
# against main (test committed first, separately):
Error: node-b never observed the V2 delegate's contract write. […]
test result: FAILED. 0 passed; 1 failed

# with the fix:
test test_v2_delegate_update_propagates_to_second_peer ... ok
```

**A correction to the issue's framing follows from this.** #5479 says "loses writes silently". What the log establishes is narrower and worth having on record: the write's own propagation never happens, but a V2 write is not necessarily *lost* — a later pull (a GET, a subscribe-driven state fetch, or the 300s anti-entropy heartbeat) can still carry it to a peer that is interested. The severity is "propagates only by accident, with unbounded latency, and not at all to a peer that never pulls", not "the bytes are gone".

### Deterministic tests

`pool_tests::v2_delegate_propagation_tests` — tests driving the production closure against a real `OpManager`/`Ring`, so the regression stays covered in a fast unit run even when the 3-node E2E is not exercised:

- it queues a fan-out naming the written contract;
- it still bumps the generation and invalidates both `StateStore` caches — the legs that already existed were not traded for the new one;
- it suppresses the broadcast for a contract flagged non-idempotent, so V2 is not a hole in the #4279 storm suppression;
- with no `OpManager` (unit-test and local-only executors) it still invalidates the caches and does not panic.

### Pins

The three affected source-scrape pins are rewritten rather than renumbered. The installer pin now asserts there is **one** installer, **two** callers, and that the single callback performs all three legs — anchored on API surface (`cache_invalidator.invalidate(`, `.commit_state_write(`, `queue_v2_delegate_broadcast(`, `is_contract_broken(`) rather than on local variable names, so a rename inside it cannot make it pass vacuously. It counts real call sites through a comment- and string-stripping helper rather than a raw substring search: the callback's own comment block names all four symbols, so `contains` was satisfied by the prose alone, and deleting the propagation call left the pin green. Verified by mutation.

The five test callbacks in `delegate_api.rs` move with the signature, and the two that asserted a byte count now assert the **bytes** — which pins both the metering attribution and the broadcast payload.

## Update after review

Three review rounds changed the design and found three defects in the fix itself. Recording what moved, because most of the description above predates it.

**The queued event carries the contract id, not the state.** The event-loop notification channel is bounded by message *count*, and a contract state runs to `MAX_STATE_SIZE`, so queueing states made the queue's retained bytes a function of state size rather than of the count bound. `NodeEvent::V2DelegateStateChanged` names the contract; the handler reads current state when it drains. Two consequences: queue cost no longer scales with state size, and repeated writes to one contract coalesce into a single fan-out carrying the newest value rather than a snapshot frozen at emit time. The drain read is bounded (2 s) because it runs inline on the network event loop, where an unbounded await is the #4549 wedge documented at the top of `p2p_protoc.rs`.

**Bookkeeping is unconditional; only the fan-out is gated on `content_changed`.** Gating the whole post-write hook skipped `Ring::commit_state_write`, whose generation bump is what tells a scheduled `EvictContract` that a contract was written after the eviction was queued (`pool.rs::remove_contract` guard 3). A V2 write commits to storage *before* the hook, so an identical rewrite could be reclaimed by an in-flight eviction. V1's `NoChange` short-circuit is not a precedent: V1 short-circuits *before* writing, so nothing is owed.

**The drain read races the loop it depends on, and one case is not recoverable here.** The read is a `GetQuery` to the serial `contract_handling` loop, and the event it drains was queued by a delegate write that ran *on* that loop — so it waits for that delegate to return. A bounded retry (3 attempts, 1s/2s/3s) covers a delegate that was merely busy. It does **not** cover a delegate that requests user input: `prompter.prompt(..)` is awaited inline inside `handle_delegate_with_contract_requests`, which `contract_handling` awaits in turn, so the loop is held for as long as a human takes to answer. Such a write commits, is reported successful to the delegate, and its broadcast is dropped.

That is a real limitation of this PR, not a regression — without it these writes do not propagate at all — but the PR's claim needs the qualifier. It is counted and WARNed rather than silent, and a peer hosting or actively using the contract re-learns the state within one anti-entropy round (`INTEREST_HEARTBEAT_INTERVAL`, 300 s). **#5544/#5554 is the actual fix**: parking delegates off the loop removes the precondition, and it is next in this workstream.

The anti-entropy recovery above was verified rather than assumed. It holds structurally: the heartbeat summarize (`node::summary_if_hosted_or_in_use`) and the broadcast fan-out (`broadcast_queue::should_broadcast_contract`) are gated on the *same* `should_summarize_or_broadcast` predicate, deliberately shared so the two cannot drift. So wherever a dropped broadcast would have been delivered, anti-entropy also runs; and where it would not have run, the broadcast would have been dropped downstream regardless.

**A failed drain read is distinguished from "not hosted".** Both were `None`, so a transient `GetQuery` failure silently discarded the announcement of a write that had already committed — #5479's own shape, inside its fix. Now three-way, with the failure reported and counted.

**Concurrency note.** `state_content_changed` reads and the write that follows are not atomic. Correctness rests on delegate `process()` being globally serialized by the contract-handling loop, which remains true after #5554. Per-delegate exclusion would *not* be sufficient, because the racing pair is two different delegates writing one contract. The durable fix is to fold the comparison into the same ReDb write transaction as the store; recorded at the function.

### A lint would serve better than vigilance

Three separate places in this change logged a dropped or suppressed operation at `debug!`, which `release_max_level_info` (`crates/core/Cargo.toml`) compiles out — so the drop left no evidence in a release build, the #4981 shape that `.claude/rules/code-style.md` already documents. **Two of the three were introduced by the same person who reported the class, in this PR, after reporting it.** Knowing a failure class does not make it visible in your own work. A lint for `debug!` on a drop or refusal path would catch what review caught here by luck and repetition.

## Not in scope

**#5486** — after this change a V2 write reaches the network but still not this node's own local fan-out: WebSocket clients and other delegates subscribed on the same node see nothing. The `DelegateNotificationSender` is installed on the executor *after* the callback is built (`pool.rs:538/563/816`) and the WS subscriber maps need `&mut Executor`, so wiring it needs pool-construction changes. Doing it here would grow a propagation fix into a pool refactor.

Closes #5479

Related: #5485 (buffer-and-replay design), #5486 (local fan-out gap), #5481 (the executor-side sibling), #5467.

[AI-assisted - Claude]

https://claude.ai/code/session_014tq59dRUCNsHR1GuUkguHw

## Dependency on #5493, and what this PR is on its own

**This fix is real but PARTIAL until #5493 lands, and that is worth stating plainly rather than leaving a reader to infer it from the Problem section.** The broadcast gate is `(is_hosting_contract || contract_in_use) && contract_state_present`. A V2 delegate write adds nothing to the hosting cache, and `contract_in_use` counts client subscriptions and downstream subscribers only — a *delegate* subscription is neither. So for the case #5467 actually cares about, this PR emits the broadcast and the gate then drops it.

What this PR does deliver on its own: a contract the node already hosts, or that some client or downstream peer is already using, now propagates a V2 delegate write instead of silently keeping it local. What it does not deliver until #5493 registers delegate subscriptions as demand: propagation for a contract the node holds *only* because a delegate is interested in it.

Merge order is therefore #5554, then #5493, then this — though #5493 is now gated behind #5565 (a freenet-stdlib wire change), so this may reasonably land first and be completed by #5493 later.

## Review record

Full-tier review was re-run on `4ef5823c0` after the original gate died partway through when its session hit a usage limit. **The external non-Claude pass could not run: `codex` is out of credit until Sep 7.** Per `multi-model-review.md` the external pass was substituted with additional independent Claude lenses rather than skipped, and this note records the substitution: lenses were code-first, testing (executing real mutations rather than reasoning about coverage), skeptical, and big-picture.

One item is deliberately carried as a follow-up rather than fixed here: `native_api::state_content_changed` does a read-then-write that is not atomic. Its racing pair is two *different* delegates writing the *same* contract, which per-delegate exclusion permits by construction — it is safe only because at most one delegate `process()` executes node-wide, a property supplied entirely by everything being awaited from the one `contract_handling` loop, with no lock anywhere. That property is now pinned by a call-graph test added on #5554 (`every_delegate_run_is_reached_from_the_serial_loop`), so the dependency is guarded rather than merely assumed. The durable fix is to fold the comparison into the same ReDb write transaction as the store, as `update_state_sync` already does.
