### PR TITLE
fix(fdev): surface the error text behind 'contract error' in verify-merge

### DIFF
--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -767,6 +767,38 @@ pub enum Inconclusive {
     NotReproducible,
 }
 
+impl Inconclusive {
+    /// The text this variant carries, where it carries one.
+    ///
+    /// Deliberately exhaustive, with NO wildcard arm, and deliberately HERE rather
+    /// than in the tool that formats it. `#[non_exhaustive]` stops other crates
+    /// matching exhaustively, so `fdev`'s report had to use a wildcard - and a
+    /// wildcard is how the contract's own error text came to be dropped for every
+    /// `ContractError`, hiding the second-largest inconclusive class behind a bare
+    /// count (#5461).
+    ///
+    /// Inside the defining crate the compiler CAN enforce the coverage, so it does:
+    /// adding a variant in any shape - `Foo(String)`, `Foo(Box<str>)`,
+    /// `Foo { reason: String }` - fails the build here until it says whether it
+    /// carries text. The `Display` impl below already depends on the same property,
+    /// so this is a demonstrated guarantee rather than a hopeful one, and it replaces
+    /// a source-scraping test that could only ever recognise one syntactic shape.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            Inconclusive::ContractError(text)
+            | Inconclusive::ResourceLimit(text)
+            | Inconclusive::MalformedCase(text) => Some(text),
+            Inconclusive::InputNotValid
+            | Inconclusive::RelatedRequired
+            | Inconclusive::NoOutputState
+            | Inconclusive::RoundLimit
+            | Inconclusive::NoDeltaPath
+            | Inconclusive::StateNotSettled
+            | Inconclusive::NotReproducible => None,
+        }
+    }
+}
+
 impl std::fmt::Display for Inconclusive {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -22,7 +22,7 @@
 //! fdev verify-merge --wasm contract.wasm --transition before.bin after.bin
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -641,6 +641,48 @@ fn find_code_in_store(store: &Path, bundle: &ReplayBundle) -> anyhow::Result<Vec
     Ok(code.data().to_vec())
 }
 
+/// Read the operator's `--wasm`, accepting either raw WASM or a contract-store file.
+///
+/// A store entry is not raw WASM. It is a VERSIONED encoding, a version header
+/// followed by the code, and only the code is hashed — `find_code_in_store` documents
+/// the same trap on the lookup side. Handing one to `--wasm` therefore failed the
+/// bundle's identity check with "supplied code is blake3:...", which reads as *wrong
+/// contract* and sends the reader hunting for a problem they do not have: the file was
+/// the right one, in the wrong form.
+///
+/// Raw bytes are tried first, so any input that works today keeps working and behaves
+/// identically; the unwrapped form is only ever consulted after the raw form has
+/// already failed. The candidate is then offered to `resolve_code` rather than judged
+/// here, so that function remains the single place deciding whether code matches a
+/// bundle: this widens what is ACCEPTED without widening what is TRUSTED. When neither
+/// form matches, the raw bytes are returned so the caller reports exactly the
+/// mismatch it reports today — a genuinely wrong contract still says so.
+fn read_supplied_wasm(path: &PathBuf, bundle: &ReplayBundle) -> anyhow::Result<Vec<u8>> {
+    let raw = read_file(path)?;
+    if bundle.resolve_code(Some(raw.clone())).is_ok() {
+        return Ok(raw);
+    }
+    // Not a store file (or unreadable as one): hand back the raw bytes and let the
+    // caller produce its ordinary mismatch error.
+    let Ok((code, _version)) = ContractCode::load_versioned_from_path(path) else {
+        return Ok(raw);
+    };
+    let unwrapped = code.data().to_vec();
+    if unwrapped == raw || bundle.resolve_code(Some(unwrapped.clone())).is_err() {
+        return Ok(raw);
+    }
+    // STDERR, for the same reason as the bundle note below: `--json` puts one JSON
+    // document on stdout and a stray line ahead of it breaks every consumer parsing
+    // it. Said out loud rather than handled silently, because the bytes being verified
+    // are not the bytes the operator named on the command line.
+    eprintln!(
+        "note: {} is a contract-store file (a versioned encoding), not raw WASM; \
+         using the contract code inside it, which matches the bundle.",
+        path.display()
+    );
+    Ok(unwrapped)
+}
+
 /// Load the WASM, parameters and corpus, either from `--bundle` or from
 /// `--wasm` / `--params` / `--state`.
 fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<LoadedInputs> {
@@ -652,7 +694,7 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<LoadedInputs> {
         // replaying it: the run looks authoritative and means nothing, whether it
         // reports findings or a clean bill of health.
         let supplied = match (&config.wasm, &config.contract_store) {
-            (Some(path), _) => Some(read_file(path)?),
+            (Some(path), _) => Some(read_supplied_wasm(path, &bundle)?),
             (None, Some(store)) => Some(find_code_in_store(store, &bundle)?),
             (None, None) => None,
         };
@@ -1133,10 +1175,55 @@ struct Finding {
     right: String,
 }
 
+/// How many distinct detail texts to report per inconclusive reason.
+///
+/// The texts come from contract code, so their number is bounded only by the case
+/// count: a contract that embeds a state hash in its error message produces a
+/// distinct string per case, and listing 435 of those would bury the question the
+/// reader actually has ("is this one bug, or eight?") rather than answer it. Five
+/// separates those two cases comfortably; the rest is reported as a count so the
+/// truncation is visible instead of silent.
+const MAX_INCONCLUSIVE_EXAMPLES: usize = 5;
+
+/// Longest detail text reported, in characters after escaping.
+///
+/// Contract-authored strings have no length bound and this text is copied into bug
+/// reports, so it is capped. Deduplication happens on the presented (escaped and
+/// truncated) form, so two messages sharing a long prefix count as one — which is
+/// why the overflow count below says "distinct message(s)" rather than "distinct
+/// error(s)".
+const MAX_INCONCLUSIVE_EXAMPLE_CHARS: usize = 200;
+
 #[derive(Serialize)]
 struct InconclusiveReason {
     reason: &'static str,
     occurrences: usize,
+    /// Distinct texts behind this reason, most frequent first. Empty for the
+    /// reasons that carry no text at all (`RoundLimit`, `RelatedRequired`, ...).
+    examples: Vec<InconclusiveExample>,
+    /// Distinct texts not listed because [`MAX_INCONCLUSIVE_EXAMPLES`] was reached.
+    ///
+    /// Reported rather than dropped, for the same reason `findings_too_large` is: a
+    /// reader has to be able to tell a complete list from a sample, and this whole
+    /// change exists because something was being dropped quietly.
+    distinct_messages_omitted: usize,
+}
+
+/// One distinct detail text and how many cases produced it.
+#[derive(Serialize)]
+struct InconclusiveExample {
+    text: String,
+    occurrences: usize,
+}
+
+/// Running tally for one inconclusive reason while a report is being built.
+#[derive(Default)]
+struct ReasonTally {
+    occurrences: usize,
+    /// `BTreeMap` so equally-frequent texts order deterministically: two runs over
+    /// the same corpus must produce byte-identical reports, or diffing them (the
+    /// normal way to see whether a contract change helped) is worthless.
+    details: BTreeMap<String, usize>,
 }
 
 impl Report {
@@ -1157,7 +1244,7 @@ impl Report {
         let mut inconclusive = 0usize;
 
         let mut findings: Vec<Finding> = Vec::new();
-        let mut inconclusive_reasons: HashMap<&'static str, usize> = HashMap::new();
+        let mut inconclusive_reasons: HashMap<&'static str, ReasonTally> = HashMap::new();
 
         for (_, outcome) in outcomes {
             match outcome {
@@ -1181,21 +1268,46 @@ impl Report {
                 }
                 PropertyOutcome::Inconclusive(reason) => {
                     inconclusive += 1;
-                    *inconclusive_reasons
+                    let tally = inconclusive_reasons
                         .entry(inconclusive_label(reason))
-                        .or_insert(0) += 1;
+                        .or_default();
+                    tally.occurrences += 1;
+                    if let Some(detail) = inconclusive_detail(reason) {
+                        *tally.details.entry(present_detail(detail)).or_insert(0) += 1;
+                    }
                 }
             }
         }
 
         let mut inconclusive_reasons: Vec<InconclusiveReason> = inconclusive_reasons
             .into_iter()
-            .map(|(reason, occurrences)| InconclusiveReason {
-                reason,
-                occurrences,
+            .map(|(reason, tally)| {
+                let mut details: Vec<(String, usize)> = tally.details.into_iter().collect();
+                // Most frequent first, then lexicographic. The frequency order makes
+                // the first line the representative case; the lexicographic tiebreak
+                // is what keeps the choice from depending on hash iteration order.
+                details.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                let distinct_messages_omitted =
+                    details.len().saturating_sub(MAX_INCONCLUSIVE_EXAMPLES);
+                details.truncate(MAX_INCONCLUSIVE_EXAMPLES);
+                InconclusiveReason {
+                    reason,
+                    occurrences: tally.occurrences,
+                    examples: details
+                        .into_iter()
+                        .map(|(text, occurrences)| InconclusiveExample { text, occurrences })
+                        .collect(),
+                    distinct_messages_omitted,
+                }
             })
             .collect();
-        inconclusive_reasons.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        // Ties broken by label for the same reason as above: a report that reorders
+        // between identical runs cannot be diffed.
+        inconclusive_reasons.sort_by(|a, b| {
+            b.occurrences
+                .cmp(&a.occurrences)
+                .then_with(|| a.reason.cmp(b.reason))
+        });
 
         Report {
             corpus_states: corpus.states.len(),
@@ -1275,6 +1387,23 @@ impl Report {
             )?;
             for r in &self.inconclusive_reasons {
                 writeln!(out, "  {}: {}", r.reason, r.occurrences)?;
+                // The text the contract actually produced. Without it the largest
+                // text-carrying bucket is a number and nothing else, and a reader
+                // cannot tell one recurring bug from many unrelated ones.
+                for example in &r.examples {
+                    writeln!(
+                        out,
+                        "      {} case(s) \u{2014} {}",
+                        example.occurrences, example.text
+                    )?;
+                }
+                if r.distinct_messages_omitted > 0 {
+                    writeln!(
+                        out,
+                        "      \u{2026} and {} further distinct message(s) not shown",
+                        r.distinct_messages_omitted
+                    )?;
+                }
             }
         }
 
@@ -1392,6 +1521,48 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
         Inconclusive::StateNotSettled => "observed result state never settles",
         Inconclusive::NotReproducible => "finding did not reproduce",
         _ => "other",
+    }
+}
+
+/// The text an [`Inconclusive`] carries, where its variant carries one.
+///
+/// [`inconclusive_label`] deliberately collapses to a fixed set of buckets so the
+/// summary stays countable. This is the other half of the same answer, and without
+/// it the buckets that DO carry text are undiagnosable from the tool's own output:
+/// measured on a 64-bundle live corpus, 435 of 2,622 inconclusive cases were
+/// `contract error` and not one of them could be read (#5461).
+///
+/// The wildcard arm is forced - `Inconclusive` is `#[non_exhaustive]` - and it is
+/// exactly how the text was lost in the first place, so a source pin
+/// (`inconclusive_detail_covers_every_text_carrying_variant`) fails the build if a
+/// new text-carrying variant is added without being listed here.
+fn inconclusive_detail(reason: &Inconclusive) -> Option<&str> {
+    match reason {
+        Inconclusive::ContractError(text)
+        | Inconclusive::ResourceLimit(text)
+        | Inconclusive::MalformedCase(text) => Some(text),
+        _ => None,
+    }
+}
+
+/// Make a contract-authored string safe and bounded for the report.
+///
+/// Two hazards, both from one fact: this text is written by the contract under test,
+/// which is the thing we are least entitled to trust.
+///
+/// Control characters are escaped first. A message containing a newline would
+/// otherwise forge report lines - a fabricated `violation:` line is one `\n` away -
+/// and a bare carriage return would overwrite the line the reader just saw. Escaping
+/// before truncating also means the cap bounds what is actually printed rather than
+/// what was parsed.
+fn present_detail(text: &str) -> String {
+    let escaped: String = text.escape_debug().collect();
+    match escaped.char_indices().nth(MAX_INCONCLUSIVE_EXAMPLE_CHARS) {
+        // Slice at a `char_indices` boundary, never at a byte offset: a multi-byte
+        // character straddling the cap would panic the whole run on an input the
+        // contract chooses.
+        Some((byte_idx, _)) => format!("{}\u{2026}", &escaped[..byte_idx]),
+        None => escaped,
     }
 }
 
@@ -2801,6 +2972,375 @@ mod tests {
     /// not be counted as a violation, and it must not fail the command — a
     /// deprecation notice that broke every affected author's build in release
     /// *n* would make the two-release notice period meaningless.
+    /// Build a report whose only outcomes are inconclusive contract errors.
+    fn report_from_contract_errors(messages: &[&str]) -> Report {
+        let outcomes: Vec<(ConformanceCase, PropertyOutcome)> = messages
+            .iter()
+            .map(|message| {
+                (
+                    ConformanceCase::new(
+                        ConformanceProperty::StateCommutativity,
+                        vec![Bytes::from(vec![1u8]), Bytes::from(vec![2u8])],
+                    ),
+                    PropertyOutcome::Inconclusive(Inconclusive::ContractError(
+                        (*message).to_string(),
+                    )),
+                )
+            })
+            .collect();
+        Report::build(&Corpus::default(), &outcomes, None, Vec::new())
+    }
+
+    fn contract_error_bucket(report: &Report) -> &InconclusiveReason {
+        report
+            .inconclusive_reasons
+            .iter()
+            .find(|r| r.reason == "contract error")
+            .expect("the contract-error bucket vanished from the report")
+    }
+
+    /// The text behind `contract error` must reach the report.
+    ///
+    /// It was carried on the variant, printed by `Inconclusive`'s own `Display`, and
+    /// then discarded at the reporting layer — so the second-largest inconclusive
+    /// class was undiagnosable from the tool's own output. Measured on a 64-bundle
+    /// live corpus: 435 of 2,622 inconclusive cases were `contract error`, and
+    /// nothing in `--json`, the human report or `RUST_LOG=debug` could say what any
+    /// of them said (#5461). A reader saw a count and nothing else, which is exactly
+    /// the information needed to tell one recurring bug from eight unrelated ones.
+    #[test]
+    fn contract_error_text_reaches_the_report() {
+        let report = report_from_contract_errors(&[
+            "signature verification failed",
+            "signature verification failed",
+            "signature verification failed",
+            "stale nonce",
+        ]);
+
+        let reason = contract_error_bucket(&report);
+        assert_eq!(reason.occurrences, 4);
+        assert_eq!(
+            reason
+                .examples
+                .iter()
+                .map(|e| (e.text.as_str(), e.occurrences))
+                .collect::<Vec<_>>(),
+            vec![("signature verification failed", 3), ("stale nonce", 1)],
+            "distinct messages must carry their own counts, most frequent first: \
+             that breakdown is the whole answer to 'is this one bug or several'"
+        );
+        assert_eq!(reason.distinct_messages_omitted, 0);
+
+        let rendered = render_human(&report);
+        assert!(
+            rendered.contains("signature verification failed"),
+            "the human report still hides the contract's own error text:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("stale nonce"),
+            "only the most common message survived, so a second distinct failure \
+             stays invisible:\n{rendered}"
+        );
+    }
+
+    /// A reason that carries no text must not grow an empty example list in the
+    /// human output.
+    ///
+    /// Most inconclusive reasons carry nothing (`RoundLimit`, `RelatedRequired`),
+    /// and they are the majority of a real run. If the new lines fired for them too,
+    /// every clean-ish report would gain blank noise.
+    #[test]
+    fn a_textless_reason_reports_no_examples() {
+        let outcomes = vec![(
+            ConformanceCase::new(
+                ConformanceProperty::StateCommutativity,
+                vec![Bytes::from(vec![1u8])],
+            ),
+            PropertyOutcome::Inconclusive(Inconclusive::RoundLimit),
+        )];
+        let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
+        let reason = &report.inconclusive_reasons[0];
+        assert!(reason.examples.is_empty());
+        assert_eq!(reason.distinct_messages_omitted, 0);
+    }
+
+    /// Distinct messages past the cap are counted, never silently dropped.
+    ///
+    /// The cap exists because the count of distinct texts is bounded only by the
+    /// case count — a contract that embeds a state hash in its error produces one
+    /// per case. Capping without saying so would reintroduce this issue's own
+    /// defect in miniature: output that looks complete and is not.
+    #[test]
+    fn distinct_messages_beyond_the_cap_are_counted_not_dropped() {
+        let messages: Vec<String> = (0..MAX_INCONCLUSIVE_EXAMPLES + 3)
+            .map(|i| format!("distinct failure {i}"))
+            .collect();
+        let refs: Vec<&str> = messages.iter().map(String::as_str).collect();
+        let report = report_from_contract_errors(&refs);
+
+        let reason = contract_error_bucket(&report);
+        assert_eq!(reason.examples.len(), MAX_INCONCLUSIVE_EXAMPLES);
+        assert_eq!(
+            reason.distinct_messages_omitted, 3,
+            "the overflow count must say how many distinct messages were not shown"
+        );
+
+        let rendered = render_human(&report);
+        assert!(
+            rendered.contains("3 further distinct message(s) not shown"),
+            "the human report presented a truncated list as if it were complete:\n{rendered}"
+        );
+    }
+
+    /// Equal counts must order deterministically, for messages and for reasons.
+    ///
+    /// The reason tally is drained through a `HashMap`, whose iteration order is
+    /// randomly seeded per process, so two equally-frequent reasons came out in a
+    /// different order on each run over the same corpus. Comparing two runs is the
+    /// normal way to check whether a contract fix helped, and it is worthless
+    /// against a report that reshuffles itself.
+    ///
+    /// The message half below is belt-and-braces: those come from a `BTreeMap`
+    /// through a stable sort, so they were already ordered. The reason half is the
+    /// one that was genuinely unstable.
+    #[test]
+    fn equal_counts_order_deterministically() {
+        let report = report_from_contract_errors(&["b failure", "a failure"]);
+        let texts: Vec<&str> = contract_error_bucket(&report)
+            .examples
+            .iter()
+            .map(|e| e.text.as_str())
+            .collect();
+        assert_eq!(texts, vec!["a failure", "b failure"]);
+
+        let case = || {
+            ConformanceCase::new(
+                ConformanceProperty::StateCommutativity,
+                vec![Bytes::from(vec![1u8])],
+            )
+        };
+        let outcomes = vec![
+            (
+                case(),
+                PropertyOutcome::Inconclusive(Inconclusive::RoundLimit),
+            ),
+            (
+                case(),
+                PropertyOutcome::Inconclusive(Inconclusive::ContractError("boom".to_string())),
+            ),
+        ];
+        let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
+        let reasons: Vec<&str> = report
+            .inconclusive_reasons
+            .iter()
+            .map(|r| r.reason)
+            .collect();
+        assert_eq!(
+            reasons,
+            vec!["contract error", "reconciliation round budget exhausted"],
+            "two reasons with equal counts must order by label, not by whatever \
+             the hash map happened to yield on this run"
+        );
+    }
+
+    /// The `--wasm` fallback must be reached through `load_inputs`, not merely exist.
+    ///
+    /// Written after the unit test below survived a mutation that removed the
+    /// fallback from `load_inputs` entirely: that test calls `read_supplied_wasm`
+    /// directly, so it proves the helper works and says nothing about whether the
+    /// command uses it. A guard on one layer is not a guard on the layer above it.
+    ///
+    /// This drives the real CLI surface (`ConformanceConfig` is the clap parser) so
+    /// the wiring itself is under test.
+    #[test]
+    fn load_inputs_uses_the_store_file_fallback_for_wasm() {
+        use clap::Parser;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let code = b"\0asm-not-really-but-bytes-are-bytes".to_vec();
+
+        let mut bundle = ReplayBundle::new(code.clone(), Vec::new());
+        bundle.states.push(vec![1u8, 2, 3]);
+        let bundle_path = dir.path().join("corpus.bin");
+        bundle.write_to(&bundle_path).expect("write bundle");
+
+        // The contract, in the form a node's contract store holds it.
+        let store_path = dir.path().join("stored.wasm");
+        std::fs::write(
+            &store_path,
+            ContractCode::from(code.clone())
+                .to_bytes_versioned(freenet_stdlib::prelude::APIVersion::Version0_0_1)
+                .expect("encode versioned"),
+        )
+        .expect("write store form");
+
+        let config = ConformanceConfig::try_parse_from([
+            "verify-merge",
+            "--bundle",
+            bundle_path.to_str().expect("utf-8 path"),
+            "--wasm",
+            store_path.to_str().expect("utf-8 path"),
+        ])
+        .expect("the flags this test uses must stay parseable");
+
+        let loaded = load_inputs(&config).expect(
+            "--wasm given a contract-store file was rejected: before the fix this \
+             failed the bundle's identity check and reported it as the wrong contract",
+        );
+        assert_eq!(
+            loaded.wasm, code,
+            "the unwrapped contract code must be used"
+        );
+    }
+
+    /// `--wasm` must accept a contract-store file, not only raw WASM.
+    ///
+    /// A store entry is a versioned encoding, a header followed by the code, and
+    /// only the code is hashed. Passing one to `--wasm` therefore failed the
+    /// bundle's identity check with "supplied code is blake3:...", which reads as
+    /// WRONG CONTRACT and sends the reader hunting for a problem they do not have:
+    /// the file was the right one, in the wrong form (#5461).
+    #[test]
+    fn wasm_accepts_a_contract_store_file_as_well_as_raw_wasm() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Not valid WASM, and it does not need to be: nothing here compiles it.
+        let code = b"\0asm-not-really-but-bytes-are-bytes".to_vec();
+        let bundle = ReplayBundle::new(code.clone(), Vec::new());
+
+        // Raw WASM behaves exactly as before. This is the case the fallback must
+        // never be able to reinterpret, which is why the raw form is tried first.
+        let raw_path = dir.path().join("raw.wasm");
+        std::fs::write(&raw_path, &code).expect("write raw");
+        assert_eq!(read_supplied_wasm(&raw_path, &bundle).expect("raw"), code);
+
+        // The same contract, in the form a node's contract store holds it.
+        let encoded = ContractCode::from(code.clone())
+            .to_bytes_versioned(freenet_stdlib::prelude::APIVersion::Version0_0_1)
+            .expect("encode versioned");
+        assert_ne!(
+            encoded, code,
+            "the stored form must differ from the raw form, or this test proves \
+             nothing about unwrapping one"
+        );
+        let store_path = dir.path().join("stored.wasm");
+        std::fs::write(&store_path, &encoded).expect("write store form");
+        assert_eq!(
+            read_supplied_wasm(&store_path, &bundle).expect("store form"),
+            code,
+            "a contract-store file passed to --wasm was still rejected as though \
+             it were a different contract"
+        );
+
+        // Widening what is ACCEPTED must not widen what is TRUSTED: a genuinely
+        // different contract stays refused, in both forms.
+        let other = ReplayBundle::new(b"different code entirely".to_vec(), Vec::new());
+        for path in [&raw_path, &store_path] {
+            let supplied = read_supplied_wasm(path, &other).expect("reading succeeds");
+            assert!(
+                other.resolve_code(Some(supplied)).is_err(),
+                "code that does not belong to the bundle resolved against it \
+                 anyway, from {}",
+                path.display()
+            );
+        }
+    }
+
+    /// A contract-authored message must not be able to forge report lines.
+    ///
+    /// This text is written by the contract under test, which is the thing we are
+    /// least entitled to trust, and it is now printed into a report people read to
+    /// decide whether a contract is sound. A bare newline would let it fabricate a
+    /// `[violation]` line; a carriage return would let it overwrite the line above.
+    #[test]
+    fn a_contract_message_cannot_forge_report_lines() {
+        let report =
+            report_from_contract_errors(&["boom\n  [violation] StateCommutativity: forged"]);
+        let rendered = render_human(&report);
+
+        assert!(
+            !rendered.contains("\n  [violation]"),
+            "a newline in the contract's error text forged a findings line:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("\\n"),
+            "the newline was neither escaped nor stripped:\n{rendered}"
+        );
+    }
+
+    /// Truncation slices on a character boundary.
+    ///
+    /// Slicing a `String` at a byte offset panics when a multi-byte character
+    /// straddles it, and the bytes here are chosen by the contract under test — so a
+    /// byte-offset cap would be a contract-triggerable crash of the entire run,
+    /// taking every other case's result with it.
+    #[test]
+    fn a_long_multibyte_message_is_truncated_without_panicking() {
+        let presented = present_detail(&"e\u{301}".repeat(MAX_INCONCLUSIVE_EXAMPLE_CHARS * 2));
+        assert_eq!(
+            presented.chars().count(),
+            MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1,
+            "expected exactly the cap plus one ellipsis: {presented}"
+        );
+        assert!(presented.ends_with('\u{2026}'));
+    }
+
+    /// A message at or under the cap is reported whole, with no ellipsis.
+    ///
+    /// The counterpart to the test above: a cap that fired on everything would
+    /// satisfy it while making every message unreadable.
+    #[test]
+    fn a_short_message_is_not_truncated() {
+        assert_eq!(present_detail("stale nonce"), "stale nonce");
+    }
+
+    /// Pin: every `Inconclusive` variant carrying text is reported by
+    /// [`inconclusive_detail`].
+    ///
+    /// That match needs a wildcard arm, because `Inconclusive` is
+    /// `#[non_exhaustive]` and this crate cannot match it exhaustively. A wildcard
+    /// is precisely how the text was lost the first time, so a new text-carrying
+    /// variant would land in it and be silently undiagnosable again with every test
+    /// still green. Scraping the source is the only check available here, since the
+    /// compiler cannot be made to demand the coverage.
+    #[test]
+    fn inconclusive_detail_covers_every_text_carrying_variant() {
+        let enum_src = include_str!("../../core/src/conformance/property.rs");
+        let start = enum_src
+            .find("pub enum Inconclusive {")
+            .expect("the Inconclusive enum moved; this pin can no longer find it");
+        let body = &enum_src[start..];
+        let body = &body[..body.find("\n}").expect("Inconclusive has no closing brace")];
+
+        let text_carrying: Vec<&str> = body
+            .lines()
+            .filter_map(|line| line.trim().strip_suffix("(String),"))
+            .collect();
+        // Fail closed. If the scrape silently matched nothing, every assertion below
+        // would pass vacuously and the pin would guard the wildcard it exists for
+        // by doing nothing at all.
+        assert!(
+            text_carrying.len() >= 3,
+            "expected to find the known text-carrying variants (ContractError, \
+             ResourceLimit, MalformedCase); the scrape found {text_carrying:?}"
+        );
+
+        let detail_src = include_str!("conformance.rs");
+        let fn_start = detail_src
+            .find("fn inconclusive_detail(")
+            .expect("inconclusive_detail moved; this pin can no longer find it");
+        let fn_body = &detail_src[fn_start..];
+        let fn_body = &fn_body[..fn_body.find("\n}").expect("inconclusive_detail has no end")];
+
+        for variant in text_carrying {
+            assert!(
+                fn_body.contains(&format!("Inconclusive::{variant}(")),
+                "Inconclusive::{variant} carries text but inconclusive_detail does \
+                 not report it, so it would vanish into the wildcard arm and be \
+                 undiagnosable from the tool's output - the exact defect #5461 fixed"
+            );
+        }
+    }
+
     #[test]
     fn a_code_diagnostic_is_never_removal_eligible() {
         let outcomes = vec![(

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1551,17 +1551,13 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
 /// measured on a 64-bundle live corpus, 435 of 2,622 inconclusive cases were
 /// `contract error` and not one of them could be read (#5461).
 ///
-/// The wildcard arm is forced - `Inconclusive` is `#[non_exhaustive]` - and it is
-/// exactly how the text was lost in the first place, so a source pin
-/// (`inconclusive_detail_covers_every_text_carrying_variant`) fails the build if a
-/// new text-carrying variant is added without being listed here.
+/// Delegates to [`Inconclusive::detail`] rather than matching here. This crate
+/// cannot match `#[non_exhaustive]` exhaustively, so any match written at this end
+/// needs a wildcard arm - and the wildcard is exactly how the text was lost the
+/// first time. Owning the answer in the defining crate makes the compiler refuse a
+/// new variant that has not declared whether it carries text.
 fn inconclusive_detail(reason: &Inconclusive) -> Option<&str> {
-    match reason {
-        Inconclusive::ContractError(text)
-        | Inconclusive::ResourceLimit(text)
-        | Inconclusive::MalformedCase(text) => Some(text),
-        _ => None,
-    }
+    reason.detail()
 }
 
 /// Make a contract-authored string safe and bounded for the report.
@@ -3007,23 +3003,31 @@ mod tests {
         assert_eq!(code_diagnostics(&wasm), Vec::new());
     }
 
-    /// Build a report whose only outcomes are inconclusive contract errors.
-    fn report_from_contract_errors(messages: &[&str]) -> Report {
-        let outcomes: Vec<(ConformanceCase, PropertyOutcome)> = messages
-            .iter()
-            .map(|message| {
+    /// Build a report whose only outcomes are the given inconclusive reasons.
+    fn report_from_inconclusive(reasons: Vec<Inconclusive>) -> Report {
+        let outcomes: Vec<(ConformanceCase, PropertyOutcome)> = reasons
+            .into_iter()
+            .map(|reason| {
                 (
                     ConformanceCase::new(
                         ConformanceProperty::StateCommutativity,
                         vec![Bytes::from(vec![1u8]), Bytes::from(vec![2u8])],
                     ),
-                    PropertyOutcome::Inconclusive(Inconclusive::ContractError(
-                        (*message).to_string(),
-                    )),
+                    PropertyOutcome::Inconclusive(reason),
                 )
             })
             .collect();
         Report::build(&Corpus::default(), &outcomes, None, Vec::new())
+    }
+
+    /// Build a report whose only outcomes are inconclusive contract errors.
+    fn report_from_contract_errors(messages: &[&str]) -> Report {
+        report_from_inconclusive(
+            messages
+                .iter()
+                .map(|m| Inconclusive::ContractError((*m).to_string()))
+                .collect(),
+        )
     }
 
     use super::stdout_purity_pin::code_only;
@@ -3079,26 +3083,39 @@ mod tests {
         );
     }
 
-    /// A reason that carries no text must not grow an empty example list in the
-    /// human output.
+    /// A reason that carries no text is still counted, and grows no example lines.
     ///
-    /// Most inconclusive reasons carry nothing (`RoundLimit`, `RelatedRequired`),
-    /// and they are the majority of a real run. If the new lines fired for them too,
-    /// every clean-ish report would gain blank noise.
+    /// Two properties, because they fail in opposite directions. Most inconclusive
+    /// reasons carry nothing (`RoundLimit`, `RelatedRequired`) and are the bulk of a
+    /// real run: if the new example lines fired for them, every report would gain
+    /// blank noise; if the tally were moved inside the has-text branch, every one of
+    /// them would report `: 0` and the majority of the summary would read as empty.
     #[test]
-    fn a_textless_reason_reports_no_examples() {
-        let outcomes = vec![(
-            ConformanceCase::new(
-                ConformanceProperty::StateCommutativity,
-                vec![Bytes::from(vec![1u8])],
-            ),
-            PropertyOutcome::Inconclusive(Inconclusive::RoundLimit),
-        )];
-        let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
-        let reason = &report.inconclusive_reasons[0];
-        assert!(reason.examples.is_empty());
-    }
+    fn a_textless_reason_is_counted_and_reports_no_examples() {
+        let report = report_from_inconclusive(vec![
+            Inconclusive::RoundLimit,
+            Inconclusive::RoundLimit,
+            Inconclusive::RoundLimit,
+        ]);
 
+        let reason = &report.inconclusive_reasons[0];
+        assert_eq!(
+            reason.occurrences, 3,
+            "a reason that carries no text must still be counted; counting only \
+             text-carrying cases empties the majority of a real run's summary"
+        );
+        assert!(reason.examples.is_empty());
+
+        let rendered = render_human(&report);
+        assert!(
+            !rendered.contains("further distinct message(s)"),
+            "the hidden-tail line fired for a reason with nothing to hide:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("may contain application state"),
+            "the sensitivity note fired for a report with no contract text in it:\n{rendered}"
+        );
+    }
     /// The readability cap trims the HUMAN report only, and says what it hid.
     ///
     /// The cap exists because the count of distinct texts is bounded only by the
@@ -3153,55 +3170,57 @@ mod tests {
 
     /// Equal counts must order deterministically, for messages and for reasons.
     ///
-    /// The reason tally is drained through a `HashMap`, whose iteration order is
-    /// randomly seeded per process, so two equally-frequent reasons came out in a
-    /// different order on each run over the same corpus. Comparing two runs is the
-    /// normal way to check whether a contract fix helped, and it is worthless
-    /// against a report that reshuffles itself.
+    /// The reason tally is drained through a `HashMap` whose iteration order is
+    /// randomly seeded, so equally-frequent reasons came out differently on each run
+    /// over the same corpus. Comparing two runs is the normal way to check whether a
+    /// contract fix helped, and it is worthless against a report that reshuffles
+    /// itself.
     ///
-    /// The message half below is belt-and-braces: those come from a `BTreeMap`
-    /// through a stable sort, so they were already ordered. The reason half is the
-    /// one that was genuinely unstable.
+    /// FOUR equal-count reasons, rebuilt twenty times, deliberately. An earlier
+    /// version used two, which a stable sort orders correctly by luck about half the
+    /// time - so on a single CI run a regression had even odds of merging. Four
+    /// reasons give twenty-four permutations, and each rebuild draws a fresh
+    /// `HashMap` seed, so an unordered implementation has no realistic chance of
+    /// passing.
+    ///
+    /// The message half is belt-and-braces: those come from a `BTreeMap` through a
+    /// stable sort, so they were already ordered. The reason half was the unstable
+    /// one.
     #[test]
     fn equal_counts_order_deterministically() {
-        let report = report_from_contract_errors(&["b failure", "a failure"]);
-        let texts: Vec<&str> = contract_error_bucket(&report)
+        let message_report = report_from_contract_errors(&["b failure", "a failure"]);
+        let texts: Vec<&str> = contract_error_bucket(&message_report)
             .examples
             .iter()
             .map(|e| e.text.as_str())
             .collect();
         assert_eq!(texts, vec!["a failure", "b failure"]);
 
-        let case = || {
-            ConformanceCase::new(
-                ConformanceProperty::StateCommutativity,
-                vec![Bytes::from(vec![1u8])],
-            )
-        };
-        let outcomes = vec![
-            (
-                case(),
-                PropertyOutcome::Inconclusive(Inconclusive::RoundLimit),
-            ),
-            (
-                case(),
-                PropertyOutcome::Inconclusive(Inconclusive::ContractError("boom".to_string())),
-            ),
+        let expected = vec![
+            "contract error",
+            "input not valid",
+            "reconciliation round budget exhausted",
+            "requires related contract state",
         ];
-        let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
-        let reasons: Vec<&str> = report
-            .inconclusive_reasons
-            .iter()
-            .map(|r| r.reason)
-            .collect();
-        assert_eq!(
-            reasons,
-            vec!["contract error", "reconciliation round budget exhausted"],
-            "two reasons with equal counts must order by label, not by whatever \
-             the hash map happened to yield on this run"
-        );
+        for round in 0..20 {
+            let report = report_from_inconclusive(vec![
+                Inconclusive::RoundLimit,
+                Inconclusive::RelatedRequired,
+                Inconclusive::ContractError("boom".to_string()),
+                Inconclusive::InputNotValid,
+            ]);
+            let reasons: Vec<&str> = report
+                .inconclusive_reasons
+                .iter()
+                .map(|r| r.reason)
+                .collect();
+            assert_eq!(
+                reasons, expected,
+                "round {round}: reasons with equal counts must order by label, not \
+                 by whatever the hash map yielded this time"
+            );
+        }
     }
-
     /// A contract-authored message must not be able to forge report lines.
     ///
     /// This text is written by the contract under test, which is the thing we are
@@ -3256,6 +3275,146 @@ mod tests {
             MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1
         );
         assert!(presented.ends_with('\u{2026}'));
+    }
+
+    /// Every text-carrying reason reaches the report, not just `ContractError`.
+    ///
+    /// `ResourceLimit` and `MalformedCase` carry text for the same reason and had no
+    /// behavioural coverage at all: dropping them from the accessor left every test
+    /// green. `ContractError` is merely the one that dominates a real corpus.
+    #[test]
+    fn resource_limit_and_malformed_case_text_reaches_the_report_too() {
+        for (reason, label, text) in [
+            (
+                Inconclusive::ResourceLimit("fuel exhausted".to_string()),
+                "resource limit hit",
+                "fuel exhausted",
+            ),
+            (
+                Inconclusive::MalformedCase("needs two states".to_string()),
+                "malformed case",
+                "needs two states",
+            ),
+        ] {
+            let report = report_from_inconclusive(vec![reason]);
+            let bucket = report
+                .inconclusive_reasons
+                .iter()
+                .find(|r| r.reason == label)
+                .unwrap_or_else(|| panic!("no {label} bucket in the report"));
+
+            assert_eq!(
+                bucket
+                    .examples
+                    .iter()
+                    .map(|e| e.text.as_str())
+                    .collect::<Vec<_>>(),
+                vec![text],
+                "{label} carries text that never reached the report"
+            );
+            assert!(render_human(&report).contains(text));
+        }
+    }
+
+    /// Each message is printed under the reason it belongs to.
+    ///
+    /// Every other rendering test builds a report with ONE inconclusive reason, so
+    /// the association between a bucket and its texts was never exercised - and that
+    /// association is the entire point of the change. Moving the example loop out of
+    /// the reason loop, so all messages print together at the end, passed the whole
+    /// suite.
+    #[test]
+    fn each_message_prints_under_its_own_reason() {
+        let report = report_from_inconclusive(vec![
+            Inconclusive::ContractError("rejected by contract".to_string()),
+            Inconclusive::ResourceLimit("fuel exhausted".to_string()),
+        ]);
+        let rendered = render_human(&report);
+
+        let position = |needle: &str| {
+            rendered
+                .find(needle)
+                .unwrap_or_else(|| panic!("{needle:?} missing from:\n{rendered}"))
+        };
+        let contract_header = position("contract error:");
+        let resource_header = position("resource limit hit:");
+        let contract_text = position("rejected by contract");
+        let resource_text = position("fuel exhausted");
+
+        // Each message must sit between its own header and the next one, which is
+        // what "attributed to its bucket" means in a flat text report.
+        assert!(
+            contract_header < contract_text && contract_text < resource_header,
+            "the contract-error message is not under the contract-error \
+             heading:\n{rendered}"
+        );
+        assert!(
+            resource_header < resource_text,
+            "the resource-limit message is not under its heading:\n{rendered}"
+        );
+    }
+
+    /// `--json` must actually carry the examples.
+    ///
+    /// Only the human half was asserted, so a `#[serde(skip)]` on `examples` passed
+    /// the suite. That matters more now the two formats deliberately DIFFER - human
+    /// capped, JSON complete - because a reader cannot otherwise tell the design
+    /// from a bug.
+    #[test]
+    fn the_json_report_carries_the_examples() {
+        let report = report_from_contract_errors(&["signature check failed"]);
+        let json = serde_json::to_string(&report).expect("the report must serialize");
+
+        assert!(
+            json.contains("\"examples\""),
+            "the examples field never reached --json: {json}"
+        );
+        assert!(
+            json.contains("signature check failed"),
+            "--json carries the field but not the text: {json}"
+        );
+        assert!(
+            json.contains("\"occurrences\":1"),
+            "--json dropped the per-message count: {json}"
+        );
+    }
+
+    /// The human report prints the per-message case count, not just the text.
+    ///
+    /// The counts were asserted on the struct and only `contains(text)` on the
+    /// rendering, so the breakdown that answers "one bug or eight" could vanish from
+    /// what a human actually reads while the test protecting it stayed green.
+    #[test]
+    fn the_human_report_prints_each_messages_case_count() {
+        let report = report_from_contract_errors(&["twice", "twice", "once"]);
+        let rendered = render_human(&report);
+
+        assert!(
+            rendered.contains("2 cases \u{2014} \"twice\""),
+            "the per-message case count is missing from the rendering:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("1 case \u{2014} \"once\""),
+            "a single case must read \"1 case\", not \"1 case(s)\":\n{rendered}"
+        );
+    }
+
+    /// Escaping happens BEFORE truncation, so the cap bounds what is printed.
+    ///
+    /// Truncating the raw text first and escaping after leaves the cap describing
+    /// what was parsed rather than what appears: 200 control characters would print
+    /// as 1,200. The rustdoc claimed this ordering with nothing asserting it.
+    #[test]
+    fn the_cap_bounds_what_is_printed_not_what_was_parsed() {
+        let presented = present_detail(&"\u{7}".repeat(MAX_INCONCLUSIVE_EXAMPLE_CHARS));
+
+        assert_eq!(
+            presented.chars().count(),
+            MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1,
+            "each bell character escapes to six, so truncating before escaping \
+             would print far past the cap: {presented}"
+        );
+        assert!(presented.starts_with("\\u{7}"));
     }
 
     /// Pin: `present_detail` hands `take_presented` a LAZY iterator.
@@ -3354,12 +3513,28 @@ mod tests {
     /// Truncation slices on a character boundary.
     ///
     /// Slicing a `String` at a byte offset panics when a multi-byte character
-    /// straddles it, and the bytes here are chosen by the contract under test — so a
+    /// straddles it, and the bytes here are chosen by the contract under test - so a
     /// byte-offset cap would be a contract-triggerable crash of the entire run,
     /// taking every other case's result with it.
+    ///
+    /// The fixture's sensitivity is load-bearing and non-obvious: `str::escape_debug`
+    /// escapes a grapheme-extending character only when it BEGINS the string, so
+    /// `"e\u{301}"` repeated stays multi-byte all the way through escaping and the
+    /// byte at the cap lands mid-character. Lead with the combining mark, or pick a
+    /// character that escaping turns into ASCII, and this silently becomes an
+    /// all-ASCII test that still passes while guarding nothing. The assertion below
+    /// pins that the escaped form really is still multi-byte.
     #[test]
     fn a_long_multibyte_message_is_truncated_without_panicking() {
-        let presented = present_detail(&"e\u{301}".repeat(MAX_INCONCLUSIVE_EXAMPLE_CHARS * 2));
+        let message = "e\u{301}".repeat(MAX_INCONCLUSIVE_EXAMPLE_CHARS * 2);
+        let escaped: String = message.escape_debug().collect();
+        assert!(
+            escaped.len() > escaped.chars().count(),
+            "the fixture stopped being multi-byte after escaping, so it no longer \
+             exercises a byte-offset slice at all"
+        );
+
+        let presented = present_detail(&message);
         assert_eq!(
             presented.chars().count(),
             MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1,
@@ -3367,7 +3542,6 @@ mod tests {
         );
         assert!(presented.ends_with('\u{2026}'));
     }
-
     /// A message at or under the cap is reported whole, with no ellipsis.
     ///
     /// The counterpart to the test above: a cap that fired on everything would
@@ -3375,101 +3549,6 @@ mod tests {
     #[test]
     fn a_short_message_is_not_truncated() {
         assert_eq!(present_detail("stale nonce"), "stale nonce");
-    }
-
-    /// Pin: every `Inconclusive` variant carrying text is reported by
-    /// [`inconclusive_detail`].
-    ///
-    /// That match needs a wildcard arm, because `Inconclusive` is `#[non_exhaustive]`
-    /// and this crate cannot match it exhaustively. A wildcard is precisely how the
-    /// text was lost the first time, so a new text-carrying variant would land in it
-    /// and be silently undiagnosable again with every test still green. Scraping the
-    /// source is the only check available, since the compiler cannot be made to
-    /// demand the coverage.
-    ///
-    /// "Carries text" is deliberately matched on the whole variant declaration rather
-    /// than the literal `Name(String),` shape: `Foo(String, usize)`, `Foo(Box<str>)`
-    /// and `Foo { reason: String }` all carry text and all slip past a suffix match,
-    /// which would leave the pin guarding only the three variants that already exist.
-    #[test]
-    fn inconclusive_detail_covers_every_text_carrying_variant() {
-        let enum_src = include_str!("../../core/src/conformance/property.rs");
-        let start = enum_src
-            .find("pub enum Inconclusive {")
-            .expect("the Inconclusive enum moved; this pin can no longer find it");
-        let body = &enum_src[start..];
-        let body = &body[..body.find("\n}").expect("Inconclusive has no closing brace")];
-
-        // Accumulate each variant's full declaration, so a multi-line struct variant
-        // is judged as one unit rather than line by line.
-        let mut variants: Vec<(String, String)> = Vec::new();
-        let mut pending = String::new();
-        for line in body.lines().skip(1) {
-            let trimmed = line.trim();
-            if trimmed.starts_with("///") || trimmed.starts_with("#[") || trimmed.is_empty() {
-                continue;
-            }
-            pending.push_str(trimmed);
-            pending.push(' ');
-            // A declaration ends at the comma that closes it, once brackets balance.
-            let balanced = pending.matches('(').count() == pending.matches(')').count()
-                && pending.matches('{').count() == pending.matches('}').count();
-            if !(trimmed.ends_with(',') && balanced) {
-                continue;
-            }
-            let declaration = std::mem::take(&mut pending);
-            let name: String = declaration
-                .chars()
-                .take_while(|c| c.is_alphanumeric() || *c == '_')
-                .collect();
-            if !name.is_empty() {
-                variants.push((name, declaration));
-            }
-        }
-
-        let text_carrying: Vec<&str> = variants
-            .iter()
-            .filter(|(_, declaration)| {
-                declaration.contains("String") || declaration.contains("str")
-            })
-            .map(|(name, _)| name.as_str())
-            .collect();
-
-        // Fail closed, on both halves. If the scrape silently matched nothing, or
-        // matched only text-carrying variants, every assertion below would pass
-        // vacuously and the pin would guard the wildcard by doing nothing at all.
-        assert!(
-            variants.len() >= 8,
-            "the variant scrape broke: found {} declaration(s) in an enum that has \
-             far more: {variants:?}",
-            variants.len()
-        );
-        assert!(
-            text_carrying.len() >= 3,
-            "expected at least the known text-carrying variants (ContractError, \
-             ResourceLimit, MalformedCase); the scrape found {text_carrying:?}"
-        );
-        assert!(
-            variants.len() > text_carrying.len(),
-            "every variant was judged text-carrying, so the filter is matching \
-             something other than what it claims: {variants:?}"
-        );
-
-        let detail_src = include_str!("conformance.rs");
-        let fn_start = detail_src
-            .find("fn inconclusive_detail(")
-            .expect("inconclusive_detail moved; this pin can no longer find it");
-        let fn_body = &detail_src[fn_start..];
-        let fn_body = &fn_body[..fn_body.find("\n}").expect("inconclusive_detail has no end")];
-
-        for variant in text_carrying {
-            assert!(
-                fn_body.contains(&format!("Inconclusive::{variant}")),
-                "Inconclusive::{variant} carries text but inconclusive_detail does \
-                 not report it, so it would vanish into the wildcard arm and be \
-                 undiagnosable from the tool's output - the exact defect #5461 fixed"
-            );
-        }
     }
 
     /// The whole point of the channel: a code diagnostic is DIAGNOSTIC. It must

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -526,10 +526,16 @@ async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::
     println!("evidence {}", evidence.id());
     println!("  contract : {}", evidence.contract);
     println!("  property : {}", evidence.property);
+    // `v.detail` is deserialized from an evidence file ANOTHER PEER produced, and
+    // this function's own stated contract is that `evidence.observed` is never
+    // trusted. It was nonetheless interpolated raw into the operator's terminal, so
+    // a sender could embed a newline and forge a `verdict  :` line in the exact
+    // format the real one uses - on the one command here built to consume hostile
+    // input. `v.property` is an enum and carries no free text.
     println!(
         "  claimed  : {}",
         match &evidence.observed {
-            Some(v) => format!("{} ({})", v.property, v.detail),
+            Some(v) => format!("{} ({})", v.property, present_detail(&v.detail)),
             None => "nothing recorded by the sender".to_string(),
         }
     );
@@ -562,7 +568,14 @@ async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::
             Ok(())
         }
         PropertyOutcome::Inconclusive(reason) => {
-            println!("  verdict  : INCONCLUSIVE \u{2014} {reason}");
+            // `Display for Inconclusive` interpolates the contract's own error text
+            // raw, so this is the same untrusted-text-to-terminal path the report
+            // side escapes. Escaping the rendered line whole is safe: the static
+            // prefixes it adds contain nothing escapable.
+            println!(
+                "  verdict  : INCONCLUSIVE \u{2014} {}",
+                present_detail(&reason.to_string())
+            );
             Ok(())
         }
     }
@@ -641,48 +654,6 @@ fn find_code_in_store(store: &Path, bundle: &ReplayBundle) -> anyhow::Result<Vec
     Ok(code.data().to_vec())
 }
 
-/// Read the operator's `--wasm`, accepting either raw WASM or a contract-store file.
-///
-/// A store entry is not raw WASM. It is a VERSIONED encoding, a version header
-/// followed by the code, and only the code is hashed — `find_code_in_store` documents
-/// the same trap on the lookup side. Handing one to `--wasm` therefore failed the
-/// bundle's identity check with "supplied code is blake3:...", which reads as *wrong
-/// contract* and sends the reader hunting for a problem they do not have: the file was
-/// the right one, in the wrong form.
-///
-/// Raw bytes are tried first, so any input that works today keeps working and behaves
-/// identically; the unwrapped form is only ever consulted after the raw form has
-/// already failed. The candidate is then offered to `resolve_code` rather than judged
-/// here, so that function remains the single place deciding whether code matches a
-/// bundle: this widens what is ACCEPTED without widening what is TRUSTED. When neither
-/// form matches, the raw bytes are returned so the caller reports exactly the
-/// mismatch it reports today — a genuinely wrong contract still says so.
-fn read_supplied_wasm(path: &PathBuf, bundle: &ReplayBundle) -> anyhow::Result<Vec<u8>> {
-    let raw = read_file(path)?;
-    if bundle.resolve_code(Some(raw.clone())).is_ok() {
-        return Ok(raw);
-    }
-    // Not a store file (or unreadable as one): hand back the raw bytes and let the
-    // caller produce its ordinary mismatch error.
-    let Ok((code, _version)) = ContractCode::load_versioned_from_path(path) else {
-        return Ok(raw);
-    };
-    let unwrapped = code.data().to_vec();
-    if unwrapped == raw || bundle.resolve_code(Some(unwrapped.clone())).is_err() {
-        return Ok(raw);
-    }
-    // STDERR, for the same reason as the bundle note below: `--json` puts one JSON
-    // document on stdout and a stray line ahead of it breaks every consumer parsing
-    // it. Said out loud rather than handled silently, because the bytes being verified
-    // are not the bytes the operator named on the command line.
-    eprintln!(
-        "note: {} is a contract-store file (a versioned encoding), not raw WASM; \
-         using the contract code inside it, which matches the bundle.",
-        path.display()
-    );
-    Ok(unwrapped)
-}
-
 /// Load the WASM, parameters and corpus, either from `--bundle` or from
 /// `--wasm` / `--params` / `--state`.
 fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<LoadedInputs> {
@@ -694,7 +665,7 @@ fn load_inputs(config: &ConformanceConfig) -> anyhow::Result<LoadedInputs> {
         // replaying it: the run looks authoritative and means nothing, whether it
         // reports findings or a clean bill of health.
         let supplied = match (&config.wasm, &config.contract_store) {
-            (Some(path), _) => Some(read_supplied_wasm(path, &bundle)?),
+            (Some(path), _) => Some(read_file(path)?),
             (None, Some(store)) => Some(find_code_in_store(store, &bundle)?),
             (None, None) => None,
         };
@@ -1175,14 +1146,20 @@ struct Finding {
     right: String,
 }
 
-/// How many distinct detail texts to report per inconclusive reason.
+/// How many distinct detail texts the HUMAN report shows per inconclusive reason.
 ///
 /// The texts come from contract code, so their number is bounded only by the case
 /// count: a contract that embeds a state hash in its error message produces a
 /// distinct string per case, and listing 435 of those would bury the question the
 /// reader actually has ("is this one bug, or eight?") rather than answer it. Five
-/// separates those two cases comfortably; the rest is reported as a count so the
-/// truncation is visible instead of silent.
+/// separates those two cases comfortably.
+///
+/// This is a READABILITY bound and so it applies to the human report alone. `--json`
+/// carries every distinct message: a machine consumer has no width constraint, the
+/// tally already holds them all so nothing is saved by dropping them, and a capped
+/// machine format would hand a hostile contract a cheap way to bury its real failure
+/// behind five high-frequency decoys. The human report says how much it is not
+/// showing, in both messages and cases, and points at `--json` for the rest.
 const MAX_INCONCLUSIVE_EXAMPLES: usize = 5;
 
 /// Longest detail text reported, in characters after escaping.
@@ -1198,22 +1175,36 @@ const MAX_INCONCLUSIVE_EXAMPLE_CHARS: usize = 200;
 struct InconclusiveReason {
     reason: &'static str,
     occurrences: usize,
-    /// Distinct texts behind this reason, most frequent first. Empty for the
+    /// Every distinct text behind this reason, most frequent first. Empty for the
     /// reasons that carry no text at all (`RoundLimit`, `RelatedRequired`, ...).
-    examples: Vec<InconclusiveExample>,
-    /// Distinct texts not listed because [`MAX_INCONCLUSIVE_EXAMPLES`] was reached.
     ///
-    /// Reported rather than dropped, for the same reason `findings_too_large` is: a
-    /// reader has to be able to tell a complete list from a sample, and this whole
-    /// change exists because something was being dropped quietly.
-    distinct_messages_omitted: usize,
+    /// Complete here on purpose; only the human report trims it. See
+    /// [`MAX_INCONCLUSIVE_EXAMPLES`].
+    examples: Vec<InconclusiveExample>,
 }
 
 /// One distinct detail text and how many cases produced it.
+///
+/// The text is written by the CONTRACT, so it can carry real application state - a
+/// rejected value, a member key, a room id - and the corpora these runs replay are
+/// captured from live peers. `bundle.rs` and `capture.rs` both mark that material
+/// sensitive; this is the path that lifts it out of those files and onto a terminal,
+/// from which it is easily pasted into a bug report. The human report says so where
+/// it prints them; treat `--json` containing them the same way.
 #[derive(Serialize)]
 struct InconclusiveExample {
     text: String,
     occurrences: usize,
+}
+
+/// "1 case" / "N cases". The findings section already reads this way; the
+/// inconclusive examples printed "1 case(s)".
+fn case_count(n: usize) -> String {
+    if n == 1 {
+        "1 case".to_string()
+    } else {
+        format!("{n} cases")
+    }
 }
 
 /// Running tally for one inconclusive reason while a report is being built.
@@ -1287,9 +1278,6 @@ impl Report {
                 // the first line the representative case; the lexicographic tiebreak
                 // is what keeps the choice from depending on hash iteration order.
                 details.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-                let distinct_messages_omitted =
-                    details.len().saturating_sub(MAX_INCONCLUSIVE_EXAMPLES);
-                details.truncate(MAX_INCONCLUSIVE_EXAMPLES);
                 InconclusiveReason {
                     reason,
                     occurrences: tally.occurrences,
@@ -1297,7 +1285,6 @@ impl Report {
                         .into_iter()
                         .map(|(text, occurrences)| InconclusiveExample { text, occurrences })
                         .collect(),
-                    distinct_messages_omitted,
                 }
             })
             .collect();
@@ -1385,23 +1372,55 @@ impl Report {
                 "\ninconclusive ({} total \u{2014} NOT passes: these cases reached no verdict, so they say nothing about the contract):",
                 self.inconclusive
             )?;
+            // Said once, above the messages rather than beside each one: these
+            // strings come from the contract, and a contract error routinely names
+            // what it rejected. The corpora replayed here are captured from live
+            // peers, and `bundle.rs` and `capture.rs` both mark that material
+            // sensitive - this is the path that brings it to a terminal.
+            if self
+                .inconclusive_reasons
+                .iter()
+                .any(|r| !r.examples.is_empty())
+            {
+                writeln!(
+                    out,
+                    "  (quoted messages are written by the contract and may contain \
+                     application state)"
+                )?;
+            }
             for r in &self.inconclusive_reasons {
                 writeln!(out, "  {}: {}", r.reason, r.occurrences)?;
                 // The text the contract actually produced. Without it the largest
                 // text-carrying bucket is a number and nothing else, and a reader
                 // cannot tell one recurring bug from many unrelated ones.
-                for example in &r.examples {
+                //
+                // Quoted because `escape_debug` escapes `"`, so the quotes mark the
+                // exact extent of contract-authored text. Without them a message of
+                // wide or combining characters can wrap past the terminal width and
+                // its tail reads like a line of the report.
+                for example in r.examples.iter().take(MAX_INCONCLUSIVE_EXAMPLES) {
                     writeln!(
                         out,
-                        "      {} case(s) \u{2014} {}",
-                        example.occurrences, example.text
+                        "      {} \u{2014} \"{}\"",
+                        case_count(example.occurrences),
+                        example.text
                     )?;
                 }
-                if r.distinct_messages_omitted > 0 {
+                let hidden = r.examples.len().saturating_sub(MAX_INCONCLUSIVE_EXAMPLES);
+                if hidden > 0 {
+                    // Both numbers, because "3 further messages" alone cannot
+                    // distinguish 3 stray cases from 300, and the reader needs to
+                    // know whether what is hidden is the bulk of the bucket.
+                    let hidden_cases: usize = r
+                        .examples
+                        .iter()
+                        .skip(MAX_INCONCLUSIVE_EXAMPLES)
+                        .map(|e| e.occurrences)
+                        .sum();
                     writeln!(
                         out,
-                        "      \u{2026} and {} further distinct message(s) not shown",
-                        r.distinct_messages_omitted
+                        "      \u{2026} and {hidden} further distinct message(s), \
+                         {hidden_cases} case(s), not shown \u{2014} --json has all of them"
                     )?;
                 }
             }
@@ -1556,14 +1575,34 @@ fn inconclusive_detail(reason: &Inconclusive) -> Option<&str> {
 /// before truncating also means the cap bounds what is actually printed rather than
 /// what was parsed.
 fn present_detail(text: &str) -> String {
-    let escaped: String = text.escape_debug().collect();
-    match escaped.char_indices().nth(MAX_INCONCLUSIVE_EXAMPLE_CHARS) {
-        // Slice at a `char_indices` boundary, never at a byte offset: a multi-byte
-        // character straddling the cap would panic the whole run on an input the
-        // contract chooses.
-        Some((byte_idx, _)) => format!("{}\u{2026}", &escaped[..byte_idx]),
-        None => escaped,
+    // `str::escape_debug`, not `char::escape_debug` in a loop: the former escapes a
+    // LEADING grapheme-extend character and leaves one mid-string alone, and driving
+    // it per character would silently lose that distinction.
+    //
+    // Bounded by [`take_presented`] BEFORE anything is collected, because the
+    // iterator is lazy: only as much of the message is read as the cap needs.
+    // Escaping the whole string and truncating afterwards bounds the OUTPUT while
+    // leaving the WORK unbounded - escaping expands a control character roughly
+    // sixfold, this runs once per inconclusive CASE (deduplication happens on the
+    // result, not before it), and the contract chooses both length and content. That
+    // is a wall-clock denial of service against the tool, not merely an allocation
+    // spike.
+    take_presented(text.escape_debug())
+}
+
+/// The bounded half of [`present_detail`], taken over an iterator rather than a
+/// `&str` so that the laziness above is testable: a test can hand this a source that
+/// panics the moment it is read past the cap, which is the only way to assert that
+/// the work is bounded rather than merely the output.
+fn take_presented(escaped: impl Iterator<Item = char>) -> String {
+    // One char past the cap is enough to know whether anything was dropped, and is
+    // all that is ever read.
+    let mut chars: Vec<char> = escaped.take(MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1).collect();
+    if chars.len() > MAX_INCONCLUSIVE_EXAMPLE_CHARS {
+        chars.truncate(MAX_INCONCLUSIVE_EXAMPLE_CHARS);
+        chars.push('\u{2026}');
     }
+    chars.into_iter().collect()
 }
 
 /// Source pin on `load_inputs`' output stream.
@@ -2968,10 +3007,6 @@ mod tests {
         assert_eq!(code_diagnostics(&wasm), Vec::new());
     }
 
-    /// The whole point of the channel: a code diagnostic is DIAGNOSTIC. It must
-    /// not be counted as a violation, and it must not fail the command — a
-    /// deprecation notice that broke every affected author's build in release
-    /// *n* would make the two-release notice period meaningless.
     /// Build a report whose only outcomes are inconclusive contract errors.
     fn report_from_contract_errors(messages: &[&str]) -> Report {
         let outcomes: Vec<(ConformanceCase, PropertyOutcome)> = messages
@@ -2990,6 +3025,8 @@ mod tests {
             .collect();
         Report::build(&Corpus::default(), &outcomes, None, Vec::new())
     }
+
+    use super::stdout_purity_pin::code_only;
 
     fn contract_error_bucket(report: &Report) -> &InconclusiveReason {
         report
@@ -3029,7 +3066,6 @@ mod tests {
             "distinct messages must carry their own counts, most frequent first: \
              that breakdown is the whole answer to 'is this one bug or several'"
         );
-        assert_eq!(reason.distinct_messages_omitted, 0);
 
         let rendered = render_human(&report);
         assert!(
@@ -3061,34 +3097,57 @@ mod tests {
         let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
         let reason = &report.inconclusive_reasons[0];
         assert!(reason.examples.is_empty());
-        assert_eq!(reason.distinct_messages_omitted, 0);
     }
 
-    /// Distinct messages past the cap are counted, never silently dropped.
+    /// The readability cap trims the HUMAN report only, and says what it hid.
     ///
     /// The cap exists because the count of distinct texts is bounded only by the
-    /// case count — a contract that embeds a state hash in its error produces one
-    /// per case. Capping without saying so would reintroduce this issue's own
-    /// defect in miniature: output that looks complete and is not.
+    /// case count: a contract that embeds a state hash in its error produces one per
+    /// case, and a wall of them buries the question the reader has. But that is a
+    /// terminal-width concern, so `--json` keeps everything - a machine consumer has
+    /// no width limit, the tally already holds them all, and a capped machine format
+    /// would let a hostile contract bury its real failure behind five high-frequency
+    /// decoys.
+    ///
+    /// Capping without saying so, in either format, would reintroduce this issue's
+    /// own defect in miniature: output that looks complete and is not.
     #[test]
-    fn distinct_messages_beyond_the_cap_are_counted_not_dropped() {
-        let messages: Vec<String> = (0..MAX_INCONCLUSIVE_EXAMPLES + 3)
-            .map(|i| format!("distinct failure {i}"))
-            .collect();
+    fn the_cap_trims_the_human_report_only_and_says_what_it_hid() {
+        // Frequencies chosen so the hidden tail is a KNOWN number of cases: the
+        // first five messages appear twice each, the last three once each.
+        let mut messages: Vec<String> = Vec::new();
+        for i in 0..MAX_INCONCLUSIVE_EXAMPLES {
+            messages.push(format!("frequent failure {i}"));
+            messages.push(format!("frequent failure {i}"));
+        }
+        for i in 0..3 {
+            messages.push(format!("rare failure {i}"));
+        }
         let refs: Vec<&str> = messages.iter().map(String::as_str).collect();
         let report = report_from_contract_errors(&refs);
 
         let reason = contract_error_bucket(&report);
-        assert_eq!(reason.examples.len(), MAX_INCONCLUSIVE_EXAMPLES);
         assert_eq!(
-            reason.distinct_messages_omitted, 3,
-            "the overflow count must say how many distinct messages were not shown"
+            reason.examples.len(),
+            MAX_INCONCLUSIVE_EXAMPLES + 3,
+            "--json must carry every distinct message; trimming it there loses data \
+             that no machine consumer needed trimmed"
         );
 
         let rendered = render_human(&report);
+        assert_eq!(
+            rendered.matches("frequent failure").count(),
+            MAX_INCONCLUSIVE_EXAMPLES,
+            "the human report must show exactly the cap:\n{rendered}"
+        );
         assert!(
-            rendered.contains("3 further distinct message(s) not shown"),
-            "the human report presented a truncated list as if it were complete:\n{rendered}"
+            !rendered.contains("rare failure"),
+            "the human report showed past its own cap:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("3 further distinct message(s), 3 case(s), not shown"),
+            "the hidden tail must be reported in BOTH messages and cases: '3 further \
+             messages' alone cannot distinguish 3 stray cases from 300:\n{rendered}"
         );
     }
 
@@ -3143,108 +3202,6 @@ mod tests {
         );
     }
 
-    /// The `--wasm` fallback must be reached through `load_inputs`, not merely exist.
-    ///
-    /// Written after the unit test below survived a mutation that removed the
-    /// fallback from `load_inputs` entirely: that test calls `read_supplied_wasm`
-    /// directly, so it proves the helper works and says nothing about whether the
-    /// command uses it. A guard on one layer is not a guard on the layer above it.
-    ///
-    /// This drives the real CLI surface (`ConformanceConfig` is the clap parser) so
-    /// the wiring itself is under test.
-    #[test]
-    fn load_inputs_uses_the_store_file_fallback_for_wasm() {
-        use clap::Parser;
-
-        let dir = tempfile::tempdir().expect("temp dir");
-        let code = b"\0asm-not-really-but-bytes-are-bytes".to_vec();
-
-        let mut bundle = ReplayBundle::new(code.clone(), Vec::new());
-        bundle.states.push(vec![1u8, 2, 3]);
-        let bundle_path = dir.path().join("corpus.bin");
-        bundle.write_to(&bundle_path).expect("write bundle");
-
-        // The contract, in the form a node's contract store holds it.
-        let store_path = dir.path().join("stored.wasm");
-        std::fs::write(
-            &store_path,
-            ContractCode::from(code.clone())
-                .to_bytes_versioned(freenet_stdlib::prelude::APIVersion::Version0_0_1)
-                .expect("encode versioned"),
-        )
-        .expect("write store form");
-
-        let config = ConformanceConfig::try_parse_from([
-            "verify-merge",
-            "--bundle",
-            bundle_path.to_str().expect("utf-8 path"),
-            "--wasm",
-            store_path.to_str().expect("utf-8 path"),
-        ])
-        .expect("the flags this test uses must stay parseable");
-
-        let loaded = load_inputs(&config).expect(
-            "--wasm given a contract-store file was rejected: before the fix this \
-             failed the bundle's identity check and reported it as the wrong contract",
-        );
-        assert_eq!(
-            loaded.wasm, code,
-            "the unwrapped contract code must be used"
-        );
-    }
-
-    /// `--wasm` must accept a contract-store file, not only raw WASM.
-    ///
-    /// A store entry is a versioned encoding, a header followed by the code, and
-    /// only the code is hashed. Passing one to `--wasm` therefore failed the
-    /// bundle's identity check with "supplied code is blake3:...", which reads as
-    /// WRONG CONTRACT and sends the reader hunting for a problem they do not have:
-    /// the file was the right one, in the wrong form (#5461).
-    #[test]
-    fn wasm_accepts_a_contract_store_file_as_well_as_raw_wasm() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        // Not valid WASM, and it does not need to be: nothing here compiles it.
-        let code = b"\0asm-not-really-but-bytes-are-bytes".to_vec();
-        let bundle = ReplayBundle::new(code.clone(), Vec::new());
-
-        // Raw WASM behaves exactly as before. This is the case the fallback must
-        // never be able to reinterpret, which is why the raw form is tried first.
-        let raw_path = dir.path().join("raw.wasm");
-        std::fs::write(&raw_path, &code).expect("write raw");
-        assert_eq!(read_supplied_wasm(&raw_path, &bundle).expect("raw"), code);
-
-        // The same contract, in the form a node's contract store holds it.
-        let encoded = ContractCode::from(code.clone())
-            .to_bytes_versioned(freenet_stdlib::prelude::APIVersion::Version0_0_1)
-            .expect("encode versioned");
-        assert_ne!(
-            encoded, code,
-            "the stored form must differ from the raw form, or this test proves \
-             nothing about unwrapping one"
-        );
-        let store_path = dir.path().join("stored.wasm");
-        std::fs::write(&store_path, &encoded).expect("write store form");
-        assert_eq!(
-            read_supplied_wasm(&store_path, &bundle).expect("store form"),
-            code,
-            "a contract-store file passed to --wasm was still rejected as though \
-             it were a different contract"
-        );
-
-        // Widening what is ACCEPTED must not widen what is TRUSTED: a genuinely
-        // different contract stays refused, in both forms.
-        let other = ReplayBundle::new(b"different code entirely".to_vec(), Vec::new());
-        for path in [&raw_path, &store_path] {
-            let supplied = read_supplied_wasm(path, &other).expect("reading succeeds");
-            assert!(
-                other.resolve_code(Some(supplied)).is_err(),
-                "code that does not belong to the bundle resolved against it \
-                 anyway, from {}",
-                path.display()
-            );
-        }
-    }
-
     /// A contract-authored message must not be able to forge report lines.
     ///
     /// This text is written by the contract under test, which is the thing we are
@@ -3264,6 +3221,133 @@ mod tests {
         assert!(
             rendered.contains("\\n"),
             "the newline was neither escaped nor stripped:\n{rendered}"
+        );
+    }
+
+    /// The work is bounded, not merely the output.
+    ///
+    /// `present_detail` originally collected the WHOLE escaped string and truncated
+    /// afterwards. Escaping expands a control character roughly sixfold and this runs
+    /// once per inconclusive CASE (deduplication happens on the result), so a hostile
+    /// multi-megabyte message meant gigabytes of escaping across a run for output
+    /// that was thrown away: a wall-clock denial of service against the tool.
+    ///
+    /// Asserted by handing the bounded half a source that panics the moment it is
+    /// read past the cap. That is the only way to test laziness - the finished string
+    /// looks identical either way, which is exactly why the original passed every
+    /// test while doing unbounded work.
+    #[test]
+    fn presenting_a_detail_reads_no_further_than_the_cap() {
+        let mut read = 0usize;
+        let watched = std::iter::from_fn(|| {
+            read += 1;
+            assert!(
+                read <= MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1,
+                "read {read} characters for a {MAX_INCONCLUSIVE_EXAMPLE_CHARS}-character \
+                 cap; the escaping must stop at the cap, or an oversized contract \
+                 message is expanded in full before being discarded"
+            );
+            Some('x')
+        });
+
+        let presented = take_presented(watched);
+        assert_eq!(
+            presented.chars().count(),
+            MAX_INCONCLUSIVE_EXAMPLE_CHARS + 1
+        );
+        assert!(presented.ends_with('\u{2026}'));
+    }
+
+    /// Pin: `present_detail` hands `take_presented` a LAZY iterator.
+    ///
+    /// The test above proves `take_presented` reads no further than the cap. It says
+    /// nothing about its caller, and a mutation that restores
+    /// `text.escape_debug().collect::<Vec<char>>().into_iter()` survives it with
+    /// every test green - the finished string is identical, only the work differs.
+    /// That is the whole defect: unbounded work behind bounded-looking output.
+    ///
+    /// Sourced-scraped because laziness leaves no trace in the return value, and
+    /// timing or allocation assertions would be flaky. Any `collect` in this body
+    /// re-materialises the escaped string in full, so its absence is the property.
+    #[test]
+    fn present_detail_does_not_collect_before_bounding() {
+        let body = code_only("fn present_detail(");
+
+        assert!(
+            body.contains("take_presented(text.escape_debug())"),
+            "the scraped region is not present_detail's body any more:\n{body}"
+        );
+        assert!(
+            !body.contains("collect"),
+            "present_detail collects before bounding, so the whole escaped string is \
+             built and thrown away: escaping expands a control character roughly \
+             sixfold and this runs once per inconclusive CASE:\n{body}"
+        );
+    }
+
+    /// Escapes and direction overrides are neutralised, not just newlines.
+    ///
+    /// `a_contract_message_cannot_forge_report_lines` checks `\n` alone, so replacing
+    /// the escaping with `text.replace('\n', "\\n")` would keep it green while ESC
+    /// and RLO leaked. ESC lets a contract recolour or erase the report around it;
+    /// U+202E reverses the visual order of everything after it, which is enough to
+    /// make a message read as a different one.
+    #[test]
+    fn escapes_and_direction_overrides_are_neutralised() {
+        let presented = present_detail("red\u{1b}[31m and reversed \u{202e}drawrkcab");
+
+        assert!(
+            !presented.contains('\u{1b}'),
+            "a raw ESC survived into the report: {presented}"
+        );
+        assert!(
+            !presented.contains('\u{202e}'),
+            "a raw right-to-left override survived into the report: {presented}"
+        );
+        assert!(
+            presented.contains("\\u{1b}") && presented.contains("\\u{202e}"),
+            "both should appear in escaped form rather than be dropped: {presented}"
+        );
+    }
+
+    /// Pin: `verify_evidence` routes both untrusted strings through the escaper.
+    ///
+    /// This command exists to consume evidence ANOTHER PEER produced, and its own
+    /// rustdoc says `evidence.observed` is never trusted - yet it interpolated the
+    /// sender's `detail` straight into the terminal, and printed `Inconclusive`
+    /// through a `Display` impl that embeds the contract's raw error text. A newline
+    /// in either forges a `verdict  :` line in the exact format of the real one.
+    ///
+    /// A source pin rather than a behavioural test because reaching this function
+    /// needs a WASM runtime and a real evidence file, which is a large fixture for a
+    /// one-call property. It is scoped tightly and fails closed: if the function is
+    /// renamed or the prints move, the scrape stops matching and the test fails.
+    #[test]
+    fn verify_evidence_escapes_the_text_it_does_not_trust() {
+        let body = code_only("async fn verify_evidence(");
+
+        assert!(
+            body.contains("claimed  :") && body.contains("INCONCLUSIVE"),
+            "the scraped region is not verify_evidence's body any more:\n{body}"
+        );
+        assert!(
+            body.contains("present_detail(&v.detail)"),
+            "the SENDER's `detail` is interpolated raw again:\n{body}"
+        );
+        assert!(
+            body.contains("present_detail(&reason.to_string())"),
+            "the `Inconclusive` rendering embeds the contract's own error text and \
+             must be escaped too:\n{body}"
+        );
+        // The REPRODUCED branch deliberately does NOT escape: that `Violation` is
+        // built locally by `verify_case`, whose `detail` values are static strings
+        // plus lengths (`verifier.rs:329-482`), never contract-authored text.
+        // Asserting it stays raw keeps this pin honest about which of the two is
+        // trusted, so a future reader does not "fix" the wrong one.
+        assert!(
+            body.contains("v.property, v.detail"),
+            "the locally-computed REPRODUCED line changed shape; re-check whether \
+             its `detail` can now carry contract text:\n{body}"
         );
     }
 
@@ -3296,12 +3380,17 @@ mod tests {
     /// Pin: every `Inconclusive` variant carrying text is reported by
     /// [`inconclusive_detail`].
     ///
-    /// That match needs a wildcard arm, because `Inconclusive` is
-    /// `#[non_exhaustive]` and this crate cannot match it exhaustively. A wildcard
-    /// is precisely how the text was lost the first time, so a new text-carrying
-    /// variant would land in it and be silently undiagnosable again with every test
-    /// still green. Scraping the source is the only check available here, since the
-    /// compiler cannot be made to demand the coverage.
+    /// That match needs a wildcard arm, because `Inconclusive` is `#[non_exhaustive]`
+    /// and this crate cannot match it exhaustively. A wildcard is precisely how the
+    /// text was lost the first time, so a new text-carrying variant would land in it
+    /// and be silently undiagnosable again with every test still green. Scraping the
+    /// source is the only check available, since the compiler cannot be made to
+    /// demand the coverage.
+    ///
+    /// "Carries text" is deliberately matched on the whole variant declaration rather
+    /// than the literal `Name(String),` shape: `Foo(String, usize)`, `Foo(Box<str>)`
+    /// and `Foo { reason: String }` all carry text and all slip past a suffix match,
+    /// which would leave the pin guarding only the three variants that already exist.
     #[test]
     fn inconclusive_detail_covers_every_text_carrying_variant() {
         let enum_src = include_str!("../../core/src/conformance/property.rs");
@@ -3311,17 +3400,59 @@ mod tests {
         let body = &enum_src[start..];
         let body = &body[..body.find("\n}").expect("Inconclusive has no closing brace")];
 
-        let text_carrying: Vec<&str> = body
-            .lines()
-            .filter_map(|line| line.trim().strip_suffix("(String),"))
+        // Accumulate each variant's full declaration, so a multi-line struct variant
+        // is judged as one unit rather than line by line.
+        let mut variants: Vec<(String, String)> = Vec::new();
+        let mut pending = String::new();
+        for line in body.lines().skip(1) {
+            let trimmed = line.trim();
+            if trimmed.starts_with("///") || trimmed.starts_with("#[") || trimmed.is_empty() {
+                continue;
+            }
+            pending.push_str(trimmed);
+            pending.push(' ');
+            // A declaration ends at the comma that closes it, once brackets balance.
+            let balanced = pending.matches('(').count() == pending.matches(')').count()
+                && pending.matches('{').count() == pending.matches('}').count();
+            if !(trimmed.ends_with(',') && balanced) {
+                continue;
+            }
+            let declaration = std::mem::take(&mut pending);
+            let name: String = declaration
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                variants.push((name, declaration));
+            }
+        }
+
+        let text_carrying: Vec<&str> = variants
+            .iter()
+            .filter(|(_, declaration)| {
+                declaration.contains("String") || declaration.contains("str")
+            })
+            .map(|(name, _)| name.as_str())
             .collect();
-        // Fail closed. If the scrape silently matched nothing, every assertion below
-        // would pass vacuously and the pin would guard the wildcard it exists for
-        // by doing nothing at all.
+
+        // Fail closed, on both halves. If the scrape silently matched nothing, or
+        // matched only text-carrying variants, every assertion below would pass
+        // vacuously and the pin would guard the wildcard by doing nothing at all.
+        assert!(
+            variants.len() >= 8,
+            "the variant scrape broke: found {} declaration(s) in an enum that has \
+             far more: {variants:?}",
+            variants.len()
+        );
         assert!(
             text_carrying.len() >= 3,
-            "expected to find the known text-carrying variants (ContractError, \
+            "expected at least the known text-carrying variants (ContractError, \
              ResourceLimit, MalformedCase); the scrape found {text_carrying:?}"
+        );
+        assert!(
+            variants.len() > text_carrying.len(),
+            "every variant was judged text-carrying, so the filter is matching \
+             something other than what it claims: {variants:?}"
         );
 
         let detail_src = include_str!("conformance.rs");
@@ -3333,7 +3464,7 @@ mod tests {
 
         for variant in text_carrying {
             assert!(
-                fn_body.contains(&format!("Inconclusive::{variant}(")),
+                fn_body.contains(&format!("Inconclusive::{variant}")),
                 "Inconclusive::{variant} carries text but inconclusive_detail does \
                  not report it, so it would vanish into the wildcard arm and be \
                  undiagnosable from the tool's output - the exact defect #5461 fixed"
@@ -3341,6 +3472,10 @@ mod tests {
         }
     }
 
+    /// The whole point of the channel: a code diagnostic is DIAGNOSTIC. It must
+    /// not be counted as a violation, and it must not fail the command — a
+    /// deprecation notice that broke every affected author's build in release
+    /// *n* would make the two-release notice period meaningless.
     #[test]
     fn a_code_diagnostic_is_never_removal_eligible() {
         let outcomes = vec![(


### PR DESCRIPTION
## Problem

`Inconclusive::ContractError` carries the contract's own error message — its `Display` impl even prints it — but the reporting layer collapsed the variant to a fixed label and threw the payload away. The text appeared in neither `--json` nor the human report, and no log level recovered it.

On a 64-bundle live capture corpus that bucket is the **second-largest** source of inconclusive results: **435 of 2,622 cases (16.6%)**. Not one could be diagnosed from the tool's own output, which is what made the second-largest inconclusive class the least likely to ever get fixed — nobody could tell whether it was one bug in one contract or eight unrelated ones.

This matters more here than in an ordinary CLI. The whole design of the subsystem is that "we could not tell" stays distinguishable from "it is fine", and that principle is applied carefully at the case level. It stopped one level short: *why* a case was inconclusive was discarded for this bucket.

## Approach

Distinct messages are reported with their own counts, most frequent first. A breakdown rather than a single representative, because the breakdown is what answers "one bug or several". `ResourceLimit` and `MalformedCase` carry text for the same reason and get the same treatment.

**The accessor lives in `crates/core`, not in `fdev`.** `Inconclusive` is `#[non_exhaustive]`, so a match written in `fdev` needs a wildcard arm — and a wildcard is precisely how the text came to be dropped. `Inconclusive::detail()` matches exhaustively inside the defining crate, so the **compiler** refuses a new variant that has not declared whether it carries text. Verified across five shapes, including three that a source-scraping test did not recognise:

| new variant | build fails? |
|---|---|
| `Timeout(String)` | yes |
| `Diagnostic { detail: String }` | yes |
| `Timeout(Box<str>)` | yes |
| `Timeout(String, u64)` | yes |
| `Plain` (no payload) | yes |

The text is written by the contract under test, which is the thing we are least entitled to trust, so:

- **Control characters are escaped**, and the messages are printed in quotes. A newline would otherwise forge a `[violation]` line; `escape_debug` escapes `"`, so the quotes mark the exact extent of contract text that could otherwise wrap past the terminal width and read as report output.
- **The escaping is bounded lazily.** Escaping expands a control character roughly sixfold and runs once per inconclusive *case* (dedup happens on the result), so collecting the whole escaped string before truncating meant unbounded work behind bounded-looking output — a wall-clock denial of service, not merely an allocation spike.
- **Truncation slices on a character boundary**, never a byte offset the contract chooses where to place.
- **The report says the messages are contract-authored and may carry application state.** `bundle.rs` and `capture.rs` both mark captured material sensitive; this is the path that brings it to a terminal and into pasted bug reports.

**The five-example cap applies to the human report only.** It is a terminal-width concern; `--json` carries every distinct message. The tally already held them all, so nothing was saved by dropping them, and a capped machine format would let a hostile contract bury its real failure behind five high-frequency decoys. The human report names the hidden tail in both messages **and** cases — "3 further messages" alone cannot distinguish 3 stray cases from 300.

Equal-count ties break by label, so two runs over one corpus produce byte-identical reports. The reason order previously came out of a randomly seeded `HashMap`.

`verify_evidence` also had two unescaped sinks for the same untrusted text — the sender's `detail`, and an `Inconclusive` rendered through a `Display` impl that embeds the contract's raw error. That function's own rustdoc says `evidence.observed` is never trusted, and it is the one command built to consume hostile input. Both now go through the escaper. The `REPRODUCED` branch deliberately stays raw: that `Violation` is built locally and its `detail` values are static strings plus lengths (`verifier.rs:329-482`), verified, and a test pins that so nobody "fixes" the wrong one.

## Verified on live data

Replaying a real capture bundle. Before, this read `contract error: 17` and nothing else:

```
inconclusive (18 total — NOT passes: these cases reached no verdict…):
  (quoted messages are written by the contract and may contain application state)
  contract error: 17
      5 cases — "invalid contract update"
      4 cases — "invalid contract update, reason: New state version … must be higher than current version …"
      …
      … and 2 further distinct message(s), 2 case(s), not shown — --json has all of them
```

One bare rejection plus one template parameterised by two version numbers. The issue's question — one bug or eight? — is answered on sight.

## Testing

**17 mutations, all killed**, across three rounds. The rounds mattered: my first suite killed 12 of 12, and the testing lens then killed only 8 of its own 22 against that same code, because it mutated behaviours I had not thought to mutate. What it found, now all covered:

- `ResourceLimit` and `MalformedCase` had no behavioural coverage at all.
- No test checked a message was printed **under the reason it belongs to** — the whole point of the change. Detaching the example loop from the reason loop passed the entire suite.
- `occurrences` was unasserted for textless reasons, so moving the tally inside the has-text branch made `RoundLimit`, `RelatedRequired` and `InputNotValid` report `: 0` — the bulk of a real run — with tests green.
- Nothing asserted the new fields survive `--json`; `#[serde(skip)]` passed.
- The rendered per-message case count was unasserted.
- The escape-before-truncate *ordering* was unpinned.
- `equal_counts_order_deterministically` used two reasons, which a stable sort orders correctly by luck about half the time, so a regression had even odds of merging on a single CI run. Now four reasons over twenty rebuilds.

Two survivors across the rounds were **my mutations being wrong**, not test gaps — one an equivalent mutant (taking the input prefix before escaping is provably identical output, since escaping never shrinks), one a layering slip where my test drove a helper directly and said nothing about its caller. Both are recorded in the commit messages.

## What was split out

The issue's secondary request — `--wasm` rejecting a contract-store file with a misleading "wrong contract" error — **is not in this PR**. `--wasm` is read in three places and the fix covered one; doing it properly (`verify_evidence` has an identity check available, the non-bundle path does not) is its own change with its own review, and as one commit it could not have been reverted independently of the fix that closes this issue. Follow-up filed.

Closes #5461

[AI-assisted - Claude]

https://claude.ai/code/session_01K1tXeM2YX8Y9e7u4nALPva
