### PR TITLE
docs: use role-based gateway names in examples and fixtures

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3898,7 +3898,7 @@ impl std::hash::Hash for GatewayConfig {
 ///
 /// ```toml
 /// [gateways.address]
-/// host = "gw2.freenet.org"
+/// host = "gw1.freenet.org"
 /// port = 31337            # optional; defaults to 31337 when omitted
 /// ```
 ///
@@ -3906,7 +3906,7 @@ impl std::hash::Hash for GatewayConfig {
 ///
 /// ```toml
 /// [gateways.address]
-/// hostname = "gw2.freenet.org:31337"   # host[:port] packed into one string
+/// hostname = "gw1.freenet.org:31337"   # host[:port] packed into one string
 /// ```
 ///
 /// ```toml
@@ -6151,7 +6151,7 @@ shutdown-drain-secs = 42
                    location = 0.25\n\
                    \n\
                    [gateways.address]\n\
-                   host = \"gw2.freenet.org\"\n\
+                   host = \"gw1.freenet.org\"\n\
                    port = 31337\n";
         assert!(
             toml::from_str::<Gateways>(doc).is_err(),
@@ -6531,7 +6531,7 @@ shutdown-drain-secs = 42
     fn gateways_toml_public_key_is_accepted_in_both_spellings() {
         for key in ["public_key", "public-key"] {
             let doc = format!(
-                "[[gateways]]\naddress = {{ host = \"gw2.freenet.org\", port = 31337 }}\n\
+                "[[gateways]]\naddress = {{ host = \"gw1.freenet.org\", port = 31337 }}\n\
                  {key} = \"/tmp/freenet-5124/vega.pub\"\n"
             );
             let gateways: Gateways = toml::from_str(&doc)
@@ -8216,14 +8216,14 @@ shutdown-drain-secs = 42
             [[gateways]]
             public_key = "keys/public.vega.gw.pem"
             [gateways.address]
-            host = "gw2.freenet.org"
+            host = "gw1.freenet.org"
             port = 31337
         "#;
         let gateways: Gateways = toml::from_str(toml_str).unwrap();
         assert_eq!(
             gateways.gateways[0].address,
             Address::Host {
-                host: "gw2.freenet.org".to_string(),
+                host: "gw1.freenet.org".to_string(),
                 port: 31337
             }
         );
@@ -8256,13 +8256,13 @@ shutdown-drain-secs = 42
             [[gateways]]
             public_key = "keys/public.vega.gw.pem"
             [gateways.address]
-            host = "gw2.freenet.org"
+            host = "gw1.freenet.org"
         "#;
         let gateways: Gateways = toml::from_str(toml_str).unwrap();
         assert_eq!(
             gateways.gateways[0].address,
             Address::Host {
-                host: "gw2.freenet.org".to_string(),
+                host: "gw1.freenet.org".to_string(),
                 port: DEFAULT_GATEWAY_PORT
             }
         );
@@ -8312,7 +8312,7 @@ shutdown-drain-secs = 42
         let gateways = Gateways {
             gateways: vec![GatewayConfig {
                 address: Address::Host {
-                    host: "gw2.freenet.org".to_string(),
+                    host: "gw1.freenet.org".to_string(),
                     port: 31337,
                 },
                 public_key_path: PathBuf::from("keys/k.pem"),
@@ -8324,7 +8324,7 @@ shutdown-drain-secs = 42
         // sibling keys), matching the new wire form in the issue — not nested
         // under a `[gateways.address.host]` sub-table (the derived enum form).
         assert!(
-            serialized.contains("host = \"gw2.freenet.org\"")
+            serialized.contains("host = \"gw1.freenet.org\"")
                 && serialized.contains("port = 31337"),
             "unexpected serialized form:\n{serialized}"
         );
@@ -8346,14 +8346,14 @@ shutdown-drain-secs = 42
     fn test_address_legacy_variants_serialize_unchanged() {
         let hostname = Gateways {
             gateways: vec![GatewayConfig {
-                address: Address::Hostname("gw2.freenet.org:31337".to_string()),
+                address: Address::Hostname("gw1.freenet.org:31337".to_string()),
                 public_key_path: PathBuf::from("keys/k.pem"),
                 location: None,
             }],
         };
         let s = toml::to_string(&hostname).unwrap();
         assert!(
-            s.contains("hostname = \"gw2.freenet.org:31337\""),
+            s.contains("hostname = \"gw1.freenet.org:31337\""),
             "legacy hostname form changed:\n{s}"
         );
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3898,7 +3898,7 @@ impl std::hash::Hash for GatewayConfig {
 ///
 /// ```toml
 /// [gateways.address]
-/// host = "vega.locut.us"
+/// host = "gw2.freenet.org"
 /// port = 31337            # optional; defaults to 31337 when omitted
 /// ```
 ///
@@ -3906,7 +3906,7 @@ impl std::hash::Hash for GatewayConfig {
 ///
 /// ```toml
 /// [gateways.address]
-/// hostname = "vega.locut.us:31337"   # host[:port] packed into one string
+/// hostname = "gw2.freenet.org:31337"   # host[:port] packed into one string
 /// ```
 ///
 /// ```toml
@@ -6151,7 +6151,7 @@ shutdown-drain-secs = 42
                    location = 0.25\n\
                    \n\
                    [gateways.address]\n\
-                   host = \"vega.locut.us\"\n\
+                   host = \"gw2.freenet.org\"\n\
                    port = 31337\n";
         assert!(
             toml::from_str::<Gateways>(doc).is_err(),
@@ -6531,7 +6531,7 @@ shutdown-drain-secs = 42
     fn gateways_toml_public_key_is_accepted_in_both_spellings() {
         for key in ["public_key", "public-key"] {
             let doc = format!(
-                "[[gateways]]\naddress = {{ host = \"vega.locut.us\", port = 31337 }}\n\
+                "[[gateways]]\naddress = {{ host = \"gw2.freenet.org\", port = 31337 }}\n\
                  {key} = \"/tmp/freenet-5124/vega.pub\"\n"
             );
             let gateways: Gateways = toml::from_str(&doc)
@@ -8139,7 +8139,7 @@ shutdown-drain-secs = 42
                     location: None,
                 },
                 GatewayConfig {
-                    address: Address::Hostname("technic.locut.us".to_string()),
+                    address: Address::Hostname("gw1.freenet.org".to_string()),
                     public_key_path: PathBuf::from("path/to/key"),
                     location: None,
                 },
@@ -8152,8 +8152,12 @@ shutdown-drain-secs = 42
 
     // ---- Address deserialization: backward compat + new host/port form (#1388) ----
 
-    /// Legacy single-string form, exactly as it appears in the deployed
-    /// `https://freenet.org/keys/gateways.toml` today. MUST keep parsing.
+    /// Legacy single-string form, exactly as it appeared in the deployed
+    /// `https://freenet.org/keys/gateways.toml` for years (retired 2026-08-29,
+    /// replaced by role-based `gwN.freenet.org` names). MUST keep parsing —
+    /// peers holding a cached copy of the old file still need it. Deliberately
+    /// NOT updated to the new hostname: this pins the historical value real
+    /// deployments actually used, not an arbitrary example.
     #[test]
     fn test_address_deser_legacy_hostname_string() {
         let toml_str = r#"
@@ -8171,7 +8175,9 @@ shutdown-drain-secs = 42
     }
 
     /// Legacy single-string form without a port still parses (port is resolved
-    /// later by `parse_socket_addr`, which now defaults to 31337).
+    /// later by `parse_socket_addr`, which now defaults to 31337). Same
+    /// historical-value reasoning as the sibling test above: left as the real
+    /// pre-2026-08-29 deployed hostname on purpose.
     #[test]
     fn test_address_deser_legacy_hostname_string_no_port() {
         let toml_str = r#"
@@ -8210,14 +8216,14 @@ shutdown-drain-secs = 42
             [[gateways]]
             public_key = "keys/public.vega.gw.pem"
             [gateways.address]
-            host = "vega.locut.us"
+            host = "gw2.freenet.org"
             port = 31337
         "#;
         let gateways: Gateways = toml::from_str(toml_str).unwrap();
         assert_eq!(
             gateways.gateways[0].address,
             Address::Host {
-                host: "vega.locut.us".to_string(),
+                host: "gw2.freenet.org".to_string(),
                 port: 31337
             }
         );
@@ -8250,13 +8256,13 @@ shutdown-drain-secs = 42
             [[gateways]]
             public_key = "keys/public.vega.gw.pem"
             [gateways.address]
-            host = "vega.locut.us"
+            host = "gw2.freenet.org"
         "#;
         let gateways: Gateways = toml::from_str(toml_str).unwrap();
         assert_eq!(
             gateways.gateways[0].address,
             Address::Host {
-                host: "vega.locut.us".to_string(),
+                host: "gw2.freenet.org".to_string(),
                 port: DEFAULT_GATEWAY_PORT
             }
         );
@@ -8306,7 +8312,7 @@ shutdown-drain-secs = 42
         let gateways = Gateways {
             gateways: vec![GatewayConfig {
                 address: Address::Host {
-                    host: "vega.locut.us".to_string(),
+                    host: "gw2.freenet.org".to_string(),
                     port: 31337,
                 },
                 public_key_path: PathBuf::from("keys/k.pem"),
@@ -8318,7 +8324,8 @@ shutdown-drain-secs = 42
         // sibling keys), matching the new wire form in the issue — not nested
         // under a `[gateways.address.host]` sub-table (the derived enum form).
         assert!(
-            serialized.contains("host = \"vega.locut.us\"") && serialized.contains("port = 31337"),
+            serialized.contains("host = \"gw2.freenet.org\"")
+                && serialized.contains("port = 31337"),
             "unexpected serialized form:\n{serialized}"
         );
         assert!(
@@ -8339,14 +8346,14 @@ shutdown-drain-secs = 42
     fn test_address_legacy_variants_serialize_unchanged() {
         let hostname = Gateways {
             gateways: vec![GatewayConfig {
-                address: Address::Hostname("vega.locut.us:31337".to_string()),
+                address: Address::Hostname("gw2.freenet.org:31337".to_string()),
                 public_key_path: PathBuf::from("keys/k.pem"),
                 location: None,
             }],
         };
         let s = toml::to_string(&hostname).unwrap();
         assert!(
-            s.contains("hostname = \"vega.locut.us:31337\""),
+            s.contains("hostname = \"gw2.freenet.org:31337\""),
             "legacy hostname form changed:\n{s}"
         );
 

--- a/crates/fdev/README-FULL.md
+++ b/crates/fdev/README-FULL.md
@@ -64,11 +64,11 @@ By default, `fdev` connects to a local Freenet node at `ws://127.0.0.1:7509`. Yo
 
 ```bash
 # Connect via gateway proxy (e.g. from CI/CD)
-fdev --node-url "ws://nova.locut.us:7520/SECRET/v1/contract/command?encodingProtocol=native" \
+fdev --node-url "ws://gw1.freenet.org:7520/SECRET/v1/contract/command?encodingProtocol=native" \
     website publish ./public/ --key my-site
 
 # Or via environment variable
-export FREENET_NODE_URL="ws://nova.locut.us:7520/SECRET/v1/contract/command?encodingProtocol=native"
+export FREENET_NODE_URL="ws://gw1.freenet.org:7520/SECRET/v1/contract/command?encodingProtocol=native"
 fdev website publish ./public/ --key my-site
 ```
 


### PR DESCRIPTION
## Problem

The `locut.us` domain is registered to a private home address and appears across the public repos. It has already been removed from the peer-facing `gateways.toml` (freenet/web#123, merged and deployed); this covers the doc comments and test fixtures in freenet-core that still reference the old machine-based names.

## Approach

Examples and non-behavioural fixtures now use `gw1.freenet.org` / `gw2.freenet.org`, which are live A records for the current gateways.

**Two back-compat tests are deliberately NOT updated.** They pin the legacy single-string form exactly as it appeared in the deployed `gateways.toml` for years, and peers holding a cached copy of that file still need it to parse. Rewriting them to the new hostname would swap a real historical value for an arbitrary example and weaken what the tests prove. Both now carry a comment explaining why, since "why is this one still the old name?" is the obvious question for a future reader.

## Testing

Doc comments and test data only — no behaviour change. `cargo fmt --check` clean.

[AI-assisted - Claude]
