### PR TITLE
fix(telemetry): default the OTLP endpoint to telemetry.freenet.org

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -963,7 +963,9 @@ impl ConfigArgs {
             if !cfg.telemetry.enabled {
                 self.telemetry.enabled = false;
             }
-            if self.telemetry.endpoint.is_none() {
+            if self.telemetry.endpoint.is_none()
+                && cfg.telemetry.endpoint != LEGACY_TELEMETRY_ENDPOINT
+            {
                 self.telemetry
                     .endpoint
                     .get_or_insert(cfg.telemetry.endpoint);
@@ -2765,6 +2767,21 @@ pub struct WebsocketApiArgs {
 /// indefinitely — changing this default does not retroactively update
 /// already-deployed peers, only builds made after this merges.
 pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "http://telemetry.freenet.org:4318";
+
+/// The endpoint `DEFAULT_TELEMETRY_ENDPOINT` used before 2026-09.
+///
+/// `build()` PERSISTS the resolved telemetry endpoint into `config.toml`, and
+/// the file value is merged back on every start — so without this sentinel an
+/// existing node keeps the old endpoint forever, even after auto-updating, and
+/// the change would reach FRESH INSTALLS ONLY. Same failure mode and same
+/// remedy as `LEGACY_FLAT_HOSTING_BUDGET_BYTES` above.
+///
+/// A FILE value equal to this exact string is treated as auto-derived rather
+/// than an operator choice, so it re-derives to the current default. An
+/// explicit `--telemetry-endpoint` or env var is parsed into `self` BEFORE the
+/// file merge and still wins, including if an operator genuinely wants this
+/// value.
+pub const LEGACY_TELEMETRY_ENDPOINT: &str = "http://nova.locut.us:4318";
 
 #[derive(clap::Parser, Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryArgs {
@@ -7020,6 +7037,51 @@ shutdown-drain-secs = 42
             rebuilt.max_hosting_storage,
             crate::ring::default_hosting_budget_bytes(),
             "a config.toml without the key must re-derive the budget from live RAM"
+        );
+    }
+    /// The telemetry endpoint is PERSISTED into config.toml by `build()`, so
+    /// changing `DEFAULT_TELEMETRY_ENDPOINT` alone reaches FRESH INSTALLS ONLY —
+    /// an existing node merges its stored value back on every start and keeps
+    /// the old endpoint forever, even after auto-updating. Same shape as the
+    /// hosting-budget sentinel above.
+    ///
+    /// (a) a stored value equal to the legacy default must RE-DERIVE, and
+    /// (b) a genuinely operator-chosen value must SURVIVE.
+    #[tokio::test]
+    async fn legacy_telemetry_endpoint_re_derives_but_explicit_survives() {
+        // (a) upgrade boot with the legacy endpoint persisted.
+        let legacy_dir = tempfile::tempdir().unwrap();
+        clap_bare_args(legacy_dir.path()).build().await.unwrap();
+        let cfg_path = legacy_dir.path().join("config.toml");
+        let existing = std::fs::read_to_string(&cfg_path).unwrap();
+        let legacy = existing.replace(DEFAULT_TELEMETRY_ENDPOINT, LEGACY_TELEMETRY_ENDPOINT);
+        assert!(
+            legacy.contains(LEGACY_TELEMETRY_ENDPOINT),
+            "fixture must actually contain the legacy endpoint, got:\n{legacy}"
+        );
+        std::fs::write(&cfg_path, legacy).unwrap();
+        let upgraded = clap_bare_args(legacy_dir.path()).build().await.unwrap();
+        assert_eq!(
+            upgraded.telemetry.endpoint, DEFAULT_TELEMETRY_ENDPOINT,
+            "a persisted LEGACY telemetry endpoint must re-derive on upgrade, \
+             otherwise this change reaches fresh installs only"
+        );
+
+        // (b) an operator's own endpoint must not be clobbered by the sentinel.
+        let custom_dir = tempfile::tempdir().unwrap();
+        clap_bare_args(custom_dir.path()).build().await.unwrap();
+        let custom_path = custom_dir.path().join("config.toml");
+        let base = std::fs::read_to_string(&custom_path).unwrap();
+        let chosen = "http://otel.example.invalid:4318";
+        std::fs::write(
+            &custom_path,
+            base.replace(DEFAULT_TELEMETRY_ENDPOINT, chosen),
+        )
+        .unwrap();
+        let kept = clap_bare_args(custom_dir.path()).build().await.unwrap();
+        assert_eq!(
+            kept.telemetry.endpoint, chosen,
+            "an operator-chosen endpoint must survive; only the legacy default re-derives"
         );
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2753,9 +2753,18 @@ pub struct WebsocketApiArgs {
     pub per_user_export_min_interval_secs: Option<u64>,
 }
 
-/// Default telemetry endpoint (nova.locut.us OTLP collector).
-/// Using domain name for resilience to IP changes.
-pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "http://nova.locut.us:4318";
+/// Default telemetry endpoint (telemetry.freenet.org OTLP collector).
+/// Using domain name for resilience to IP changes. Deliberately the
+/// telemetry role name, not a gateway name (gw1/gw2.freenet.org) — coupling
+/// this to a gateway's name would drag the telemetry default along with any
+/// future gateway host move.
+///
+/// NOTE: every binary released before this change has the OLD default
+/// (`nova.locut.us:4318`) baked in and will keep sending telemetry there for
+/// as long as it runs. That DNS record must stay resolving to the collector
+/// indefinitely — changing this default does not retroactively update
+/// already-deployed peers, only builds made after this merges.
+pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "http://telemetry.freenet.org:4318";
 
 #[derive(clap::Parser, Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryArgs {


### PR DESCRIPTION
## Problem

`DEFAULT_TELEMETRY_ENDPOINT` is compiled into every binary and pointed at a personal domain registered to a private home address. This constant is the widest distribution that name has.

## Approach

Use the telemetry **role** name, `telemetry.freenet.org:4318`. Deliberately not a gateway name: `gw1`/`gw2.freenet.org` resolve to the same host today, but naming the collector after a gateway would couple the telemetry default to gateway addressing and drag it along with any future gateway host move.

Verified the endpoint genuinely serves OTLP, not merely resolves — `200 {"partialSuccess":{}}`, with a 404 control on a bogus path.

## The part that needed a second pass

**Changing the constant alone was not enough, and an earlier version of this PR claimed a bound that was wrong.**

`build()` **persists** the resolved endpoint into `config.toml` (`config.rs:1479-1482` → `1509-1513`), and the file value is merged back on every start (`config.rs:966`). So an existing node keeps the old endpoint **forever**, even after auto-updating to a binary carrying the new default. The change would have reached **fresh installs only**. Confirmed against four real `config.toml` files on a production host.

This PR previously said the change "affects only builds made after this merges". That was asserted without checking the persist path, and it is narrower than stated.

Fixed with the sentinel pattern this repo **already uses for exactly this failure mode** — `LEGACY_FLAT_HOSTING_BUDGET_BYTES`, whose comment says outright that the value *"must be re-derived, or the hardening would reach fresh installs only"*.

A **file** value equal to the legacy default is now treated as auto-derived rather than an operator choice, so it re-derives to the current default. An explicit `--telemetry-endpoint` or env var is parsed before the file merge and still wins — including for an operator who genuinely wants the old endpoint.

## What this still does NOT do

Binaries released **before** this merges keep the old default and will keep sending there for as long as they run — no config change reaches a binary that never learned the new value. **That DNS record must keep resolving to the collector indefinitely.** Removing the domain from source does not remove it from the field; deleting the record would silently cut telemetry from every peer still on an older build.

## Testing

`legacy_telemetry_endpoint_re_derives_but_explicit_survives` covers both halves: a persisted legacy endpoint re-derives on upgrade, and an operator-chosen endpoint survives.

Mutation-checked rather than assumed — removing the sentinel fails it with `left: nova.locut.us:4318, right: telemetry.freenet.org:4318`, which is the shipped defect reproduced. It also clears the Rule Lint check that was rejecting a `fix:` title with no test.

[AI-assisted - Claude]
