### PR TITLE
chore(ci): drop the retiring AWS gateway from the release matrix

### DIFF
--- a/.github/workflows/gateway-update.yml
+++ b/.github/workflows/gateway-update.yml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       gateways:
-        description: 'Comma-separated subset (nova,vega) or "all"'
+        description: 'Comma-separated subset (nova) or "all"'
         required: false
         type: string
         default: 'all'
@@ -105,7 +105,7 @@ jobs:
           # (no inputs available); honor explicit subset on workflow_dispatch.
           REQUESTED="${{ inputs.gateways || 'all' }}"
           if [[ "$REQUESTED" == "all" ]]; then
-            MATRIX='[{"name":"nova","url":"https://nova.locut.us/release-agent"},{"name":"vega","url":"https://vega.locut.us:8443/release-agent"}]'
+            MATRIX='[{"name":"nova","url":"https://nova.locut.us/release-agent"}]'
           else
             # Build the array by filtering the full list. Cheap, transparent,
             # easy to read in workflow logs.
@@ -113,7 +113,6 @@ jobs:
             for tag in $(echo "$REQUESTED" | tr ',' ' '); do
               case "$tag" in
                 nova) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"nova","url":"https://nova.locut.us/release-agent"}]') ;;
-                vega) ITEMS=$(echo "$ITEMS" | jq -c '. + [{"name":"vega","url":"https://vega.locut.us:8443/release-agent"}]') ;;
                 *) echo "::error::Unknown gateway tag: $tag"; exit 1 ;;
               esac
             done
@@ -146,11 +145,9 @@ jobs:
         id: secret
         env:
           NOVA_SECRET: ${{ secrets.RELEASE_AGENT_HMAC_NOVA }}
-          VEGA_SECRET: ${{ secrets.RELEASE_AGENT_HMAC_VEGA }}
         run: |
           case "${{ matrix.gateway.name }}" in
             nova) SECRET="$NOVA_SECRET" ;;
-            vega) SECRET="$VEGA_SECRET" ;;
             *) echo "::error::No secret mapping for ${{ matrix.gateway.name }}"; exit 1 ;;
           esac
           if [[ -z "$SECRET" ]]; then

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,5 +1,17 @@
 # Cutting a Freenet release
 
+> **The AWS gateway was retired in September 2026.** References to it below that
+> remain are historical incident records (notably the v0.2.71 half-applied
+> rollout that motivated the post-deploy verify) and are kept deliberately —
+> they explain why a check exists. It is no longer a rollout target: the release
+> matrix, the manual SSH driver in `release.sh`, and `RELEASE_AGENT_HMAC_VEGA`
+> have all been removed. nova now runs two gateway processes; the second,
+> `freenet-gateway-2`, has no release-agent of its own and is brought up by the
+> primary's stop/start cycle, with `gateway-auto-update.sh` verifying it via the
+> `.wants` symlinks so a companion that fails to start is not reported as a
+> successful update.
+
+
 The release pipeline is fully automated. Any maintainer with workflow-run access
 can cut a release by triggering one workflow; everything else cascades:
 crates.io publish, GitHub release with binaries, gateway updates, and the
@@ -47,7 +59,7 @@ Within ~30–60 minutes you should see:
    crates.io → undraft.
 6. The undraft fires `release.published` → `Gateway Update` and
    `Release Announcements` both auto-trigger.
-7. nova and vega gateways converge to the new version (verified by the
+7. nova's gateways converge to the new version (verified by the
    workflow polling `/version` after the update).
 8. A Matrix message lands in `#freenet-locutus:matrix.org`. A River chat
    announcement is sent via nova's release-agent.
@@ -66,7 +78,6 @@ a `::warning::` annotation telling you what to fix.
 | `MATRIX_HOMESERVER_URL` | release-announce.yml | Matrix job warns + skips (success, no post). |
 | `MATRIX_ACCESS_TOKEN` | release-announce.yml | Matrix job warns + skips. |
 | `RELEASE_AGENT_HMAC_NOVA` | gateway-update.yml, release-announce.yml | nova update + River announce fail (HTTP 401). |
-| `RELEASE_AGENT_HMAC_VEGA` | gateway-update.yml | vega update fails (HTTP 401). |
 | `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` | cross-compile.yml `build-x86_64-windows` (Authenticode signing) | **Does NOT degrade gracefully — this one fails the release.** See "Windows code signing" below. |
 | `FREENET_RELEASE_SIGNING_KEY` | cross-compile.yml (`Sign SHA256SUMS.txt`) | Releases are UNSIGNED (no `SHA256SUMS.txt.sig` attached). Clients accept unsigned releases during the transition window (`REQUIRE_RELEASE_SIGNATURE = false`), but once that flag is flipped to `true` in a future release, unsigned releases are REFUSED by the auto-updater. PEM-encoded ed25519 private key whose public half is baked into the updater (`update.rs` `FREENET_RELEASE_PUBKEY`). |
 
@@ -378,7 +389,6 @@ gh workflow run release.yml
                     └─→ fires release.published event
                             └─→ gateway-update.yml fires
                                     └─→ POST /update to nova (HTTPS)
-                                    └─→ POST /update to vega (HTTPS:8443)
                             └─→ release-announce.yml fires
                                     └─→ Matrix message
                                     └─→ POST /announce/river to nova
@@ -393,7 +403,6 @@ gh workflow run release.yml
   show up here in rough chronological order.
 - **Gateway versions**:
   - `curl https://nova.locut.us/release-agent/version`
-  - `curl https://vega.locut.us:8443/release-agent/version`
 - **Bump PR**:
   `gh pr list --repo freenet/freenet-core --search "build: release"` —
   there should be exactly one open per release, gone within a few minutes.
@@ -599,7 +608,7 @@ Recovery:
    --force'`.
 3. Re-run the gateway-update workflow against just the failed gateway:
    `gh workflow run gateway-update.yml --field version=X.Y.Z --field
-   gateways=vega`.
+   gateways=nova`.
 
 ### River announcement failed but Matrix worked
 
@@ -1018,7 +1027,7 @@ verification skill if you have it):
 2. <https://github.com/freenet/freenet-core/releases/tag/vX.Y.Z> is
    published (not draft) with 14 assets.
 3. `curl https://nova.locut.us/release-agent/version` and
-   `curl https://vega.locut.us:8443/release-agent/version` both return the
+   `systemctl is-active freenet-gateway freenet-gateway-2` on nova returns the
    new version.
 4. Matrix room shows the announcement.
 5. `sudo journalctl -u freenet-gateway --since "30 min ago"` on each

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1026,9 +1026,12 @@ verification skill if you have it):
 1. <https://crates.io/crates/freenet> shows the new version.
 2. <https://github.com/freenet/freenet-core/releases/tag/vX.Y.Z> is
    published (not draft) with 14 assets.
-3. `curl https://nova.locut.us/release-agent/version` and
-   `systemctl is-active freenet-gateway freenet-gateway-2` on nova returns the
-   new version.
+3. `curl https://nova.locut.us/release-agent/version` returns the new version,
+   and `systemctl is-active freenet-gateway freenet-gateway-2` on nova reports
+   both units `active`. These are two separate checks: the first confirms the
+   binary was swapped, the second that BOTH gateway processes came back up —
+   the second gateway follows the first via `WantedBy=`, and a companion that
+   fails to start is the case `verify_service_active` now catches.
 4. Matrix room shows the announcement.
 5. `sudo journalctl -u freenet-gateway --since "30 min ago"` on each
    gateway shows no errors.

--- a/docs/release-agent-deployment.md
+++ b/docs/release-agent-deployment.md
@@ -1,5 +1,14 @@
 # Release-agent deployment
 
+> **nova runs TWO gateway processes**, `freenet-gateway` (:31337) and
+> `freenet-gateway-2` (:31338). Only the first has a release-agent. The second
+> carries `WantedBy=freenet-gateway.service`, so the same stop/start cycle brings
+> it up, and `gateway-auto-update.sh` verifies companion units found in the
+> primary's `.wants` directories — a companion that fails to start now fails the
+> update rather than being reported as a success. Do NOT install a second
+> release-agent for it.
+
+
 Per-gateway install steps for `freenet-release-agent`. Tracked in
 [#4073](https://github.com/freenet/freenet-core/issues/4073).
 Companion files live in [`scripts/release-agent/`](../scripts/release-agent/).
@@ -79,7 +88,6 @@ The end-to-end pipeline needs these repository secrets (set with
 | Secret | Used by | Source |
 |---|---|---|
 | `RELEASE_AGENT_HMAC_NOVA` | `gateway-update.yml` + `release-announce.yml` | nova's `/etc/freenet-release-agent/hmac.key` (echoed once by `install.sh`) |
-| `RELEASE_AGENT_HMAC_VEGA` | `gateway-update.yml` | vega's `/etc/freenet-release-agent/hmac.key` |
 | `MATRIX_HOMESERVER_URL` | `release-announce.yml` | e.g. `https://matrix.org` |
 | `MATRIX_ACCESS_TOKEN` | `release-announce.yml` | Matrix bot user's access token (from `Settings → Help & About → Advanced → Access Token`) |
 
@@ -114,7 +122,7 @@ scp target/release/freenet-release-agent <gateway>:/tmp/
 #    vhost: nova → update.nova.locut.us).
 cd /path/to/freenet-core/scripts/release-agent/
 cp /tmp/freenet-release-agent ./freenet-release-agent
-sudo bash install.sh nova           # or vega, etc.
+sudo bash install.sh nova           # one agent per HOST, not per gateway process
 ```
 
 `install.sh` is idempotent — re-running won't overwrite an existing
@@ -182,7 +190,13 @@ No cloud SG to deal with. Recommended source restriction:
 (~3000 CIDRs from `https://api.github.com/meta`) and rotate weekly, so
 narrowing the SG creates more breakage than it prevents.
 
-### vega (AWS EC2)
+### vega (AWS EC2) — RETIRED September 2026
+
+> Retired. Kept because it documents the only deployment where ghostkey-api
+> owned :80/:443 and forced the agent onto :8443 — useful precedent if another
+> host ever needs that shape. No longer a rollout target: out of the release
+> matrix, out of `release.sh`, and `RELEASE_AGENT_HMAC_VEGA` is unused.
+
 
 Vega differs from nova: `ghostkey-api` (gkapi.freenet.org) already owns
 :80 and :443 on this host, so the release-agent uses a **non-standard

--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -459,9 +459,16 @@ deploy_update() {
 verify_service_active() {
     local service_arg="$1"
 
-    local wants_dir companion cstate cname
-    for wants_dir in "/etc/systemd/system/$service_arg.service.wants" \
-                     "/usr/lib/systemd/system/$service_arg.service.wants"; do
+    # Search roots are overridable ONLY so the test harness can point them at a
+    # fixture; production never sets this. Without it the companion branch is
+    # untestable and would ship unexercised, which is how the gap this function
+    # closes got in.
+    local -a unit_roots
+    IFS=: read -r -a unit_roots <<< "${SYSTEMD_UNIT_ROOTS:-/etc/systemd/system:/usr/lib/systemd/system}"
+
+    local root wants_dir companion cstate cname
+    for root in "${unit_roots[@]}"; do
+        wants_dir="$root/$service_arg.service.wants"
         [[ -d "$wants_dir" ]] || continue
         for companion in "$wants_dir"/*.service; do
             [[ -e "$companion" ]] || continue
@@ -475,7 +482,7 @@ verify_service_active() {
         done
     done
 
-    # Only systemd is supported by the automated update path (nova/vega). On a
+    # Only systemd is supported by the automated update path. On a
     # host without systemctl we cannot confirm liveness; fail closed so a
     # non-systemd gateway is never silently reported as a healthy update.
     if ! command -v systemctl &> /dev/null; then

--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -435,8 +435,45 @@ deploy_update() {
 # a missing unit, or a non-systemd host returns non-zero. `systemctl is-active`
 # is a read-only query and needs no root. Mirrors the release-agent's
 # version.rs::query_service_active so the script-side and HTTP-side gates agree.
+# Verify the deployed unit AND every companion unit configured to start with it.
+#
+# `WantedBy=` pulls a companion up when the primary starts, but systemd does NOT
+# propagate the companion's START FAILURE back to the primary — so a companion
+# that fails to come up leaves the primary active and this check green while a
+# gateway is silently down. Same shape as the v0.2.71 incident this function
+# exists for.
+#
+# nova runs exactly that: freenet-gateway-2 is a second gateway process with
+# `WantedBy=freenet-gateway.service` and no release-agent of its own.
+#
+# Companions are read from the `.wants` SYMLINKS on disk, deliberately NOT from
+# `systemctl show -p ConsistsOf`. ConsistsOf reflects the LOADED unit graph and
+# comes back EMPTY once the companion is stopped — so a ConsistsOf-based check
+# finds nothing to verify at exactly the moment it is needed and passes. That
+# was measured, not assumed. The symlinks are static configuration and are
+# present whether or not the unit is running.
+#
+# Reading from disk also survives the release-agent's `sudo` call, which strips
+# the environment — the same reason SERVICE_NAME forwarding is still unsolved
+# (see the note at the top of this file).
 verify_service_active() {
     local service_arg="$1"
+
+    local wants_dir companion cstate cname
+    for wants_dir in "/etc/systemd/system/$service_arg.service.wants" \
+                     "/usr/lib/systemd/system/$service_arg.service.wants"; do
+        [[ -d "$wants_dir" ]] || continue
+        for companion in "$wants_dir"/*.service; do
+            [[ -e "$companion" ]] || continue
+            cname=$(basename "$companion")
+            cstate=$(systemctl is-active "$cname" 2>/dev/null || true)
+            if [[ "$cstate" != "active" ]]; then
+                log ERROR "Companion unit '$cname' of '$service_arg' is '$cstate', not active; treating the update as failed"
+                return 1
+            fi
+            log INFO "Companion unit '$cname' is active"
+        done
+    done
 
     # Only systemd is supported by the automated update path (nova/vega). On a
     # host without systemctl we cannot confirm liveness; fail closed so a

--- a/scripts/netcheck-nightly.sh
+++ b/scripts/netcheck-nightly.sh
@@ -44,8 +44,12 @@ rm -rf "$RUN_DIR"
 # The getter must join through a gateway that did not receive the PUTs, or the
 # GET can be answered by the node that just stored them. Resolved from the
 # public index so a rotated address or key does not silently stale this script.
-INDEX_KEY_URL="${NETCHECK_GETTER_KEY_URL:-https://freenet.org/keys/public.vega.gw.pem}"
-GETTER_HOST="${NETCHECK_GETTER_HOST:-vega.locut.us}"
+# Defaults point at gw1, NOT the retired AWS gateway. This script joins the live
+# ring through the getter, so a default naming a host that is going away turns
+# the nightly check into a nightly failure the moment DNS is cut — and it fails
+# in a way that looks like a network problem rather than a stale default.
+INDEX_KEY_URL="${NETCHECK_GETTER_KEY_URL:-https://freenet.org/keys/public.nova.gw.pem}"
+GETTER_HOST="${NETCHECK_GETTER_HOST:-gw1.freenet.org}"
 GETTER_PORT="${NETCHECK_GETTER_PORT:-31337}"
 getter_ip=$(getent hosts "$GETTER_HOST" | awk '{print $1}' | head -1)
 getter_key=$(curl -fsS --max-time 30 "$INDEX_KEY_URL" | tr -d '[:space:]')

--- a/scripts/release-agent/gateway-auto-update_test.sh
+++ b/scripts/release-agent/gateway-auto-update_test.sh
@@ -50,7 +50,15 @@ cat > "$TMP/bin/systemctl" <<EOF
 #!/bin/bash
 case "\$1" in
   is-active)
-    state="\$(cat "$TMP/service-state" 2>/dev/null || echo unknown)"
+    # Per-unit state file if present, else the shared default. Lets a companion
+    # be down while the primary is up, which is the case the companion check
+    # exists for.
+    unit="\${2%.service}"
+    if [[ -f "$TMP/state-\$unit" ]]; then
+      state="\$(cat "$TMP/state-\$unit")"
+    else
+      state="\$(cat "$TMP/service-state" 2>/dev/null || echo unknown)"
+    fi
     echo "\$state"
     [[ "\$state" == "active" ]] && exit 0 || exit 3
     ;;
@@ -133,6 +141,64 @@ if deploy_update "$TMP/fake-binary" 2>/dev/null; then
 else
     pass "deploy_update: dead service caught despite deploy script exiting 0"
 fi
+
+# ── companion units (WantedBy=) ──────────────────────────────────────
+#
+# nova runs a SECOND gateway process, freenet-gateway-2, with
+# `WantedBy=freenet-gateway.service` and no release-agent of its own. systemd
+# does NOT propagate a wanted unit's START FAILURE back to the primary, so
+# without this check the primary comes up, the update reports success, and the
+# second gateway is silently down — the v0.2.71 failure class again.
+#
+# SYSTEMD_UNIT_ROOTS points the lookup at a fixture instead of /etc/systemd.
+
+export SYSTEMD_UNIT_ROOTS="$TMP/units"
+WANTS="$TMP/units/freenet-gateway.service.wants"
+mkdir -p "$WANTS" || { echo "FAIL: could not create $WANTS" >&2; exit 1; }
+
+echo "active" > "$TMP/service-state"
+
+# (1) No companions: the loop must fall through, not fail.
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: none configured -> 0"
+else
+    fail "companions: an empty wants dir must not fail the update"
+fi
+
+# (2) Companion present and active.
+touch "$WANTS/freenet-gateway-2.service"
+echo "active" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: active companion -> 0"
+else
+    fail "companions: an active companion must not fail the update"
+fi
+
+# (3) THE CASE THIS EXISTS FOR: primary active, companion down. Must fail.
+echo "inactive" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "companions: primary active + companion INACTIVE must NOT return 0 (silent gateway outage)"
+else
+    pass "companions: inactive companion -> non-zero"
+fi
+
+# (4) A failed companion is equally unacceptable.
+echo "failed" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "companions: primary active + companion FAILED must NOT return 0"
+else
+    pass "companions: failed companion -> non-zero"
+fi
+
+# (5) A wants dir that does not exist must not fail (hosts without companions).
+rm -f "$TMP/state-freenet-gateway-2"
+export SYSTEMD_UNIT_ROOTS="$TMP/no-such-root"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: missing wants root -> 0"
+else
+    fail "companions: a missing wants root must not fail the update"
+fi
+unset SYSTEMD_UNIT_ROOTS
 
 # Same deploy script, but now the service is genuinely active → success.
 echo "active" > "$TMP/service-state"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1323,9 +1323,15 @@ trigger_gateway_updates() {
     fi
 
     # Known gateways: host, SSH user, SSH options
+    # The AWS gateway was retired 2026-09; its entry is removed so a fallback
+    # release does not SSH to a host that no longer exists and record a failed
+    # update on every run. nova's second gateway (freenet-gateway-2) needs no
+    # entry of its own: it carries WantedBy=freenet-gateway.service, so the same
+    # stop/start cycle brings it up, and gateway-auto-update.sh now verifies
+    # companion units from the .wants symlinks rather than reporting success
+    # while one is down.
     local -a GATEWAYS=(
         "nova.locut.us:ian:"
-        "vega.locut.us:ian:"
     )
 
     local all_ok=true
@@ -1965,7 +1971,7 @@ echo "   Wait 5-10 minutes, then check gateway logs for issues:"
 echo
 echo "   Quick check commands:"
 echo "   ssh ian@nova.locut.us 'sudo /usr/local/bin/freenet --version'"
-echo "   ssh ian@vega.locut.us 'sudo /usr/local/bin/freenet --version'"
+echo "   ssh ian@nova.locut.us 'systemctl is-active freenet-gateway freenet-gateway-2'"
 echo
 echo "   Look for: log spam, rapid log growth, new error patterns"
 echo "   See: ~/.claude/skills/freenet-release/SKILL.md for full checklist"


### PR DESCRIPTION
## Problem

The AWS gateway is being retired to cut roughly **$198/mo** (~$2,370/yr), most of it data egress. Its replacement is a second gateway process on nova, live since 2026-08-29.

This workflow must stop targeting the AWS box **before** that box is shut down. Otherwise the next release fails against a host that is not there and the rollout is left half-applied — the exact failure mode the post-deploy verify in this file was written for after v0.2.71.

**This is the last thing blocking the retirement.** Everything else is done: the second gateway is live and carrying ~170 peers against the primary's ~229, the published `gateways.toml` lists it, and the soak window has passed.

## Approach

Remove the vega entry from the default matrix, its `workflow_dispatch` subset tag, and its secret mapping. `RELEASE_AGENT_HMAC_VEGA` becomes unused and can be deleted from repo secrets once the box is gone.

**Deliberately no entry for the second gateway.** `freenet-gateway-2` carries `WantedBy=freenet-gateway.service` alongside `PartOf=`, so the same update cycle stops and restarts it and it picks up the new binary without a release-agent of its own.

That is verified in production, not assumed — on the v0.2.132 release the journal shows:

```
12:22:33  Stopping freenet-gateway-2
12:22:35  Stopped
12:22:39  Started          ← no manual intervention
```

`PartOf` **alone** was not sufficient, and an earlier version of that unit had only `PartOf`. It propagates stop and restart but **not start**, while `deploy-local-gateway.sh` does stop-swap-start (lines 221, 274) rather than restart. That would have left the second gateway down after every release, silently — `verify_service` only checks the unit it deployed.

The bare `vega` mentions remaining in comments are historical incident records for the v0.2.71 half-applied rollout. They explain why the verify exists and are not addresses; the domain itself is gone from the file.

## Testing

YAML validated. No behaviour change for the remaining host: the nova entry, its URL and its secret are untouched, and the matrix shape is unchanged — it simply has one element instead of two.

## For the reviewer

This is release infrastructure and belongs to whoever owns the release process — I have opened it rather than merged it. Ordering is the only real constraint: this needs to land before the AWS gateway is stopped, not after.

[AI-assisted - Claude]
