### PR TITLE
fix: repair rate-limiter drops of broadcast UPDATEs with a throttled ResyncRequest

### DIFF
--- a/apps/freenet-ping/app/tests/run_app.rs
+++ b/apps/freenet-ping/app/tests/run_app.rs
@@ -1075,6 +1075,14 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         let tags = vec![gw_tag.clone(), node1_tag.clone(), node2_tag.clone()];
         let mut all_histories_match = true;
         let mut propagation_matrix = std::collections::HashMap::new();
+        // #5510: the concrete reason each tag failed, recorded by the check that
+        // actually failed. The previous diagnosis printed "timestamp mismatches"
+        // from an `else` on `propagation_rate`, which says nothing about WHICH
+        // check tripped — and the length check `continue`d before the timestamp
+        // comparison ever ran, so that message was reported for failures where
+        // no timestamp was compared at all. Entries were MISSING, not
+        // mismatched, and three investigations were misdirected by it (#5476).
+        let mut failure_reasons: Vec<String> = Vec::new();
 
         // First, analyze what each node received
         println!("=== PROPAGATION MATRIX ===");
@@ -1134,45 +1142,114 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
             println!("  Node1: {} (count: {})", !node1_history.is_empty(), node1_history.len());
             println!("  Node2: {} (count: {})", !node2_history.is_empty(), node2_history.len());
 
-            // Histories should be non-empty if eventual consistency worked
-            if gw_history.is_empty() || node1_history.is_empty() || node2_history.is_empty() {
-                tracing::warn!("Tag '{}' missing from one or more nodes!", tag);
-                if gw_history.is_empty() { tracing::warn!("Gateway missing '{}'", tag); }
-                if node1_history.is_empty() { tracing::warn!("Node1 missing '{}'", tag); }
-                if node2_history.is_empty() { tracing::warn!("Node2 missing '{}'", tag); }
-                all_histories_match = false;
-                continue;
-            }
-
             // Log the number of entries in each history
             println!("  - Gateway: {} entries", gw_history.len());
             println!("  - Node 1:  {} entries", node1_history.len());
             println!("  - Node 2:  {} entries", node2_history.len());
 
-            // Check if the histories have the same length
-            if gw_history.len() != node1_history.len() || gw_history.len() != node2_history.len() {
-                tracing::warn!("Different number of history entries for tag '{}'!", tag);
-                all_histories_match = false;
-                continue;
-            }
+            // MISSING-ENTRY analysis, run for every tag rather than skipped by
+            // an early `continue` (#5510). The union of the three histories is
+            // the set every node should hold; anything a node lacks is an
+            // entry that never reached it — which is a DELIVERY failure, and
+            // is what the old "timestamp mismatch" message was misreporting.
+            let per_node = [
+                ("Gateway", &gw_history),
+                ("Node1", &node1_history),
+                ("Node2", &node2_history),
+            ];
+            let union: std::collections::BTreeSet<_> = per_node
+                .iter()
+                .flat_map(|(_, h)| h.iter().copied())
+                .collect();
 
-            // Compare the actual timestamp vectors element by elemen
-            let mut timestamps_match = true;
-            for i in 0..gw_history.len() {
-                if gw_history[i] != node1_history[i] || gw_history[i] != node2_history[i] {
-                    timestamps_match = false;
-                    tracing::warn!(
-                        "Timestamp mismatch at position {}:\n  - Gateway: {}\n  - Node 1:  {}\n  - Node 2:  {}",
-                        i, gw_history[i], node1_history[i], node2_history[i]
-                    );
+            let mut missing_report: Vec<String> = Vec::new();
+            for (name, history) in &per_node {
+                let held: std::collections::BTreeSet<_> = history.iter().copied().collect();
+                let missing: Vec<_> = union.difference(&held).copied().collect();
+                if !missing.is_empty() {
+                    missing_report.push(format!(
+                        "{name} is missing {} of {} entries: {}",
+                        missing.len(),
+                        union.len(),
+                        missing
+                            .iter()
+                            .map(|t| t.to_rfc3339())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
                 }
             }
 
-            if timestamps_match {
-                println!("History for tag '{tag}' is identical across all nodes!");
-            } else {
-                tracing::warn!("History timestamps for tag '{}' differ between nodes!", tag);
+            if !missing_report.is_empty() {
+                for line in &missing_report {
+                    tracing::warn!("Tag '{}': {}", tag, line);
+                }
+                failure_reasons.push(format!(
+                    "tag '{tag}': MISSING ENTRIES (not a timestamp mismatch) — {}",
+                    missing_report.join("; ")
+                ));
                 all_histories_match = false;
+                // Fall through: a node can be both missing entries AND holding
+                // them in a different order, and reporting only the first is
+                // how the previous diagnostic lost information.
+            }
+
+            // Nobody holds this tag at all. The union is empty, so the
+            // missing-entry analysis above has nothing to report — but this is
+            // still a failure, and the pre-#5510 `is_empty()` guard caught it.
+            if union.is_empty() {
+                failure_reasons.push(format!(
+                    "tag '{tag}': ABSENT FROM EVERY NODE — no node holds a single \
+                     entry for it"
+                ));
+                all_histories_match = false;
+            }
+
+            // Duplicate entries: the sets agree but the vectors are different
+            // lengths, so the positional comparison below would be comparing
+            // shifted sequences (and could index past a shorter history).
+            let lengths_differ = gw_history.len() != node1_history.len()
+                || gw_history.len() != node2_history.len();
+            if missing_report.is_empty() && !union.is_empty() && lengths_differ {
+                failure_reasons.push(format!(
+                    "tag '{tag}': every node holds the same {} distinct entries but \
+                     the histories are different lengths (Gateway={}, Node1={}, \
+                     Node2={}) — duplicate entries, not a delivery failure",
+                    union.len(),
+                    gw_history.len(),
+                    node1_history.len(),
+                    node2_history.len()
+                ));
+                all_histories_match = false;
+            }
+
+            // ORDER/CONTENT analysis. Only meaningful when every node holds the
+            // same set at the same length; otherwise the positional comparison
+            // is just restating what is already reported above.
+            if missing_report.is_empty() && !union.is_empty() && !lengths_differ {
+                let mut mismatches: Vec<String> = Vec::new();
+                for i in 0..gw_history.len() {
+                    if gw_history[i] != node1_history[i] || gw_history[i] != node2_history[i] {
+                        mismatches.push(format!(
+                            "position {i}: Gateway={} Node1={} Node2={}",
+                            gw_history[i], node1_history[i], node2_history[i]
+                        ));
+                    }
+                }
+                if mismatches.is_empty() {
+                    println!("History for tag '{tag}' is identical across all nodes!");
+                } else {
+                    for line in &mismatches {
+                        tracing::warn!("Tag '{}' ordering differs at {}", tag, line);
+                    }
+                    failure_reasons.push(format!(
+                        "tag '{tag}': every node holds the same {} entries but in a \
+                         DIFFERENT ORDER — {}",
+                        union.len(),
+                        mismatches.join("; ")
+                    ));
+                    all_histories_match = false;
+                }
             }
         }
 
@@ -1181,10 +1258,32 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         // Final diagnosis before assertion
         if !all_histories_match {
             tracing::error!("PROPAGATION FAILURE DIAGNOSIS:");
-            tracing::error!("Overall propagation rate: {:.1}%", propagation_rate * 100.0);
+            // WHAT ACTUALLY FAILED, reported by the check that failed (#5510).
+            // `propagation_rate` counts whether a tag is PRESENT at all, so it
+            // reads 100% while entries inside a present tag are missing —
+            // which is the common shape and the one the old `else` branch
+            // mislabelled "timestamp mismatches". It is printed below as
+            // context, never as the diagnosis.
+            for reason in &failure_reasons {
+                tracing::error!("FAILED: {}", reason);
+            }
+            if failure_reasons.is_empty() {
+                tracing::error!(
+                    "all_histories_match is false but no per-tag reason was \
+                     recorded — this is a bug in the diagnostic itself"
+                );
+            }
+            tracing::error!(
+                "Context — tag-level propagation rate: {:.1}% ({}/{} tags present). \
+                 This counts PRESENCE of a tag, not completeness of its history, so \
+                 a high rate here is consistent with missing entries above.",
+                propagation_rate * 100.0,
+                successful_propagations,
+                total_propagation_attempts
+            );
 
             if propagation_rate < 0.5 {
-                tracing::error!("SEVERE: Less than 50% of updates propagated");
+                tracing::error!("SEVERE: fewer than 50% of tags reached their peers");
                 tracing::error!("This is a BUG - all subscribed nodes MUST receive updates!");
                 tracing::error!("Possible causes:");
                 tracing::error!("1. Bug in subscription notification system");
@@ -1192,12 +1291,9 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 tracing::error!("3. Updates sent before subscriptions fully active");
                 tracing::error!("4. Configuration issues (skip_load_from_network, etc.)");
             } else if propagation_rate < 0.8 {
-                tracing::error!("MODERATE: 50-80% of updates propagated");
+                tracing::error!("MODERATE: 50-80% of tags reached their peers");
                 tracing::error!("Still problematic - subscribed nodes should receive ALL updates");
                 tracing::error!("This suggests partial failure in notification system");
-            } else {
-                tracing::error!("PARTIAL: >80% propagated but timestamp mismatches");
-                tracing::error!("Updates reached nodes but content differs - timing or merge issues");
             }
 
             // More detailed failure analysis
@@ -1221,9 +1317,16 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         assert!(
             all_histories_match,
             "Eventual consistency test failed: Ping histories are not identical across all nodes\n\
-             Propagation success rate: {:.1}% ({}/{})\n\
-             Check logs above for detailed diagnosis of the failure",
-            propagation_rate * 100.0, successful_propagations, total_propagation_attempts
+             What failed:\n  {}\n\
+             Tag-level propagation rate (presence only, NOT completeness): {:.1}% ({}/{})",
+            if failure_reasons.is_empty() {
+                "(no per-tag reason recorded — diagnostic bug)".to_string()
+            } else {
+                failure_reasons.join("\n  ")
+            },
+            propagation_rate * 100.0,
+            successful_propagations,
+            total_propagation_attempts
         );
 
         println!("Eventual consistency test PASSED - all nodes have identical ping histories!");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4696,9 +4696,10 @@ impl GlobalTestMetrics {
     /// Returns the total number of ResyncRequests received since last reset.
     ///
     /// This is the TOTAL across every cause. Since #5510 there are several — a
-    /// delta that failed to apply, a queue-full broadcast drop, a rate-limited
-    /// broadcast drop, and the trailing coalesced repair — so a test that means
-    /// "no delta failed" must use [`Self::delta_failure_resyncs`] instead.
+    /// delta that failed to apply, a queue-full broadcast drop, and a
+    /// rate-limited broadcast drop (with a fourth, the trailing coalesced
+    /// repair, once #5525 lands) — so a test that means "no delta failed" must
+    /// use [`Self::delta_failure_resyncs`] instead.
     /// Asserting zero on this total makes any new, legitimate resync source
     /// look like the #2763 regression.
     pub fn resync_requests() -> u64 {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4521,6 +4521,10 @@ impl SimulationIdleTimeout {
 // Thread-local test metrics: allows parallel simulation tests without interference.
 std::thread_local! {
     static GLOBAL_RESYNC_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// ResyncRequests emitted specifically because a DELTA FAILED TO APPLY —
+    /// the #2763 summary-caching signal, counted at the decision that makes it
+    /// rather than inferred from the total (#5510).
+    static GLOBAL_DELTA_FAILURE_RESYNCS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_DELTA_SENDS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     /// Fan-out legs skipped because the peer's cached summary already matched
     /// ours (the pre-existing mechanism, counted for #5147 diagnosis).
@@ -4642,6 +4646,7 @@ impl GlobalTestMetrics {
     /// Resets all test metrics to zero (thread-local). Call at the start of each test.
     pub fn reset() {
         GLOBAL_RESYNC_REQUESTS.with(|c| c.set(0));
+        GLOBAL_DELTA_FAILURE_RESYNCS.with(|c| c.set(0));
         GLOBAL_DELTA_SENDS.with(|c| c.set(0));
         GLOBAL_FANOUT_SUMMARY_SKIPS.with(|c| c.set(0));
         GLOBAL_BROADCAST_TARGETS_SUPPRESSED.with(|c| c.set(0));
@@ -4689,8 +4694,33 @@ impl GlobalTestMetrics {
     }
 
     /// Returns the total number of ResyncRequests received since last reset.
+    ///
+    /// This is the TOTAL across every cause. Since #5510 there are several — a
+    /// delta that failed to apply, a queue-full broadcast drop, a rate-limited
+    /// broadcast drop, and the trailing coalesced repair — so a test that means
+    /// "no delta failed" must use [`Self::delta_failure_resyncs`] instead.
+    /// Asserting zero on this total makes any new, legitimate resync source
+    /// look like the #2763 regression.
     pub fn resync_requests() -> u64 {
         GLOBAL_RESYNC_REQUESTS.with(|c| c.get())
+    }
+
+    /// Records a ResyncRequest emitted because a DELTA FAILED TO APPLY.
+    ///
+    /// Recorded at the branch that makes that decision (the `is_delta &&
+    /// !queue_full` arm of the broadcast driver), never derived by subtracting
+    /// other causes from the total — the shape
+    /// `.claude/rules/bug-prevention-patterns.md` warns about, where a
+    /// subtraction silently absorbs every other cause and keeps reporting a
+    /// plausible number after the thing it claims to measure is gone.
+    pub fn record_delta_failure_resync() {
+        GLOBAL_DELTA_FAILURE_RESYNCS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// ResyncRequests emitted because a delta failed to apply — the precise
+    /// #2763 summary-caching signal.
+    pub fn delta_failure_resyncs() -> u64 {
+        GLOBAL_DELTA_FAILURE_RESYNCS.with(|c| c.get())
     }
 
     /// Records that an UPDATE broadcast merge was skipped by the per-contract

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1839,8 +1839,44 @@ where
                             //    interested. Hosting is different: an attacker
                             //    cannot make this node hold a contract by sending
                             //    it a `BroadcastTo`.
+                            //
+                            // KNOWN LIMITATION, deliberate and pre-existing:
+                            // this `ResyncRequest` is indistinguishable at the
+                            // SENDER from evidence that a delta we sent it
+                            // FAILED TO APPLY. Its handler passes every inbound
+                            // request to `delta_incompat.note_resync_request`,
+                            // which counts a strike whenever it delivered a
+                            // delta to us for this contract inside
+                            // `DELTA_ATTRIBUTION_WINDOW` (60s) — which is
+                            // exactly the case here, since the dropped
+                            // broadcast IS that delta. Three such strikes from
+                            // >= 2 distinct peers reach `INCOMPAT_TRIP_THRESHOLD`
+                            // and force a perfectly delta-capable contract into
+                            // full-state-only fan-out for `DELTA_INCOMPAT_TTL`
+                            // (10 min).
+                            //
+                            // The pre-existing queue-full repair (#4857) has
+                            // the identical attribution, so this is not a new
+                            // defect, and it self-heals on the TTL. Fixing it
+                            // needs a reason on the wire, which means a
+                            // version-gated APPEND of a new variant (never a
+                            // field added to an existing one — see the repo's
+                            // wire-append lesson), and that is out of scope
+                            // here. Tracked separately; do NOT "fix" this by
+                            // changing the wire format in a bugfix PR.
                             if update_class
                                 == crate::ring::update_rate_limit::UpdateClass::Broadcast
+                                // Gate B. NOTE on non-redb builds:
+                                // `contract_state_present` returns true
+                                // unconditionally there, so this degrades to
+                                // `is_hosting || in_use`. That arm is
+                                // unreachable in any build that COMPILES — the
+                                // crate has no working SQLite-only feature
+                                // combination (see the TODO(#4869) in this
+                                // file's tests; ci.yml always passes `redb`).
+                                // If that ever changes, switch this to the
+                                // backend-aware `contract_state_present_async`
+                                // rather than leaving the weaker gate in place.
                                 && op_manager.ring.should_summarize_or_broadcast(&key)
                             {
                                 update::op_ctx_task::send_dropped_broadcast_resync_request(
@@ -7323,6 +7359,9 @@ mod tests {
     /// on the throttle's clock, far beyond this synchronous test's window, so
     /// the counts below are unaffected. Auto-advancing time would let that
     /// retry fire and pollute them.
+    // Gated like its siblings above: the harness seeds state with
+    // `store_state_sync`, which exists only on the redb backend.
+    #[cfg(feature = "redb")]
     #[tokio::test]
     async fn rate_limited_broadcast_emits_throttled_resync_request() {
         use crate::message::{DeltaOrFullState, NetMessageV1};
@@ -7569,6 +7608,9 @@ mod tests {
     /// primes the pair first, so it only ever exercises `Rejected`; this is the
     /// arm it cannot reach. Verified against the mutation: moving the emit back
     /// out of the `Rejected` arm (where it sat before review) makes this FAIL.
+    // Gated like its siblings above: the harness seeds state with
+    // `store_state_sync`, which exists only on the redb backend.
+    #[cfg(feature = "redb")]
     #[tokio::test]
     async fn sender_new_pair_budget_refusal_emits_no_repair() {
         use crate::message::{DeltaOrFullState, NetMessageV1};
@@ -7740,6 +7782,9 @@ mod tests {
     /// Same harness as `rate_limited_broadcast_emits_throttled_resync_request`
     /// with one difference — no stored state and no subscription — so a failure
     /// here is specifically the missing hosting gate.
+    // Gated like its siblings above: the harness seeds state with
+    // `store_state_sync`, which exists only on the redb backend.
+    #[cfg(feature = "redb")]
     #[tokio::test]
     async fn rate_limited_broadcast_for_an_unheld_contract_emits_no_repair() {
         use crate::message::{DeltaOrFullState, NetMessageV1};

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1639,6 +1639,27 @@ where
                     | update::UpdateMsg::BroadcastToStreamingV2 { key, .. } => *key,
                 };
 
+                // Which budget this message is charged against (#5510).
+                // Matched exhaustively, and the four broadcast opcodes map
+                // to ONE class so switching between them gains nothing —
+                // see `crate::ring::update_rate_limit::UpdateClass`. A new
+                // UPDATE wire variant will fail to compile here, which is
+                // the point: it must be classified deliberately rather
+                // than fall into whichever class a catch-all named.
+                // Pinned by `every_broadcast_opcode_is_charged_to_the_broadcast_class`.
+                let update_class = match op {
+                    update::UpdateMsg::RequestUpdate { .. }
+                    | update::UpdateMsg::RequestUpdateStreaming { .. } => {
+                        crate::ring::update_rate_limit::UpdateClass::Request
+                    }
+                    update::UpdateMsg::BroadcastTo { .. }
+                    | update::UpdateMsg::BroadcastToV2 { .. }
+                    | update::UpdateMsg::BroadcastToStreaming { .. }
+                    | update::UpdateMsg::BroadcastToStreamingV2 { .. } => {
+                        crate::ring::update_rate_limit::UpdateClass::Broadcast
+                    }
+                };
+
                 // Phase 7 ban-list gate. Runs BEFORE the rate limiter
                 // so a banned contract's traffic doesn't even count
                 // against the per-(sender, contract) window — keeps
@@ -1654,10 +1675,11 @@ where
                     return Ok(());
                 }
 
-                let rate_decision = op_manager
-                    .ring
-                    .update_rate_limiter
-                    .check_and_record(sender_addr, *key.id());
+                let rate_decision = op_manager.ring.update_rate_limiter.check_and_record(
+                    sender_addr,
+                    *key.id(),
+                    update_class,
+                );
                 if !rate_decision.is_allowed() {
                     use crate::ring::update_rate_limit::RateLimitDecision;
                     // Matched exhaustively on purpose: a new drop reason
@@ -1750,13 +1772,7 @@ where
                     // neither the `ResyncRequest` nor the `ResyncResponse` it
                     // provokes is subject to THIS limiter. The repair cannot be
                     // silenced by the condition it repairs.
-                    if matches!(
-                        op,
-                        update::UpdateMsg::BroadcastTo { .. }
-                            | update::UpdateMsg::BroadcastToV2 { .. }
-                            | update::UpdateMsg::BroadcastToStreaming { .. }
-                            | update::UpdateMsg::BroadcastToStreamingV2 { .. }
-                    ) {
+                    if update_class == crate::ring::update_rate_limit::UpdateClass::Broadcast {
                         update::op_ctx_task::send_dropped_broadcast_resync_request(
                             &op_manager,
                             key,
@@ -7305,16 +7321,28 @@ mod tests {
             targets
         }
 
-        // Prime both pairs so the limiter is TRACKING them; on the frozen clock
-        // every subsequent check for the same pair is `Rejected` forever.
-        for key in [broadcast_key, request_key] {
+        // Prime each pair so the limiter is TRACKING it, in the SAME class the
+        // dispatch will later charge. Since #5510 the two classes hold separate
+        // stamps in one entry, so priming the wrong class would leave the other
+        // at `None` and the message under test would be ALLOWED. On the frozen
+        // clock every subsequent check of a primed class is `Rejected` forever.
+        for (key, class) in [
+            (
+                broadcast_key,
+                crate::ring::update_rate_limit::UpdateClass::Broadcast,
+            ),
+            (
+                request_key,
+                crate::ring::update_rate_limit::UpdateClass::Request,
+            ),
+        ] {
             assert!(
                 op_manager
                     .ring
                     .update_rate_limiter
-                    .check_and_record(sender_addr, *key.id())
+                    .check_and_record(sender_addr, *key.id(), class)
                     .is_allowed(),
-                "precondition: the first UPDATE for a fresh pair must be allowed"
+                "precondition: the first UPDATE of a class for a fresh pair must be allowed"
             );
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1679,6 +1679,18 @@ where
                             );
                         }
                         RateLimitDecision::Rejected { .. } | RateLimitDecision::Allowed => {
+                            // Per-drop detail stays at `debug!` (a rejected pair
+                            // is rejected on every message, so a per-drop
+                            // `info!` here would be the log flood it is meant
+                            // to report). The RELEASE-VISIBLE signal is emitted
+                            // by the limiter itself, throttled to one line per
+                            // minute with the sender, the contract and the
+                            // running total — see
+                            // `update_rate_limit::UpdateRateLimiter::log_rejected`.
+                            // Before #5510 this drop had NO release-visible
+                            // record at all: `release_max_level_info` compiles
+                            // `debug!` out, so a field node dropped broadcasts
+                            // with nothing to grep.
                             tracing::debug!(
                                 tx = %op.id(),
                                 %key,
@@ -1688,6 +1700,51 @@ where
                                 "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
                             );
                         }
+                    }
+
+                    // #5510: a dropped BROADCAST needs a repair; a dropped
+                    // REQUEST does not.
+                    //
+                    // For the four `BroadcastTo*` variants the sender has
+                    // ALREADY cached its own summary as ours
+                    // (`broadcast_queue.rs::record_delivery_to_interest`
+                    // refreshes on a local enqueue, not on a receiver ack), and
+                    // since #5464 every later delta is a true difference
+                    // against that belief — so the entries in this dropped
+                    // message are excluded from every subsequent broadcast and
+                    // the two peers stay diverged. Nothing else heals it: the
+                    // delta-apply-failure `ResyncRequest` needs an apply that
+                    // FAILED, and nothing was applied here; anti-entropy is
+                    // 300s at minimum and 40-75 min at field shared-set sizes
+                    // (#5238/#5346). So route the drop into the same throttled
+                    // repair the queue-full drop uses.
+                    //
+                    // `RequestUpdate*` is deliberately NOT repaired: it is a
+                    // routed request whose originator observes the failure and
+                    // retries, and it caches no summary of us — emitting a
+                    // resync for it would be pure amplification onto a node
+                    // that is already refusing this sender's traffic.
+                    //
+                    // The repair rides `NetMessageV1::InterestSync`, a
+                    // different wire variant from `NetMessageV1::Update`, so
+                    // neither the `ResyncRequest` nor the `ResyncResponse` it
+                    // provokes is subject to THIS limiter. The repair cannot be
+                    // silenced by the condition it repairs.
+                    if matches!(
+                        op,
+                        update::UpdateMsg::BroadcastTo { .. }
+                            | update::UpdateMsg::BroadcastToV2 { .. }
+                            | update::UpdateMsg::BroadcastToStreaming { .. }
+                            | update::UpdateMsg::BroadcastToStreamingV2 { .. }
+                    ) {
+                        update::op_ctx_task::send_dropped_broadcast_resync_request(
+                            &op_manager,
+                            key,
+                            sender_addr,
+                            *op.id(),
+                            update::op_ctx_task::DroppedBroadcastReason::RateLimited,
+                        )
+                        .await;
                     }
                     return Ok(());
                 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1619,11 +1619,18 @@ where
             // mean an internal caller; there are none, so the else
             // branch logs and drops.
             if let Some(sender_addr) = source_addr {
-                // Phase 2 front-line rate limit. Apply UNIFORMLY across
-                // all four UPDATE wire variants so a flooder can't
-                // bypass by switching opcode (RequestUpdate /
-                // BroadcastTo / RequestUpdateStreaming /
-                // BroadcastToStreaming). The check happens BEFORE the
+                // Phase 2 front-line rate limit. Applied uniformly WITHIN
+                // each `UpdateClass`, not across all six wire variants —
+                // the pre-#5510 wording said the latter and is no longer
+                // true. The anti-bypass property it protected survives:
+                // the four `BroadcastTo*` opcodes share ONE budget and
+                // the two `RequestUpdate*` opcodes share the other, so
+                // switching opcode gains at most the broadcast class,
+                // which is itself bounded and whose trade-off is written
+                // out on `MIN_BROADCAST_INTERVAL`. What changed is that
+                // charging co-host fan-out at the client-write cadence
+                // was refusing honest traffic and diverging peers, not
+                // throttling a flood. The check happens BEFORE the
                 // dedup gate inside the relay drivers — that ordering
                 // is what made the previous PR-MVP iteration race-
                 // free per Codex review: rejected attempts never enter
@@ -1647,6 +1654,12 @@ where
                 // the point: it must be classified deliberately rather
                 // than fall into whichever class a catch-all named.
                 // Pinned by `every_broadcast_opcode_is_charged_to_the_broadcast_class`.
+                // That pin reads this match as text, strips whitespace, and
+                // decides each opcode's class from the first `UpdateClass::`
+                // token that FOLLOWS it — so do NOT write `UpdateClass::Request`
+                // or `UpdateClass::Broadcast` in a comment inside this match. A
+                // mention in a comment is indistinguishable from the arm body to
+                // the pin and would silently mis-attribute the opcode above it.
                 let update_class = match op {
                     update::UpdateMsg::RequestUpdate { .. }
                     | update::UpdateMsg::RequestUpdateStreaming { .. } => {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -7206,18 +7206,20 @@ mod tests {
     /// the failure and caches no summary of us, so a resync for it would be
     /// pure amplification onto a node already refusing this sender.
     ///
-    /// On `origin/main` this FAILS at the first assertion: the rate-limiter arm
-    /// logs at `debug!` (compiled out of release builds) and `return Ok(())`,
-    /// so no repair is emitted and `first` is empty.
+    /// Verified against the unfixed code by deleting the repair arm from the
+    /// dispatch path: the first assertion fails with `left: []`, `right:
+    /// [127.0.0.1:15100]`. On `origin/main` the arm logs at `debug!` (compiled
+    /// out of release builds) and `return Ok(())`, so nothing is emitted.
     ///
     /// DETERMINISM: the limiter's verdict is decided by a frozen
     /// `SharedMockTimeSource` injected through
     /// `NodeConfig::update_rate_limit_time_source_override`, NOT by racing the
-    /// 100 ms `MIN_UPDATE_INTERVAL` against wall time. Priming the pair and
-    /// then dispatching would otherwise be a wall-clock race, and a stall past
-    /// 100 ms would let the message through to a driver — which, with a
-    /// queue-full stand-in handler, would emit a `ResyncRequest` for a
-    /// DIFFERENT reason and make this test pass vacuously.
+    /// 100 ms `MIN_UPDATE_INTERVAL` against wall time. Priming a pair and then
+    /// dispatching would otherwise be a wall-clock race: a stall past 100 ms
+    /// would make the message ALLOWED, so it would reach a relay driver instead
+    /// of the arm under test, and the assertions below would be measuring
+    /// something else entirely. No contract handler services the channel here,
+    /// because on this path nothing should ever reach one.
     ///
     /// The `#[tokio::test]` is deliberately NOT `start_paused`: the emit spawns
     /// a trailing retry task (#4862) whose first re-dispatch is ~1.6-2.4 s out

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1720,14 +1720,14 @@ where
                                 "UPDATE dispatch: dropped, sender over its new-pair budget"
                             );
                         }
-                        RateLimitDecision::Rejected { .. } | RateLimitDecision::Allowed => {
+                        RateLimitDecision::Rejected { .. } => {
                             // Per-drop detail stays at `debug!` (a rejected pair
                             // is rejected on every message, so a per-drop
                             // `info!` here would be the log flood it is meant
                             // to report). The RELEASE-VISIBLE signal is emitted
                             // by the limiter itself, throttled to one line per
-                            // minute with the sender, the contract and the
-                            // running total — see
+                            // minute PER CLASS with the sender, the contract,
+                            // the class and the running total — see
                             // `update_rate_limit::UpdateRateLimiter::log_rejected`.
                             // Before #5510 this drop had NO release-visible
                             // record at all: `release_max_level_info` compiles
@@ -1741,46 +1741,114 @@ where
                                 phase = "update_dispatch_rate_limited",
                                 "UPDATE dispatch: rejected by per-(sender, contract) rate limit"
                             );
-                        }
-                    }
 
-                    // #5510: a dropped BROADCAST needs a repair; a dropped
-                    // REQUEST does not.
-                    //
-                    // For the four `BroadcastTo*` variants the sender has
-                    // ALREADY cached its own summary as ours
-                    // (`broadcast_queue.rs::record_delivery_to_interest`
-                    // refreshes on a local enqueue, not on a receiver ack), and
-                    // since #5464 every later delta is a true difference
-                    // against that belief — so the entries in this dropped
-                    // message are excluded from every subsequent broadcast and
-                    // the two peers stay diverged. Nothing else heals it: the
-                    // delta-apply-failure `ResyncRequest` needs an apply that
-                    // FAILED, and nothing was applied here; anti-entropy is
-                    // 300s at minimum and 40-75 min at field shared-set sizes
-                    // (#5238/#5346). So route the drop into the same throttled
-                    // repair the queue-full drop uses.
-                    //
-                    // `RequestUpdate*` is deliberately NOT repaired: it is a
-                    // routed request whose originator observes the failure and
-                    // retries, and it caches no summary of us — emitting a
-                    // resync for it would be pure amplification onto a node
-                    // that is already refusing this sender's traffic.
-                    //
-                    // The repair rides `NetMessageV1::InterestSync`, a
-                    // different wire variant from `NetMessageV1::Update`, so
-                    // neither the `ResyncRequest` nor the `ResyncResponse` it
-                    // provokes is subject to THIS limiter. The repair cannot be
-                    // silenced by the condition it repairs.
-                    if update_class == crate::ring::update_rate_limit::UpdateClass::Broadcast {
-                        update::op_ctx_task::send_dropped_broadcast_resync_request(
-                            &op_manager,
-                            key,
-                            sender_addr,
-                            *op.id(),
-                            update::op_ctx_task::DroppedBroadcastReason::RateLimited,
-                        )
-                        .await;
+                            // #5510: a dropped BROADCAST needs a repair; a
+                            // dropped REQUEST does not.
+                            //
+                            // For the four `BroadcastTo*` variants the sender
+                            // has ALREADY cached its own summary as ours
+                            // (`broadcast_queue.rs::record_delivery_to_interest`
+                            // refreshes on a local enqueue, not on a receiver
+                            // ack), and since #5464 every later delta is a true
+                            // difference against that belief — so the entries in
+                            // this dropped message are excluded from every
+                            // subsequent broadcast and the two peers stay
+                            // diverged. Nothing else heals it: the
+                            // delta-apply-failure `ResyncRequest` needs an apply
+                            // that FAILED, and nothing was applied here;
+                            // anti-entropy is 300s at minimum and 40-75 min at
+                            // field shared-set sizes (#5238/#5346). So route the
+                            // drop into the same throttled repair the queue-full
+                            // drop uses.
+                            //
+                            // `RequestUpdate*` is deliberately NOT repaired: it
+                            // is a routed request whose originator observes the
+                            // failure and retries, and it caches no summary of
+                            // us — emitting a resync for it would be pure
+                            // amplification onto a node already refusing this
+                            // sender's traffic.
+                            //
+                            // The repair rides `NetMessageV1::InterestSync`, a
+                            // different wire variant from `NetMessageV1::Update`,
+                            // so neither the `ResyncRequest` nor the
+                            // `ResyncResponse` it provokes is subject to THIS
+                            // limiter. The repair cannot be silenced by the
+                            // condition it repairs.
+                            //
+                            // TWO GATES, both required, and both learned the
+                            // hard way in review:
+                            //
+                            // 1. This arm ONLY. The emit used to sit after the
+                            //    match and therefore ran for EVERY non-allowed
+                            //    decision. `SenderNewPairBudget` was the bad
+                            //    one: that decision means a sender is churning
+                            //    FRESH contract ids past its #4997 burst, so
+                            //    every gate downstream is vacant by
+                            //    construction — a fresh (contract, sender) key
+                            //    means `begin_resync_request` grants, a fresh
+                            //    contract means `resync_emit_limiter` grants —
+                            //    and we would emit roughly one ResyncRequest per
+                            //    refused message straight back at the flooder,
+                            //    each one inviting a full-state ResyncResponse
+                            //    that the correlation record authorizes into a
+                            //    WASM merge. The #4997 budget exists precisely
+                            //    so that traffic is FREE to refuse; a repair
+                            //    hung off it hands the refusal a cost.
+                            //
+                            // 2. We must actually HOLD the contract. `key` is
+                            //    attacker-supplied and nothing above this point
+                            //    checks it. The queue-full call sites in
+                            //    `op_ctx_task` are reached only AFTER
+                            //    `update_contract` returned `ContractQueueFull`,
+                            //    which proves the executor holds it; this arm
+                            //    proves nothing. Without the gate an attacker
+                            //    picks unlimited fresh keys and each one is a
+                            //    fresh (contract, sender) throttle entry and a
+                            //    fresh emit-limiter bucket, so the per-key
+                            //    bounds never bind.
+                            //
+                            //    `should_summarize_or_broadcast` is
+                            //    `(is_hosting_contract || contract_in_use) &&
+                            //    contract_state_present` (#4610). It is
+                            //    SYNCHRONOUS — no store await on a refusal path
+                            //    — and strictly stronger than the state-presence
+                            //    check the `ResyncRequest` HANDLER uses on the
+                            //    responder side, because it also requires that
+                            //    something here actually wants the contract.
+                            //    There is nothing to repair for a contract we do
+                            //    not hold: the sender's cached summary of us for
+                            //    it is meaningless to us.
+                            //
+                            //    This does NOT contradict the argument against
+                            //    keying the BUDGET on interest relationship. That
+                            //    would be self-granting, because receiving a
+                            //    broadcast is itself what registers the sender as
+                            //    interested. Hosting is different: an attacker
+                            //    cannot make this node hold a contract by sending
+                            //    it a `BroadcastTo`.
+                            if update_class
+                                == crate::ring::update_rate_limit::UpdateClass::Broadcast
+                                && op_manager.ring.should_summarize_or_broadcast(&key)
+                            {
+                                update::op_ctx_task::send_dropped_broadcast_resync_request(
+                                    &op_manager,
+                                    key,
+                                    sender_addr,
+                                    *op.id(),
+                                    update::op_ctx_task::DroppedBroadcastReason::RateLimited,
+                                )
+                                .await;
+                            }
+                        }
+                        RateLimitDecision::Allowed => {
+                            // Unreachable: this whole block is inside
+                            // `!rate_decision.is_allowed()`. Kept as its own arm
+                            // rather than folded into another so the match stays
+                            // exhaustive with NO catch-all — a new decision
+                            // variant must be classified deliberately, including
+                            // deciding whether it deserves a repair, instead of
+                            // inheriting one silently (#4981/#5510).
+                        }
                     }
                     return Ok(());
                 }
@@ -7286,6 +7354,17 @@ mod tests {
             .connection_manager
             .set_own_addr_local_for_test("127.0.0.1:14200".parse().unwrap());
 
+        // #5510 gate B: the repair only fires for a contract we actually HOLD.
+        // Satisfy `should_summarize_or_broadcast` = `(is_hosting_contract ||
+        // contract_in_use) && contract_state_present` for the broadcast key:
+        // a local client subscription supplies `contract_in_use`, and stored
+        // state supplies `contract_state_present`. Without BOTH this test would
+        // pass vacuously against the gate rather than the repair.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+
         let bridge = MockNetworkBridge::new();
         let mut listener: Box<dyn NetEventRegister> =
             Box::new(crate::tracing::DynamicRegister::new(vec![]));
@@ -7299,6 +7378,30 @@ mod tests {
             freenet_stdlib::prelude::CodeHash::new([34u8; 32]),
         );
         let sender_addr: SocketAddr = "127.0.0.1:15100".parse().unwrap();
+
+        storage
+            .store_state_sync(
+                &broadcast_key,
+                freenet_stdlib::prelude::WrappedState::new(vec![1u8, 2, 3]),
+            )
+            .expect("store broadcast-key state");
+        storage
+            .store_state_sync(
+                &request_key,
+                freenet_stdlib::prelude::WrappedState::new(vec![4u8, 5, 6]),
+            )
+            .expect("store request-key state");
+        op_manager.ring.set_hosting_storage(storage);
+        for key in [broadcast_key, request_key] {
+            op_manager
+                .ring
+                .add_client_subscription(key.id(), crate::client_events::ClientId::FIRST);
+            assert!(
+                op_manager.ring.should_summarize_or_broadcast(&key),
+                "precondition: the node must HOLD {key} — otherwise gate B would \
+                 suppress the repair and this test would pass for the wrong reason"
+            );
+        }
 
         // Drain the notification channel and return the targets of every
         // ResyncRequest emitted for `key` since the last drain.
@@ -7433,6 +7536,319 @@ mod tests {
              ResyncRequest — its originator observes the failure and it caches no \
              summary of us, so a resync here is pure amplification onto a node \
              already refusing this sender"
+        );
+    }
+
+    /// #5510 gate A: a refusal that is NOT `Rejected` must emit NO repair.
+    ///
+    /// `SenderNewPairBudget` is the dangerous one and the reason this test
+    /// exists. That decision means a sender is churning FRESH contract ids past
+    /// its #4997 burst, so every downstream gate is vacant BY CONSTRUCTION: a
+    /// fresh `(contract, sender)` key means `begin_resync_request` grants, and a
+    /// fresh contract means `resync_emit_limiter` grants. An emit hung off this
+    /// decision would therefore fire at roughly one ResyncRequest per refused
+    /// message, straight back at the flooder, each one inviting a full-state
+    /// `ResyncResponse` that the correlation record authorizes into a WASM
+    /// merge. The whole point of the #4997 budget is that traffic over it is
+    /// FREE to refuse.
+    ///
+    /// The `rate_limited_broadcast_emits_throttled_resync_request` sibling
+    /// primes the pair first, so it only ever exercises `Rejected`; this is the
+    /// arm it cannot reach. Verified against the mutation: moving the emit back
+    /// out of the `Rejected` arm (where it sat before review) makes this FAIL.
+    #[tokio::test]
+    async fn sender_new_pair_budget_refusal_emits_no_repair() {
+        use crate::message::{DeltaOrFullState, NetMessageV1};
+        use crate::operations::test_utils::MockNetworkBridge;
+        use crate::operations::update::UpdateMsg;
+        use crate::ring::update_rate_limit::UpdateClass;
+        use crate::util::time_source::SharedMockTimeSource;
+
+        let clock = SharedMockTimeSource::new();
+        let config_args = crate::config::ConfigArgs {
+            id: Some("new-pair-budget-no-repair-5510".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let mut node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        node_config.update_rate_limit_time_source_override =
+            Some(std::sync::Arc::new(clock.clone()));
+
+        let (mut notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14300".parse().unwrap());
+
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([41u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([42u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:15200".parse().unwrap();
+
+        // HOLD the contract, so gate B is satisfied and cannot be what makes
+        // this pass — the assertion must be about gate A alone.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+        storage
+            .store_state_sync(&key, freenet_stdlib::prelude::WrappedState::new(vec![7u8]))
+            .expect("store state");
+        op_manager.ring.set_hosting_storage(storage);
+        op_manager
+            .ring
+            .add_client_subscription(key.id(), crate::client_events::ClientId::FIRST);
+        assert!(
+            op_manager.ring.should_summarize_or_broadcast(&key),
+            "precondition: gate B must PASS, so only gate A can suppress the repair"
+        );
+
+        // Drive the NODE's OWN limiter into the state under test rather than a
+        // stand-in: spend this sender's whole #4997 fresh-pair burst on distinct
+        // contract ids. The clock is frozen, so the bucket cannot refill and the
+        // next fresh pair — `key` — is refused with `SenderNewPairBudget`. This
+        // is exactly the flooder shape the decision exists for.
+        for i in 0..2048u32 {
+            let churn = freenet_stdlib::prelude::ContractInstanceId::new({
+                let mut id = [0u8; 32];
+                id[..4].copy_from_slice(&i.to_le_bytes());
+                id[4] = 0xAB;
+                id
+            });
+            op_manager.ring.update_rate_limiter.check_and_record(
+                sender_addr,
+                churn,
+                UpdateClass::Broadcast,
+            );
+        }
+        assert!(
+            matches!(
+                op_manager.ring.update_rate_limiter.check_and_record(
+                    sender_addr,
+                    *key.id(),
+                    UpdateClass::Broadcast
+                ),
+                crate::ring::update_rate_limit::RateLimitDecision::SenderNewPairBudget
+            ),
+            "precondition: after spending the whole fresh-pair burst on a frozen \
+             clock, the next fresh pair must be refused with SenderNewPairBudget"
+        );
+        let budget_refusals_before = op_manager
+            .ring
+            .update_rate_limiter
+            .new_pair_budget_rejected_total();
+
+        let bridge = MockNetworkBridge::new();
+        let mut listener: Box<dyn NetEventRegister> =
+            Box::new(crate::tracing::DynamicRegister::new(vec![]));
+
+        handle_pure_network_message_v1(
+            NetMessageV1::Update(UpdateMsg::BroadcastTo {
+                id: Transaction::new::<UpdateMsg>(),
+                key,
+                payload: DeltaOrFullState::Delta(vec![1, 2, 3]),
+                sender_summary_bytes: Vec::new(),
+            }),
+            Some(sender_addr),
+            op_manager.clone(),
+            bridge.clone(),
+            listener.as_mut(),
+            None,
+        )
+        .await
+        .expect("dispatch must not error on a new-pair-budget drop");
+
+        assert_eq!(
+            op_manager
+                .ring
+                .update_rate_limiter
+                .new_pair_budget_rejected_total(),
+            budget_refusals_before + 1,
+            "precondition: the dispatch must have been refused by the new-pair \
+             budget, not by the per-pair interval"
+        );
+
+        let mut emitted = Vec::new();
+        while let Ok(ev) = notification_rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::SendInterestMessage {
+                message: crate::message::InterestMessage::ResyncRequest { key: k },
+                ..
+            }) = ev
+            {
+                emitted.push(k);
+            }
+        }
+        assert!(
+            emitted.is_empty(),
+            "#5510 gate A: a SenderNewPairBudget refusal MUST emit no repair — \
+             every gate downstream is vacant for a fresh contract id, so this \
+             would be ~1 ResyncRequest per refused message back at a flooder, \
+             each inviting a full-state response into a WASM merge. Got {emitted:?}"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "and it must take no node-wide follow-up slot"
+        );
+    }
+
+    /// #5510 gate B: a `Rejected` broadcast for a contract this node does NOT
+    /// hold must emit no repair.
+    ///
+    /// `key` is attacker-supplied and nothing before this point validates it.
+    /// The queue-full call sites in `op_ctx_task` are reached only after
+    /// `update_contract` returned `ContractQueueFull`, which proves the executor
+    /// holds the contract; the dispatch arm proves nothing. Without the gate an
+    /// attacker picks unlimited fresh keys, and because every key is a fresh
+    /// throttle entry AND a fresh emit-limiter bucket, none of the per-key
+    /// bounds bind.
+    ///
+    /// Same harness as `rate_limited_broadcast_emits_throttled_resync_request`
+    /// with one difference — no stored state and no subscription — so a failure
+    /// here is specifically the missing hosting gate.
+    #[tokio::test]
+    async fn rate_limited_broadcast_for_an_unheld_contract_emits_no_repair() {
+        use crate::message::{DeltaOrFullState, NetMessageV1};
+        use crate::operations::test_utils::MockNetworkBridge;
+        use crate::operations::update::UpdateMsg;
+        use crate::ring::update_rate_limit::UpdateClass;
+        use crate::util::time_source::SharedMockTimeSource;
+
+        let clock = SharedMockTimeSource::new();
+        let config_args = crate::config::ConfigArgs {
+            id: Some("unheld-contract-no-repair-5510".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let mut node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        node_config.update_rate_limit_time_source_override =
+            Some(std::sync::Arc::new(clock.clone()));
+
+        let (mut notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14400".parse().unwrap());
+
+        // An EMPTY store: the key below is not held, and with a store attached
+        // `contract_state_present` answers honestly rather than conservatively.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+        op_manager.ring.set_hosting_storage(storage);
+
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([51u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([52u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:15300".parse().unwrap();
+
+        assert!(
+            !op_manager.ring.should_summarize_or_broadcast(&key),
+            "precondition: this node must NOT hold the contract"
+        );
+
+        // Prime the pair so the dispatch below is a `Rejected` refusal — the one
+        // decision that DOES carry a repair. Only gate B can suppress it.
+        assert!(
+            op_manager
+                .ring
+                .update_rate_limiter
+                .check_and_record(sender_addr, *key.id(), UpdateClass::Broadcast)
+                .is_allowed(),
+            "precondition: the first broadcast for a fresh pair must be allowed"
+        );
+
+        let bridge = MockNetworkBridge::new();
+        let mut listener: Box<dyn NetEventRegister> =
+            Box::new(crate::tracing::DynamicRegister::new(vec![]));
+
+        handle_pure_network_message_v1(
+            NetMessageV1::Update(UpdateMsg::BroadcastTo {
+                id: Transaction::new::<UpdateMsg>(),
+                key,
+                payload: DeltaOrFullState::Delta(vec![1, 2, 3]),
+                sender_summary_bytes: Vec::new(),
+            }),
+            Some(sender_addr),
+            op_manager.clone(),
+            bridge.clone(),
+            listener.as_mut(),
+            None,
+        )
+        .await
+        .expect("dispatch must not error on a rate-limited drop");
+
+        assert_eq!(
+            op_manager.ring.update_rate_limiter.rejected_total(),
+            1,
+            "precondition: the dispatch must have been refused as `Rejected`, the \
+             decision that carries a repair"
+        );
+
+        let mut emitted = Vec::new();
+        while let Ok(ev) = notification_rx.notifications_receiver.try_recv() {
+            if let either::Either::Right(NodeEvent::SendInterestMessage {
+                message: crate::message::InterestMessage::ResyncRequest { key: k },
+                ..
+            }) = ev
+            {
+                emitted.push(k);
+            }
+        }
+        assert!(
+            emitted.is_empty(),
+            "#5510 gate B: a rate-limited broadcast for a contract we do NOT hold \
+             MUST emit no repair — `key` is attacker-supplied, and without this \
+             gate unlimited fresh keys each get a fresh throttle entry and a fresh \
+             emit-limiter bucket, so no per-key bound binds. Got {emitted:?}"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "and it must take no node-wide follow-up slot"
         );
     }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -488,6 +488,25 @@ pub struct NodeConfig {
     /// outside tests.
     #[serde(skip)]
     pub(crate) hosting_time_source_override: Option<crate::util::time_source::DynTimeSource>,
+
+    /// Optional clock override for the UPDATE dispatch rate limiter
+    /// (`crate::ring::update_rate_limit::UpdateRateLimiter`).
+    ///
+    /// SEPARATE from [`Self::hosting_time_source_override`] on purpose: the
+    /// hosting override is already read by several sims to compress hosting
+    /// TTLs, and folding the rate limiter onto it would silently change what
+    /// those sims measure. `None` in production, where the `Ring`'s default
+    /// `Arc<InstantTimeSrc>` is used.
+    ///
+    /// Exists so a test can decide the limiter's verdict rather than racing a
+    /// 100 ms wall-clock window: priming a `(sender, contract)` pair and then
+    /// dispatching a message that must be REJECTED is only deterministic if the
+    /// clock cannot advance in between (#5510).
+    ///
+    /// Not cfg-gated, for the same reason as `hosting_time_source_override`.
+    #[serde(skip)]
+    pub(crate) update_rate_limit_time_source_override:
+        Option<crate::util::time_source::DynTimeSource>,
 }
 
 impl NodeConfig {
@@ -672,6 +691,7 @@ impl NodeConfig {
             broadcast_target_list_floor_override: None,
             advertise_seeded_hosts: false,
             hosting_time_source_override: None,
+            update_rate_limit_time_source_override: None,
         })
     }
 
@@ -7167,6 +7187,223 @@ mod tests {
             }
             other => panic!("expected Some(ResyncResponse) for a held contract, got {other:?}"),
         }
+    }
+
+    /// #5510 behavioral reproduction: an inbound `BroadcastTo` REFUSED by the
+    /// UPDATE dispatch rate limiter MUST emit exactly one throttled
+    /// `ResyncRequest` back to the sender, and a refused `RequestUpdate` MUST
+    /// NOT.
+    ///
+    /// Why the asymmetry is the whole point of the test. The sender of a
+    /// broadcast has already cached its own summary as ours
+    /// (`broadcast_queue.rs::record_delivery_to_interest` refreshes on a local
+    /// enqueue, not on a receiver ack), and since #5464 every later broadcast
+    /// is a true difference against that belief — so the entries in the refused
+    /// message are excluded from every subsequent delta and the two peers stay
+    /// diverged permanently. Nothing else heals it: the delta-apply-failure
+    /// `ResyncRequest` needs an apply that FAILED, and nothing was applied.
+    /// A refused `RequestUpdate` is a routed request whose originator observes
+    /// the failure and caches no summary of us, so a resync for it would be
+    /// pure amplification onto a node already refusing this sender.
+    ///
+    /// On `origin/main` this FAILS at the first assertion: the rate-limiter arm
+    /// logs at `debug!` (compiled out of release builds) and `return Ok(())`,
+    /// so no repair is emitted and `first` is empty.
+    ///
+    /// DETERMINISM: the limiter's verdict is decided by a frozen
+    /// `SharedMockTimeSource` injected through
+    /// `NodeConfig::update_rate_limit_time_source_override`, NOT by racing the
+    /// 100 ms `MIN_UPDATE_INTERVAL` against wall time. Priming the pair and
+    /// then dispatching would otherwise be a wall-clock race, and a stall past
+    /// 100 ms would let the message through to a driver — which, with a
+    /// queue-full stand-in handler, would emit a `ResyncRequest` for a
+    /// DIFFERENT reason and make this test pass vacuously.
+    ///
+    /// The `#[tokio::test]` is deliberately NOT `start_paused`: the emit spawns
+    /// a trailing retry task (#4862) whose first re-dispatch is ~1.6-2.4 s out
+    /// on the throttle's clock, far beyond this synchronous test's window, so
+    /// the counts below are unaffected. Auto-advancing time would let that
+    /// retry fire and pollute them.
+    #[tokio::test]
+    async fn rate_limited_broadcast_emits_throttled_resync_request() {
+        use crate::message::{DeltaOrFullState, NetMessageV1};
+        use crate::operations::test_utils::MockNetworkBridge;
+        use crate::operations::update::UpdateMsg;
+        use crate::util::time_source::SharedMockTimeSource;
+
+        // Frozen clock for the limiter only (see DETERMINISM above).
+        let clock = SharedMockTimeSource::new();
+        let config_args = crate::config::ConfigArgs {
+            id: Some("rate-limited-broadcast-resync-5510".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let mut node_config = NodeConfig::new(config_args.build().await.expect("build Config"))
+            .await
+            .expect("build NodeConfig");
+        node_config.update_rate_limit_time_source_override =
+            Some(std::sync::Arc::new(clock.clone()));
+
+        let (mut notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14200".parse().unwrap());
+
+        let bridge = MockNetworkBridge::new();
+        let mut listener: Box<dyn NetEventRegister> =
+            Box::new(crate::tracing::DynamicRegister::new(vec![]));
+
+        let broadcast_key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([31u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([32u8; 32]),
+        );
+        let request_key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            freenet_stdlib::prelude::ContractInstanceId::new([33u8; 32]),
+            freenet_stdlib::prelude::CodeHash::new([34u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:15100".parse().unwrap();
+
+        // Drain the notification channel and return the targets of every
+        // ResyncRequest emitted for `key` since the last drain.
+        fn drain_resync_targets(
+            rx: &mut crate::node::EventLoopNotificationsReceiver,
+            key: freenet_stdlib::prelude::ContractKey,
+        ) -> Vec<SocketAddr> {
+            let mut targets = Vec::new();
+            while let Ok(ev) = rx.notifications_receiver.try_recv() {
+                if let either::Either::Right(NodeEvent::SendInterestMessage {
+                    target,
+                    message: crate::message::InterestMessage::ResyncRequest { key: k },
+                }) = ev
+                {
+                    if k == key {
+                        targets.push(target);
+                    }
+                }
+            }
+            targets
+        }
+
+        // Prime both pairs so the limiter is TRACKING them; on the frozen clock
+        // every subsequent check for the same pair is `Rejected` forever.
+        for key in [broadcast_key, request_key] {
+            assert!(
+                op_manager
+                    .ring
+                    .update_rate_limiter
+                    .check_and_record(sender_addr, *key.id())
+                    .is_allowed(),
+                "precondition: the first UPDATE for a fresh pair must be allowed"
+            );
+        }
+
+        let broadcast = |tx: Transaction, payload: Vec<u8>| {
+            NetMessageV1::Update(UpdateMsg::BroadcastTo {
+                id: tx,
+                key: broadcast_key,
+                payload: DeltaOrFullState::Delta(payload),
+                sender_summary_bytes: Vec::new(),
+            })
+        };
+
+        // 1. A refused BROADCAST emits exactly one ResyncRequest to the sender.
+        handle_pure_network_message_v1(
+            broadcast(Transaction::new::<UpdateMsg>(), vec![1, 2, 3]),
+            Some(sender_addr),
+            op_manager.clone(),
+            bridge.clone(),
+            listener.as_mut(),
+            None,
+        )
+        .await
+        .expect("dispatch must not error on a rate-limited drop");
+
+        assert_eq!(
+            op_manager.ring.update_rate_limiter.rejected_total(),
+            1,
+            "precondition: the frozen clock must make the second check for a \
+             tracked pair a per-pair rejection (not a capacity or new-pair-budget \
+             drop, which are different arms)"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, broadcast_key),
+            vec![sender_addr],
+            "#5510: a rate-limiter drop of a BroadcastTo MUST emit exactly one \
+             ResyncRequest so the sender clears its poisoned summary cache and \
+             re-sends — otherwise the lost entries are excluded from every later \
+             delta and the peers stay diverged permanently"
+        );
+
+        // 2. A second refused broadcast within the throttle window emits none
+        //    (bounds the #4251 amplification).
+        handle_pure_network_message_v1(
+            broadcast(Transaction::new::<UpdateMsg>(), vec![4, 5, 6]),
+            Some(sender_addr),
+            op_manager.clone(),
+            bridge.clone(),
+            listener.as_mut(),
+            None,
+        )
+        .await
+        .expect("dispatch must not error on a rate-limited drop");
+
+        assert!(
+            drain_resync_targets(&mut notification_rx, broadcast_key).is_empty(),
+            "a second rate-limiter drop within the throttle window MUST NOT emit \
+             another ResyncRequest (bounds #4251 amplification)"
+        );
+
+        // 3. A refused REQUEST emits none. Distinct contract key, so its own
+        //    (contract, sender) resync window is untouched by steps 1-2 — a
+        //    shared key would make this pass for the wrong reason.
+        handle_pure_network_message_v1(
+            NetMessageV1::Update(UpdateMsg::RequestUpdate {
+                id: Transaction::new::<UpdateMsg>(),
+                key: request_key,
+                related_contracts: freenet_stdlib::prelude::RelatedContracts::default(),
+                value: freenet_stdlib::prelude::WrappedState::new(vec![7, 8, 9]),
+            }),
+            Some(sender_addr),
+            op_manager.clone(),
+            bridge.clone(),
+            listener.as_mut(),
+            None,
+        )
+        .await
+        .expect("dispatch must not error on a rate-limited drop");
+
+        assert_eq!(
+            op_manager.ring.update_rate_limiter.rejected_total(),
+            3,
+            "precondition: all three dispatches must have been refused by the \
+             per-pair rate limit"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, request_key).is_empty(),
+            "#5510: a rate-limiter drop of a RequestUpdate MUST NOT emit a \
+             ResyncRequest — its originator observes the failure and it caches no \
+             summary of us, so a resync here is pure amplification onto a node \
+             already refusing this sender"
+        );
     }
 
     /// #4864 round-8 (Codex P1): an UNSOLICITED `ResyncResponse` — one with NO

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1243,18 +1243,64 @@ async fn drive_relay_request_update(
     Ok(())
 }
 
-/// On a queue-full broadcast drop, emit a RATE-LIMITED `ResyncRequest` to the
-/// sender so it clears its poisoned summary cache of us and re-sends the change
-/// it believes we already have (#4857).
+/// Why an inbound broadcast was dropped, for
+/// [`send_dropped_broadcast_resync_request`]'s telemetry.
 ///
-/// A `ContractQueueFull` drop is SILENT: the receiver never applied the delta /
-/// full state, but the SENDER cached its own summary as ours on send-Ok
+/// The repair is identical for both — the sender's summary cache is poisoned
+/// the same way either way — but the OPERATOR reading `resync_request_sent`
+/// needs to tell them apart: a queue-full drop means this node's executor is
+/// saturated, a rate-limited drop means the `(sender, contract)` pair exceeded
+/// the dispatch budget in `crate::ring::update_rate_limit`. Those call for
+/// different responses, so they must not share one label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DroppedBroadcastReason {
+    /// `ContractQueueFull` from the executor (#4857).
+    QueueFull,
+    /// Refused by the per-(sender, contract) UPDATE dispatch rate limiter
+    /// in `node.rs` before any driver ran (#5510).
+    RateLimited,
+}
+
+impl DroppedBroadcastReason {
+    /// Stable telemetry label. `"queue_full"` is preserved verbatim from the
+    /// pre-#5510 log line so existing operator greps keep working.
+    fn as_str(self) -> &'static str {
+        match self {
+            DroppedBroadcastReason::QueueFull => "queue_full",
+            DroppedBroadcastReason::RateLimited => "rate_limited",
+        }
+    }
+}
+
+/// On a DROPPED inbound broadcast, emit a RATE-LIMITED `ResyncRequest` to the
+/// sender so it clears its poisoned summary cache of us and re-sends the change
+/// it believes we already have (#4857, #5510).
+///
+/// Two distinct drops land here, and the reason they need the SAME repair is
+/// the reason they are handled by one helper:
+///
+/// - `ContractQueueFull` at the executor (#4857) — the delta / full state
+///   reached this node but was never applied.
+/// - Refusal by the dispatch rate limiter in `node.rs` (#5510) — the payload
+///   never even reached a driver. `reason` distinguishes the two in telemetry;
+///   see `DroppedBroadcastReason`.
+///
+/// Both are SILENT to the sender: it cached its own summary as ours on send-Ok
 /// (`broadcast_queue.rs::record_delivery_to_interest`), so it believes we are
-/// current and will never re-send the dropped change. Left unhealed, a
-/// rarely-changing field (member_info, a ban, a config) diverges permanently
-/// until the ~5-min InterestSync heartbeat happens to correct it. An inbound
-/// `ResyncRequest` makes the sender clear that cached summary (node.rs handler)
-/// and re-send full state.
+/// current and will never re-send the dropped change. Since #5464 the payload
+/// is a true difference against that belief, so once the belief is wrong the
+/// lost entries are excluded from every LATER delta too — the divergence is
+/// permanent, not just delayed. Left unhealed, a rarely-changing field
+/// (member_info, a ban, a config) diverges until the InterestSync heartbeat
+/// happens to correct it, which is 300s at minimum and 40-75 min at field
+/// shared-set sizes since #5238/#5346. An inbound `ResyncRequest` makes the
+/// sender clear that cached summary (node.rs handler) and re-send full state.
+///
+/// The `ResyncRequest` this emits, and the `ResyncResponse` it provokes, both
+/// ride `NetMessageV1::InterestSync` — NOT `NetMessageV1::Update` — so neither
+/// is subject to the UPDATE dispatch rate limiter that caused the #5510 drop.
+/// The repair therefore cannot be silenced by the condition it repairs. do NOT
+/// move this repair onto an `Update` wire variant.
 ///
 /// Issue #4251 suppressed this entirely because one request per dropped delta
 /// amplifies into a full-state storm onto the same saturated queue (~40
@@ -1263,16 +1309,18 @@ async fn drive_relay_request_update(
 /// request per (contract, sender) per `RESYNC_REQUEST_MIN_INTERVAL`.
 ///
 /// Shared by both broadcast drivers (`drive_relay_broadcast_to` and
-/// `drive_relay_broadcast_to_streaming`) so the two queue-full paths cannot
-/// drift. The caller keeps auto-fetch suppressed on queue-full (we already hold
-/// the contract; a GET onto the same saturated queue is pure amplification).
+/// `drive_relay_broadcast_to_streaming`) and by the `node.rs` rate-limiter drop
+/// arm, so the three drop paths cannot drift. The queue-full callers keep
+/// auto-fetch suppressed (we already hold the contract; a GET onto the same
+/// saturated queue is pure amplification).
 ///
 /// do NOT re-add an unthrottled emission — see #4251/#4857.
-async fn send_queue_full_resync_request(
+pub(crate) async fn send_dropped_broadcast_resync_request(
     op_manager: &OpManager,
     key: ContractKey,
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
+    reason: DroppedBroadcastReason,
 ) {
     // Gate 1 — per-(contract, sender)/30s throttle (#4857/#4862 + #4864 round-6).
     // RESERVE the window atomically (`begin` checks AND records under the
@@ -1291,7 +1339,8 @@ async fn send_queue_full_resync_request(
             contract = %key,
             sender = %sender_addr,
             event = "queue_full_resync_throttled",
-            "UPDATE relay: queue-full ResyncRequest throttled (rate limit) to avoid amplification"
+            reason = reason.as_str(),
+            "UPDATE relay: dropped-broadcast ResyncRequest throttled (rate limit) to avoid amplification"
         );
         return;
     };
@@ -1319,7 +1368,8 @@ async fn send_queue_full_resync_request(
             contract = %key,
             sender = %sender_addr,
             event = "queue_full_resync_suppressed_global",
-            "UPDATE relay: queue-full ResyncRequest suppressed by global per-contract cap"
+            reason = reason.as_str(),
+            "UPDATE relay: dropped-broadcast ResyncRequest suppressed by global per-contract cap"
         );
         return;
     }
@@ -1330,8 +1380,9 @@ async fn send_queue_full_resync_request(
         contract = %key,
         target = %sender_addr,
         event = "resync_request_sent",
-        reason = "queue_full",
-        "UPDATE relay: sending rate-limited ResyncRequest after queue-full drop (#4857)"
+        reason = reason.as_str(),
+        "UPDATE relay: sending rate-limited ResyncRequest after a dropped inbound \
+         broadcast (#4857/#5510)"
     );
     // #4864 round-8: record the outstanding request so the matching ResyncResponse
     // from this peer is authorized ONCE at the receive arm; an unsolicited or
@@ -1386,7 +1437,7 @@ async fn send_queue_full_resync_request(
         let op_mgr = op_manager.clone();
         GlobalExecutor::spawn(async move {
             let _slot = slot; // frees the node-wide retry slot on task exit
-            resend_queue_full_resync_request(
+            resend_dropped_broadcast_resync_request(
                 &op_mgr,
                 key,
                 sender_addr,
@@ -1401,7 +1452,7 @@ async fn send_queue_full_resync_request(
     // Immediate (first) ResyncRequest — blocking best-effort enqueue. The
     // #4862 trailing retry above re-sends the SAME request and relies on the ONE
     // correlation record made before the spawn — see
-    // `resend_queue_full_resync_request`.
+    // `resend_dropped_broadcast_resync_request`.
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {
             target: sender_addr,
@@ -1428,7 +1479,7 @@ const QUEUE_FULL_RESYNC_MAX_RETRIES: u32 = 2;
 /// Base inter-attempt delay for queue-full `ResyncRequest` retries (#4857 P2).
 ///
 /// Linear backoff: the `attempt`-th retry waits ~`attempt * BASE` (±20%
-/// jitter), MEASURED ON THE THROTTLE'S CLOCK (see `resend_queue_full_resync_request`).
+/// jitter), MEASURED ON THE THROTTLE'S CLOCK (see `resend_dropped_broadcast_resync_request`).
 /// The worst-case total span (`sum_{n=1..=MAX} n * BASE * 1.2` = 3 · 2s · 1.2 =
 /// 7.2s for the current constants) stays comfortably under
 /// `RESYNC_REQUEST_MIN_INTERVAL` (30s); the retry is ALSO hard-stopped at the
@@ -1439,7 +1490,7 @@ const QUEUE_FULL_RESYNC_RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
 /// Poll granularity for the injected-clock retry wait (#4857 P2).
 ///
 /// The util `TimeSource` the throttle uses exposes only `now()` — no sleep — so
-/// `resend_queue_full_resync_request` waits by polling `interest_manager.now()`
+/// `resend_dropped_broadcast_resync_request` waits by polling `interest_manager.now()`
 /// in bounded `tokio` increments until the injected clock reaches the attempt's
 /// target (or the reservation deadline). Small enough that a retry fires
 /// promptly once the clock reaches its target; large enough that wakeups stay
@@ -1466,7 +1517,7 @@ fn jittered_resync_retry_delay(attempt: u32) -> Duration {
 /// Trailing best-effort re-dispatch of a queue-full `ResyncRequest` (#4857 P2).
 ///
 /// Runs as a short-lived fire-and-forget task spawned by
-/// [`send_queue_full_resync_request`] AFTER its immediate ResyncRequest, and
+/// [`send_dropped_broadcast_resync_request`] AFTER its immediate ResyncRequest, and
 /// ONLY when the throttle reservation was granted. It re-dispatches the same
 /// ResyncRequest up to [`QUEUE_FULL_RESYNC_MAX_RETRIES`] times with jittered
 /// backoff so a resync dropped by the lossy event-loop → `P2pBridge::try_send`
@@ -1535,7 +1586,7 @@ fn jittered_resync_retry_delay(attempt: u32) -> Duration {
 /// do NOT add a `begin_resync_request`/`resync_emit_limiter` call here, do NOT
 /// switch to a blocking `notify_node_event`, and do NOT drive the delay/deadline
 /// off a clock other than `interest_manager.now()` — see #4251/#4857/#4864.
-async fn resend_queue_full_resync_request(
+async fn resend_dropped_broadcast_resync_request(
     op_manager: &OpManager,
     key: ContractKey,
     sender_addr: SocketAddr,
@@ -2153,7 +2204,14 @@ async fn drive_relay_broadcast_to(
                 // change. Emit a rate-limited ResyncRequest so it re-syncs. The
                 // auto-fetch branch stays suppressed on queue-full (we already
                 // hold the contract). Shared with the streaming driver.
-                send_queue_full_resync_request(op_manager, key, sender_addr, incoming_tx).await;
+                send_dropped_broadcast_resync_request(
+                    op_manager,
+                    key,
+                    sender_addr,
+                    incoming_tx,
+                    DroppedBroadcastReason::QueueFull,
+                )
+                .await;
             }
             return Err(err);
         }
@@ -2954,7 +3012,14 @@ async fn apply_streaming_broadcast(
                 // deltas merge onto a diverged base WITHOUT error — the
                 // delta-apply-failure heal never fires. Emit the same
                 // rate-limited ResyncRequest as the non-streaming path.
-                send_queue_full_resync_request(op_manager, key, sender_addr, incoming_tx).await;
+                send_dropped_broadcast_resync_request(
+                    op_manager,
+                    key,
+                    sender_addr,
+                    incoming_tx,
+                    DroppedBroadcastReason::QueueFull,
+                )
+                .await;
             }
             return Err(err);
         }
@@ -3903,7 +3968,7 @@ mod tests {
     /// broadcast drop, BOTH broadcast drivers must emit a RATE-LIMITED
     /// `ResyncRequest` — neither suppress it (permanent divergence, #4857) nor
     /// emit it unthrottled (full-state storm, #4251). Both route through the
-    /// shared `send_queue_full_resync_request` helper, which gates the
+    /// shared `send_dropped_broadcast_resync_request` helper, which gates the
     /// `InterestMessage::ResyncRequest` emit behind BOTH the per-(contract, sender)
     /// `begin_resync_request` throttle AND the global per-contract
     /// `resync_emit_limiter` cap (each a `!gate { return; }` guard before the
@@ -3949,9 +4014,9 @@ mod tests {
         );
         let ns_arm = queue_full_arm(ns, "} else if queue_full {");
         assert!(
-            ns_arm.contains("send_queue_full_resync_request("),
+            ns_arm.contains("send_dropped_broadcast_resync_request("),
             "drive_relay_broadcast_to queue-full arm MUST delegate to \
-             send_queue_full_resync_request (heals #4857)"
+             send_dropped_broadcast_resync_request (heals #4857)"
         );
         assert!(
             !ns_arm.contains("try_auto_fetch_contract"),
@@ -3982,9 +4047,9 @@ mod tests {
         );
         let st_arm = queue_full_arm(st, "} else if queue_full {");
         assert!(
-            st_arm.contains("send_queue_full_resync_request("),
+            st_arm.contains("send_dropped_broadcast_resync_request("),
             "apply_streaming_broadcast queue-full arm MUST delegate to \
-             send_queue_full_resync_request — otherwise #4857 stays OPEN on the \
+             send_dropped_broadcast_resync_request — otherwise #4857 stays OPEN on the \
              streaming full-state path"
         );
         assert!(
@@ -4000,7 +4065,7 @@ mod tests {
         // lock) then RELEASED (`cancel`) if the global cap rejects (#4864 round-6
         // item 2), so concurrent callbacks can't both pass and a globally
         // suppressed emit does not burn the window.
-        let helper = fn_body("async fn send_queue_full_resync_request(");
+        let helper = fn_body("async fn send_dropped_broadcast_resync_request(");
         let per_sender = helper.find(".begin_resync_request(").expect(
             "helper must RESERVE the per-sender throttle atomically via \
              begin_resync_request (#4864 round-6 item 2)",
@@ -4851,8 +4916,8 @@ mod tests {
     fn queue_full_resync_helper_goes_through_global_emit_cap() {
         let src = include_str!("op_ctx_task.rs");
         let start = src
-            .find("async fn send_queue_full_resync_request(")
-            .expect("send_queue_full_resync_request not found");
+            .find("async fn send_dropped_broadcast_resync_request(")
+            .expect("send_dropped_broadcast_resync_request not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -4884,9 +4949,9 @@ mod tests {
         let prod_end = src.find("\nmod tests {").unwrap_or(src.len());
         let prod = &src[..prod_end];
 
-        // EXEMPT the #4862 queue-full RETRY (`resend_queue_full_resync_request`).
+        // EXEMPT the #4862 queue-full RETRY (`resend_dropped_broadcast_resync_request`).
         // It RE-DELIVERS an emit whose `outstanding_resync_requests.record(...)`
-        // was ALREADY made by `send_queue_full_resync_request` (the initial). It
+        // was ALREADY made by `send_dropped_broadcast_resync_request` (the initial). It
         // deliberately does NOT re-record, because re-recording would re-authorize
         // a REDUNDANT `ResyncResponse` — the opposite of round-8's drop-the-
         // redundant intent (and would re-run the full-state WASM merge the record
@@ -4895,8 +4960,8 @@ mod tests {
         // once that record is consumed, a further retry's response is correctly
         // dropped. So the retry's re-send is legitimately un-recorded — skip it.
         let retry_start = prod
-            .find("async fn resend_queue_full_resync_request(")
-            .expect("resend_queue_full_resync_request (the #4862 retry) not found");
+            .find("async fn resend_dropped_broadcast_resync_request(")
+            .expect("resend_dropped_broadcast_resync_request (the #4862 retry) not found");
         let retry_end = retry_start
             + 1
             + prod[retry_start + 1..]
@@ -5533,7 +5598,7 @@ mod tests {
     /// path (event loop → `P2pBridge::try_send`) and can be dropped under the
     /// same backpressure that caused the queue-full drop. If it is, the sender
     /// never clears its poisoned summary and a one-off change diverges until the
-    /// ~5-min heartbeat. `send_queue_full_resync_request` therefore schedules a
+    /// ~5-min heartbeat. `send_dropped_broadcast_resync_request` therefore schedules a
     /// BOUNDED trailing retry that re-dispatches the ResyncRequest within the
     /// single reserved throttle window.
     ///
@@ -5883,7 +5948,7 @@ mod tests {
         let reservation_deadline = op_manager.interest_manager.now() + Duration::from_secs(30);
 
         // This test drives the retry DIRECTLY, so it does what the real caller
-        // (`send_queue_full_resync_request`) does and records the outstanding
+        // (`send_dropped_broadcast_resync_request`) does and records the outstanding
         // request first.
         //
         // Note this record is INERT here, and deliberately so: the injected clock
@@ -5900,7 +5965,7 @@ mod tests {
 
         let op_mgr = op_manager.clone();
         let handle = tokio::spawn(async move {
-            resend_queue_full_resync_request(
+            resend_dropped_broadcast_resync_request(
                 &op_mgr,
                 key,
                 sender_addr,
@@ -5934,7 +5999,7 @@ mod tests {
     /// Issue #4862 (P1): the node-wide retry-task cap bounds outstanding retry
     /// tasks even when the throttle LRU evicts active reservations under key
     /// churn. Reserving up to the cap succeeds; the next reservation is refused
-    /// (so `send_queue_full_resync_request` skips the spawn — the immediate
+    /// (so `send_dropped_broadcast_resync_request` skips the spawn — the immediate
     /// ResyncRequest still sends); freeing a slot re-admits exactly one. The
     /// outstanding count never exceeds the cap (hard CAS cap). Uses a per-node
     /// OpManager so the count is isolated from other tests.
@@ -6023,7 +6088,7 @@ mod tests {
         // (~1.6-2.4s), so a fixed first target would exceed it.
         let reservation_deadline = op_manager.interest_manager.now() + Duration::from_millis(500);
         // Driving the retry DIRECTLY, so record the outstanding request the way
-        // the real caller (`send_queue_full_resync_request`) does — otherwise the
+        // the real caller (`send_dropped_broadcast_resync_request`) does — otherwise the
         // #4863 landed-gate skips every attempt and this test would fail for a
         // reason unrelated to the clamp it is pinning. (Unlike the frozen-clock
         // test, the gate IS reachable here — the 500ms deadline clamps the first
@@ -6034,7 +6099,7 @@ mod tests {
             .record(*key.id(), sender_addr);
         let op_mgr = op_manager.clone();
         let handle = tokio::spawn(async move {
-            resend_queue_full_resync_request(
+            resend_dropped_broadcast_resync_request(
                 &op_mgr,
                 key,
                 sender_addr,
@@ -6094,7 +6159,7 @@ mod tests {
         // per-(contract, sender) throttle reservation (`begin_resync_request`) and
         // the global per-contract emit cap (`resync_emit_limiter`, #4864) — so it
         // never runs on a throttled or globally-suppressed drop.
-        let helper = fn_body("async fn send_queue_full_resync_request(");
+        let helper = fn_body("async fn send_dropped_broadcast_resync_request(");
         let gate = helper
             .find(".begin_resync_request(")
             .expect("helper must gate on begin_resync_request (per-sender throttle, #4251)");
@@ -6102,7 +6167,7 @@ mod tests {
             .find("resync_emit_limiter")
             .expect("helper must gate on the global per-contract emit cap (#4864)");
         let spawn = helper
-            .find("resend_queue_full_resync_request(")
+            .find("resend_dropped_broadcast_resync_request(")
             .expect("helper must schedule the trailing retry (heal #4857 P2)");
         assert!(
             gate < spawn && global_cap < spawn,
@@ -6178,13 +6243,13 @@ mod tests {
         // ResyncResponse look unsolicited). So the retry creates no new
         // reservation and consumes no extra global token (storm bound #4251 /
         // #4864 cap).
-        let retry = fn_body("async fn resend_queue_full_resync_request(");
+        let retry = fn_body("async fn resend_dropped_broadcast_resync_request(");
         assert!(
             !retry.contains("begin_resync_request")
                 && !retry.contains("resync_emit_limiter")
                 && !retry.contains(".record(")
                 && !retry.contains(".consume("),
-            "resend_queue_full_resync_request must NOT re-consult the throttle or \
+            "resend_dropped_broadcast_resync_request must NOT re-consult the throttle or \
              the global emit cap, and must neither re-record NOR consume the \
              outstanding-request entry — its sends belong to the caller's single \
              granted reservation, and the entry's consumption belongs to the \

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2117,6 +2117,24 @@ async fn drive_relay_broadcast_to(
             let queue_full = err.is_contract_queue_full() || err.is_scheduler_timeout();
 
             if is_delta && !queue_full {
+                // #5510: count THIS cause at the branch that DECIDES it, which
+                // is here — above the emit cap, not inside it.
+                //
+                // `GlobalTestMetrics::resync_requests()` is the total across
+                // every cause, and since this PR there are several, so a test
+                // asserting "no delta failed" cannot use the total without
+                // mistaking a rate-limited broadcast repair for the #2763
+                // summary-caching regression. But the counter must describe the
+                // FAILURE, not the emission: `simulation_integration.rs` reads
+                // it as "no delta failed to apply", and a delta that failed
+                // while the global cap happened to be exhausted failed just the
+                // same. Counting inside the `if` would have made the assertion
+                // quietly weaker exactly when the node is busy enough for the
+                // cap to bind — which is when a real regression is most likely.
+                // Same rule as `.claude/rules/bug-prevention-patterns.md`: the
+                // metric is produced by the code that makes the decision.
+                crate::config::GlobalTestMetrics::record_delta_failure_resync();
+
                 // Delta application failed → send ResyncRequest. Mirrors
                 // update.rs:710-758. Rate-limited per-contract (#4861): a poison
                 // contract that fails deltas from many senders must not drive a
@@ -2129,13 +2147,6 @@ async fn drive_relay_broadcast_to(
                     .resync_emit_limiter
                     .check_and_record(*key.id())
                 {
-                    // #5510: count THIS cause at the branch that decides it.
-                    // `GlobalTestMetrics::resync_requests()` is the total across
-                    // every cause, and since this PR there are several, so a
-                    // test asserting "no delta failed" cannot use the total
-                    // without mistaking a rate-limited broadcast repair for the
-                    // #2763 summary-caching regression.
-                    crate::config::GlobalTestMetrics::record_delta_failure_resync();
                     tracing::warn!(
                         tx = %incoming_tx,
                         contract = %key,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -3994,10 +3994,28 @@ mod tests {
         let fn_body = |name: &str| -> &str {
             let start = src.find(name).unwrap_or_else(|| panic!("{name} not found"));
             let after = &src[start + 1..];
-            let end = after
-                .find("\nasync fn ")
-                .or_else(|| after.find("\n#[cfg(test)]"))
-                .unwrap_or(after.len());
+            // Terminate on ANY fn opener, not just `async fn` (review finding
+            // 19). Plain `fn`s sit between the async ones this pin slices —
+            // `jittered_resync_retry_delay` between the two resync fns,
+            // `seed_sender_summary_from_broadcast` before the broadcast driver
+            // — so an `async fn`-only terminator ran a slice straight through
+            // them into the NEXT async fn, and a gate deleted from the sliced
+            // function would still satisfy the pin as long as the same
+            // identifier appeared anywhere downstream. Taking the MINIMUM
+            // rather than the first match matters: the openers are not in
+            // source order.
+            let end = [
+                "\nasync fn ",
+                "\nfn ",
+                "\npub async fn ",
+                "\npub fn ",
+                "\npub(",
+            ]
+            .iter()
+            .filter_map(|kw| after.find(kw))
+            .chain(after.find("\n#[cfg(test)]"))
+            .min()
+            .unwrap_or(after.len());
             &src[start..start + 1 + end]
         };
         // Slice the queue-full match arm (from `marker` up to its closing
@@ -6246,10 +6264,28 @@ mod tests {
         let fn_body = |name: &str| -> &str {
             let start = src.find(name).unwrap_or_else(|| panic!("{name} not found"));
             let after = &src[start + 1..];
-            let end = after
-                .find("\nasync fn ")
-                .or_else(|| after.find("\n#[cfg(test)]"))
-                .unwrap_or(after.len());
+            // Terminate on ANY fn opener, not just `async fn` (review finding
+            // 19). Plain `fn`s sit between the async ones this pin slices —
+            // `jittered_resync_retry_delay` between the two resync fns,
+            // `seed_sender_summary_from_broadcast` before the broadcast driver
+            // — so an `async fn`-only terminator ran a slice straight through
+            // them into the NEXT async fn, and a gate deleted from the sliced
+            // function would still satisfy the pin as long as the same
+            // identifier appeared anywhere downstream. Taking the MINIMUM
+            // rather than the first match matters: the openers are not in
+            // source order.
+            let end = [
+                "\nasync fn ",
+                "\nfn ",
+                "\npub async fn ",
+                "\npub fn ",
+                "\npub(",
+            ]
+            .iter()
+            .filter_map(|kw| after.find(kw))
+            .chain(after.find("\n#[cfg(test)]"))
+            .min()
+            .unwrap_or(after.len());
             &src[start..start + 1 + end]
         };
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1463,7 +1463,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
         tracing::warn!(
             tx = %incoming_tx,
             error = %e,
-            "UPDATE relay: failed to send queue-full ResyncRequest"
+            "UPDATE relay: failed to send dropped-broadcast ResyncRequest"
         );
     }
 }
@@ -1514,11 +1514,16 @@ fn jittered_resync_retry_delay(attempt: u32) -> Duration {
     QUEUE_FULL_RESYNC_RETRY_BASE_DELAY.mul_f64(attempt as f64 * factor)
 }
 
-/// Trailing best-effort re-dispatch of a queue-full `ResyncRequest` (#4857 P2).
+/// Trailing best-effort re-dispatch of a dropped-broadcast `ResyncRequest`
+/// (#4857 P2).
 ///
 /// Runs as a short-lived fire-and-forget task spawned by
-/// [`send_dropped_broadcast_resync_request`] AFTER its immediate ResyncRequest, and
-/// ONLY when the throttle reservation was granted. It re-dispatches the same
+/// [`send_dropped_broadcast_resync_request`] AFTER its immediate ResyncRequest,
+/// and ONLY when the throttle reservation was granted. It serves whichever drop
+/// caused that emit; the `queue_full_resync_retry_*` log events keep their
+/// pre-#5510 names (they are `debug!`, so they never reached a release build
+/// and no operator grep depends on them) rather than churning a mechanism this
+/// change does not alter. It re-dispatches the same
 /// ResyncRequest up to [`QUEUE_FULL_RESYNC_MAX_RETRIES`] times with jittered
 /// backoff so a resync dropped by the lossy event-loop → `P2pBridge::try_send`
 /// path still heals the divergence before the ~5-min heartbeat.
@@ -1712,8 +1717,8 @@ async fn resend_dropped_broadcast_resync_request(
                 target = %sender_addr,
                 attempt,
                 event = "queue_full_resync_retry_skipped_landed",
-                "UPDATE relay: queue-full ResyncRequest already landed (its \
-                 ResyncResponse was consumed), skipping the redundant \
+                "UPDATE relay: dropped-broadcast ResyncRequest already landed \
+                 (its ResyncResponse was consumed), skipping the redundant \
                  full-state re-dispatch (#4863)"
             );
             return;

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -2129,6 +2129,13 @@ async fn drive_relay_broadcast_to(
                     .resync_emit_limiter
                     .check_and_record(*key.id())
                 {
+                    // #5510: count THIS cause at the branch that decides it.
+                    // `GlobalTestMetrics::resync_requests()` is the total across
+                    // every cause, and since this PR there are several, so a
+                    // test asserting "no delta failed" cannot use the total
+                    // without mistaking a rate-limited broadcast repair for the
+                    // #2763 summary-caching regression.
+                    crate::config::GlobalTestMetrics::record_delta_failure_resync();
                     tracing::warn!(
                         tx = %incoming_tx,
                         contract = %key,
@@ -4556,6 +4563,92 @@ mod tests {
         Box<dyn std::any::Any>,
     ) {
         build_broadcast_test_node(id, DeltaOutcome::ExecReject).await
+    }
+
+    /// #5510: a delta that FAILS TO APPLY increments the delta-failure resync
+    /// counter, and a queue-full drop does NOT.
+    ///
+    /// This is what stops `test_full_state_send_no_incorrect_caching`'s new
+    /// assertion from being vacuous. That test asserts
+    /// `delta_failure_resyncs() == 0`, having previously asserted on the TOTAL
+    /// resync count; if the counter were never incremented the assertion would
+    /// pass forever and the #2763 summary-caching regression it guards would
+    /// walk straight through it. So: prove the counter FIRES on the cause it
+    /// names, and prove it does NOT fire on a different cause that also emits a
+    /// ResyncRequest — otherwise it would be the same over-broad proxy under a
+    /// new name.
+    #[tokio::test]
+    async fn a_failed_delta_is_counted_separately_from_a_queue_full_drop() {
+        // (a) FIRES on a delta-apply failure.
+        crate::config::GlobalTestMetrics::reset();
+        let (op_manager, mut notification_rx, _queries, _guard) =
+            build_broadcast_test_node("delta-failure-metric-5510", DeltaOutcome::ExecReject).await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([81u8; 32]),
+            CodeHash::new([82u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:13300".parse().unwrap();
+
+        let r = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(r.is_err(), "the stand-in handler must reject the delta");
+        assert_eq!(
+            crate::config::GlobalTestMetrics::delta_failure_resyncs(),
+            1,
+            "a delta that failed to apply MUST be counted as a delta-failure \
+             resync — this is the #2763 signal, and a counter that never fires \
+             turns its assertion into a no-op"
+        );
+        drain_resync_targets(&mut notification_rx, key);
+
+        // (b) does NOT fire on a queue-full drop, which also emits a
+        //     ResyncRequest but is a different cause entirely.
+        crate::config::GlobalTestMetrics::reset();
+        let (qf_manager, mut qf_rx, _qf_guard) =
+            build_queue_full_test_node("delta-failure-metric-5510-qf").await;
+        let qf_key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([83u8; 32]),
+            CodeHash::new([84u8; 32]),
+        );
+        let qf_sender: SocketAddr = "127.0.0.1:13400".parse().unwrap();
+
+        let qf = drive_relay_broadcast_to(
+            &qf_manager,
+            Transaction::new::<UpdateMsg>(),
+            qf_key,
+            DeltaOrFullState::Delta(vec![4, 5, 6]),
+            Vec::new(),
+            qf_sender,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(
+            qf.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error, got {qf:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut qf_rx, qf_key),
+            vec![qf_sender],
+            "precondition: the queue-full drop DID emit a ResyncRequest, so this \
+             is a real discrimination test rather than a scenario with no resync"
+        );
+        assert_eq!(
+            crate::config::GlobalTestMetrics::delta_failure_resyncs(),
+            0,
+            "a queue-full drop emits a ResyncRequest but NO delta failed, so it \
+             must not be counted as one — counting it would rebuild the same \
+             over-broad proxy #5510 replaced"
+        );
     }
 
     /// #4864 review (testing H1): the load-bearing #4861 behavior — the backoff

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -690,7 +690,14 @@ impl Ring {
             broken_invariants: BrokenInvariantsTracker::new(time_source.clone()),
             governance,
             update_rate_limiter: Arc::new(update_rate_limit::UpdateRateLimiter::new(
-                time_source.clone(),
+                // Production passes `None` and gets `time_source` (the real
+                // clock). The override exists so a test can decide the
+                // limiter's verdict instead of racing MIN_UPDATE_INTERVAL —
+                // see `NodeConfig::update_rate_limit_time_source_override`.
+                config
+                    .update_rate_limit_time_source_override
+                    .clone()
+                    .unwrap_or_else(|| time_source.clone()),
                 max_connections,
             )),
             merge_backoff: Arc::new(merge_backoff::MergeBackoff::new(time_source.clone())),

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -223,7 +223,7 @@ pub(crate) fn interest_delta_budget_for(total_ram: usize) -> usize {
 ///
 /// `pub(crate)` so the UPDATE queue-full retry (#4857 P2) can size its own
 /// tokio-clock liveness backstop to exactly one reservation window — see
-/// `operations::update::op_ctx_task::resend_queue_full_resync_request`.
+/// `operations::update::op_ctx_task::resend_dropped_broadcast_resync_request`.
 pub(crate) const RESYNC_REQUEST_MIN_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Bound on the number of (contract, peer) entries in the queue-full

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -234,6 +234,144 @@ use crate::util::time_source::TimeSource;
 /// flood pattern instantly.
 pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Minimum interval between accepted co-host BROADCASTs for the same
+/// `(sender, contract)` pair. Default 20 ms (≈50/s).
+///
+/// # Why this is not [`MIN_UPDATE_INTERVAL`] (#5510)
+///
+/// [`MIN_UPDATE_INTERVAL`]'s rationale is about a HUMAN writing to a
+/// contract, and it is right about that. It is the wrong reference class
+/// for a broadcast, because a broadcast is not a write: it is the
+/// DERIVED fan-out of a write that some peer already committed. One
+/// commit produces one broadcast per co-host neighbour, so the broadcast
+/// rate on a single `(sender, contract)` pair is the contract's
+/// AGGREGATE commit rate summed over every writer reachable through that
+/// neighbour — not one writer's cadence. A room with a few dozen people
+/// typing exceeds 10/s on one pair routinely, with no attacker involved.
+///
+/// Applying the write-cadence number to fan-out is what made #5510 a
+/// correctness bug rather than a throttle: honest co-host traffic was
+/// refused, the sender recorded it as delivered, and the two peers
+/// diverged permanently.
+///
+/// # What 20 ms is calibrated against
+///
+/// Measured on `test_ping_multi_node` (3 nodes, 3 rounds, the workload
+/// that surfaced #5510): 28 refusals in one run, 7-12 per pair, with the
+/// elapsed-since-last-accepted spread across the whole 100 ms window
+/// (p50 35 ms, p90 77 ms). At 20 ms that falls to 4 refusals in the run,
+/// roughly one per pair, which is what the throttled `ResyncRequest`
+/// repair can actually heal (it allows one per `(contract, sender)` per
+/// 30 s, so several refusals per pair per window is precisely the case
+/// the repair cannot cover).
+///
+/// # The DoS trade-off, stated plainly
+///
+/// This raises what ONE peer can force this node to do for ONE contract
+/// from ~10 to ~50 broadcasts/s. That is a real 5x, and it is the cost
+/// of the change. What still bounds it, unchanged:
+///
+/// - the per-sender new-pair budget (#4997) is untouched, so a sender's
+///   AGGREGATE ceiling across contracts is still ~210 UPDATE/s;
+/// - cost-pressure eviction (#4861/#4903) sheds a zero-demand contract
+///   whose attributed CPU, fan-out bytes, or broadcast MESSAGE rate is
+///   sustained above the floor — it measures the work actually done
+///   rather than a fixed rate, which is the control that fits a storm;
+/// - the broadcast queue already coalesces: a per-(contract, peer)
+///   keep-latest replace-on-dedup queue drained by a bounded worker, so
+///   a saturated uplink folds updates instead of accumulating them;
+/// - the contract ban list still applies ahead of this gate.
+///
+/// Do NOT set this to zero. An unbounded broadcast class re-opens the
+/// May 21 flood shape on the one message type that fans out.
+pub(crate) const MIN_BROADCAST_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Which budget an inbound UPDATE is charged against.
+///
+/// The two classes have SEPARATE stamps inside one map entry, so neither
+/// starves the other. That is deliberate: with a single shared stamp, a
+/// pair busy with fan-out would advance it every ~20 ms and a routed
+/// `RequestUpdate` from the same neighbour for the same contract would
+/// essentially never see its 100 ms of quiet — a client write silently
+/// refused because someone else's room was busy.
+///
+/// Separate stamps, one map entry: the key space, the cap, the eviction
+/// path and the per-sender new-pair budget (#4997) are all exactly as
+/// they were. A flooder that alternates classes gains only the sum of
+/// two bounded budgets, which the broadcast one dominates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UpdateClass {
+    /// `RequestUpdate` / `RequestUpdateStreaming`: a routed client write.
+    /// Charged against [`MIN_UPDATE_INTERVAL`].
+    Request,
+    /// `BroadcastTo` / `BroadcastToV2` / `BroadcastToStreaming` /
+    /// `BroadcastToStreamingV2`: co-host mesh fan-out. Charged against
+    /// [`MIN_BROADCAST_INTERVAL`], UNIFORMLY across all four so switching
+    /// broadcast opcode gains nothing.
+    Broadcast,
+}
+
+/// The last accepted timestamp per [`UpdateClass`] for one
+/// `(sender, contract)` pair.
+///
+/// `None` means "no message of that class has been accepted for this
+/// pair", which must be ALLOWED — otherwise a pair created by a
+/// broadcast would refuse the sender's first request for 100 ms for no
+/// reason. Rejections never write here: the window is measured from the
+/// last ACCEPTED message, so a flood cannot extend its own window (see
+/// `rejected_attempts_do_not_extend_window`).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PairStamps {
+    request: Option<Instant>,
+    broadcast: Option<Instant>,
+    /// The most recent accepted stamp of EITHER class — the entry's
+    /// recency for LRU eviction and for the TTL sweep.
+    ///
+    /// Carried rather than computed as `max(request, broadcast)` so it is
+    /// TOTAL: every constructor and every `set` writes it, so there is no
+    /// all-`None` case for a caller to invent a fallback for, and no
+    /// arithmetic on `Instant` that could overflow on the UPDATE receive
+    /// path. It must track the max and not one class's stamp: evicting or
+    /// expiring an entry whose OTHER class is actively in use would reset
+    /// that class's window and hand a flooder a free message.
+    latest: Instant,
+}
+
+impl PairStamps {
+    /// A fresh entry whose only accepted message so far is of `class`.
+    fn new_at(class: UpdateClass, now: Instant) -> Self {
+        let mut stamps = Self {
+            request: None,
+            broadcast: None,
+            latest: now,
+        };
+        stamps.set(class, now);
+        stamps
+    }
+
+    fn get(&self, class: UpdateClass) -> Option<Instant> {
+        match class {
+            UpdateClass::Request => self.request,
+            UpdateClass::Broadcast => self.broadcast,
+        }
+    }
+
+    /// Stamp `class` as accepted at `now`. `now` is monotonic and every
+    /// caller is under the entry's shard guard, so it is never older than
+    /// `latest`.
+    fn set(&mut self, class: UpdateClass, now: Instant) {
+        match class {
+            UpdateClass::Request => self.request = Some(now),
+            UpdateClass::Broadcast => self.broadcast = Some(now),
+        }
+        self.latest = self.latest.max(now);
+    }
+
+    fn latest(&self) -> Instant {
+        self.latest
+    }
+}
+
 /// How long an idle `(sender, contract)` entry stays in the map before
 /// being cleared by the periodic cleanup pass. Bounds memory while
 /// preserving the rate-limit signal across short-term retries.
@@ -529,7 +667,7 @@ impl RateLimitDecision {
 /// entry stores only the `Instant` of the most recent accepted UPDATE,
 /// so per-entry memory is tiny.
 pub(crate) struct UpdateRateLimiter {
-    last_accepted: DashMap<(SocketAddr, ContractInstanceId), Instant>,
+    last_accepted: DashMap<(SocketAddr, ContractInstanceId), PairStamps>,
     /// Authoritative size counter for capacity enforcement. Held
     /// in sync with `last_accepted.len()` at every stable point
     /// (incremented by successful new-pair inserts in
@@ -546,6 +684,9 @@ pub(crate) struct UpdateRateLimiter {
     /// which can be hundreds.
     size: AtomicUsize,
     min_interval: Duration,
+    /// The [`UpdateClass::Broadcast`] counterpart of `min_interval` — see
+    /// [`MIN_BROADCAST_INTERVAL`] for why fan-out needs its own number.
+    broadcast_interval: Duration,
     max_tracked_pairs: usize,
     time_source: Arc<dyn TimeSource + Send + Sync>,
     /// Total accepted UPDATEs since limiter creation. Surfaced on the
@@ -611,6 +752,7 @@ impl UpdateRateLimiter {
         Self::with_new_pair_budget(
             time_source,
             MIN_UPDATE_INTERVAL,
+            MIN_BROADCAST_INTERVAL,
             MAX_TRACKED_PAIRS,
             NEW_PAIR_BURST,
             // Floored: `max_connections` is operator-settable, and a
@@ -633,9 +775,25 @@ impl UpdateRateLimiter {
         min_interval: Duration,
         max_tracked_pairs: usize,
     ) -> Self {
+        // Both classes get `min_interval`, so a test written before the
+        // #5510 class split still means exactly what it meant. A test that
+        // wants the two apart says so via `with_class_intervals`.
+        Self::with_class_intervals(time_source, min_interval, min_interval, max_tracked_pairs)
+    }
+
+    /// [`Self::with_config`] with the two [`UpdateClass`] intervals set
+    /// independently, for the tests that exercise the split itself.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_class_intervals(
+        time_source: Arc<dyn TimeSource + Send + Sync>,
+        min_interval: Duration,
+        broadcast_interval: Duration,
+        max_tracked_pairs: usize,
+    ) -> Self {
         Self::with_new_pair_budget(
             time_source,
             min_interval,
+            broadcast_interval,
             max_tracked_pairs,
             NEW_PAIR_BURST,
             Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
@@ -649,6 +807,7 @@ impl UpdateRateLimiter {
     pub fn with_new_pair_budget(
         time_source: Arc<dyn TimeSource + Send + Sync>,
         min_interval: Duration,
+        broadcast_interval: Duration,
         max_tracked_pairs: usize,
         new_pair_burst: f64,
         max_tracked_senders: usize,
@@ -667,6 +826,7 @@ impl UpdateRateLimiter {
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
             min_interval,
+            broadcast_interval,
             max_tracked_pairs,
             time_source,
             accepted_total: AtomicU64::new(0),
@@ -707,8 +867,13 @@ impl UpdateRateLimiter {
         &self,
         sender: SocketAddr,
         contract: ContractInstanceId,
+        class: UpdateClass,
     ) -> RateLimitDecision {
         let now = self.time_source.now();
+        // The window this message is measured against. Uniform across the
+        // four broadcast opcodes, so switching opcode gains nothing — see
+        // [`UpdateClass`].
+        let min_interval = self.interval_for(class);
         let key = (sender, contract);
 
         use dashmap::mapref::entry::Entry;
@@ -734,10 +899,18 @@ impl UpdateRateLimiter {
                         self.size.fetch_sub(1, Ordering::Relaxed);
                     }
                     // Existing pair: atomic compare-and-stamp under
-                    // shard guard.
-                    let last = *entry.get();
+                    // shard guard, against THIS class's own stamp. A
+                    // `None` here means the pair exists but has never had
+                    // a message of this class accepted, which is allowed —
+                    // a pair created by fan-out must not refuse the
+                    // sender's first routed request.
+                    let Some(last) = entry.get().get(class) else {
+                        entry.get_mut().set(class, now);
+                        self.accepted_total.fetch_add(1, Ordering::Relaxed);
+                        return RateLimitDecision::Allowed;
+                    };
                     let elapsed = now.saturating_duration_since(last);
-                    if elapsed < self.min_interval {
+                    if elapsed < min_interval {
                         self.rejected_total.fetch_add(1, Ordering::Relaxed);
                         // Release the shard guard BEFORE taking the log
                         // throttle's mutex. `log_new_pair_budget` is the only
@@ -750,10 +923,10 @@ impl UpdateRateLimiter {
                         self.log_rejected(now, sender, contract);
                         return RateLimitDecision::Rejected {
                             elapsed,
-                            min_interval: self.min_interval,
+                            min_interval,
                         };
                     }
-                    *entry.get_mut() = now;
+                    entry.get_mut().set(class, now);
                     self.accepted_total.fetch_add(1, Ordering::Relaxed);
                     return RateLimitDecision::Allowed;
                 }
@@ -837,7 +1010,7 @@ impl UpdateRateLimiter {
                             }
                         }
                     }
-                    entry.insert(now);
+                    entry.insert(PairStamps::new_at(class, now));
                     self.accepted_total.fetch_add(1, Ordering::Relaxed);
                     return RateLimitDecision::Allowed;
                 }
@@ -856,6 +1029,14 @@ impl UpdateRateLimiter {
         // Every attempt lost its freed slot to a concurrent caller.
         self.capacity_rejected_total.fetch_add(1, Ordering::Relaxed);
         RateLimitDecision::CapacityExceeded
+    }
+
+    /// The minimum inter-message interval charged to `class`.
+    fn interval_for(&self, class: UpdateClass) -> Duration {
+        match class {
+            UpdateClass::Request => self.min_interval,
+            UpdateClass::Broadcast => self.broadcast_interval,
+        }
     }
 
     /// Evict the oldest tracked pairs to make room for a new one.
@@ -943,10 +1124,13 @@ impl UpdateRateLimiter {
         }
 
         let batch = (self.max_tracked_pairs / EVICTION_BATCH_DIVISOR).max(1);
+        // Ordered by the entry's MOST RECENT stamp of either class — see
+        // `PairStamps::latest`. Ordering on one class alone would evict a
+        // pair that is busy on the other, resetting its window.
         let mut entries: Vec<(Instant, (SocketAddr, ContractInstanceId))> = self
             .last_accepted
             .iter()
-            .map(|e| (*e.value(), *e.key()))
+            .map(|e| (e.value().latest(), *e.key()))
             .collect();
         if entries.is_empty() {
             // Not terminal: `size` reads at the cap while the map does
@@ -1096,8 +1280,8 @@ impl UpdateRateLimiter {
             Some(t) => t,
             None => return, // clock not advanced enough to bother
         };
-        self.last_accepted.retain(|_, last| {
-            let keep = *last >= cutoff;
+        self.last_accepted.retain(|_, stamps| {
+            let keep = stamps.latest() >= cutoff;
             if !keep {
                 self.size.fetch_sub(1, Ordering::Relaxed);
             }
@@ -1217,7 +1401,7 @@ mod tests {
     #[test]
     fn first_update_for_pair_is_allowed() {
         let (l, _ts) = mk_limiter();
-        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
         assert_eq!(d, RateLimitDecision::Allowed);
         assert_eq!(l.accepted_total(), 1);
         assert_eq!(l.rejected_total(), 0);
@@ -1227,12 +1411,12 @@ mod tests {
     fn second_update_within_min_interval_is_rejected() {
         let (l, ts) = mk_limiter();
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // Only 10ms later — well under 100ms default.
         ts.advance(Duration::from_millis(10));
-        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
         assert!(
             matches!(d, RateLimitDecision::Rejected { .. }),
             "second UPDATE 10ms after first must be rejected, got {d:?}"
@@ -1241,16 +1425,240 @@ mod tests {
         assert_eq!(l.rejected_total(), 1);
     }
 
+    /// #5510: the BROADCAST class is charged against its own, wider window.
+    ///
+    /// The pair is the same and the elapsed time is the same; only the class
+    /// differs. If the two ever collapse back onto one interval this fails, and
+    /// collapsing them is precisely how honest co-host fan-out came to be
+    /// refused and the peers came to diverge.
+    #[test]
+    fn broadcast_class_is_charged_against_its_own_interval() {
+        let (l, ts) = mk_limiter();
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Broadcast)
+                .is_allowed()
+        );
+        assert!(
+            l.check_and_record(mk_sender(2), mk_contract(1), UpdateClass::Request)
+                .is_allowed()
+        );
+
+        // 30ms: past MIN_BROADCAST_INTERVAL (20ms), well under
+        // MIN_UPDATE_INTERVAL (100ms).
+        ts.advance(Duration::from_millis(30));
+
+        assert!(
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Broadcast)
+                .is_allowed(),
+            "a broadcast 30ms after the last one must be ALLOWED — co-host fan-out \
+             carries the contract's AGGREGATE commit rate, not one writer's cadence \
+             (#5510)"
+        );
+        let d = l.check_and_record(mk_sender(2), mk_contract(1), UpdateClass::Request);
+        assert!(
+            matches!(d, RateLimitDecision::Rejected { .. }),
+            "a routed request 30ms after the last one must still be REJECTED — the \
+             write-cadence budget is unchanged by #5510, got {d:?}"
+        );
+    }
+
+    /// #5510: the two classes hold SEPARATE stamps, so busy fan-out on a pair
+    /// cannot starve a routed client write on the same pair.
+    ///
+    /// This is the property that made the two-stamp design worth its extra
+    /// field over a single shared stamp read against two thresholds. With one
+    /// shared stamp, the broadcasts below would advance it every 25ms and the
+    /// final request would never see its 100ms of quiet — a client's write
+    /// silently refused because someone else's room was busy. The assertion is
+    /// written so that the shared-stamp implementation FAILS it.
+    #[test]
+    fn broadcast_traffic_does_not_starve_routed_requests_on_the_same_pair() {
+        let (l, ts) = mk_limiter();
+        let (sender, contract) = (mk_sender(1), mk_contract(1));
+
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Request)
+                .is_allowed(),
+            "precondition: the pair's first request is allowed and stamps the \
+             request class"
+        );
+
+        // 200ms of fan-out at 25ms intervals: every broadcast is allowed and
+        // each one advances the BROADCAST stamp.
+        for i in 0..8 {
+            ts.advance(Duration::from_millis(25));
+            assert!(
+                l.check_and_record(sender, contract, UpdateClass::Broadcast)
+                    .is_allowed(),
+                "broadcast {i} at 25ms spacing must be allowed"
+            );
+        }
+
+        // 200ms have passed since the request stamp, which is more than
+        // MIN_UPDATE_INTERVAL, so the request is due regardless of how much
+        // broadcast traffic ran in between.
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Request)
+                .is_allowed(),
+            "a routed request must be judged against the REQUEST stamp alone — \
+             sharing one stamp with fan-out would starve client writes on every \
+             busy contract (#5510)"
+        );
+    }
+
+    /// #5510: on a pair that exists but has never carried this class, the first
+    /// message of the class is ALLOWED.
+    ///
+    /// The `None` case is easy to get wrong in the direction that silently
+    /// refuses: a pair created by fan-out would otherwise refuse the sender's
+    /// first routed request for a full `MIN_UPDATE_INTERVAL` for no reason.
+    #[test]
+    fn first_message_of_a_class_on_an_existing_pair_is_allowed() {
+        let (l, _ts) = mk_limiter();
+        let (sender, contract) = (mk_sender(1), mk_contract(1));
+
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Broadcast)
+                .is_allowed(),
+            "precondition: the broadcast creates the entry"
+        );
+        // No time advance at all: the strictest possible case.
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Request)
+                .is_allowed(),
+            "the pair's FIRST request must be allowed even with zero elapsed time — \
+             it has no request stamp to be measured against"
+        );
+        // ...and it is now stamped, so the next one is refused.
+        assert!(
+            !l.check_and_record(sender, contract, UpdateClass::Request)
+                .is_allowed(),
+            "the second request must be refused — the first must have stamped"
+        );
+    }
+
+    /// #5510: the TTL sweep and the LRU eviction order read the entry's
+    /// most-recent stamp of EITHER class.
+    ///
+    /// A pair whose request stamp is ancient but whose fan-out is live must not
+    /// be swept: dropping it would reset the broadcast window and hand back a
+    /// free message, which is the bound the sweep exists to preserve.
+    #[test]
+    fn ttl_sweep_reads_the_most_recent_stamp_of_either_class() {
+        let (l, ts) = mk_limiter();
+        let (sender, contract) = (mk_sender(1), mk_contract(1));
+
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Request)
+                .is_allowed()
+        );
+        // Let the REQUEST stamp go stale, keeping the broadcast side fresh.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        assert!(
+            l.check_and_record(sender, contract, UpdateClass::Broadcast)
+                .is_allowed()
+        );
+
+        l.cleanup();
+        assert_eq!(
+            l.len(),
+            1,
+            "an entry whose broadcast stamp is fresh must survive the sweep even \
+             when its request stamp is older than CLEANUP_AGE"
+        );
+
+        // And once BOTH are stale it goes.
+        ts.advance(CLEANUP_AGE + Duration::from_secs(1));
+        l.cleanup();
+        assert_eq!(l.len(), 0, "an entry stale in both classes must be swept");
+    }
+
+    /// #5510 anti-bypass pin: the dispatch in `node.rs` maps ALL FOUR broadcast
+    /// wire opcodes to one class and both request opcodes to the other.
+    ///
+    /// The budget split is only safe because switching broadcast opcode gains
+    /// nothing. `update_dispatch_gates_all_four_wire_variants` proves every
+    /// variant reaches the limiter; this proves each reaches it in the right
+    /// class. The classifier is an exhaustive `match` with no catch-all, so a
+    /// NEW variant fails to compile rather than defaulting into the wider
+    /// budget — that is deliberate, and this pin fails if someone replaces it
+    /// with a wildcard.
+    #[test]
+    fn every_broadcast_opcode_is_charged_to_the_broadcast_class() {
+        const NODE_SRC: &str = include_str!("../node.rs");
+
+        let start = NODE_SRC.find("let update_class = match op {").expect(
+            "the UPDATE dispatch must classify the message before the rate-limit \
+                 check; if the classifier moved or was renamed, update this pin rather \
+                 than deleting it",
+        );
+        let body = &NODE_SRC[start..];
+        let end = body
+            .find("\n                };")
+            .expect("could not find the end of the update_class match");
+        let body: String = body[..end].chars().filter(|c| !c.is_whitespace()).collect();
+
+        let request_arm = body
+            .find("UpdateClass::Request")
+            .expect("no Request arm in the classifier");
+        let broadcast_arm = body
+            .find("UpdateClass::Broadcast")
+            .expect("no Broadcast arm in the classifier");
+
+        for variant in [
+            "UpdateMsg::BroadcastTo{..}",
+            "UpdateMsg::BroadcastToV2{..}",
+            "UpdateMsg::BroadcastToStreaming{..}",
+            "UpdateMsg::BroadcastToStreamingV2{..}",
+        ] {
+            let at = body.split(variant).next().map(str::len).unwrap_or(0);
+            assert!(
+                body.contains(variant),
+                "broadcast opcode `{variant}` is not classified in node.rs — an \
+                 unclassified broadcast opcode is a budget bypass"
+            );
+            assert!(
+                at > request_arm,
+                "broadcast opcode `{variant}` must sit in the Broadcast arm, not the \
+                 Request arm — the four broadcast opcodes MUST share one budget so \
+                 switching between them gains nothing (#5510)"
+            );
+        }
+
+        for variant in [
+            "UpdateMsg::RequestUpdate{..}",
+            "UpdateMsg::RequestUpdateStreaming{..}",
+        ] {
+            let at = body.split(variant).next().map(str::len).unwrap_or(0);
+            assert!(
+                body.contains(variant),
+                "request opcode `{variant}` is not classified in node.rs"
+            );
+            assert!(
+                at < broadcast_arm,
+                "request opcode `{variant}` must sit in the Request arm — a routed \
+                 client write must not be charged the wider fan-out budget (#5510)"
+            );
+        }
+
+        assert!(
+            !body.contains("_=>"),
+            "the classifier must stay an exhaustive match with NO catch-all: a new \
+             UPDATE wire variant must fail to COMPILE rather than silently inherit \
+             whichever class the wildcard names"
+        );
+    }
+
     #[test]
     fn update_after_min_interval_is_allowed() {
         let (l, ts) = mk_limiter();
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // 200ms later — past the 100ms default.
         ts.advance(Duration::from_millis(200));
-        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
         assert_eq!(d, RateLimitDecision::Allowed);
         assert_eq!(l.accepted_total(), 2);
         assert_eq!(l.rejected_total(), 0);
@@ -1261,17 +1669,17 @@ mod tests {
         let (l, ts) = mk_limiter();
         // Sender 1 accepts.
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // Sender 2 immediately also accepts — different key.
         ts.advance(Duration::from_millis(1));
         assert!(
-            l.check_and_record(mk_sender(2), mk_contract(1))
+            l.check_and_record(mk_sender(2), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // Sender 1 retry 1ms later still rejected.
-        let d = l.check_and_record(mk_sender(1), mk_contract(1));
+        let d = l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
         assert!(matches!(d, RateLimitDecision::Rejected { .. }));
     }
 
@@ -1279,12 +1687,12 @@ mod tests {
     fn same_sender_different_contracts_independent() {
         let (l, _ts) = mk_limiter();
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // Same sender, different contract — independent rate limit.
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(2))
+            l.check_and_record(mk_sender(1), mk_contract(2), UpdateClass::Request)
                 .is_allowed()
         );
         assert_eq!(l.accepted_total(), 2);
@@ -1299,27 +1707,27 @@ mod tests {
         // indefinitely (the existing peer would never recover).
         let (l, ts) = mk_limiter();
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // 9 sub-100ms attempts, all rejected.
         for _ in 0..9 {
             ts.advance(Duration::from_millis(10));
             assert!(
-                !l.check_and_record(mk_sender(1), mk_contract(1))
+                !l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                     .is_allowed()
             );
         }
         // Now we're at 90ms — still rejected.
         ts.advance(Duration::from_millis(5));
         assert!(
-            !l.check_and_record(mk_sender(1), mk_contract(1))
+            !l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed()
         );
         // One more advance puts us past 100ms from the FIRST accept.
         ts.advance(Duration::from_millis(10));
         assert!(
-            l.check_and_record(mk_sender(1), mk_contract(1))
+            l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                 .is_allowed(),
             "after 105ms+ from original accept, next attempt MUST be allowed — \
              rejected attempts must not have moved the window forward"
@@ -1329,8 +1737,8 @@ mod tests {
     #[test]
     fn cleanup_removes_stale_entries() {
         let (l, ts) = mk_limiter();
-        l.check_and_record(mk_sender(1), mk_contract(1));
-        l.check_and_record(mk_sender(2), mk_contract(2));
+        l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
+        l.check_and_record(mk_sender(2), mk_contract(2), UpdateClass::Request);
         assert_eq!(l.len(), 2);
 
         // Advance past CLEANUP_AGE.
@@ -1342,7 +1750,7 @@ mod tests {
     #[test]
     fn cleanup_preserves_fresh_entries() {
         let (l, ts) = mk_limiter();
-        l.check_and_record(mk_sender(1), mk_contract(1));
+        l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request);
         // Advance partway through the cleanup age.
         ts.advance(CLEANUP_AGE / 2);
         l.cleanup();
@@ -1356,7 +1764,7 @@ mod tests {
             // Five accepts: stagger by min_interval.
             ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
             assert!(
-                l.check_and_record(mk_sender(1), mk_contract(1))
+                l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                     .is_allowed(),
                 "iter {i}"
             );
@@ -1364,7 +1772,7 @@ mod tests {
         // Three rejects: hammer with no advance.
         for _ in 0..3 {
             assert!(
-                !l.check_and_record(mk_sender(1), mk_contract(1))
+                !l.check_and_record(mk_sender(1), mk_contract(1), UpdateClass::Request)
                     .is_allowed()
             );
         }
@@ -1386,7 +1794,7 @@ mod tests {
         // Simulate 1 second of flooding at 1ms per attempt (1000
         // attempts/s — 100× over the 10/s ceiling).
         for _ in 0..1000 {
-            l.check_and_record(sender, contract);
+            l.check_and_record(sender, contract, UpdateClass::Request);
             ts.advance(Duration::from_millis(1));
         }
         // Expected admits: floor(1000ms / 100ms) + 1 (first one is
@@ -1431,14 +1839,18 @@ mod tests {
 
         // Fill the map with 8 distinct pairs — all should be Allowed.
         for i in 0..8 {
-            let d = limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1));
+            let d = limiter.check_and_record(
+                mk_sender(i + 1),
+                mk_contract(i + 1),
+                UpdateClass::Request,
+            );
             assert_eq!(d, RateLimitDecision::Allowed, "pair {i} should be allowed");
             ts.advance(Duration::from_millis(1));
         }
         assert_eq!(limiter.len(), 8);
 
         // Pair #9 is a new key at capacity: admitted, by evicting.
-        let d = limiter.check_and_record(mk_sender(99), mk_contract(99));
+        let d = limiter.check_and_record(mk_sender(99), mk_contract(99), UpdateClass::Request);
         assert_eq!(
             d,
             RateLimitDecision::Allowed,
@@ -1458,7 +1870,7 @@ mod tests {
 
         // An already-tracked pair keeps working after min_interval.
         ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
-        let d = limiter.check_and_record(mk_sender(8), mk_contract(8));
+        let d = limiter.check_and_record(mk_sender(8), mk_contract(8), UpdateClass::Request);
         assert_eq!(
             d,
             RateLimitDecision::Allowed,
@@ -1492,7 +1904,11 @@ mod tests {
 
         for i in 0..CAP {
             assert_eq!(
-                limiter.check_and_record(mk_sender(i as u8 + 1), mk_contract(i as u8 + 1)),
+                limiter.check_and_record(
+                    mk_sender(i as u8 + 1),
+                    mk_contract(i as u8 + 1),
+                    UpdateClass::Request
+                ),
                 RateLimitDecision::Allowed
             );
             // Stagger the stamps so the entries are distinguishable.
@@ -1560,6 +1976,9 @@ mod tests {
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             CAP,
             BURST as f64,
             Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
@@ -1570,7 +1989,7 @@ mod tests {
         let incumbent = mk_sender(200);
         for i in 0..CAP {
             assert_eq!(
-                limiter.check_and_record(incumbent, mk_contract(i as u8 + 1)),
+                limiter.check_and_record(incumbent, mk_contract(i as u8 + 1), UpdateClass::Request),
                 RateLimitDecision::Allowed
             );
         }
@@ -1582,7 +2001,11 @@ mod tests {
         let attacker = mk_sender(1);
         for i in 0..BURST {
             assert_eq!(
-                limiter.check_and_record(attacker, mk_contract(100 + i as u8)),
+                limiter.check_and_record(
+                    attacker,
+                    mk_contract(100 + i as u8),
+                    UpdateClass::Request
+                ),
                 RateLimitDecision::Allowed
             );
         }
@@ -1597,7 +2020,11 @@ mod tests {
         // without reserving a slot or evicting anything.
         for i in BURST..(BURST + 32) {
             assert_eq!(
-                limiter.check_and_record(attacker, mk_contract(100 + i as u8)),
+                limiter.check_and_record(
+                    attacker,
+                    mk_contract(100 + i as u8),
+                    UpdateClass::Request
+                ),
                 RateLimitDecision::SenderNewPairBudget
             );
         }
@@ -1659,6 +2086,9 @@ mod tests {
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
             Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
@@ -1670,7 +2100,7 @@ mod tests {
         // contracts.
         for i in 0..BURST {
             assert_eq!(
-                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                limiter.check_and_record(attacker, mk_contract(i as u8), UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "fresh id {i} is within the burst"
             );
@@ -1680,7 +2110,7 @@ mod tests {
         // says so, not as a capacity drop.
         for i in BURST..(BURST + 32) {
             assert_eq!(
-                limiter.check_and_record(attacker, mk_contract(i as u8)),
+                limiter.check_and_record(attacker, mk_contract(i as u8), UpdateClass::Request),
                 RateLimitDecision::SenderNewPairBudget,
                 "fresh id {i} is past the burst and must be refused"
             );
@@ -1702,12 +2132,12 @@ mod tests {
         // one interval the sender may introduce one more pair.
         ts.advance(NEW_PAIR_REFILL_INTERVAL);
         assert_eq!(
-            limiter.check_and_record(attacker, mk_contract(200)),
+            limiter.check_and_record(attacker, mk_contract(200), UpdateClass::Request),
             RateLimitDecision::Allowed,
             "one refill interval must buy exactly one more fresh pair"
         );
         assert_eq!(
-            limiter.check_and_record(attacker, mk_contract(201)),
+            limiter.check_and_record(attacker, mk_contract(201), UpdateClass::Request),
             RateLimitDecision::SenderNewPairBudget,
             "and only one"
         );
@@ -1725,6 +2155,9 @@ mod tests {
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
             Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
@@ -1733,13 +2166,13 @@ mod tests {
 
         for i in 0..BURST {
             assert_eq!(
-                limiter.check_and_record(peer, mk_contract(i as u8)),
+                limiter.check_and_record(peer, mk_contract(i as u8), UpdateClass::Request),
                 RateLimitDecision::Allowed
             );
         }
         // Budget fully spent: a fresh pair is refused from here on.
         assert_eq!(
-            limiter.check_and_record(peer, mk_contract(99)),
+            limiter.check_and_record(peer, mk_contract(99), UpdateClass::Request),
             RateLimitDecision::SenderNewPairBudget
         );
 
@@ -1749,7 +2182,7 @@ mod tests {
             ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
             for i in 0..BURST {
                 assert_eq!(
-                    limiter.check_and_record(peer, mk_contract(i as u8)),
+                    limiter.check_and_record(peer, mk_contract(i as u8), UpdateClass::Request),
                     RateLimitDecision::Allowed,
                     "round {round}, established pair {i} must be unaffected by the \
                      new-pair budget"
@@ -1796,7 +2229,7 @@ mod tests {
         for cycle in 0..CYCLES {
             for c in 0..CONTRACTS {
                 assert_eq!(
-                    limiter.check_and_record(peer, mk_contract(c)),
+                    limiter.check_and_record(peer, mk_contract(c), UpdateClass::Request),
                     RateLimitDecision::Allowed,
                     "cycle {cycle}, contract {c}: a peer relaying at the sustained rate \
                      must not be throttled, even though eviction keeps making its pairs \
@@ -1826,7 +2259,7 @@ mod tests {
             let mut id = [0u8; 32];
             id[..8].copy_from_slice(&(c as u64).to_be_bytes());
             id[8] = 0xEE; // disjoint from mk_contract's key space
-            if limiter.check_and_record(peer, ContractInstanceId::new(id))
+            if limiter.check_and_record(peer, ContractInstanceId::new(id), UpdateClass::Request)
                 == RateLimitDecision::SenderNewPairBudget
             {
                 refused += 1;
@@ -1853,6 +2286,9 @@ mod tests {
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             BURST as f64,
             Ring::DEFAULT_MAX_CONNECTIONS * SENDER_TRACKING_HEADROOM,
@@ -1862,18 +2298,18 @@ mod tests {
 
         for i in 0..BURST {
             assert_eq!(
-                limiter.check_and_record(noisy, mk_contract(i as u8)),
+                limiter.check_and_record(noisy, mk_contract(i as u8), UpdateClass::Request),
                 RateLimitDecision::Allowed
             );
         }
         assert_eq!(
-            limiter.check_and_record(noisy, mk_contract(50)),
+            limiter.check_and_record(noisy, mk_contract(50), UpdateClass::Request),
             RateLimitDecision::SenderNewPairBudget
         );
 
         for i in 0..BURST {
             assert_eq!(
-                limiter.check_and_record(quiet, mk_contract(i as u8)),
+                limiter.check_and_record(quiet, mk_contract(i as u8), UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "a second sender has its own budget, untouched by the first"
             );
@@ -1902,13 +2338,17 @@ mod tests {
         let limiter = UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             MAX_TRACKED_PAIRS,
             NEW_PAIR_BURST,
             MAX_SENDERS,
         );
 
         for i in 0..(MAX_SENDERS * 4) {
-            let d = limiter.check_and_record(mk_sender(i as u8), mk_contract(1));
+            let d =
+                limiter.check_and_record(mk_sender(i as u8), mk_contract(1), UpdateClass::Request);
             assert_eq!(
                 d,
                 RateLimitDecision::Allowed,
@@ -2052,7 +2492,7 @@ mod tests {
         for i in 1..=8u8 {
             assert!(
                 limiter
-                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request)
                     .is_allowed()
             );
         }
@@ -2061,7 +2501,7 @@ mod tests {
         for i in 1..=4u8 {
             assert!(
                 limiter
-                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request)
                     .is_allowed()
             );
         }
@@ -2090,7 +2530,7 @@ mod tests {
 
         for i in 1..=4u8 {
             assert_eq!(
-                limiter.check_and_record(mk_sender(i), mk_contract(i)),
+                limiter.check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request),
                 RateLimitDecision::CapacityExceeded,
                 "with a zero cap there is no slot for pair {i} and nothing to evict"
             );
@@ -2141,7 +2581,7 @@ mod tests {
         while limiter.capacity_evicted_total() < ORDER_TEST_EVICTED as u64 {
             let (s, c) = mk_pair(i);
             assert_eq!(
-                limiter.check_and_record(s, c),
+                limiter.check_and_record(s, c, UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "newcomer {i} must be admitted"
             );
@@ -2195,7 +2635,7 @@ mod tests {
         for i in 0..ORDER_TEST_CAP {
             let (s, c) = mk_pair(i);
             assert_eq!(
-                limiter.check_and_record(s, c),
+                limiter.check_and_record(s, c, UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "fill {i}"
             );
@@ -2217,7 +2657,7 @@ mod tests {
             let (s, c) = mk_pair(i);
             assert!(
                 matches!(
-                    limiter.check_and_record(s, c),
+                    limiter.check_and_record(s, c, UpdateClass::Request),
                     RateLimitDecision::Rejected { .. }
                 ),
                 "pair {i} is newer than the {ORDER_TEST_EVICTED} oldest and must have survived"
@@ -2226,7 +2666,7 @@ mod tests {
         for i in 0..ORDER_TEST_EVICTED {
             let (s, c) = mk_pair(i);
             assert_eq!(
-                limiter.check_and_record(s, c),
+                limiter.check_and_record(s, c, UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "pair {i} is among the {ORDER_TEST_EVICTED} oldest and must have been evicted"
             );
@@ -2261,7 +2701,7 @@ mod tests {
         for i in 0..ORDER_TEST_CAP {
             let (s, c) = mk_pair(i);
             assert_eq!(
-                limiter.check_and_record(s, c),
+                limiter.check_and_record(s, c, UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "fill {i}"
             );
@@ -2278,7 +2718,7 @@ mod tests {
         for i in (0..ORDER_TEST_CAP).filter(|i| !victims.contains(i)) {
             let (s, c) = mk_pair(i);
             assert_eq!(
-                limiter.check_and_record(s, c),
+                limiter.check_and_record(s, c, UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "refresh {i} must be accepted a full min_interval after the fill"
             );
@@ -2305,7 +2745,7 @@ mod tests {
             let (s, c) = mk_pair(i);
             assert!(
                 matches!(
-                    limiter.check_and_record(s, c),
+                    limiter.check_and_record(s, c, UpdateClass::Request),
                     RateLimitDecision::Rejected { .. }
                 ),
                 "pair {i} was refreshed, so it must be at the back of the eviction \
@@ -2332,7 +2772,7 @@ mod tests {
         for i in 1..=8u8 {
             assert!(
                 limiter
-                    .check_and_record(mk_sender(i), mk_contract(i))
+                    .check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request)
                     .is_allowed()
             );
             ts.advance(Duration::from_millis(1));
@@ -2344,10 +2784,14 @@ mod tests {
             // The incumbents stay busy, restamping themselves.
             ts.advance(MIN_UPDATE_INTERVAL + Duration::from_millis(1));
             for i in 1..=8u8 {
-                limiter.check_and_record(mk_sender(i), mk_contract(i));
+                limiter.check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request);
             }
 
-            let newcomer = limiter.check_and_record(mk_sender(100 + round), mk_contract(200));
+            let newcomer = limiter.check_and_record(
+                mk_sender(100 + round),
+                mk_contract(200),
+                UpdateClass::Request,
+            );
             assert_eq!(
                 newcomer,
                 RateLimitDecision::Allowed,
@@ -2390,7 +2834,7 @@ mod tests {
             let sender = SocketAddr::from(([10, 1, (i / 256) as u8, (i % 256) as u8], 30000));
             assert!(
                 limiter
-                    .check_and_record(sender, mk_contract(1))
+                    .check_and_record(sender, mk_contract(1), UpdateClass::Request)
                     .is_allowed()
             );
             ts.advance(Duration::from_millis(1));
@@ -2399,7 +2843,7 @@ mod tests {
 
         assert!(
             limiter
-                .check_and_record(mk_sender(99), mk_contract(99))
+                .check_and_record(mk_sender(99), mk_contract(99), UpdateClass::Request)
                 .is_allowed()
         );
         assert_eq!(
@@ -2417,7 +2861,7 @@ mod tests {
         // again.
         assert!(
             limiter
-                .check_and_record(mk_sender(98), mk_contract(98))
+                .check_and_record(mk_sender(98), mk_contract(98), UpdateClass::Request)
                 .is_allowed()
         );
         assert_eq!(
@@ -2457,7 +2901,7 @@ mod tests {
             let b = barrier.clone();
             handles.push(thread::spawn(move || {
                 b.wait();
-                l.check_and_record(sender, contract)
+                l.check_and_record(sender, contract, UpdateClass::Request)
             }));
         }
 
@@ -2609,7 +3053,11 @@ mod tests {
                 b.wait();
                 // Each thread tries a DISTINCT key, so they all
                 // exercise the new-pair (Vacant) path concurrently.
-                l.check_and_record(mk_sender((i + 1) as u8), mk_contract((i + 1) as u8))
+                l.check_and_record(
+                    mk_sender((i + 1) as u8),
+                    mk_contract((i + 1) as u8),
+                    UpdateClass::Request,
+                )
             }));
         }
 
@@ -2887,7 +3335,11 @@ mod tests {
         // Fill to cap.
         for i in 0..4 {
             assert_eq!(
-                limiter.check_and_record(mk_sender(i + 1), mk_contract(i + 1)),
+                limiter.check_and_record(
+                    mk_sender(i + 1),
+                    mk_contract(i + 1),
+                    UpdateClass::Request
+                ),
                 RateLimitDecision::Allowed
             );
         }
@@ -2895,7 +3347,7 @@ mod tests {
         // CapacityExceeded); the map stays at the cap either way, which
         // is what this test is really about.
         assert_eq!(
-            limiter.check_and_record(mk_sender(5), mk_contract(5)),
+            limiter.check_and_record(mk_sender(5), mk_contract(5), UpdateClass::Request),
             RateLimitDecision::Allowed
         );
         assert_eq!(limiter.len(), 4, "eviction keeps the map at the cap");
@@ -2906,7 +3358,7 @@ mod tests {
         // Now we should be able to add 4 more without hitting the cap.
         for i in 10..14 {
             assert_eq!(
-                limiter.check_and_record(mk_sender(i), mk_contract(i)),
+                limiter.check_and_record(mk_sender(i), mk_contract(i), UpdateClass::Request),
                 RateLimitDecision::Allowed,
                 "after cleanup, new pair (sender={i}) should be admitted"
             );
@@ -2971,6 +3423,9 @@ mod tests {
         let limiter = StdArc::new(UpdateRateLimiter::with_new_pair_budget(
             Arc::new(ts.clone()),
             MIN_UPDATE_INTERVAL,
+            // Both classes at the same interval: these fixtures predate the
+            // #5510 class split and are not about it.
+            MIN_UPDATE_INTERVAL,
             CAP,
             // The new-pair budget is not what this test is about, and a
             // synthetic flood of fresh pairs would otherwise be stopped
@@ -2992,7 +3447,7 @@ mod tests {
                     let sender = mk_sender(t as u8);
                     let mut id = [0u8; 32];
                     id[..8].copy_from_slice(&(i as u64).to_be_bytes());
-                    l.check_and_record(sender, ContractInstanceId::new(id));
+                    l.check_and_record(sender, ContractInstanceId::new(id), UpdateClass::Request);
                 }
             }));
         }

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -4,10 +4,21 @@
 //!
 //! ## What this does
 //!
-//! Maintains a `(sender_addr, contract_instance_id) → last_accepted_at`
+//! Maintains a `(sender_addr, contract_instance_id) → `[`PairStamps`]
 //! map. When a new UPDATE arrives, check the time since the last
-//! accepted UPDATE for the same pair. If under [`MIN_UPDATE_INTERVAL`],
-//! reject; otherwise stamp the new time and accept.
+//! accepted UPDATE of the SAME [`UpdateClass`] for that pair. If under
+//! that class's interval, reject; otherwise stamp the new time and
+//! accept.
+//!
+//! The two classes — routed client writes and co-host broadcast fan-out
+//! — carry SEPARATE stamps inside one map entry, and are charged against
+//! separate intervals ([`MIN_UPDATE_INTERVAL`] and
+//! [`MIN_BROADCAST_INTERVAL`]). One entry rather than two keys keeps the
+//! key space, the cap, the eviction path and the per-sender new-pair
+//! budget exactly as they were; separate stamps stop busy fan-out
+//! starving a client write on the same pair. See [`UpdateClass`] for why
+//! a broadcast is not a write, and [`MIN_BROADCAST_INTERVAL`] for the
+//! calibration and its DoS trade-off (#5510).
 //!
 //! ## What this is NOT
 //!
@@ -22,13 +33,20 @@
 //!   the rate is a flat statistical threshold, and we choose it
 //!   generously enough that legitimate traffic doesn't hit it.
 //!
-//! ## Default rate
+//! ## Default rates
 //!
 //! [`MIN_UPDATE_INTERVAL`] defaults to 100ms (≈10 UPDATEs/sec from a
 //! single peer for a single contract). Realistic human-driven contract
 //! updates (chat, settings change, post) are orders of magnitude slower
 //! than this. The 4PjqN5… incident was producing many UPDATEs per
 //! second sustained — well above this ceiling.
+//!
+//! [`MIN_BROADCAST_INTERVAL`] defaults to 20ms (≈50/sec) and applies to
+//! the four `BroadcastTo*` opcodes. A broadcast is not a write, it is
+//! the derived fan-out of a write some peer already committed, so its
+//! rate on one pair is a contract's AGGREGATE commit rate rather than
+//! one writer's cadence — see that constant's own doc, which carries the
+//! measurement, the message-zero cost and the trade-off.
 //!
 //! ## Bounded growth
 //!
@@ -209,6 +227,15 @@
 //! - **No typed wire-level error.** Rejected UPDATEs are dropped
 //!   silently. The sender's own retry / governance scoring will
 //!   detect the flood pattern from its end.
+//! - **Two rate classes, not one flat ceiling (#5510).** The doc assumes
+//!   a single per-pair rate. Applying the write-cadence number to
+//!   co-host fan-out turned out to be a correctness bug rather than a
+//!   throttle: honest broadcasts were refused, the sender recorded them
+//!   as delivered, and the two peers diverged permanently. Broadcasts
+//!   therefore get their own, still-bounded interval, uniform across the
+//!   four broadcast opcodes so switching opcode gains nothing. The
+//!   sender-side half of the doc's design is still unbuilt, and pacing
+//!   there would reduce these refusals rather than widen the allowance.
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -293,21 +320,32 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 ///
 /// - **The sender must already be a connected, authenticated peer.** The
 ///   dispatch has no `source_addr` otherwise, and
-///   `op_ctx_task::seed_sender_summary_from_broadcast` (`op_ctx_task.rs:1995`,
-///   the driver's first step) returns immediately when
+///   `op_ctx_task::seed_sender_summary_from_broadcast`, the driver's first
+///   step, returns immediately when
 ///   `get_peer_by_addr` finds no connection. This is the load-bearing bound:
 ///   the budget is per `(sender, contract)`, and a sender is a live connection
 ///   against `max_connections`, not an arbitrary address.
 /// - **For a contract this node does not host and nothing depends on, no GET is
 ///   spawned.** The full-state error arm reaches `try_auto_fetch_contract`,
-///   which returns early on `!contract_in_use` (`operations/update.rs:245`;
-///   `contract_in_use` is a live local client subscription or a downstream
-///   subscriber, `ring/hosting.rs:1725`). So an unsolicited broadcast for a
+///   which returns early on `!contract_in_use` (`operations::update::OpManager::
+///   try_auto_fetch_contract`; `contract_in_use` is a live local client
+///   subscription or a downstream subscriber). So an unsolicited broadcast for a
 ///   stranger contract cannot make this node fetch it.
 /// - **The contract's WASM does not execute for a contract we lack.** The merge
 ///   fails as missing-contract, which `is_contract_exec_rejection` explicitly
 ///   excludes — that is why the arm above can tell "code missing" from "the
 ///   contract rejected it".
+/// - **What it does touch first** is the interest map:
+///   `op_ctx_task::seed_sender_summary_from_broadcast` runs as step 1 of the
+///   driver, ahead of the dedup cache and the merge, and upserts the sender's
+///   self-reported summary. Three properties bound it, and all three predate
+///   this change: it is connected-peer only (no connection, immediate return);
+///   an EMPTY summary refreshes an existing entry's TTL and never creates one;
+///   and at `MAX_INTERESTED_PEERS_PER_CONTRACT` the map REFUSES rather than
+///   evicting, so an established co-host cannot be displaced. What this constant
+///   changes is only how fast that path can be reached for one contract. At
+///   saturation the cost is degraded efficiency rather than lost correctness:
+///   an unseeded co-host is sent full states instead of deltas.
 ///
 /// What it DOES cost, stated plainly rather than glossed: for a contract this
 /// node **does** host, every accepted broadcast is a real WASM merge, and this
@@ -316,6 +354,51 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 /// helps against a REPEATED payload; a sender varying the bytes pays the merge
 /// every time. That 5x is the actual price of this change, and the
 /// compensating bounds are the ones listed above plus those below.
+///
+/// # What a hosted-contract merge actually costs, and who meters it
+///
+/// The merge above is not unmetered work. Cost-pressure eviction
+/// (#4861/#4903) attributes per-contract WASM CPU, fan-out bytes and
+/// broadcast MESSAGE rate, and sheds a zero-demand contract whose
+/// attributed cost is sustained above the floor — it measures the work
+/// actually done rather than a fixed rate, which is the control that
+/// fits a storm. Governance meters the same traffic. So the 5x lands on
+/// an axis that is already watched, rather than on an unwatched one.
+///
+/// # The repair-side amplification, and why it is not part of this
+///
+/// A dropped broadcast provokes a `ResyncRequest`, and that emit — not
+/// the merge — was the part an attacker could have ridden on the looser
+/// class. Two gates in `node.rs` remove it, and they are why this
+/// constant can be widened at all:
+///
+/// - the repair fires ONLY on `RateLimitDecision::Rejected`, never on
+///   `SenderNewPairBudget` (where every downstream gate is vacant for a
+///   fresh contract id) or `CapacityExceeded`;
+/// - the repair fires ONLY for a contract this node actually holds, so
+///   an attacker cannot pick unlimited fresh keys to get unlimited fresh
+///   throttle entries and emit-limiter buckets.
+///
+/// # Tuning this back toward 100ms is not free
+///
+/// The obvious "safer" move is the wrong one, and the coupling is not
+/// visible from this constant alone. Raising the interval raises drop
+/// pressure; each drop that lands in a held throttle window arms a
+/// trailing repair; each repair chain holds one of the
+/// [`crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]
+/// (256) node-wide follow-up slots for up to a reservation window. So a
+/// higher interval thins the very backstop that is meant to catch the
+/// extra drops it creates, and it does so exactly when the node is
+/// busiest. Widening and narrowing this number are NOT symmetric.
+///
+/// On the adversarial side, do not lean on the #4997 per-sender budget
+/// here: it charges a token only for a pair the limiter is not currently
+/// TRACKING, so it bounds the rate of introducing new pairs (~200/s) and
+/// not sustained traffic on established ones. What bounds a hostile peer
+/// reaching many follow-up slots is the held-contract gate above — a
+/// slot is only ever taken for a contract this node holds — together
+/// with the one-repair-per-(contract, sender)-per-30s throttle and the
+/// global per-contract emit cap.
 ///
 /// Do NOT set this to zero. An unbounded broadcast class re-opens the
 /// May 21 flood shape on the one message type that fans out.
@@ -971,12 +1054,17 @@ impl UpdateRateLimiter {
                     if elapsed < min_interval {
                         self.rejected_total.fetch_add(1, Ordering::Relaxed);
                         // Release the shard guard BEFORE taking the log
-                        // throttle's mutex. `log_new_pair_budget` is the only
-                        // lock this module takes under a `last_accepted` guard,
-                        // and its ordering is documented as having no
-                        // counterpart to invert against; keeping that true
-                        // means every OTHER lock is taken with no shard guard
-                        // held.
+                        // throttle's mutex, matching what the new-pair branch
+                        // does: it too calls `drop(entry)` before
+                        // `log_new_pair_budget`. The ONE lock this module takes
+                        // while holding a `last_accepted` guard is
+                        // `new_pair_budget` (see its field doc, which explains
+                        // why that ordering has no counterpart to invert
+                        // against); every other lock, these log throttles
+                        // included, is taken with no shard guard held. Keeping
+                        // that true is what makes the field doc's claim a
+                        // complete account of the lock order rather than one
+                        // case of several.
                         drop(entry);
                         self.log_rejected(now, sender, contract, class);
                         return RateLimitDecision::Rejected {
@@ -1290,8 +1378,15 @@ impl UpdateRateLimiter {
         );
     }
 
-    /// Emit the per-pair rejection log line, at most once per
-    /// [`REJECTED_LOG_INTERVAL`].
+    /// Emit the rejection log line, at most once per
+    /// [`REJECTED_LOG_INTERVAL`] PER [`UpdateClass`].
+    ///
+    /// Read the line carefully when operating: the throttle slot is per class
+    /// and NODE-WIDE, not per pair. So this is one line a minute per class,
+    /// naming whichever `(sender, contract)` pair happened to trip it first —
+    /// a sample, not a census. `rejected_total` on the same line is the count
+    /// that is complete, and `RingStatsSnapshot::updates_rate_limited` carries
+    /// it to the dashboard.
     ///
     /// `info!` rather than `debug!` for the #4981 reason, and because #5510
     /// showed the cost of not having it: `release_max_level_info` compiles
@@ -1608,6 +1703,72 @@ mod tests {
         );
     }
 
+    /// #5510 review finding 12: CAPACITY eviction orders on the entry's most
+    /// recent stamp across BOTH classes, not on one class's.
+    ///
+    /// The TTL twin below covers the sweep; this covers the LRU, which is the
+    /// path that runs under load. A pair whose request stamp is ancient but
+    /// whose fan-out is live must survive: evicting it would reset the broadcast
+    /// window and hand the sender a free message, and at a busy node that is
+    /// precisely the pair being evicted.
+    ///
+    /// Discriminating by construction — the survivor is the pair with the OLDEST
+    /// request stamp, so an implementation ordering on the request stamp alone
+    /// evicts exactly it and fails here.
+    #[test]
+    fn capacity_eviction_orders_on_the_most_recent_stamp_of_either_class() {
+        let ts = SharedMockTimeSource::new();
+        // Cap 2 so a third pair must evict exactly one, with the batch = 1.
+        let l = UpdateRateLimiter::with_config(Arc::new(ts.clone()), MIN_UPDATE_INTERVAL, 2);
+
+        let (busy, quiet, newcomer) = (mk_contract(1), mk_contract(2), mk_contract(3));
+        let sender = mk_sender(1);
+
+        // `busy` is stamped FIRST on the request class, so on a request-only
+        // ordering it is the oldest and would be the victim.
+        assert!(
+            l.check_and_record(sender, busy, UpdateClass::Request)
+                .is_allowed()
+        );
+        ts.advance(Duration::from_secs(10));
+        assert!(
+            l.check_and_record(sender, quiet, UpdateClass::Request)
+                .is_allowed()
+        );
+
+        // ...but `busy` is live on the BROADCAST class, which makes it the most
+        // recently used entry overall.
+        ts.advance(Duration::from_secs(10));
+        assert!(
+            l.check_and_record(sender, busy, UpdateClass::Broadcast)
+                .is_allowed()
+        );
+
+        // A third pair at the cap forces one eviction.
+        ts.advance(Duration::from_secs(10));
+        assert!(
+            l.check_and_record(sender, newcomer, UpdateClass::Request)
+                .is_allowed()
+        );
+        assert_eq!(l.len(), 2, "the cap must still hold after the admission");
+
+        // The victim must be `quiet` (least recently used across both classes),
+        // NOT `busy` (oldest on the request class alone). Asserted against the
+        // map directly: a `check_and_record` probe cannot tell survival from
+        // eviction here, because enough time has passed that a surviving entry
+        // would be allowed too.
+        assert!(
+            l.last_accepted.contains_key(&(sender, busy)),
+            "the pair kept live by BROADCAST traffic must have SURVIVED — ordering \
+             eviction on the request stamp alone would evict it, resetting its \
+             broadcast window and handing the sender a free message (#5510)"
+        );
+        assert!(
+            !l.last_accepted.contains_key(&(sender, quiet)),
+            "the genuinely least-recently-used pair must be the one evicted"
+        );
+    }
+
     /// #5510: the TTL sweep and the LRU eviction order read the entry's
     /// most-recent stamp of EITHER class.
     ///
@@ -1669,46 +1830,70 @@ mod tests {
             .expect("could not find the end of the update_class match");
         let body: String = body[..end].chars().filter(|c| !c.is_whitespace()).collect();
 
-        let request_arm = body
-            .find("UpdateClass::Request")
-            .expect("no Request arm in the classifier");
-        let broadcast_arm = body
-            .find("UpdateClass::Broadcast")
-            .expect("no Broadcast arm in the classifier");
+        // Map each opcode to the arm it actually sits in, INDEPENDENT of arm
+        // order (review finding 15). An opcode's class is the class named by the
+        // FIRST class marker that follows it: in a match, an arm's patterns
+        // precede its body.
+        //
+        // The previous form compared each opcode's position against
+        // `find("UpdateClass::Request")` and `find("UpdateClass::Broadcast")`,
+        // which was one-directional and order-sensitive. With Request first,
+        // moving `RequestUpdateStreaming` INTO the Broadcast arm left its index
+        // between the two markers, so `at < broadcast_arm` still held and the pin
+        // passed while a routed client write silently gained the 5x budget —
+        // the exact regression this test exists to prevent, in the direction it
+        // could not see.
+        let class_at = |opcode: &str| -> &'static str {
+            let at = body.find(opcode).unwrap_or_else(|| {
+                panic!(
+                    "opcode `{opcode}` is not classified in node.rs — an \
+                     unclassified UPDATE opcode is a budget bypass"
+                )
+            });
+            let next_request = body[at..].find("UpdateClass::Request");
+            let next_broadcast = body[at..].find("UpdateClass::Broadcast");
+            match (next_request, next_broadcast) {
+                (Some(r), Some(b)) => {
+                    if r < b {
+                        "Request"
+                    } else {
+                        "Broadcast"
+                    }
+                }
+                (Some(_), None) => "Request",
+                (None, Some(_)) => "Broadcast",
+                (None, None) => panic!(
+                    "opcode `{opcode}` is followed by no UpdateClass at all — the \
+                     classifier is not a match over the two classes any more"
+                ),
+            }
+        };
 
-        for variant in [
+        for opcode in [
             "UpdateMsg::BroadcastTo{..}",
             "UpdateMsg::BroadcastToV2{..}",
             "UpdateMsg::BroadcastToStreaming{..}",
             "UpdateMsg::BroadcastToStreamingV2{..}",
         ] {
-            let at = body.split(variant).next().map(str::len).unwrap_or(0);
-            assert!(
-                body.contains(variant),
-                "broadcast opcode `{variant}` is not classified in node.rs — an \
-                 unclassified broadcast opcode is a budget bypass"
-            );
-            assert!(
-                at > request_arm,
-                "broadcast opcode `{variant}` must sit in the Broadcast arm, not the \
-                 Request arm — the four broadcast opcodes MUST share one budget so \
+            assert_eq!(
+                class_at(opcode),
+                "Broadcast",
+                "broadcast opcode `{opcode}` must be charged to the Broadcast \
+                 class — the four broadcast opcodes MUST share one budget so \
                  switching between them gains nothing (#5510)"
             );
         }
 
-        for variant in [
+        for opcode in [
             "UpdateMsg::RequestUpdate{..}",
             "UpdateMsg::RequestUpdateStreaming{..}",
         ] {
-            let at = body.split(variant).next().map(str::len).unwrap_or(0);
-            assert!(
-                body.contains(variant),
-                "request opcode `{variant}` is not classified in node.rs"
-            );
-            assert!(
-                at < broadcast_arm,
-                "request opcode `{variant}` must sit in the Request arm — a routed \
-                 client write must not be charged the wider fan-out budget (#5510)"
+            assert_eq!(
+                class_at(opcode),
+                "Request",
+                "request opcode `{opcode}` must be charged to the Request class — \
+                 a routed client write must not gain the wider fan-out budget \
+                 (#5510)"
             );
         }
 

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -2830,6 +2830,33 @@ mod tests {
              of release builds by release_max_level_info (#4981)"
         );
 
+        // The per-pair rejection line, in this file. Same role as the
+        // fresh-id-churn line above and the same reason: the dispatch
+        // site logs it at `debug!` on purpose (a rejected pair is
+        // rejected on every message), so THIS is the only
+        // release-visible evidence that broadcasts are being dropped.
+        // #5510 is what a missing signal here costs: co-hosts diverged
+        // permanently and a production node had nothing to grep.
+        let rejected_fn = strip_ws(fn_body(
+            this_file_raw,
+            "fn log_rejected(&self, now: Instant, sender: SocketAddr, contract: ContractInstanceId) {",
+            "per-pair-rejection",
+        ));
+        assert_eq!(
+            level_of(
+                &rejected_fn,
+                &strip_ws(concat!(
+                    "UPDATE rate limiter: dropping UPDATEs from a ",
+                    "(sender, contract) pair"
+                )),
+                "per-pair-rejection",
+            ),
+            strip_ws("tracing::info"),
+            "the per-pair rejection log must be emitted at info! or higher; debug! is compiled \
+             out of release builds by release_max_level_info, which is how the #5510 broadcast \
+             drops left no evidence on a production node"
+        );
+
         // The residual capacity drop, in the UPDATE dispatch path.
         let node_rs = strip_ws(include_str!("../node.rs"));
         assert_eq!(

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -1355,11 +1355,22 @@ impl UpdateRateLimiter {
     /// Emit the fresh-id-churn log line, at most once per
     /// [`NEW_PAIR_LOG_INTERVAL`].
     ///
-    /// Throttled for the same reason the drop is worth logging at all: a
-    /// sender over its budget is over it on every message, so an
-    /// unthrottled line here would be a steady stream on exactly the
-    /// node under load. `info!` for the #4981 reason — `debug!` is
-    /// compiled out of release builds.
+    /// Throttled because a sender that has exhausted this budget is
+    /// exhausting it by introducing FRESH pairs, and it will keep
+    /// introducing them at whatever rate produced the exhaustion — so an
+    /// unthrottled line here would be a steady stream on exactly the node
+    /// under load.
+    ///
+    /// Note what that does NOT say. The budget is charged only for a pair
+    /// the map is not currently tracking, so a sender over it is not over
+    /// it on every message: its traffic on already-established pairs is
+    /// never charged and never refused here. This bounds the RATE OF
+    /// INTRODUCTION of new pairs, not a sender's sustained throughput, and
+    /// reading it as the latter overstates what a `SenderNewPairBudget`
+    /// refusal tells an operator about the sender.
+    ///
+    /// `info!` for the #4981 reason — `debug!` is compiled out of release
+    /// builds.
     fn log_new_pair_budget(&self, now: Instant, sender: SocketAddr) {
         if !log_due(&self.last_new_pair_log, now, NEW_PAIR_LOG_INTERVAL) {
             return;

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -298,8 +298,16 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 /// from ~10 to ~50 broadcasts/s. That is a real 5x, and it is the cost
 /// of the change. What still bounds it, unchanged:
 ///
-/// - the per-sender new-pair budget (#4997) is untouched, so a sender's
-///   AGGREGATE ceiling across contracts is still ~210 UPDATE/s;
+/// - the per-pair ceiling above is the honest statement of the bound, and
+///   there is NO aggregate one. Do not read the #4997 per-sender budget as
+///   supplying it: that budget charges a token only for a pair the limiter
+///   is not currently TRACKING, so it bounds the rate of INTRODUCING pairs
+///   (~200/s) and does nothing to a sender's traffic on pairs it has
+///   already established. A peer holding N established pairs sustains
+///   ~50/s on each of them, so the aggregate scales with N. An earlier
+///   version of this doc claimed a ~210 UPDATE/s aggregate ceiling here
+///   and was wrong, in the direction that matters — it made the budget
+///   look like a bound on volume when it bounds only novelty;
 /// - cost-pressure eviction (#4861/#4903) sheds a zero-demand contract
 ///   whose attributed CPU, fan-out bytes, or broadcast MESSAGE rate is
 ///   sustained above the floor — it measures the work actually done
@@ -381,24 +389,24 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 ///
 /// # Tuning this back toward 100ms is not free
 ///
-/// The obvious "safer" move is the wrong one, and the coupling is not
-/// visible from this constant alone. Raising the interval raises drop
-/// pressure; each drop that lands in a held throttle window arms a
-/// trailing repair; each repair chain holds one of the
-/// [`crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]
-/// (256) node-wide follow-up slots for up to a reservation window. So a
-/// higher interval thins the very backstop that is meant to catch the
-/// extra drops it creates, and it does so exactly when the node is
-/// busiest. Widening and narrowing this number are NOT symmetric.
+/// The obvious "safer" move is the wrong one. Raising the interval raises
+/// drop pressure, and the repair cannot absorb the extra drops: it allows
+/// one `ResyncRequest` per `(contract, sender)` per 30s, so the SECOND and
+/// later drops inside a window are refused and, on this branch, nothing
+/// re-sends them — they wait for the next drop after the window closes, or
+/// for the ~5-minute anti-entropy heartbeat. A higher interval therefore
+/// buys drops that land squarely in the repair's blind spot. #5525 closes
+/// that spot with a trailing coalesced repair; until it lands, treat every
+/// drop beyond the first per window as unrepaired.
 ///
 /// On the adversarial side, do not lean on the #4997 per-sender budget
 /// here: it charges a token only for a pair the limiter is not currently
 /// TRACKING, so it bounds the rate of introducing new pairs (~200/s) and
-/// not sustained traffic on established ones. What bounds a hostile peer
-/// reaching many follow-up slots is the held-contract gate above — a
-/// slot is only ever taken for a contract this node holds — together
-/// with the one-repair-per-(contract, sender)-per-30s throttle and the
-/// global per-contract emit cap.
+/// not sustained traffic on established ones. What bounds a hostile peer's
+/// repair traffic is the held-contract gate above — a repair is only ever
+/// emitted for a contract this node holds — together with the
+/// one-repair-per-(contract, sender)-per-30s throttle and the global
+/// per-contract emit cap.
 ///
 /// Do NOT set this to zero. An unbounded broadcast class re-opens the
 /// May 21 flood shape on the one message type that fans out.
@@ -799,9 +807,11 @@ impl RateLimitDecision {
 
 /// Per-(sender_addr, contract_instance_id) UPDATE rate limiter.
 ///
-/// All state lives in a single [`DashMap`] keyed by the pair. Each
-/// entry stores only the `Instant` of the most recent accepted UPDATE,
-/// so per-entry memory is tiny.
+/// All state lives in a single [`DashMap`] keyed by the pair. Each entry
+/// stores a [`PairStamps`] — one accepted-UPDATE `Instant` per
+/// [`UpdateClass`], so the two classes cannot starve each other — plus the
+/// most recent of them for sweeping and eviction. Two `Instant`s and a
+/// copy, so per-entry memory is still tiny.
 pub(crate) struct UpdateRateLimiter {
     last_accepted: DashMap<(SocketAddr, ContractInstanceId), PairStamps>,
     /// Authoritative size counter for capacity enforcement. Held
@@ -1908,12 +1918,49 @@ mod tests {
             );
         }
 
+        // A `_ =>` is only the most obvious way to smuggle in a catch-all.
+        // `other => UpdateClass::Broadcast` and `_ if cond =>` both defeat a
+        // bare `!contains("_=>")` while doing exactly the damage this pin
+        // exists to prevent: a new UPDATE wire variant silently inheriting a
+        // class instead of failing to COMPILE. So assert the SHAPE of every
+        // arm rather than blacklisting one spelling of the bad one.
         assert!(
             !body.contains("_=>"),
             "the classifier must stay an exhaustive match with NO catch-all: a new \
              UPDATE wire variant must fail to COMPILE rather than silently inherit \
              whichever class the wildcard names"
         );
+
+        let variants = body.matches("UpdateMsg::").count();
+        assert_eq!(
+            variants, 6,
+            "the classifier must name all six UpdateMsg variants explicitly, found \
+             {variants}. Fewer means a variant is being matched by something other \
+             than its own name — which is a catch-all however it is spelled"
+        );
+
+        // Every `=>` must be preceded by the `}` that closes a `{..}` struct
+        // pattern. A binding arm (`other =>`) or a guard (`_ if cond =>`) ends
+        // in an identifier or a paren instead, so this rejects both without
+        // needing to enumerate them.
+        let arms = body.matches("=>").count();
+        assert_eq!(
+            arms, 2,
+            "expected exactly two arms (Request and Broadcast), found {arms}; a \
+             third arm is a catch-all or an unintended reclassification"
+        );
+        for (i, _) in body.match_indices("=>") {
+            let preceding = &body[..i];
+            assert!(
+                preceding.ends_with("}"),
+                "every classifier arm must match a named variant with a `{{..}}` \
+                 pattern, but one arm's pattern ends with {:?} — a bare identifier \
+                 binds EVERY variant (`other => ...`) and a guard leaves the \
+                 remainder unmatched, either of which lets a new wire variant \
+                 inherit a class silently",
+                preceding.chars().rev().take(12).collect::<String>()
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -282,6 +282,41 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 ///   a saturated uplink folds updates instead of accumulating them;
 /// - the contract ban list still applies ahead of this gate.
 ///
+/// # Message zero, and why the wider class is safe to hand out on it
+///
+/// The class is chosen from the wire opcode, which the SENDER picks, so a peer
+/// is on this budget from its FIRST message — there is no reputation to earn.
+/// The uniform-across-opcodes rule above stops a flooder gaining anything by
+/// SWITCHING opcode; it does not stop it simply choosing `BroadcastTo`. So what
+/// bounds the first message is what an unsolicited broadcast actually costs,
+/// traced rather than assumed:
+///
+/// - **The sender must already be a connected, authenticated peer.** The
+///   dispatch has no `source_addr` otherwise, and
+///   `op_ctx_task::seed_sender_summary_from_broadcast` (`op_ctx_task.rs:1995`,
+///   the driver's first step) returns immediately when
+///   `get_peer_by_addr` finds no connection. This is the load-bearing bound:
+///   the budget is per `(sender, contract)`, and a sender is a live connection
+///   against `max_connections`, not an arbitrary address.
+/// - **For a contract this node does not host and nothing depends on, no GET is
+///   spawned.** The full-state error arm reaches `try_auto_fetch_contract`,
+///   which returns early on `!contract_in_use` (`operations/update.rs:245`;
+///   `contract_in_use` is a live local client subscription or a downstream
+///   subscriber, `ring/hosting.rs:1725`). So an unsolicited broadcast for a
+///   stranger contract cannot make this node fetch it.
+/// - **The contract's WASM does not execute for a contract we lack.** The merge
+///   fails as missing-contract, which `is_contract_exec_rejection` explicitly
+///   excludes — that is why the arm above can tell "code missing" from "the
+///   contract rejected it".
+///
+/// What it DOES cost, stated plainly rather than glossed: for a contract this
+/// node **does** host, every accepted broadcast is a real WASM merge, and this
+/// constant raises the per-`(sender, contract)` ceiling on that from ~10/s to
+/// ~50/s. The dedup cache (`broadcast_dedup_cache`, step 3 of the driver) only
+/// helps against a REPEATED payload; a sender varying the bytes pays the merge
+/// every time. That 5x is the actual price of this change, and the
+/// compensating bounds are the ones listed above plus those below.
+///
 /// Do NOT set this to zero. An unbounded broadcast class re-opens the
 /// May 21 flood shape on the one message type that fans out.
 pub(crate) const MIN_BROADCAST_INTERVAL: Duration = Duration::from_millis(20);
@@ -335,6 +370,24 @@ pub(crate) struct PairStamps {
     /// expiring an entry whose OTHER class is actively in use would reset
     /// that class's window and hand a flooder a free message.
     latest: Instant,
+}
+
+impl UpdateClass {
+    /// Stable index for per-class arrays (the rejection-log throttles).
+    fn index(self) -> usize {
+        match self {
+            UpdateClass::Request => 0,
+            UpdateClass::Broadcast => 1,
+        }
+    }
+
+    /// Stable telemetry label.
+    fn as_str(self) -> &'static str {
+        match self {
+            UpdateClass::Request => "request",
+            UpdateClass::Broadcast => "broadcast",
+        }
+    }
 }
 
 impl PairStamps {
@@ -740,8 +793,13 @@ pub(crate) struct UpdateRateLimiter {
     /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
     last_new_pair_log: Mutex<Option<Instant>>,
     /// When the last per-pair rejection log line was written, for
-    /// [`REJECTED_LOG_INTERVAL`] throttling.
-    last_rejected_log: Mutex<Option<Instant>>,
+    /// [`REJECTED_LOG_INTERVAL`] throttling — one slot PER [`UpdateClass`].
+    ///
+    /// Per class rather than one shared slot because the two classes are now
+    /// the diagnosis: a shared slot lets a busy broadcast pair suppress the
+    /// line that would have told the operator a client's routed writes are
+    /// being refused, which is the more alarming of the two and the rarer.
+    last_rejected_log: [Mutex<Option<Instant>>; 2],
 }
 
 impl UpdateRateLimiter {
@@ -822,7 +880,7 @@ impl UpdateRateLimiter {
             new_pair_budget_rejected_total: AtomicU64::new(0),
             new_pair_budget_untracked_total: AtomicU64::new(0),
             last_new_pair_log: Mutex::new(None),
-            last_rejected_log: Mutex::new(None),
+            last_rejected_log: [Mutex::new(None), Mutex::new(None)],
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
             min_interval,
@@ -920,7 +978,7 @@ impl UpdateRateLimiter {
                         // means every OTHER lock is taken with no shard guard
                         // held.
                         drop(entry);
-                        self.log_rejected(now, sender, contract);
+                        self.log_rejected(now, sender, contract, class);
                         return RateLimitDecision::Rejected {
                             elapsed,
                             min_interval,
@@ -1246,21 +1304,34 @@ impl UpdateRateLimiter {
     ///
     /// Throttled for the same reason the other two signals are: a pair over
     /// the interval is over it on every message.
-    fn log_rejected(&self, now: Instant, sender: SocketAddr, contract: ContractInstanceId) {
-        if !log_due(&self.last_rejected_log, now, REJECTED_LOG_INTERVAL) {
+    fn log_rejected(
+        &self,
+        now: Instant,
+        sender: SocketAddr,
+        contract: ContractInstanceId,
+        class: UpdateClass,
+    ) {
+        if !log_due(
+            &self.last_rejected_log[class.index()],
+            now,
+            REJECTED_LOG_INTERVAL,
+        ) {
             return;
         }
         tracing::info!(
             %sender,
             %contract,
+            class = class.as_str(),
             rejected_total = self.rejected_total.load(Ordering::Relaxed),
-            min_interval_ms = self.min_interval.as_millis() as u64,
+            min_interval_ms = self.interval_for(class).as_millis() as u64,
             "UPDATE rate limiter: dropping UPDATEs from a (sender, contract) pair \
-             that is exceeding the minimum inter-update interval. A dropped \
-             BROADCAST is repaired by a throttled ResyncRequest (#5510); a \
-             dropped request is retried by its originator. Sustained counts here \
-             mean co-host fan-out for this contract is outrunning the per-pair \
-             budget. Throttled to one line per minute."
+             that is exceeding its class's minimum inter-update interval. \
+             class=broadcast means co-host fan-out for this contract is \
+             outrunning the per-pair budget, and each dropped broadcast is \
+             repaired by a throttled ResyncRequest (#5510). class=request means \
+             a peer's ROUTED CLIENT WRITES are being refused, which is the \
+             rarer and more alarming of the two; its originator observes the \
+             failure and retries. Throttled to one line per minute PER CLASS."
         );
     }
 
@@ -3287,7 +3358,7 @@ mod tests {
         // permanently and a production node had nothing to grep.
         let rejected_fn = strip_ws(fn_body(
             this_file_raw,
-            "fn log_rejected(&self, now: Instant, sender: SocketAddr, contract: ContractInstanceId) {",
+            "    fn log_rejected(",
             "per-pair-rejection",
         ));
         assert_eq!(

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -400,6 +400,13 @@ const MIN_TRACKED_SENDERS: usize = 64;
 /// too or it becomes the log flood it is meant to report.
 const NEW_PAIR_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
 
+/// How often the per-pair rejection signal may write a log line.
+///
+/// Same reasoning again: a `(sender, contract)` pair over
+/// [`MIN_UPDATE_INTERVAL`] is over it on every message, so an unthrottled
+/// line here would be a flood on exactly the node under load.
+const REJECTED_LOG_INTERVAL: Duration = EVICTION_LOG_INTERVAL;
+
 /// Outcome of an at-capacity eviction pass.
 ///
 /// This is an enum rather than a count of removed entries because
@@ -591,6 +598,9 @@ pub(crate) struct UpdateRateLimiter {
     /// When the last new-pair-budget log line was written, for
     /// [`NEW_PAIR_LOG_INTERVAL`] throttling.
     last_new_pair_log: Mutex<Option<Instant>>,
+    /// When the last per-pair rejection log line was written, for
+    /// [`REJECTED_LOG_INTERVAL`] throttling.
+    last_rejected_log: Mutex<Option<Instant>>,
 }
 
 impl UpdateRateLimiter {
@@ -653,6 +663,7 @@ impl UpdateRateLimiter {
             new_pair_budget_rejected_total: AtomicU64::new(0),
             new_pair_budget_untracked_total: AtomicU64::new(0),
             last_new_pair_log: Mutex::new(None),
+            last_rejected_log: Mutex::new(None),
             last_accepted: DashMap::new(),
             size: AtomicUsize::new(0),
             min_interval,
@@ -728,6 +739,15 @@ impl UpdateRateLimiter {
                     let elapsed = now.saturating_duration_since(last);
                     if elapsed < self.min_interval {
                         self.rejected_total.fetch_add(1, Ordering::Relaxed);
+                        // Release the shard guard BEFORE taking the log
+                        // throttle's mutex. `log_new_pair_budget` is the only
+                        // lock this module takes under a `last_accepted` guard,
+                        // and its ordering is documented as having no
+                        // counterpart to invert against; keeping that true
+                        // means every OTHER lock is taken with no shard guard
+                        // held.
+                        drop(entry);
+                        self.log_rejected(now, sender, contract);
                         return RateLimitDecision::Rejected {
                             elapsed,
                             min_interval: self.min_interval,
@@ -1025,6 +1045,38 @@ impl UpdateRateLimiter {
              are being dropped. Its traffic for tracked pairs is unaffected. If this \
              peer is not churning contract ids, the budget is set too low for this \
              node's working set. Throttled to one line per minute."
+        );
+    }
+
+    /// Emit the per-pair rejection log line, at most once per
+    /// [`REJECTED_LOG_INTERVAL`].
+    ///
+    /// `info!` rather than `debug!` for the #4981 reason, and because #5510
+    /// showed the cost of not having it: `release_max_level_info` compiles
+    /// `debug!` out, so on a production node a rate-limited UPDATE — including
+    /// a co-host BROADCAST, which diverges the two peers permanently until it
+    /// is repaired — left no greppable evidence at all. The drop is now
+    /// repaired (`node.rs` routes a dropped broadcast into
+    /// `send_dropped_broadcast_resync_request`), and this line is how an
+    /// operator sees that it is happening.
+    ///
+    /// Throttled for the same reason the other two signals are: a pair over
+    /// the interval is over it on every message.
+    fn log_rejected(&self, now: Instant, sender: SocketAddr, contract: ContractInstanceId) {
+        if !log_due(&self.last_rejected_log, now, REJECTED_LOG_INTERVAL) {
+            return;
+        }
+        tracing::info!(
+            %sender,
+            %contract,
+            rejected_total = self.rejected_total.load(Ordering::Relaxed),
+            min_interval_ms = self.min_interval.as_millis() as u64,
+            "UPDATE rate limiter: dropping UPDATEs from a (sender, contract) pair \
+             that is exceeding the minimum inter-update interval. A dropped \
+             BROADCAST is repaired by a throttled ResyncRequest (#5510); a \
+             dropped request is retried by its originator. Sustained counts here \
+             mean co-host fan-out for this contract is outrunning the per-pair \
+             budget. Throttled to one line per minute."
         );
     }
 

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2179,29 +2179,44 @@ fn test_full_state_send_no_incorrect_caching() {
         convergence.diverged.len()
     );
 
-    // SECONDARY ASSERTION: No ResyncRequests should be needed
-    // With correct summary caching (PR #2763), deltas should work correctly
-    // Without the fix, peers would fail to apply deltas and send ResyncRequests
+    // SECONDARY ASSERTION: no delta may FAIL TO APPLY.
+    // With correct summary caching (PR #2763), deltas apply cleanly; without
+    // it, peers fail to apply them and send ResyncRequests.
+    //
+    // #5510 made this assertion specific rather than total. It used to assert
+    // `resync_requests() == 0`, using "no resyncs at all" as a proxy for "no
+    // delta failed". That proxy held only while a delta failure was the ONLY
+    // thing that emitted a ResyncRequest. It no longer is: a queue-full drop,
+    // a rate-limited broadcast drop, and the trailing coalesced repair all emit
+    // one too, and all three are healthy behaviour. This test began failing on
+    // exactly that — `delta_sends: 0, full_state_sends: 11, resync_requests: 1`
+    // with everything converged — where the single resync was a broadcast
+    // repair and no delta had failed at all.
+    //
+    // `delta_failure_resyncs()` is counted at the branch that makes the
+    // decision (the `is_delta && !queue_full` arm of the broadcast driver),
+    // not derived by subtracting other causes from the total, so it cannot
+    // silently absorb a future fourth cause the way the old proxy did.
     let resync_count = GlobalTestMetrics::resync_requests();
+    let delta_failure_resyncs = GlobalTestMetrics::delta_failure_resyncs();
     let delta_sends = GlobalTestMetrics::delta_sends();
     let full_state_sends = GlobalTestMetrics::full_state_sends();
 
     tracing::info!(
-        "Broadcast stats - delta_sends: {}, full_state_sends: {}, resync_requests: {}",
+        "Broadcast stats - delta_sends: {}, full_state_sends: {}, \
+         resync_requests: {} (of which delta-failure: {})",
         delta_sends,
         full_state_sends,
-        resync_count
+        resync_count,
+        delta_failure_resyncs
     );
 
-    // Note: Some resyncs may occur during normal operation (e.g., initial state sync),
-    // but excessive resyncs indicate the caching bug. We check for zero resyncs in this
-    // controlled scenario where all peers start fresh and updates flow correctly.
     assert_eq!(
-        resync_count, 0,
-        "PR #2763 REGRESSION: {} ResyncRequests detected! \
-         This indicates deltas are failing due to incorrect summary caching. \
-         With the fix, no resyncs should be needed in this scenario.",
-        resync_count
+        delta_failure_resyncs, 0,
+        "PR #2763 REGRESSION: {delta_failure_resyncs} ResyncRequest(s) were \
+         emitted because a DELTA FAILED TO APPLY, which is what incorrect \
+         summary caching looks like. ({resync_count} resyncs in total; the \
+         others, if any, are broadcast-drop repairs and are not this bug.)"
     );
 
     // TERTIARY ASSERTION: Verify broadcast activity

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2186,9 +2186,10 @@ fn test_full_state_send_no_incorrect_caching() {
     // #5510 made this assertion specific rather than total. It used to assert
     // `resync_requests() == 0`, using "no resyncs at all" as a proxy for "no
     // delta failed". That proxy held only while a delta failure was the ONLY
-    // thing that emitted a ResyncRequest. It no longer is: a queue-full drop,
-    // a rate-limited broadcast drop, and the trailing coalesced repair all emit
-    // one too, and all three are healthy behaviour. This test began failing on
+    // thing that emitted a ResyncRequest. It no longer is: a queue-full drop
+    // and a rate-limited broadcast drop both emit one too (and #5525 adds a
+    // third, the trailing coalesced repair), all of them healthy behaviour.
+    // This test began failing on
     // exactly that — `delta_sends: 0, full_state_sends: 11, resync_requests: 1`
     // with everything converged — where the single resync was a broadcast
     // repair and no delta had failed at all.
@@ -2196,7 +2197,7 @@ fn test_full_state_send_no_incorrect_caching() {
     // `delta_failure_resyncs()` is counted at the branch that makes the
     // decision (the `is_delta && !queue_full` arm of the broadcast driver),
     // not derived by subtracting other causes from the total, so it cannot
-    // silently absorb a future fourth cause the way the old proxy did.
+    // silently absorb a future cause the way the old proxy did.
     let resync_count = GlobalTestMetrics::resync_requests();
     let delta_failure_resyncs = GlobalTestMetrics::delta_failure_resyncs();
     let delta_sends = GlobalTestMetrics::delta_sends();


### PR DESCRIPTION
## Problem

`crates/core/src/node.rs` applies `update_rate_limiter.check_and_record()` uniformly
across all six UPDATE wire variants before the relay drivers, and on rejection logs and
`return Ok(())`. For the four `BroadcastTo*` variants that drop is unrepairable:

- **The sender has already recorded it as delivered.** `record_delivery_to_interest`
  (`broadcast_queue.rs`) refreshes its cached summary of us on a *send-Ok*, and send-Ok
  for the bridge is a local enqueue, not a receiver acknowledgement.
- **Since #5464 the payload is a true difference against that belief**, so the entries in
  the dropped message are excluded from *every later delta*, not just this one. The
  divergence is permanent rather than delayed.
- **Neither existing repair fires.** The delta-apply-failure `ResyncRequest` needs an
  apply that *failed*, and nothing was applied. Anti-entropy is 300s at minimum and
  40-75 min at field shared-set sizes since #5238/#5346.
- **The drop was invisible in production.** The `Rejected` arm logged at `debug!`, which
  `release_max_level_info` compiles out of release builds.

Part of #5510. Not `Closes`: the drops a held throttle window swallows are the
issue's own "nothing ever re-sends them" for that case, and they are closed by
#5525, which carries the `Closes`.

## Approach

Four parts, one of which (part 3) is now a pointer to the stacked #5525 rather than a
change in this diff — the numbering is kept so the review history stays readable. Both
the repair and the budget change are needed: repair alone left the flake at 5 fail / 10,
which is what sent me to the budget with a measurement rather than an assertion.

### 1. Route the drop into the existing repair

`send_queue_full_resync_request` becomes `send_dropped_broadcast_resync_request`,
`pub(crate)`, and takes a `DroppedBroadcastReason` so the two causes stay distinguishable
in telemetry (`reason = "queue_full"` is preserved verbatim; the new one is
`"rate_limited"`). The `node.rs` rate-limiter arm calls it for the four broadcast
variants.

`RequestUpdate*` is deliberately **not** repaired: it is a routed request whose
originator observes the failure, and it caches no summary of us, so a resync there would
be pure amplification onto a node already refusing this sender.

Throttling is unchanged and inherited: one request per `(contract, sender)` per
`RESYNC_REQUEST_MIN_INTERVAL` (30s), the global per-contract `resync_emit_limiter` cap,
and the node-wide retry-task slot cap.

### 2. What the repair provokes, and whether the limiter can silence it

Checked by reading the code, then confirmed end-to-end in a run log rather than assumed.
The `ResyncRequest` is emitted as `NodeEvent::SendInterestMessage`, which reaches the wire
as `NetMessageV1::InterestSync`. The handler in `node.rs::handle_interest_sync_message`
answers with `InterestMessage::ResyncResponse`, which the dispatch site wraps in
`NetMessageV1::InterestSync` again. **Neither direction is a `NetMessageV1::Update`, so
neither touches the UPDATE rate limiter that caused the drop.** The repair cannot be
silenced by the condition it repairs. A branch run shows the full round trip: 6 requests
sent with `reason="rate_limited"`, 6 received, 6 full-state responses sent, 6 received.

The response *is* subject to two separate limiters in the responder
(`resync_response_limiter` per `(peer, contract)`, and `resync_response_global_limiter`
per contract). One honest limitation follows: the responder clears its cached summary of
us (`clear_peer_summary`) *after* those two gates, so when the response is suppressed
neither leg of the repair fires on that attempt and the requester heals on a later window.

### 3. The drops the throttle itself swallows — split out to #5525

The throttle allows one repair per `(contract, sender)` per
`RESYNC_REQUEST_MIN_INTERVAL` (30s). Every *further* drop inside that window is still
refused with nothing to re-send it, which is #5510's "nothing ever re-sends them" for
that case, still open after part 1. The #4862 trailing retry does not cover it: it
re-delivers the SAME already-authorized request in case the lossy notify path lost it,
stops as soon as the first `ResyncResponse` lands, and carries no knowledge of anything
dropped since.

**That residual is fixed in #5525, stacked on this branch**, not here. It was originally
part of this PR and was split out after review: it is a distinct mechanism (a flag on the
reservation, a bounded follow-up chain, a coalesced emit at the window's close) with its
own failure modes, and reviewing it inside a PR whose subject is the rate limiter made
both harder to read. Merge this first, then #5525.

The residual is bounded meanwhile: a swallowed drop is repaired by the next drop on that
pair once the window has closed, or by the ~5-minute InterestSync anti-entropy heartbeat.

### 4. Make the drop visible in release

This deliberately copies the shape the `SenderNewPairBudget` arm already uses rather
than the `CapacityExceeded` one: the per-drop line in `node.rs` stays at `debug!`,
because a rejected pair is rejected on *every* message and a per-drop `info!` would be
the flood it is meant to report. The release-visible signal is a new throttled
`UpdateRateLimiter::log_rejected`, one line per minute carrying the sender, the
contract, the class and the running total, alongside the existing `rejected_total`
counter. It mirrors `log_eviction` and `log_new_pair_budget`, and
`capacity_signals_are_logged_above_debug_level` is extended to pin its level (verified:
downgrading it to `debug!` fails that pin).

The throttle is **per class**, not one shared slot. With one slot a busy broadcast pair
would suppress the line that says a peer's *routed client writes* are being refused —
the rarer and more alarming of the two — so the class is both a field on the line and
the key of its throttle.

The `match rate_decision` stays exhaustive with no catch-all, as the #4981 comment
requires: a new decision variant must get its own arm rather than silently landing at
`debug!` and vanishing from release builds.

The rejected counter **is** already exported, so no new counter was needed: `p2p_impl.rs`
maps `rate_limiter.rejected_total()` to `RingStatsSnapshot::updates_rate_limited`, which
the node's home page renders as the "Rate-limited" tile and `freenet service report`
uploads.

### 5. Fix the misleading test diagnostic

`test_ping_multi_node` printed "PARTIAL: >80% propagated but timestamp mismatches" from an
`else` on `propagation_rate` regardless of which check failed, and the length check
`continue`d before any timestamp was compared, so that message was reported for failures
where no timestamp comparison ever ran. It misdirected three investigations (#5476).

The per-tag analysis now computes the union of the three histories and reports, per node,
exactly which entries are missing; it distinguishes missing entries, an absent tag,
duplicate entries, and a genuine ordering difference; and the diagnosis and the assertion
print the recorded reasons. `propagation_rate` is kept, relabelled as what it measures:
tag *presence*, not history completeness, which is why it read 100% while entries inside a
present tag were missing.

On a failing run it now says, verbatim:

```
FAILED: tag 'ping-from-gw': MISSING ENTRIES (not a timestamp mismatch) —
  Node1 is missing 1 of 3 entries: 2026-09-01T23:28:48.201686526+00:00;
  Node2 is missing 1 of 3 entries: 2026-09-01T23:28:48.201686526+00:00
Context — tag-level propagation rate: 100.0% (6/6 tags present).
```

## Design decision: broadcast budget

**This is the part to veto if you disagree with it.**

`MIN_UPDATE_INTERVAL`'s rationale is about a human writing to a contract, and it is right
about that. It is the wrong reference class for a broadcast: a broadcast is not a write,
it is the **derived fan-out of a write some peer already committed**. One commit produces
one broadcast per co-host neighbour, so the broadcast rate on a single
`(sender, contract)` pair is the contract's **aggregate commit rate summed over every
writer reachable through that neighbour**, not one writer's cadence.

### Why the repair alone was not enough, measured

I implemented parts 1-3 first and measured before touching the calibration.

| build | `test_ping_multi_node` |
|---|---|
| clean `origin/main` @ `f70708446` | **6 fail / 10** |
| parts 1-3 only (repair + logging + diagnostic) | **5 fail / 10** |

Runs alternated between the two worktrees so machine-load drift hits both equally; default
nextest profile, so `retries = 0` and each run is one honest attempt.

Instrumenting the limiter to log every refusal with its elapsed-since-last-accepted:
6 runs were attempted, 5 produced drop data (the 6th aborted before the update phase),
and those 5 pool to n=145 refusals — 28, 28, 29, 34, 26:

- 26-34 refusals per run, **7-12 per `(sender, contract)` pair**
- elapsed spread across the whole window: min 0.12ms, **p50 42.6ms**, p90 88.3ms, max 99.9ms
- **only 6 resyncs emitted per run**, because the repair is throttled to one per
  `(contract, sender)` per 30s

That is the gap. With 7-12 refusals per pair and one repair per pair per 30s, most
refusals are unrepaired, and a failing run shows the two client nodes stuck at 2 of 3
gateway entries for the entire 90s convergence poll, flat, never moving. The repair makes
a *residual* drop survivable; it cannot carry a drop rate this high.

### The change

`UpdateClass { Request, Broadcast }` and `MIN_BROADCAST_INTERVAL = 20ms` (50/s). The four
broadcast opcodes share one class, so switching opcode gains nothing — the property the
original uniform-across-opcodes comment was protecting, kept intact. The classifier is an
exhaustive `match` with no catch-all, so a new UPDATE wire variant fails to **compile**
rather than silently inheriting a budget.

The two classes hold **separate stamps inside one map entry**. That is the design choice
worth reviewing. A single shared stamp read against two thresholds would be a smaller
diff, but on a pair busy with fan-out it would advance every ~20ms and a routed
`RequestUpdate` from the same neighbour for the same contract would essentially never see
its 100ms of quiet — a client's write silently refused because someone else's room was
busy. Separate stamps in one entry avoid that while leaving the key space, the cap, the
eviction path and the per-sender new-pair budget (#4997) **exactly as they were**. A
per-class map or a second limiter instance would have doubled the #4997 budget, which is
the compensating control for eviction, so neither was acceptable.

### Why the budget is keyed by opcode class, not by interest relationship

The tempting alternative is to give the wider budget only to peers we already
co-host with, and leave strangers on the write-cadence number. That is
self-granting, and the mechanism is worth naming so nobody re-proposes it:
**receiving a broadcast is itself what registers the sender as interested.**
`seed_sender_summary_from_broadcast` is the FIRST step of the broadcast driver, on
both the non-streaming and the streaming path, and calls
`InterestManager::upsert_peer_summary_from`, which **creates** the entry when absent
(`entry.insert(peer.clone(), PeerInterest::new(...))`). So an attacker's *first* broadcast would establish the
relationship that qualifies it for the wider budget, and the gate would grant
itself. Keying on the opcode class has no such feedback edge.

### Message zero: what an unsolicited broadcast costs before it is rejected

The class comes from the wire opcode, which the **sender** picks, so a peer is on the
50/s budget from its first message — there is no reputation to earn. The uniformity
rule stops a flooder gaining anything by *switching* opcode; it does not stop one
simply choosing `BroadcastTo`. So the question is what an unsolicited broadcast
actually costs. Traced rather than assumed:

- **The sender must already be a connected, authenticated peer.** The dispatch has no
  `source_addr` otherwise, and `seed_sender_summary_from_broadcast`
  returns immediately when `get_peer_by_addr` finds no connection. This is the load-bearing bound: the budget is per `(sender, contract)`,
  and a sender is a live connection against `max_connections`, not an arbitrary
  address.
- **For a contract this node does not host and nothing depends on, no GET is
  spawned.** The full-state error arm reaches `try_auto_fetch_contract`, which returns
  early on `!contract_in_use` (`Ring::contract_in_use` — a live local client
  subscription or a downstream subscriber).
- **The repair emit is itself gated on `should_summarize_or_broadcast`**, so an
  unsolicited broadcast for a contract this node does not hold provokes no
  `ResyncRequest` at all. Worth naming its cost, since it sits on the rejection path: it
  is an in-memory hosting read AND a redb point lookup for `contract_state_present`
  (#4610). That is not free, but it is paid only on a *rejected* broadcast, which the
  20ms budget already bounds to 50/s per `(sender, contract)`, and it buys the avoidance
  of asking a peer for a WASM summarize plus a full-state transfer we would discard.
- **The contract's WASM does not execute for a contract we lack.** The merge fails as
  missing-contract, which `is_contract_exec_rejection` explicitly excludes — that is
  how the arm tells "code missing" apart from "the contract rejected it".

- **What it touches first** is the interest map: `seed_sender_summary_from_broadcast`
  runs as step 1 of the driver, ahead of the dedup cache and the merge, and upserts the
  sender's self-reported summary. Three properties bound it, all pre-existing: it is
  connected-peer only; an *empty* summary refreshes an existing entry's TTL and never
  creates one; and at `MAX_INTERESTED_PEERS_PER_CONTRACT` the map **refuses** rather
  than evicting, so an established co-host cannot be displaced. What this change alters
  is only how fast that path can be reached for one contract, and at saturation the cost
  is degraded efficiency — full states instead of deltas — not lost correctness.

**What it does cost, stated plainly:** for a contract this node *does* host, every
accepted broadcast is a real WASM merge, and this constant raises the
per-`(sender, contract)` ceiling on that from ~10/s to ~50/s. The dedup cache only
helps against a *repeated* payload; a sender varying the bytes pays the merge every
time. That is the honest shape of the 5x — 5x on merges for hosted contracts, not
merely 5x on messages.

That merge is not unmetered work, which is what makes the 5x acceptable rather than
merely bounded: cost-pressure eviction (#4861/#4903) attributes per-contract WASM CPU,
fan-out bytes and broadcast **message** rate and sheds a zero-demand contract whose cost
is sustained above the floor, and governance meters the same traffic. The 5x lands on an
axis that is already watched.

### The repair-side amplification, and the two gates that remove it

Review found the more serious half: it was not the merge an attacker would ride on the
looser class, it was the **repair**. Two gates in the dispatch arm remove it, and they
compound — the first gave unlimited rate, the second unlimited key space:

- **The repair fires only on `RateLimitDecision::Rejected`.** It used to sit after the
  match and run for every non-allowed decision. `SenderNewPairBudget` was the dangerous
  one: that decision means a sender is churning *fresh contract ids* past its #4997
  burst, so every downstream gate is vacant by construction — a fresh
  `(contract, sender)` key means `begin_resync_request` grants, a fresh contract means
  `resync_emit_limiter` grants — and the node would emit roughly one `ResyncRequest` per
  refused message straight back at the flooder, each inviting a full-state response that
  the correlation record authorizes into a WASM merge. The #4997 budget exists precisely
  so that traffic over it is *free* to refuse.
- **The repair fires only for a contract this node holds.** `key` is attacker-supplied
  and nothing upstream validates it. The queue-full call sites are reached only after
  `update_contract` returned `ContractQueueFull`, which proves the executor holds it; the
  dispatch arm proved nothing. Gated on `should_summarize_or_broadcast`, which is
  `(is_hosting_contract || contract_in_use) && contract_state_present` (#4610):
  synchronous, so a refusal path pays no store await, and strictly stronger than the
  state-presence check the `ResyncRequest` *handler* uses, because it also requires that
  something here wants the contract.

This does not contradict the argument against keying the *budget* on interest
relationship, above. That would be self-granting, because receiving a broadcast is what
registers the sender as interested. Hosting is different: an attacker cannot make this
node hold a contract by sending it a `BroadcastTo`.

### The DoS trade-off, stated plainly

This raises what **one peer can force this node to do for one contract** from ~10 to ~50
broadcasts/s. That is a real 5x and it is the cost of the change. What still bounds it,
unchanged:

- the per-sender new-pair budget (#4997) is untouched, so a sender's **aggregate** ceiling
  across contracts is still ~210 UPDATE/s;
- cost-pressure eviction (#4861/#4903) sheds a zero-demand contract whose attributed CPU,
  fan-out bytes, or broadcast **message** rate is sustained above the floor — it measures
  work actually done rather than a fixed rate, which is the control that fits a storm;
- the broadcast queue already coalesces (per-`(contract, peer)` keep-latest
  replace-on-dedup, drained by a bounded worker), so a saturated uplink folds updates;
- the contract ban list still runs ahead of this gate.

It is not set to zero, and the constant's rustdoc says why not.

## Testing

**Regression test.** `node::tests::rate_limited_broadcast_emits_throttled_resync_request`
asserts that a refused `BroadcastTo` emits exactly one throttled `ResyncRequest` to the
sender, that a second refusal in the same window emits none, and that a refused
`RequestUpdate` emits none. Verified to FAIL with the repair arm removed:
`left: []`, `right: [127.0.0.1:15100]`.

It is deterministic rather than racing the limiter: `NodeConfig::
update_rate_limit_time_source_override` (new, mirroring the existing
`hosting_time_source_override`) injects a frozen `SharedMockTimeSource`, so priming a pair
and then dispatching a message that must be *refused* cannot be turned into an *allowed*
message by a scheduling stall — which would have sent it to a relay driver and made the
assertions measure something else.

**Budget tests, each verified against the mutation it exists to catch** rather than merely
passing:

| test | mutation | result |
|---|---|---|
| `broadcast_class_is_charged_against_its_own_interval` | collapse the two intervals | FAILS |
| `broadcast_traffic_does_not_starve_routed_requests_on_the_same_pair` | one shared stamp | FAILS |
| `first_message_of_a_class_on_an_existing_pair_is_allowed` | one shared stamp | FAILS |
| `every_broadcast_opcode_is_charged_to_the_broadcast_class` | move one broadcast opcode into the Request arm | FAILS |
| `ttl_sweep_reads_the_most_recent_stamp_of_either_class` | — | guards the sweep/LRU reading `latest()` |

**Log-level pin.** `capacity_signals_are_logged_above_debug_level` is extended to the new
`log_rejected` site, so a future downgrade to `debug!` — which is what made #5510 invisible
in the field — fails CI.

**A/B re-run on the current head after the split** (the split changed what this branch
contains, so the earlier numbers no longer described it). Same protocol throughout: 10
runs per side, alternated between the two worktrees so machine-load drift hits both
equally, default nextest profile so `retries = 0` and each run is one honest attempt.

| build | `test_ping_multi_node` |
|---|---|
| clean `origin/main` @ `f70708446` | **5 fail / 10** |
| this branch (post-split head) | **0 fail / 10** |

The full picture across all three measurement rounds, every run on the same machine:

| build | result |
|---|---|
| `origin/main` (round 1) | 6 fail / 10 |
| repair + logging + diagnostic only | 5 fail / 10 |
| `origin/main` (round 2) | 3 fail / 10 |
| repair + budget (round 2) | **0 fail / 10** |
| `origin/main` (round 3, post-split) | 5 fail / 10 |
| this branch (round 3, post-split) | **0 fail / 10** |

Main's own control moved 6/10, then 3/10, then 5/10 across the three rounds with no code
change at all, which is worth stating plainly rather than quietly picking the flattering
round: this test's failure rate is load-dependent, so the honest read is "0/10 against a
same-session control that failed 5/10", not a precise rate. Note also what the round-3
numbers do NOT establish — the branch scored 0/10 in round 2 as well, when it still
carried the coalesced-repair chain now split into #5525, so these runs do not attribute
the improvement between the two PRs. The mechanism is what carries the claim, and the
instrumented counts (7-12 refusals per pair, 6 repairs per run) are the direct
measurement of it.

`cargo fmt --all` and `cargo clippy --all-targets --features testing -- -D warnings` are
clean.

### Why there is no deterministic simulation test, measured rather than assumed

`test-philosophy.md` prefers a `run_simulation_direct`-style test over the real-network
`test_ping_multi_node` for behaviour like this, so I checked whether the existing harness
can drive co-host fan-out above the broadcast budget between two peers. It cannot, and
the check was empirical: the closest existing test,
`test_sustained_update_fanout_no_full_state_storm` (1 gateway, 2 subscribers, 20 sustained
UPDATEs), reports `delta_sends=81, full_state_sends=2, resyncs=0`. **Zero** refusals, so
zero exercise of this path — a test built on it would pass whether or not any of this PR
existed.

Three concrete things the harness lacks:

1. **No control over inter-operation spacing.** `ScheduledOperation` is `{node, operation}`
   with no delay, and events are dispatched by event id at harness-controlled pacing, so a
   test cannot place N broadcasts inside one 20 ms window for one `(sender, contract)`
   pair.
2. **No knob for the limiter's clock.** The only clock operation, `AdvanceHostingClock`,
   drives the hosting manager's injected clock; the UPDATE rate limiter reads the `Ring`'s
   own `time_source`, which has no simulation override. So the window cannot be compressed
   from the other direction either.
3. **No test-visible refusal counter.** `GlobalTestMetrics` has no limiter-rejection
   metric, so even if drops did occur a test could not assert non-vacuously that they had;
   it could only observe `resync_requests()` on the receiving side, which is indirect.

Filed as #5523 rather than built here, since (1) and (2) are harness changes rather than
changes to this fix.

### Why the #4862 trailing retry does not already cover this

**It is engaged**, and it was engaged for the 5 fail / 10 measurement above, so it is not
the missing piece. `send_dropped_broadcast_resync_request` spawns
`resend_dropped_broadcast_resync_request` from inside the shared helper, above the immediate enqueue, so every caller gets it — including the new
rate-limiter arm, with no call-site work.

It is delivery insurance, not a deferred repair. `reservation_deadline` is a hard **stop**,
not a wake-up: the loop in `resend_dropped_broadcast_resync_request` returns the moment
`now >= reservation_deadline`, so nothing ever fires *at* the window's end. And the
re-dispatch is gated on the #4863 correlation record still being outstanding (the
`queue_full_resync_retry_skipped_landed` arm), so it returns as soon as the first `ResyncResponse` has been
consumed. It re-sends the *same* request, carrying no knowledge of anything dropped since.

The run logs agree. `queue_full_resync_retry_skipped_landed` is the one `info!` in that
function, and it appears exactly 6 times in each failing branch run — once per emitted
request, every one stopping early with "already landed (its ResyncResponse was consumed),
skipping the redundant full-state re-dispatch".

### Divergence bound in production

With the repair in place, and stated with its condition rather than as a flat number:

- A drop with **no reservation held**: `ResyncRequest` fires immediately, the sender clears
  its cached summary and sends full state. Healed in about one RTT.
- A drop **inside a held 30s window**: refused at the time, and on THIS branch nothing
  re-sends it. It recovers when the next drop on that pair arrives after the window has
  closed, or at the ~5-minute InterestSync anti-entropy heartbeat if no further drop
  comes. #5525, stacked on this branch, bounds that to about one throttle window (30s)
  plus an RTT, independent of further traffic arriving.

So the honest statement of what this PR alone achieves: it makes the refusals rare in the
first place (the budget change), and it repairs every drop that is not already inside a
held window. The residual is real and is not claimed as fixed here.

## What I did not do

- **Sender-side pacing** — see Follow-ups.
- **The drops a held throttle window swallows** — split out to #5525, stacked on this
  branch. See part 3.

## Known limitations

**The repair's `ResyncRequest` is attributed as delta-incompatibility evidence.**
Verified end to end rather than assumed: the message carries a contract key and no
reason, and the sender's handler passes every inbound request to
`DeltaIncompat::note_resync_request`, which strikes whenever it delivered a delta to
us for that contract inside `DELTA_ATTRIBUTION_WINDOW` (60s). That is exactly this
case — the dropped broadcast *is* that delta. `INCOMPAT_TRIP_THRESHOLD` is 3 effective
strikes, and resync strikes count only once >= 2 distinct peers have contributed, so
three repairs from two peers force a perfectly delta-capable contract into
full-state-only fan-out for `DELTA_INCOMPAT_TTL` (10 minutes).

It inverts the memo's intent — it stops the node computing deltas that *would* have
applied — and it does so when the network is busy enough to be dropping broadcasts,
which is when full-state fan-out costs most. It self-heals on the TTL, so it is wasted
bandwidth and CPU, not a correctness bug.

**Not introduced here.** The pre-existing queue-full repair (#4857) has had the
identical attribution since it landed; this PR adds a second emitter with the same
shape, raising the rate at which it can happen without creating it. Fixing it needs a
reason on the wire, which means a version-gated APPEND of a new `InterestMessage`
variant — never a field added to the existing one, which shifts the bincode layout for
every peer that has not upgraded. That is a protocol change and belongs in its own PR.
Filed as **#5526**, with the trace; a comment at the emit site records it too.

**Gate B degrades on non-redb builds.** `HostingManager::contract_state_present`
returns `true` unconditionally there, so the gate becomes `is_hosting || in_use`, which
can hold for a phantom contract with no stored state. Checked both halves rather than
assuming: the crate has **no compilable SQLite-only feature combination** (the
`TODO(#4869)` in `node.rs` records ~52 lib errors, the SQLite backend having drifted
~15 methods behind redb), and `ci.yml` always passes `redb`. So the weak arm is
unreachable in any build that compiles. Left as-is with a comment saying to switch to
the backend-aware `contract_state_present_async` if that ever changes.

## Follow-ups

- **Deterministic simulation coverage for rate-limiter refusals** — #5523, with the
  measurement above.
- **Ten pre-existing `\nasync fn`-only source slicers** in this file's pin helpers,
  each separately pinned. Left alone here: correcting them is unrelated to #5510 and
  would touch ten tests in a PR that is already large.
- **Sender-side pacing off the broadcast-queue drain.** `MIN_UPDATE_INTERVAL` is
  receive-side only today — verified: outside `update_rate_limit.rs` the constant has no
  non-comment references in the tree. Pacing at the sender, off the queue drain, is
  complementary to this receive-side budget and would reduce the refusals rather than
  widen the allowance. To be filed separately after this lands; no code change here.

https://claude.ai/code/session_01XpSr7Uomp7TUw5RH1KqV6Z

[AI-assisted - Claude]

