### PR TITLE
fix(conformance): report runtime harness failures separately from contract rejections

### DIFF
--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -732,16 +732,6 @@ pub enum Inconclusive {
     /// The contract returned an error. A single rejection is not a conformance
     /// failure — contracts are supposed to reject updates they consider illegitimate.
     ContractError(String),
-    /// The host or the WASM module itself failed (trap, missing export, store
-    /// error) — not the contract rejecting its input.
-    ///
-    /// Kept just as non-enforceable as [`Inconclusive::ContractError`]: a harness or
-    /// runtime bug is not a merge-law proof either, and removing a contract for a
-    /// defect in the code that executes it would be exactly backwards. What must not
-    /// be shared is the LABEL — see #5509. Naming a runtime trap "contract error"
-    /// accuses the wrong party for every case of this kind, and it is the only
-    /// signal that would ever tell us the harness itself has a bug.
-    RuntimeError(String),
     /// `update_state` returned neither a new state nor a related-contract request.
     NoOutputState,
     /// Execution hit a fuel, memory or time limit, so we never saw the real answer.
@@ -775,6 +765,23 @@ pub enum Inconclusive {
     /// evidence about the law this case was checking, and reporting it as such would
     /// name the wrong property and the wrong severity.
     NotReproducible,
+    /// The host or the WASM module itself failed (trap, missing export, store
+    /// error) — not the contract rejecting its input.
+    ///
+    /// Kept just as non-enforceable as [`Inconclusive::ContractError`]: a harness or
+    /// runtime bug is not a merge-law proof either, and removing a contract for a
+    /// defect in the code that executes it would be exactly backwards. What must not
+    /// be shared is the LABEL — see #5509. Naming a runtime trap "contract error"
+    /// accuses the wrong party for every case of this kind, and it is the only
+    /// signal that would ever tell us the harness itself has a bug.
+    ///
+    /// Appended at the END of the enum rather than beside `ContractError` where it
+    /// reads most naturally: `Inconclusive` derives `Serialize`/`Deserialize` and
+    /// bincode's default config encodes an enum's variant index as a wire
+    /// discriminant, so inserting a variant in the middle would silently renumber
+    /// every variant declared after it. See
+    /// `inconclusive_wire_variant_indices_are_frozen` below.
+    RuntimeError(String),
 }
 
 impl Inconclusive {
@@ -816,7 +823,7 @@ impl std::fmt::Display for Inconclusive {
             Inconclusive::InputNotValid => f.write_str("an input state is not valid"),
             Inconclusive::RelatedRequired => f.write_str("contract requires related state"),
             Inconclusive::ContractError(e) => write!(f, "contract error: {e}"),
-            Inconclusive::RuntimeError(e) => write!(f, "runtime/harness error: {e}"),
+            Inconclusive::RuntimeError(e) => write!(f, "runtime/harness failure: {e}"),
             Inconclusive::NoOutputState => f.write_str("update produced no state"),
             Inconclusive::ResourceLimit(e) => write!(f, "resource limit: {e}"),
             Inconclusive::RoundLimit => f.write_str("reconciliation round budget exhausted"),

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -732,6 +732,16 @@ pub enum Inconclusive {
     /// The contract returned an error. A single rejection is not a conformance
     /// failure — contracts are supposed to reject updates they consider illegitimate.
     ContractError(String),
+    /// The host or the WASM module itself failed (trap, missing export, store
+    /// error) — not the contract rejecting its input.
+    ///
+    /// Kept just as non-enforceable as [`Inconclusive::ContractError`]: a harness or
+    /// runtime bug is not a merge-law proof either, and removing a contract for a
+    /// defect in the code that executes it would be exactly backwards. What must not
+    /// be shared is the LABEL — see #5509. Naming a runtime trap "contract error"
+    /// accuses the wrong party for every case of this kind, and it is the only
+    /// signal that would ever tell us the harness itself has a bug.
+    RuntimeError(String),
     /// `update_state` returned neither a new state nor a related-contract request.
     NoOutputState,
     /// Execution hit a fuel, memory or time limit, so we never saw the real answer.
@@ -786,6 +796,7 @@ impl Inconclusive {
     pub fn detail(&self) -> Option<&str> {
         match self {
             Inconclusive::ContractError(text)
+            | Inconclusive::RuntimeError(text)
             | Inconclusive::ResourceLimit(text)
             | Inconclusive::MalformedCase(text) => Some(text),
             Inconclusive::InputNotValid
@@ -805,6 +816,7 @@ impl std::fmt::Display for Inconclusive {
             Inconclusive::InputNotValid => f.write_str("an input state is not valid"),
             Inconclusive::RelatedRequired => f.write_str("contract requires related state"),
             Inconclusive::ContractError(e) => write!(f, "contract error: {e}"),
+            Inconclusive::RuntimeError(e) => write!(f, "runtime/harness error: {e}"),
             Inconclusive::NoOutputState => f.write_str("update produced no state"),
             Inconclusive::ResourceLimit(e) => write!(f, "resource limit: {e}"),
             Inconclusive::RoundLimit => f.write_str("reconciliation round budget exhausted"),

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -764,6 +764,35 @@ fn a_rejected_update_is_inconclusive_not_a_violation() {
     );
 }
 
+/// A host or WASM failure (a trap, a missing export, a store error) is not the
+/// contract rejecting anything — it is the runtime executing it that broke. #5509:
+/// this used to collapse into `ContractError`, accusing the contract for a defect
+/// that may well be ours.
+#[test]
+fn a_runtime_failure_is_inconclusive_not_a_contract_error() {
+    let mut fake = Fake::conforming().merging(|_a, _b| {
+        Err(OracleError::runtime(
+            "missing contract export: update_state",
+        ))
+    });
+    assert_inconclusive(
+        verify_case(
+            &mut fake,
+            &case(ConformanceProperty::StateCommutativity, &[&[1, 2], &[2, 3]]),
+        ),
+        Inconclusive::RuntimeError("missing contract export: update_state".into()),
+    );
+}
+
+/// Neither culprit is removal-eligible, whatever the label says: `Inconclusive`
+/// never reaches `PropertyOutcome::Violated`, so the split label above cannot make a
+/// runtime bug more actionable against the contract than it already wasn't.
+#[test]
+fn a_runtime_failure_is_never_enforceable() {
+    let outcome = PropertyOutcome::Inconclusive(Inconclusive::RuntimeError("trap".into()));
+    assert!(!outcome.is_enforceable_violation());
+}
+
 /// A contract waiting on a related contract has not failed anything; it has told us
 /// we are missing context. Removing it for that would delete every contract that
 /// composes with another.

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -793,6 +793,53 @@ fn a_runtime_failure_is_never_enforceable() {
     assert!(!outcome.is_enforceable_violation());
 }
 
+/// `Inconclusive` derives `Serialize`/`Deserialize`, and bincode's default config
+/// encodes an enum's variant as a little-endian `u32` index ahead of its payload —
+/// so inserting a variant anywhere but the end silently renumbers every variant
+/// declared after it. Nothing persists or ships a bare `Inconclusive` today (it
+/// travels only inside an in-process `PropertyOutcome`, never serialized to disk or
+/// wire), so this is not yet an observable break — but the type is `pub`,
+/// non-exhaustive, and explicitly Serialize/Deserialize, which is exactly the shape
+/// that acquires a wire consumer without every future editor noticing. Pinned the
+/// same way as `InterestMessage` (`message.rs`,
+/// `interest_message_wire_variant_indices_are_frozen`): freeze the index of every
+/// variant that exists today, so a future insertion in the middle is caught here.
+#[test]
+fn inconclusive_wire_variant_indices_are_frozen() {
+    fn variant_index(v: &Inconclusive) -> u32 {
+        let bytes = bincode::serialize(v).expect("serialize Inconclusive");
+        u32::from_le_bytes(bytes[..4].try_into().expect("variant index prefix"))
+    }
+
+    assert_eq!(variant_index(&Inconclusive::InputNotValid), 0);
+    assert_eq!(variant_index(&Inconclusive::RelatedRequired), 1);
+    assert_eq!(
+        variant_index(&Inconclusive::ContractError(String::new())),
+        2
+    );
+    assert_eq!(variant_index(&Inconclusive::NoOutputState), 3);
+    assert_eq!(
+        variant_index(&Inconclusive::ResourceLimit(String::new())),
+        4
+    );
+    assert_eq!(variant_index(&Inconclusive::RoundLimit), 5);
+    assert_eq!(
+        variant_index(&Inconclusive::MalformedCase(String::new())),
+        6
+    );
+    assert_eq!(variant_index(&Inconclusive::NoDeltaPath), 7);
+    assert_eq!(variant_index(&Inconclusive::StateNotSettled), 8);
+    assert_eq!(variant_index(&Inconclusive::NotReproducible), 9);
+    // Appended (#5509): must stay LAST. A future variant goes after this one, not
+    // before it.
+    assert_eq!(
+        variant_index(&Inconclusive::RuntimeError(String::new())),
+        10,
+        "RuntimeError must stay the last variant — insert new variants after it, \
+         never before"
+    );
+}
+
 /// A contract waiting on a related contract has not failed anything; it has told us
 /// we are missing context. Removing it for that would delete every contract that
 /// composes with another.

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -892,12 +892,15 @@ fn apply_updates<O: ConformanceOracle + ?Sized>(
 fn inconclusive_from(err: OracleError) -> Inconclusive {
     match err.kind {
         OracleErrorKind::Resource => Inconclusive::ResourceLimit(err.message),
-        // A host or WASM failure is reported alongside a contract rejection because
+        // A contract rejection and a host/WASM failure are both non-enforceable —
         // neither is a merge-law proof, and treating a trap as a violation would
-        // mean removing a contract for a bug in the runtime executing it.
-        OracleErrorKind::Contract | OracleErrorKind::Runtime => {
-            Inconclusive::ContractError(err.message)
-        }
+        // mean removing a contract for a bug in the runtime executing it. That
+        // severity call is shared and stays shared. The LABEL is not: a trap in the
+        // host or the WASM module is not the contract's fault, and folding it into
+        // `ContractError` names the wrong culprit and hides the one signal that
+        // would tell us the harness itself has a bug (#5509).
+        OracleErrorKind::Contract => Inconclusive::ContractError(err.message),
+        OracleErrorKind::Runtime => Inconclusive::RuntimeError(err.message),
     }
 }
 

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1373,8 +1373,11 @@ impl Report {
                 self.inconclusive
             )?;
             // Said once, above the messages rather than beside each one: these
-            // strings come from the contract, and a contract error routinely names
-            // what it rejected. The corpora replayed here are captured from live
+            // strings mostly come from the contract - a contract error routinely
+            // names what it rejected - but a runtime/harness failure's text comes
+            // from the WASM runtime executing an attacker-influenceable module
+            // instead, so it is untrusted for the same reason and gets the same
+            // treatment below. The corpora replayed here are captured from live
             // peers, and `bundle.rs` and `capture.rs` both mark that material
             // sensitive - this is the path that brings it to a terminal.
             if self
@@ -1384,8 +1387,8 @@ impl Report {
             {
                 writeln!(
                     out,
-                    "  (quoted messages are written by the contract and may contain \
-                     application state)"
+                    "  (quoted messages come from the contract or the WASM runtime \
+                     executing it, and may contain application state)"
                 )?;
             }
             for r in &self.inconclusive_reasons {
@@ -1565,10 +1568,12 @@ fn inconclusive_detail(reason: &Inconclusive) -> Option<&str> {
     reason.detail()
 }
 
-/// Make a contract-authored string safe and bounded for the report.
+/// Make an `Inconclusive` detail string safe and bounded for the report.
 ///
-/// Two hazards, both from one fact: this text is written by the contract under test,
-/// which is the thing we are least entitled to trust.
+/// Two hazards, both from one fact: this text comes from the contract under test or
+/// the WASM runtime executing it, neither of which we are entitled to trust — the
+/// runtime's own error text can embed detail (an export name, a trap message) drawn
+/// from the same attacker-influenceable module.
 ///
 /// Control characters are escaped first. A message containing a newline would
 /// otherwise forge report lines - a fabricated `violation:` line is one `\n` away -

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1532,6 +1532,11 @@ fn inconclusive_label(reason: &Inconclusive) -> &'static str {
         Inconclusive::InputNotValid => "input not valid",
         Inconclusive::RelatedRequired => "requires related contract state",
         Inconclusive::ContractError(_) => "contract error",
+        // Deliberately a distinct label from `ContractError`, not merely a distinct
+        // variant: the two mean opposite things about who is at fault (a contract
+        // rejecting its input vs. the host/WASM runtime itself failing), and sharing
+        // the label is what lost that distinction in the first place (#5509).
+        Inconclusive::RuntimeError(_) => "runtime/harness failure",
         Inconclusive::NoOutputState => "update produced no output state",
         Inconclusive::ResourceLimit(_) => "resource limit hit",
         Inconclusive::RoundLimit => "reconciliation round budget exhausted",
@@ -3080,6 +3085,59 @@ mod tests {
             rendered.contains("stale nonce"),
             "only the most common message survived, so a second distinct failure \
              stays invisible:\n{rendered}"
+        );
+    }
+
+    /// A host/WASM failure must land in its own bucket, under its own text, never
+    /// folded into `contract error` (#5509).
+    ///
+    /// `Inconclusive::ContractError` and `Inconclusive::RuntimeError` name opposite
+    /// culprits — the contract rejecting its input vs. the runtime executing it
+    /// failing — and sharing a label is the exact defect this test exists to catch:
+    /// a report that could not tell "many contracts misbehave" from "our own harness
+    /// has a bug" (#5461, answered for the text but not the taxonomy by #5506).
+    #[test]
+    fn runtime_failure_is_a_separate_bucket_from_contract_error() {
+        let report = report_from_inconclusive(vec![
+            Inconclusive::ContractError("signature does not chain to the owner".to_string()),
+            Inconclusive::RuntimeError("missing contract export: update_state".to_string()),
+            Inconclusive::RuntimeError("missing contract export: update_state".to_string()),
+        ]);
+
+        let contract_bucket = contract_error_bucket(&report);
+        assert_eq!(contract_bucket.occurrences, 1);
+        assert_eq!(
+            contract_bucket.examples[0].text,
+            "signature does not chain to the owner"
+        );
+
+        let runtime_bucket = report
+            .inconclusive_reasons
+            .iter()
+            .find(|r| r.reason == "runtime/harness failure")
+            .expect("the runtime/harness bucket is missing from the report");
+        assert_eq!(runtime_bucket.occurrences, 2);
+        assert_eq!(
+            runtime_bucket
+                .examples
+                .iter()
+                .map(|e| (e.text.as_str(), e.occurrences))
+                .collect::<Vec<_>>(),
+            vec![("missing contract export: update_state", 2)]
+        );
+
+        let rendered = render_human(&report);
+        assert!(
+            rendered.contains("runtime/harness failure"),
+            "the human report never names the runtime/harness bucket:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("missing contract export: update_state"),
+            "the runtime failure's own text never reaches the report:\n{rendered}"
+        );
+        assert_ne!(
+            contract_bucket.reason, runtime_bucket.reason,
+            "a contract rejection and a runtime trap must never share a label"
         );
     }
 


### PR DESCRIPTION
## Problem

`fdev verify-merge`'s `contract error` bucket merges two things the type system already distinguishes (`crates/core/src/conformance/verifier.rs`):

```rust
OracleErrorKind::Contract | OracleErrorKind::Runtime => Inconclusive::ContractError(err.message),
```

`Contract` means the contract itself rejected the input — usually correct behaviour. `Runtime` means the host or the WASM module failed (trap, missing export, store error) — not the contract's fault at all, and possibly our own bug. Both were reported to the user as `contract error`, naming the wrong culprit for every case of the second kind.

#5461 asked whether the bucket was "one bug in one contract, eight unrelated contract bugs, or a defect in the runtime harness". #5506 answered the first two by surfacing the error text. This closes the third.

## Approach

- Added `Inconclusive::RuntimeError(String)` (`crates/core/src/conformance/property.rs`), with `detail()` and `Display` extended. `detail()` is exhaustively matched inside the defining crate (added in #5506), so the compiler forced every call site that needed updating.
- Split `inconclusive_from()` in `crates/core/src/conformance/verifier.rs`: `OracleErrorKind::Contract` still maps to `ContractError`, `OracleErrorKind::Runtime` now maps to `RuntimeError`. The severity reasoning in the existing comment is unchanged and extended to say the label is split while enforceability is not.
- Added the `"runtime/harness failure"` label in `crates/fdev/src/conformance.rs::inconclusive_label`, distinct from `"contract error"`; the `Display` impl uses the same wording.
- Both variants remain **non-enforceable by construction**: `PropertyOutcome::is_enforceable_violation()` only matches `Violated`, and `Inconclusive` can never reach that arm — so nothing here changes what is removal-eligible, only what the report calls it.
- `RuntimeError` is appended at the **end** of the `Inconclusive` enum, not beside `ContractError` where it reads most naturally: the enum derives `Serialize`/`Deserialize` and is `pub` + `#[non_exhaustive]`, and bincode's default config encodes an enum's variant as a wire discriminant, so inserting in the middle would have silently renumbered every later variant. Nothing persists or ships a bare `Inconclusive` today, but the shape invites a future wire consumer without anyone noticing — pinned by `inconclusive_wire_variant_indices_are_frozen`, mirroring `interest_message_wire_variant_indices_are_frozen` in `message.rs`.
- Grepped every consumer of the `Inconclusive` taxonomy (`grep -rn "ContractError\|Inconclusive::" crates/`). Only `fdev`'s CLI report needed updating — `shadow.rs`, `status.rs`, `capture.rs`, `policy.rs` all match on `PropertyOutcome::Inconclusive(_)` generically or track only the aggregate count, not per-reason labels. No docs reference the taxonomy. The `Report` JSON has no schema-version field; this adds a new value under the existing `reason` string field, which is additive for any consumer keying off known reasons and non-breaking for one that already handles unknown reasons as `fdev`'s own `_ => "other"` wildcard does — but a consumer doing an exhaustive match on the reason string outside this repo would need updating (worth flagging since shadow-mode telemetry may care).
- Refreshed two comments in `crates/fdev/src/conformance.rs` that claimed inconclusive detail text always comes from the contract — a runtime/harness failure's text comes from the WASM runtime instead, and is untrusted for the same reason (it can embed detail drawn from the attacker-influenceable module).

## Testing

- `crates/core/src/conformance/tests.rs`:
  - `a_runtime_failure_is_inconclusive_not_a_contract_error` — a `Runtime` oracle error yields `RuntimeError`, not `ContractError`.
  - `a_runtime_failure_is_never_enforceable` — pins non-enforceability through `is_enforceable_violation()`.
  - `inconclusive_wire_variant_indices_are_frozen` — freezes the bincode discriminant of all 11 `Inconclusive` variants; `RuntimeError` must stay last.
- `crates/fdev/src/conformance.rs`: `runtime_failure_is_a_separate_bucket_from_contract_error` — a report with both a `ContractError` and two `RuntimeError`s lands in two distinct buckets with distinct labels and text, and the human report shows both.
- Verified each new test fails without the fix (reverted the `verifier.rs` split, and separately reverted the enum ordering) and passes with it.
- Full suite: `cargo test -p freenet --lib conformance` (250 passed) and `cargo test -p fdev conformance` (64 passed), `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean.

## Measurement

Ran the built `fdev verify-merge --bundle ... --contract-store ... --json` against the live capture corpus at a 66-bundle capture directory (the same kind of corpus the #5461/#5506 "64-bundle live corpus, 435/2,622" figure was measured against — not the identical snapshot, since it's a live capture peer's directory that keeps growing; treat the two as different samples, not a before/after of the same data).

Result, with `--max-cases 50` per bundle (see caveat below) and a 90s per-bundle timeout:

| | count |
|---|---|
| bundles measured | 54 of 64 found |
| bundles skipped — contract WASM no longer in the local store | 7 |
| bundles skipped — timed out at 90s even at `--max-cases 50` | 3 |
| total cases run | 2,229 |
| total inconclusive | 237 |
| **`contract error`** | **124** |
| **`runtime/harness failure`** | **0** |

On this sample, **zero** of the inconclusive cases were runtime/harness failures — every inconclusive case was a genuine contract rejection. So for this corpus the answer to "have we been reading harness bugs as contract bugs" is no, at this sample size. That's a real answer, not a null result: it means the taxonomy split doesn't (yet) reveal a hidden harness-bug population here, though a larger or different corpus could still surface one, and the split is now available going forward regardless.

**Caveat on `--max-cases 50`:** the default is 512, but running the full default against this corpus is impractically slow — investigated separately and filed as #5518 (not a bug in this PR's code: case generation is already well-bounded, generating 512 cases in ~1ms; the cost is genuine per-case WASM execution time on large captured states, up to several seconds per call with the real contract runtime, and `verify-merge` has no overall time budget or progress output to make that bearable at scale). Capping at 50 cases/bundle was needed to get this measurement to complete at all; the reported counts are drawn from that reduced sample, not the full corpus.

Closes #5509

https://claude.ai/code/session_01XpSr7Uomp7TUw5RH1KqV6Z

[AI-assisted - Claude]
