### PR TITLE
fix(conformance): report merge(A, A) != A instead of iterating past it

### DIFF
--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -133,8 +133,8 @@ pub use minimize::{MinimizeConfig, MinimizeReport, minimize};
 pub use oracle::{ConformanceOracle, OracleError, OracleErrorKind};
 pub use policy::{ConformanceAction, EnforcementMode, decide};
 pub use property::{
-    ConformanceProperty, Inconclusive, OutputDigest, PremiseSource, PropertyOutcome, Severity,
-    Violation,
+    ConformanceProperty, IdempotenceSettling, Inconclusive, OutputDigest, PremiseSource,
+    PropertyOutcome, Severity, Violation,
 };
 pub use runtime_oracle::{OracleBuildError, RuntimeOracle};
 pub use sampler::{Admission, ContractSampler, SamplerConfig, Stratum};

--- a/crates/core/src/conformance/capture.rs
+++ b/crates/core/src/conformance/capture.rs
@@ -912,6 +912,12 @@ async fn run_writer(
                     cases = report.cases,
                     inconclusive = report.inconclusive,
                     would_remove = report.would_remove,
+                    // Emitted beside the total, never instead of it. The
+                    // subset that CONVERGES is the part of `would_remove` an
+                    // enforcement gate must not read as removal-worthy, and a
+                    // counter that never leaves the process cannot inform the
+                    // decision it was collected for.
+                    would_remove_settled = report.would_remove_settled,
                     reported = report.reported,
                     skipped_no_code = report.skipped_no_code,
                     skipped_no_samples = report.skipped_no_samples,

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -36,7 +36,7 @@ use super::verifier::ConformanceCase;
 /// Bump when the meaning of a field changes. A peer that does not understand a
 /// schema version rejects the evidence rather than guessing: misinterpreting a
 /// reproducer is exactly how a false positive would spread.
-pub const EVIDENCE_SCHEMA_VERSION: u16 = 1;
+pub const EVIDENCE_SCHEMA_VERSION: u16 = 2;
 
 /// Hard ceiling on one evidence object's input bytes.
 ///

--- a/crates/core/src/conformance/policy.rs
+++ b/crates/core/src/conformance/policy.rs
@@ -110,6 +110,7 @@ mod tests {
             left: OutputDigest::of(b"left"),
             right: OutputDigest::of(b"right"),
             detail: "test".to_string(),
+            settling: None,
         })
     }
 
@@ -131,6 +132,7 @@ mod tests {
             left: OutputDigest::of(b"left"),
             right: OutputDigest::of(b"right"),
             detail: "claims to be enforceable".to_string(),
+            settling: None,
         });
 
         assert!(

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -740,8 +740,14 @@ pub enum IdempotenceSettling {
     /// non-convergent, and the case an enforcement policy can act on without
     /// waiting for the install path to be fixed.
     NeverSettled,
-    /// The contract errored, trapped, hit a resource ceiling or asked for related
-    /// state during CLASSIFICATION, so whether it settles is unknown.
+    /// Classification could not complete, so whether the state settles is unknown.
+    ///
+    /// The cause may be the CONTRACT (it rejected the re-applied state) or OURS
+    /// (the runtime trapped, a resource ceiling was hit, a related contract was
+    /// wanted). The finding's `detail` names which, because collapsing those two
+    /// into one indistinguishable outcome destroys the only signal that would tell
+    /// us the harness has a bug — see #5509, and #5517's rule that a runtime
+    /// failure must never wear a contract error's label.
     ///
     /// The violation still stands: `merge(A, A) != A` was already established by a
     /// merge that succeeded. Only the follow-up applies failed, and they exist

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -740,6 +740,27 @@ pub enum IdempotenceSettling {
     /// non-convergent, and the case an enforcement policy can act on without
     /// waiting for the install path to be fixed.
     NeverSettled,
+    /// The contract errored, trapped, hit a resource ceiling or asked for related
+    /// state during CLASSIFICATION, so whether it settles is unknown.
+    ///
+    /// The violation still stands: `merge(A, A) != A` was already established by a
+    /// merge that succeeded. Only the follow-up applies failed, and they exist
+    /// solely to say which KIND of break it is.
+    ///
+    /// This variant exists because the alternative was losing the finding. The
+    /// classification merges used to propagate their error out of the whole check,
+    /// which turned an established violation into "we could not tell" — and the
+    /// never-settling class GROWS its state on every apply, so it is the most
+    /// likely to trip a fuel or size ceiling on the second or third one. The class
+    /// an enforcement policy can act on was the class that vanished, and a hostile
+    /// contract could arrange it in one line by trapping on the second identical
+    /// merge.
+    ///
+    /// Deliberately not folded into `NeverSettled` (that is the harsher label and
+    /// asserting it without evidence is exactly the sin this issue is about) nor
+    /// into `settling: None` (ambiguous with "this property carries no settling
+    /// data at all").
+    Indeterminate,
 }
 
 impl std::fmt::Display for Violation {

--- a/crates/core/src/conformance/property.rs
+++ b/crates/core/src/conformance/property.rs
@@ -703,6 +703,43 @@ pub struct Violation {
     pub right: OutputDigest,
     /// Human-readable statement of what was compared. Diagnostics only; never parsed.
     pub detail: String,
+    /// Extra structure for [`ConformanceProperty::StateIdempotence`]; `None` for
+    /// every other property. See [`IdempotenceSettling`].
+    pub settling: Option<IdempotenceSettling>,
+}
+
+/// How a contract's state behaved when `merge(A, A)` was re-applied after the
+/// first application changed it.
+///
+/// Carried structurally rather than folded into [`Violation::detail`], which is
+/// documented as diagnostic and never parsed. This distinction is the one an
+/// eventual removal policy has to branch on: a contract that normalises once and
+/// then holds still is a materially different animal from one that mutates on
+/// every redelivery, and only the second is unambiguously non-convergent.
+///
+/// It is deliberately NOT a severity fork. Both are `Severity::Violation`, because
+/// `merge(A, A) != A` breaks idempotence either way. Letting the settling
+/// behaviour choose the severity would repeat the move that produced the defect
+/// this replaced: bending the *classification* to soften an *enforcement*
+/// consequence (#5462).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum IdempotenceSettling {
+    /// The state changed this many times and then stopped changing.
+    ///
+    /// A correct CANONICALIZING contract lands here with a count of 1: the PUT
+    /// install path stores the client's raw bytes without ever running
+    /// `update_state`, so a peer can hold a non-canonical state and the first
+    /// merge legitimately rewrites it. The finding is still real — two peers
+    /// delivered the same updates hold different bytes until unrelated traffic
+    /// arrives — but the harm is phantom anti-entropy rather than divergence.
+    /// Canonicalising at install removes this class entirely.
+    SettledAfter(u32),
+    /// No fixpoint within the budget: the state changes on every re-apply, so
+    /// redelivery of the same state keeps mutating it. Unambiguously
+    /// non-convergent, and the case an enforcement policy can act on without
+    /// waiting for the install path to be fixed.
+    NeverSettled,
 }
 
 impl std::fmt::Display for Violation {

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -146,6 +146,21 @@ pub struct ShadowReport {
     /// Deliberately additive rather than subtracted from `would_remove`: the
     /// finding IS removal-eligible, and netting it off would be the severity fork
     /// the #5462 decision rejected, hidden in a metric.
+    ///
+    /// Read it as a CASE count, not a contract count, and do not read the ratio
+    /// against `would_remove` as "the benign fraction of contracts". Idempotence
+    /// draws a fixed handful of cases per probe while a contract breaking several
+    /// properties feeds the total from each, so the multiplier is not equal across
+    /// the two populations and the ratio systematically misstates the fraction. It
+    /// tells you the class is present and roughly how loud, which is what it is
+    /// for.
+    ///
+    /// `Indeterminate` findings are in `would_remove` and in NEITHER subset. That
+    /// is the conservative default — an unknown class must not be counted benign —
+    /// but it means a residual exists that this pair of numbers cannot show, and
+    /// `Indeterminate` is adversarially reachable (see its rustdoc), so a nonzero
+    /// gap between the total and the sum of what you can classify is itself worth
+    /// looking at.
     pub would_remove_settled: usize,
     /// Diagnostic-severity findings, which never propose removal in any mode.
     pub reported: usize,
@@ -1011,11 +1026,34 @@ mod settled_counter_tests {
     /// silently start under-counting the moment enforcement became reachable.
     #[test]
     fn both_removal_arms_route_through_the_counter() {
+        // Bounded by brace-counting to `probe_one`'s OWN body, not by splitting on
+        // its signature and reading to end-of-file. An unbounded region silently
+        // widens to swallow unrelated code — including this test module — and then
+        // passes for the wrong reason. That is the trap the repo documents on its
+        // other scrapes, and my first version of this pin walked into it.
         let src = include_str!("shadow.rs");
-        let body = src
-            .split("async fn probe_one(")
-            .nth(1)
+        let start = src
+            .find("async fn probe_one(")
             .expect("probe_one not found");
+        let after = &src[start..];
+        let open = after.find('{').expect("probe_one has no body");
+        let mut depth = 0usize;
+        let mut end = open;
+        for (i, c) in after[open..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = open + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(end > open, "could not bound probe_one's body");
+        let body = &after[open..end];
 
         for arm in [
             "ConformanceAction::WouldRemove(violation) => {",

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -1004,18 +1004,38 @@ mod settled_counter_tests {
             &mut report,
             &violation_with(Some(IdempotenceSettling::NeverSettled)),
         );
+        count_would_remove(
+            &mut report,
+            &violation_with(Some(IdempotenceSettling::Indeterminate)),
+        );
         count_would_remove(&mut report, &violation_with(None));
 
         assert_eq!(
-            report.would_remove, 3,
-            "every removal-proposing decision counts toward the total, including \
-             the settled ones: they are removal-eligible findings"
+            report.would_remove, 4,
+            "every removal-proposing decision counts toward the total exactly ONCE, \
+             including the settled ones: they are removal-eligible findings"
         );
         assert_eq!(
             report.would_remove_settled, 1,
-            "only the settled class is in the subset — NeverSettled and the \
-             properties that carry no settling data are not"
+            "only the SETTLED class is in the subset. `Indeterminate` must not be: \
+             it is an unknown class, and counting an unknown as benign asserts the \
+             very thing that variant exists to refuse. `NeverSettled` and the \
+             properties carrying no settling data are excluded too"
         );
+    }
+
+    /// Each decision increments the total exactly once.
+    ///
+    /// Added after mutation: incrementing `would_remove` again alongside the shared
+    /// helper survived, because the test above asserted a total that happened to
+    /// match the doubled count. A drifting total is the specific thing the shared
+    /// helper exists to prevent.
+    #[test]
+    fn a_single_decision_increments_the_total_exactly_once() {
+        let mut report = ShadowReport::default();
+        count_would_remove(&mut report, &violation_with(None));
+        assert_eq!(report.would_remove, 1);
+        assert_eq!(report.would_remove_settled, 0);
     }
 
     /// Pin: BOTH removal-proposing arms route through the one counter.

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -1088,6 +1088,16 @@ mod settled_counter_tests {
                 "{arm} must count through the shared helper, or the two counters \
                  drift while the comment beside them claims they cannot"
             );
+            // And ONLY through it. Calling the helper does not stop an arm also
+            // incrementing on its own, which double-counts the number Phase 5 is
+            // judged on — and a test that calls the helper directly cannot see a
+            // second increment at the call site.
+            assert!(
+                !window.contains("report.would_remove"),
+                "{arm} touches the counters directly as well as through the shared \
+                 helper; that double-counts `would_remove` and no helper-level test \
+                 can observe it"
+            );
         }
     }
 }

--- a/crates/core/src/conformance/shadow.rs
+++ b/crates/core/src/conformance/shadow.rs
@@ -126,7 +126,27 @@ pub struct ShadowReport {
     pub inconclusive: usize,
     /// Violations that would have caused a removal, had enforcement been on. The
     /// number the RFC's Phase 5 gate is judged on.
+    ///
+    /// Read it together with `would_remove_settled`. Since #5462 this total includes
+    /// contracts that DO converge — a canonicalizing contract breaks idempotence by
+    /// rewriting a non-canonical stored state once, and is reported honestly rather
+    /// than suppressed. Comparing this number across that change, or against a
+    /// future where the PUT install path canonicalizes, compares different
+    /// populations.
     pub would_remove: usize,
+    /// The subset of `would_remove` whose finding says the state SETTLED.
+    ///
+    /// Carried as its own counter because `would_remove` is a bare `usize` with
+    /// nowhere to record that a finding is benign, and this is the number Phase 5
+    /// is judged on. Leaving the distinction out would pre-filter the corpus by
+    /// omission — the same move as the fixpoint gate #5462 removed, one layer up:
+    /// the population would look uniformly removal-worthy when a large and
+    /// knowable part of it is waiting on an install-path fix instead.
+    ///
+    /// Deliberately additive rather than subtracted from `would_remove`: the
+    /// finding IS removal-eligible, and netting it off would be the severity fork
+    /// the #5462 decision rejected, hidden in a metric.
+    pub would_remove_settled: usize,
     /// Diagnostic-severity findings, which never propose removal in any mode.
     pub reported: usize,
     /// Probes cut short by [`PROBE_TIME_BUDGET`].
@@ -511,6 +531,23 @@ pub(crate) async fn probe_with_budget(
     (report, findings)
 }
 
+/// Count a removal-proposing decision, and whether its finding is the class that
+/// converges.
+///
+/// One function for BOTH `WouldRemove` and `Remove` deliberately. The comment
+/// between those two arms says they are handled together precisely so shadow and
+/// enforcement cannot drift — counting the settled subset in only one of them
+/// would have introduced that drift while the comment claimed otherwise.
+fn count_would_remove(report: &mut ShadowReport, violation: &super::property::Violation) {
+    report.would_remove += 1;
+    if matches!(
+        violation.settling,
+        Some(crate::conformance::IdempotenceSettling::SettledAfter(_))
+    ) {
+        report.would_remove_settled += 1;
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn probe_one(
     instance: &ContractInstanceId,
@@ -659,7 +696,7 @@ async fn probe_one(
                 });
             }
             ConformanceAction::WouldRemove(violation) => {
-                report.would_remove += 1;
+                count_would_remove(report, &violation);
                 findings.push(Finding {
                     contract: instance_copy,
                     violation,
@@ -672,7 +709,7 @@ async fn probe_one(
             // removal as a would-remove keeps this honest if a future caller reaches
             // it before the removal path exists.
             ConformanceAction::Remove(violation) => {
-                report.would_remove += 1;
+                count_would_remove(report, &violation);
                 findings.push(Finding {
                     contract: instance_copy,
                     violation,
@@ -913,6 +950,88 @@ pub(crate) async fn probe_fixture_contract(
     // contract was still warming up.
     count_awaiting_samples(&mut report, awaiting);
     Ok((id, report, findings))
+}
+
+#[cfg(test)]
+mod settled_counter_tests {
+    use super::*;
+    use crate::conformance::{
+        ConformanceProperty, IdempotenceSettling, OutputDigest, Severity, Violation,
+    };
+
+    fn violation_with(settling: Option<IdempotenceSettling>) -> Violation {
+        Violation {
+            property: ConformanceProperty::StateIdempotence,
+            severity: Severity::Violation,
+            left: OutputDigest::of(&[1u8]),
+            right: OutputDigest::of(&[2u8]),
+            detail: "test".to_string(),
+            settling,
+        }
+    }
+
+    /// The settled subset is counted, and is ADDITIVE rather than netted off.
+    ///
+    /// `would_remove` is documented as the number Phase 5 is judged on, and since
+    /// #5462 it includes contracts that converge. Subtracting the settled ones
+    /// would be the severity fork the decision rejected, hidden in a metric; the
+    /// finding really is removal-eligible. So the total must stay whole and the
+    /// subset must be reported beside it.
+    #[test]
+    fn settled_findings_are_counted_beside_the_total_not_deducted_from_it() {
+        let mut report = ShadowReport::default();
+
+        count_would_remove(
+            &mut report,
+            &violation_with(Some(IdempotenceSettling::SettledAfter(1))),
+        );
+        count_would_remove(
+            &mut report,
+            &violation_with(Some(IdempotenceSettling::NeverSettled)),
+        );
+        count_would_remove(&mut report, &violation_with(None));
+
+        assert_eq!(
+            report.would_remove, 3,
+            "every removal-proposing decision counts toward the total, including \
+             the settled ones: they are removal-eligible findings"
+        );
+        assert_eq!(
+            report.would_remove_settled, 1,
+            "only the settled class is in the subset — NeverSettled and the \
+             properties that carry no settling data are not"
+        );
+    }
+
+    /// Pin: BOTH removal-proposing arms route through the one counter.
+    ///
+    /// The comment between them says they are handled together so shadow and
+    /// enforcement cannot drift. A test of `count_would_remove` alone cannot see an
+    /// arm that stopped calling it, which is exactly how the settled subset would
+    /// silently start under-counting the moment enforcement became reachable.
+    #[test]
+    fn both_removal_arms_route_through_the_counter() {
+        let src = include_str!("shadow.rs");
+        let body = src
+            .split("async fn probe_one(")
+            .nth(1)
+            .expect("probe_one not found");
+
+        for arm in [
+            "ConformanceAction::WouldRemove(violation) => {",
+            "ConformanceAction::Remove(violation) => {",
+        ] {
+            let at = body
+                .find(arm)
+                .unwrap_or_else(|| panic!("arm missing: {arm}"));
+            let window = &body[at..at + 200.min(body.len() - at)];
+            assert!(
+                window.contains("count_would_remove("),
+                "{arm} must count through the shared helper, or the two counters \
+                 drift while the comment beside them claims they cannot"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -818,6 +818,7 @@ mod tests {
                 left: OutputDigest::of(b"a"),
                 right: OutputDigest::of(b"b"),
                 detail: "synthesised for the unreachable branch".to_string(),
+                settling: None,
             },
             would_remove: true,
         };

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -242,10 +242,46 @@ impl CheckedContract {
     /// absence, and forgetting a confirmed violation because the next sample missed
     /// it is the green-pill failure in a slower form.
     pub(crate) fn note_finding(&mut self, finding: MergeFinding) {
-        if self.findings.iter().any(|f| f.property == finding.property) {
+        if let Some(existing) = self
+            .findings
+            .iter_mut()
+            .find(|f| f.property == finding.property)
+        {
+            // Deduplicating on the property alone would silently pick whichever
+            // classification arrived first. Since #5462 two `state_idempotence`
+            // findings on one contract can carry DIFFERENT settling classes, and
+            // they are not equally important: `NeverSettled` is the one an
+            // enforcement policy can act on, while `SettledAfter` is waiting on the
+            // install-path fix. Keeping the first would let a benign case mask a
+            // non-convergent one on the same contract — the operator would read
+            // "settles after a rewrite" for a contract that also never settles.
+            //
+            // So the SERIOUS classification wins the slot, and an unknown one
+            // outranks a benign one because it has not been shown to be benign.
+            if settling_rank(finding.settling) > settling_rank(existing.settling) {
+                existing.settling = finding.settling;
+            }
             return;
         }
         self.findings.insert(0, finding);
+    }
+}
+
+/// How much a settling classification should outrank another for the one slot a
+/// property gets per contract.
+///
+/// Not a severity — every one of these is `Severity::Violation` and #5462 exists
+/// partly to keep it that way. This orders how much a reader NEEDS to see it when
+/// two findings for one property must collapse to one: an unknown class outranks a
+/// benign one because it has not been shown benign, and a never-settling class
+/// outranks both because it is the case enforcement can act on without waiting for
+/// the install path.
+fn settling_rank(settling: Option<IdempotenceSettling>) -> u8 {
+    match settling {
+        Some(IdempotenceSettling::NeverSettled) => 3,
+        Some(IdempotenceSettling::Indeterminate) => 2,
+        Some(IdempotenceSettling::SettledAfter(_)) => 1,
+        None => 0,
     }
 }
 
@@ -590,6 +626,55 @@ mod tests {
             severity: Severity::Violation,
             settling: None,
             would_remove: true,
+        }
+    }
+
+    /// Deduplication keeps the classification a reader most needs to see.
+    ///
+    /// One property gets one slot per contract, so when two `state_idempotence`
+    /// findings arrive with different settling classes, one is discarded. Keeping
+    /// whichever arrived first would let a benign case mask a non-convergent one on
+    /// the same contract: the operator would read "settles after a rewrite" for a
+    /// contract that also never settles.
+    ///
+    /// This is NOT a severity ordering — all of these are `Severity::Violation` and
+    /// #5462 exists partly to keep it that way. It orders how badly a reader needs
+    /// to see it.
+    #[test]
+    fn deduplication_keeps_the_more_serious_settling_class() {
+        for (first, second, expected) in [
+            (
+                Some(IdempotenceSettling::SettledAfter(1)),
+                Some(IdempotenceSettling::NeverSettled),
+                Some(IdempotenceSettling::NeverSettled),
+            ),
+            // Order must not decide it.
+            (
+                Some(IdempotenceSettling::NeverSettled),
+                Some(IdempotenceSettling::SettledAfter(1)),
+                Some(IdempotenceSettling::NeverSettled),
+            ),
+            // Unknown outranks benign: it has not been SHOWN benign.
+            (
+                Some(IdempotenceSettling::SettledAfter(1)),
+                Some(IdempotenceSettling::Indeterminate),
+                Some(IdempotenceSettling::Indeterminate),
+            ),
+        ] {
+            let mut record = CheckedContract::new(instance(1), 1, 0, Instant::now());
+            let mut a = finding(1, "state_idempotence");
+            a.settling = first;
+            let mut b = finding(1, "state_idempotence");
+            b.settling = second;
+            record.note_finding(a);
+            record.note_finding(b);
+
+            let kept = record.findings();
+            assert_eq!(kept.len(), 1, "one property still gets one slot");
+            assert_eq!(
+                kept[0].settling, expected,
+                "arrived {first:?} then {second:?}; the slot must hold {expected:?}"
+            );
         }
     }
 

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -78,7 +78,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use parking_lot::RwLock;
 use tokio::time::Instant;
 
-use super::property::Severity;
+use super::property::{IdempotenceSettling, Severity};
 use super::shadow::{Finding, JudgedContract};
 
 /// How many recently-checked contracts to remember.
@@ -120,10 +120,23 @@ pub struct MergeFinding {
     pub contract: ContractInstanceId,
     /// The law that was broken, e.g. `state_commutativity`.
     pub property: &'static str,
-    /// `Violation` means the contract cannot converge. `Diagnostic` means it is legal
-    /// but wasteful — the distinction an operator most needs, because only the first
-    /// would ever justify removal.
+    /// `Diagnostic` means the contract is legal but wasteful. `Violation` means it
+    /// broke an algebraic law and would be removal-eligible under enforcement.
+    ///
+    /// It does NOT mean "cannot converge". That was true when every `Violation` was
+    /// a divergence, and `state_idempotence` now reports a class that converges: a
+    /// canonicalizing contract normalises a state once and then holds still, which
+    /// breaks idempotence while still agreeing with its peers in the end. Read
+    /// `settling` before telling an operator what a `state_idempotence` row means.
     pub severity: Severity,
+    /// For `state_idempotence`, which KIND of break this is; `None` for every other
+    /// property.
+    ///
+    /// Carried here and not only in `fdev` because this is the path that generates
+    /// the shadow corpus, and `ConformanceAction::WouldRemove` is documented as the
+    /// number the enforcement gate is judged on. A distinction that exists only in
+    /// the offline tool is a distinction the policy it was collected for never sees.
+    pub settling: Option<IdempotenceSettling>,
     /// Whether enforcement, were it enabled, would have removed the contract for this.
     pub would_remove: bool,
 }
@@ -477,6 +490,7 @@ pub(crate) fn checked_contracts(
             contract: finding.contract,
             property: finding.violation.property.as_str(),
             severity: finding.violation.property.severity(),
+            settling: finding.violation.settling,
             would_remove: finding.would_remove,
         };
         match out.iter_mut().find(|c| c.contract == finding.contract) {
@@ -574,6 +588,7 @@ mod tests {
             contract: instance(n),
             property,
             severity: Severity::Violation,
+            settling: None,
             would_remove: true,
         }
     }

--- a/crates/core/src/conformance/status.rs
+++ b/crates/core/src/conformance/status.rs
@@ -629,6 +629,47 @@ mod tests {
         }
     }
 
+    /// The node path carries the classification from the finding to the record.
+    ///
+    /// Added after mutation: replacing `settling: finding.violation.settling` with
+    /// `None` in `checked_contracts` passed both suites. The panel test constructs
+    /// a `MergeFinding` directly, so it proves the panel RENDERS a class it is
+    /// handed and says nothing about whether the node ever hands it one — the same
+    /// layering gap that let the field sit write-only for a whole round.
+    #[test]
+    fn the_node_path_carries_settling_from_the_violation() {
+        use crate::conformance::property::{ConformanceProperty, OutputDigest, Violation};
+
+        let contract = instance(3);
+        let findings = vec![super::super::shadow::Finding {
+            contract,
+            violation: Violation {
+                property: ConformanceProperty::StateIdempotence,
+                severity: Severity::Violation,
+                left: OutputDigest::of(&[1u8]),
+                right: OutputDigest::of(&[2u8]),
+                detail: "merge(A, A) != A".to_string(),
+                settling: Some(IdempotenceSettling::NeverSettled),
+            },
+            would_remove: true,
+        }];
+
+        let out = checked_contracts(&[], &findings);
+        let kept = out
+            .iter()
+            .flat_map(|c| c.findings())
+            .find(|f| f.property == "state_idempotence")
+            .expect("the finding must reach the record");
+
+        assert_eq!(
+            kept.settling,
+            Some(IdempotenceSettling::NeverSettled),
+            "the classification must survive the trip from Violation to \
+             MergeFinding; dropping it here is invisible to any test that builds \
+             a MergeFinding by hand"
+        );
+    }
+
     /// Deduplication keeps the classification a reader most needs to see.
     ///
     /// One property gets one slot per contract, so when two `state_idempotence`

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -175,7 +175,24 @@ fn case(property: ConformanceProperty, states: &[&[u8]]) -> ConformanceCase {
 #[track_caller]
 fn assert_violates(outcome: PropertyOutcome, property: ConformanceProperty) {
     match outcome {
-        PropertyOutcome::Violated(v) => assert_eq!(v.property, property, "wrong property flagged"),
+        PropertyOutcome::Violated(v) => {
+            assert_eq!(v.property, property, "wrong property flagged");
+            // Every property EXCEPT idempotence must carry no settling data.
+            //
+            // Asserted in the shared helper rather than per test: eight sites build
+            // a `Violation` by hand and each sets `settling: None` on its own, so a
+            // per-site test would cover one and leave the copy-paste hazard on the
+            // rest. A stray classification here reads to an enforcement policy as a
+            // judgement the verifier never made.
+            if property != ConformanceProperty::StateIdempotence {
+                assert!(
+                    v.settling.is_none(),
+                    "{property} carried settling data ({:?}); only state_idempotence \
+                     classifies settling",
+                    v.settling
+                );
+            }
+        }
         other @ (PropertyOutcome::Holds | PropertyOutcome::Inconclusive(_)) => {
             panic!("expected a {property} violation, got {other:?}")
         }
@@ -1037,6 +1054,42 @@ fn an_idempotence_reordering_is_named_as_an_encoding_problem() {
         v.detail.contains("ENCODING is not canonical"),
         "a reordering must be named as an encoding problem, or the author is sent \
          to the install path when the fix is a deterministic encoding: {}",
+        v.detail
+    );
+}
+
+/// The encoding note is ABSENT when the rewrite genuinely changed content.
+///
+/// Added after mutation: appending the note unconditionally survived, because the
+/// only test asserted it IS present when it should be. A note saying "the merge
+/// agreed on content, only the byte order differs", attached to a merge that
+/// changed content, sends the author to the encoding when the defect is in the
+/// merge — the same misdirection the note exists to prevent, pointed the other way.
+#[test]
+fn the_encoding_note_is_absent_when_content_actually_changed() {
+    // Adds a byte the original does not contain, so the two are not permutations.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            let mut out = a.to_vec();
+            if !out.contains(&9) {
+                out.push(9);
+            }
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[1u8, 2, 3]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("still a violation: {outcome:?}");
+    };
+    assert!(
+        !v.detail.contains("ENCODING is not canonical"),
+        "the merge changed CONTENT, not just byte order; claiming otherwise sends \
+         the author to the encoding when the defect is in the merge: {}",
         v.detail
     );
 }

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -24,8 +24,8 @@ use super::evidence::{
 use super::generator::{Corpus, GeneratorConfig, generate_cases};
 use super::oracle::{ConformanceOracle, OracleError};
 use super::property::{
-    ConformanceProperty, IdempotenceSettling, Inconclusive, PremiseSource, PropertyOutcome,
-    Severity,
+    ConformanceProperty, IdempotenceSettling, Inconclusive, OutputDigest, PremiseSource,
+    PropertyOutcome, Severity,
 };
 use super::verifier::{Bytes, ConformanceCase, verify_case};
 
@@ -661,6 +661,151 @@ fn a_canonicalizing_contract_is_flagged_and_says_it_settled() {
          losing that distinction is what made this indistinguishable from a \
          contract that never converges"
     );
+
+    // The digests are not decoration. `reproduced_identically` uses exactly these
+    // two to decide whether an idempotence violation reproduced, and both halves
+    // of the fdev report publish them as the example. This PR CHANGED which state
+    // `left` carries — main reported the final non-settling state, this reports the
+    // first merge's output — and nothing asserted it until the testing lens
+    // mutated both and watched the suite pass.
+    assert_eq!(
+        v.left,
+        OutputDigest::of(&[1u8, 2, 3]),
+        "`left` must be the output of merge(A, A), the value that demonstrates the \
+         break"
+    );
+    assert_eq!(
+        v.right,
+        OutputDigest::of(raw),
+        "`right` must be the original state it was compared against"
+    );
+}
+
+/// The evidence schema version tracks `Violation`'s shape.
+///
+/// Added after mutation: reverting `EVIDENCE_SCHEMA_VERSION` to 1 passed the entire
+/// suite, even though `Violation` gained a field that travels inside
+/// `ConformanceEvidence.observed` and is written to disk by `fdev`. A stale version
+/// means a v2 writer and a v1 reader disagree about the bytes with nothing saying so.
+///
+/// A bare equality assertion on purpose: it is meant to FAIL the next time the
+/// struct changes, so the author has to decide whether the schema moves with it
+/// rather than discovering later that it did not.
+#[test]
+fn the_evidence_schema_version_moved_with_the_violation_shape() {
+    assert_eq!(
+        super::evidence::EVIDENCE_SCHEMA_VERSION,
+        2,
+        "`Violation` gained `settling` in #5462, so the schema had to move to 2. If \
+         you are changing that struct again, bump this deliberately rather than \
+         editing the assertion to match"
+    );
+}
+
+/// The budget is 3 merges, and a contract that would settle on the 4th is
+/// `NeverSettled`.
+///
+/// Added after mutation: widening the loop to `1..=MAX` (4 merges) passed the whole
+/// suite. The settling fixtures were budget-insensitive above the floor — the
+/// countdown from `[2]` pins the LOWER bound and the appending fake never settles at
+/// any budget — so nothing drew the boundary the property actually turns on.
+#[test]
+fn a_contract_that_would_settle_one_apply_late_is_never_settled() {
+    // [3] -> [2] -> [1] -> [0], so it needs FOUR merges to reach a fixpoint.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            let mut out = a.to_vec();
+            if let Some(first) = out.first_mut() {
+                *first = first.saturating_sub(1);
+            }
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[3u8]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("still a violation regardless of where it settles: {outcome:?}");
+    };
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::NeverSettled),
+        "settling beyond the budget is NOT observed settling: within the 3 merges \
+         this check spends, the state changed every time"
+    );
+}
+
+/// The classification loop merges a state with ITSELF, not with the original.
+///
+/// Added after mutation: `merge(&current, &current)` -> `merge(&current, a)` passed
+/// the whole suite, because every settling fixture either ignored its second operand
+/// or was a union where the two are equal for the states used. The loop could have
+/// been iterating a different function entirely.
+#[test]
+fn the_classification_loop_re_merges_the_state_with_itself() {
+    // Reads BOTH operands: a self-merge canonicalizes and settles, while merging
+    // against anything else concatenates and grows without end.
+    let mut fake = Fake::conforming()
+        .merging(|a, b| {
+            if a == b {
+                Ok(union(a, a))
+            } else {
+                Ok(a.iter().chain(b.iter()).copied().collect())
+            }
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let raw: &[u8] = &[3, 1, 3, 2];
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[raw]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("a canonicalizing contract is still reported: {outcome:?}");
+    };
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::SettledAfter(1)),
+        "re-merging the rewritten state with ITSELF settles at once; merging it \
+         against the original would grow forever and report NeverSettled"
+    );
+}
+
+/// `settling` is `None` for every property that is not `state_idempotence`.
+///
+/// Added after mutation: making the generic `violation()` constructor stamp
+/// `Some(NeverSettled)` onto every property passed the whole suite, even though the
+/// field's own rustdoc promises `None` for all of them. A stray value here would be
+/// read by an enforcement policy as a classification the verifier never made.
+#[test]
+fn other_properties_carry_no_settling_data() {
+    let mut fake = Fake::conforming()
+        .merging(|a, b| {
+            // Order-dependent: breaks commutativity without touching idempotence.
+            let mut out = a.to_vec();
+            out.extend_from_slice(b);
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateCommutativity, &[&[1u8], &[2u8]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("the fixture must break commutativity for this to test anything: {outcome:?}");
+    };
+    assert_eq!(v.property, ConformanceProperty::StateCommutativity);
+    assert_eq!(
+        v.settling, None,
+        "only state_idempotence classifies settling; a value here is a \
+         classification the verifier never made"
+    );
 }
 
 /// The rewrite count is the real number of rewrites, not a constant.
@@ -699,6 +844,17 @@ fn the_settled_after_count_reports_the_actual_number_of_rewrites() {
         v.settling,
         Some(IdempotenceSettling::SettledAfter(2)),
         "the count must be the number of rewrites actually observed"
+    );
+    // `left` must be the FIRST merge's output, not the state the classification
+    // loop walked to. The canonicalizing test cannot see the difference — it
+    // settles after one rewrite, so the two are the same value there — which is
+    // why reporting `current` instead of `once` survived until this fixture, where
+    // they differ ([2] -> once [1] -> current [0]).
+    assert_eq!(
+        v.left,
+        OutputDigest::of(&[1u8]),
+        "`left` is the output of merge(A, A), the value that demonstrates the \
+         break, not wherever the classification loop happened to stop"
     );
 }
 

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -24,7 +24,8 @@ use super::evidence::{
 use super::generator::{Corpus, GeneratorConfig, generate_cases};
 use super::oracle::{ConformanceOracle, OracleError};
 use super::property::{
-    ConformanceProperty, Inconclusive, PremiseSource, PropertyOutcome, Severity,
+    ConformanceProperty, IdempotenceSettling, Inconclusive, PremiseSource, PropertyOutcome,
+    Severity,
 };
 use super::verifier::{Bytes, ConformanceCase, verify_case};
 
@@ -615,17 +616,23 @@ fn multi_round_convergence_is_not_a_cycle() {
     ));
 }
 
-/// A canonicalizing contract rewrites a non-canonical stored state once and then
-/// settles. That first change is real and is NOT a defect.
+/// A canonicalizing contract IS flagged, and is distinguishable from one that
+/// never settles.
 ///
-/// This is the shape the repo already documents on
-/// `executor_impl::probe_identical_input_idempotency`: the PUT install path stores
-/// the client's raw bytes without running `update_state`, so a peer can be holding a
-/// state its own contract has never normalized. A single-apply idempotence check
-/// flags every such contract, which is why that probe iterates to a fixpoint and why
-/// this one does too.
+/// This reverses the earlier behaviour deliberately (#5462). The old test asserted
+/// that a contract which rewrites a non-canonical stored state once and then
+/// settles is not flagged, on the reasoning that the first change is not the
+/// contract's fault: the PUT install path stores the client's raw bytes without
+/// running `update_state`, so a peer can hold a state its own contract has never
+/// normalized.
+///
+/// That reasoning is true and it does not license a pass. Two peers handed the same
+/// updates then hold different bytes until unrelated traffic happens to arrive, and
+/// their summaries differ, so anti-entropy fires over a difference carrying no
+/// information. Suppressing the finding bent the classification to soften an
+/// enforcement consequence; the distinction is kept as DATA instead.
 #[test]
-fn a_canonicalizing_contract_is_not_flagged() {
+fn a_canonicalizing_contract_is_flagged_and_says_it_settled() {
     // Sorts and dedups whatever it is given, then is stable forever after.
     let mut fake = Fake::conforming()
         .merging(|a, b| Ok(union(a, b)))
@@ -633,9 +640,120 @@ fn a_canonicalizing_contract_is_not_flagged() {
 
     // A raw, non-canonical stored state: unsorted with a duplicate.
     let raw: &[u8] = &[3, 1, 3, 2];
-    assert_holds(verify_case(
+    let outcome = verify_case(
         &mut fake,
         &case(ConformanceProperty::StateIdempotence, &[raw]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("merge(A, A) != A must be reported, not suppressed: {outcome:?}");
+    };
+    assert_eq!(
+        v.severity,
+        Severity::Violation,
+        "the settling behaviour must not soften the severity: that is the severity \
+         fork the decision on #5462 rejected"
+    );
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::SettledAfter(1)),
+        "a canonicalizing contract rewrites exactly once and then holds still; \
+         losing that distinction is what made this indistinguishable from a \
+         contract that never converges"
+    );
+}
+
+/// The rewrite count is the real number of rewrites, not a constant.
+///
+/// Added after mutation testing: changing `rewrites += 1` to `rewrites += 0`
+/// survived every other test here, because they all use contracts that stabilise
+/// after exactly one rewrite — where a stuck counter and a correct one are
+/// indistinguishable. A contract needing two rewrites separates them.
+///
+/// The count matters because it is the part an enforcement policy would threshold
+/// on: "normalises once at install" and "keeps churning for several rounds" are
+/// different claims about a contract, and both are `SettledAfter`.
+#[test]
+fn the_settled_after_count_reports_the_actual_number_of_rewrites() {
+    // Counts down to zero, one step per merge, then holds still.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            let mut out = a.to_vec();
+            if let Some(first) = out.first_mut() {
+                *first = first.saturating_sub(1);
+            }
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    // [2] -> [1] -> [0] -> [0]: two rewrites before it settles.
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[2u8]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("a state that is rewritten twice must still be reported: {outcome:?}");
+    };
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::SettledAfter(2)),
+        "the count must be the number of rewrites actually observed"
+    );
+}
+
+/// A contract that mutates on every re-apply is flagged the same way, and is
+/// distinguished by its settling data rather than by its severity.
+///
+/// The counterpart to the test above, and the reason the distinction is worth
+/// carrying: these two are operationally very different — one is waiting on the
+/// install-path fix, the other is unambiguously non-convergent — and before #5462
+/// the verifier reported them identically (both `Holds` if they settled within the
+/// budget, both a bare violation otherwise).
+#[test]
+fn a_never_settling_contract_is_flagged_as_never_settling() {
+    // Appends a byte every time it is merged, so it never reaches a fixpoint.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            let mut out = a.to_vec();
+            out.push(0);
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[1u8]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("a state that mutates on every re-apply must be reported: {outcome:?}");
+    };
+    assert_eq!(v.severity, Severity::Violation);
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::NeverSettled),
+        "never reaching a fixpoint must be recorded as such, since it is the case \
+         an enforcement policy can act on without waiting for the install path"
+    );
+}
+
+/// An idempotent contract still passes, with no finding at all.
+///
+/// The floor under both tests above: if removing the fixpoint gate had made
+/// `StateIdempotence` report on everything, they would both still pass while the
+/// property became worthless.
+#[test]
+fn an_idempotent_contract_still_holds() {
+    let mut fake = Fake::conforming()
+        .merging(|a, b| Ok(union(a, b)))
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    // Already canonical: sorted, no duplicates, so merge(A, A) == A on the first try.
+    let canonical: &[u8] = &[1, 2, 3];
+    assert_holds(verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[canonical]),
     ));
 }
 

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -738,6 +738,138 @@ fn a_never_settling_contract_is_flagged_as_never_settling() {
     );
 }
 
+/// A settling classification that differs between runs is NOT reported as
+/// reproduced.
+///
+/// The verifier re-runs a failing case and requires the same failure before
+/// asserting it. That check compared only the digests, so a contract could produce
+/// identical `merge(A, A)` bytes on both runs — reproducing by that measure —
+/// while its settling classification differed. The field the whole change exists
+/// to carry, and the one an enforcement policy branches on, would then be reported
+/// as though it had reproduced when it had not.
+///
+/// A contract whose settling varies IS non-deterministic, and the existing
+/// escalation names that under the property which describes it rather than
+/// asserting a classification we did not observe twice.
+#[test]
+fn settling_must_reproduce_or_the_finding_is_not_reproducible() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let b_merges = Arc::new(AtomicUsize::new(0));
+    let seen = Arc::clone(&b_merges);
+
+    // `merge(A, A)` is stable across runs, so the DIGESTS reproduce. Re-applying
+    // the rewritten state settles the first time it is asked and not the second,
+    // so only the CLASSIFICATION differs between the two runs.
+    let mut fake = Fake::conforming()
+        .merging(move |a, _b| {
+            if a == [1u8] {
+                return Ok(vec![1, 9]);
+            }
+            if a == [1u8, 9] {
+                if seen.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Ok(vec![1, 9]);
+                }
+                return Ok(vec![1, 9, 9]);
+            }
+            Ok(a.to_vec())
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[1u8]]),
+    );
+
+    assert!(
+        !matches!(outcome, PropertyOutcome::Violated(_)),
+        "the digests reproduced but the settling classification did not, so the \
+         finding must not be asserted as reproduced: {outcome:?}"
+    );
+}
+
+/// A contract that fails DURING classification still gets its violation reported.
+///
+/// The classification merges must not `?` their error out of the check: the
+/// violation was already established by the merge that succeeded, and propagating
+/// would turn a contract we caught into "we could not tell". The never-settling
+/// class grows its state on every apply, so it is the likeliest to hit a fuel or
+/// size ceiling on exactly these follow-up merges — the class an enforcement
+/// policy can act on would be the one that vanished. A contract could arrange
+/// that deliberately by trapping on the second identical merge.
+#[test]
+fn a_contract_that_errors_during_classification_still_reports_the_violation() {
+    // The first merge succeeds and changes the state; re-applying the CHANGED
+    // state traps. Keyed on the INPUT rather than a call counter deliberately:
+    // `verify_case` re-runs the whole check to test reproducibility, so a counter
+    // makes the re-run's first merge fail too, and the test then proves nothing
+    // about the classification path it exists for.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            if a == [1u8] {
+                Ok(vec![1, 9])
+            } else {
+                Err(OracleError::contract("trapped on re-apply"))
+            }
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[1u8]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!(
+            "the violation was established by the first merge and must survive a \
+             failure in the follow-ups that only classify it: {outcome:?}"
+        );
+    };
+    assert_eq!(v.severity, Severity::Violation);
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::Indeterminate),
+        "an unknown classification must say so, not borrow NeverSettled's harsher \
+         label without evidence"
+    );
+}
+
+/// A merge that only PERMUTES bytes is named as an encoding problem here too.
+///
+/// Every `compare`-based property routes through `is_reordering` and says so,
+/// because the two cases call for opposite fixes: make the encoding canonical
+/// versus fix the merge. Idempotence bypassed `compare`, so without this it told a
+/// byte-permuting contract to go and look at the PUT install path — confidently,
+/// and wrongly. `a_merge_that_only_reorders_bytes_is_named_as_an_encoding_problem`
+/// is the equivalent guard on the commutativity path.
+#[test]
+fn an_idempotence_reordering_is_named_as_an_encoding_problem() {
+    // Reverses on the first apply, then holds still.
+    let mut fake = Fake::conforming()
+        .merging(|a, _b| {
+            let mut out = a.to_vec();
+            if !out.windows(2).all(|w| w[0] >= w[1]) {
+                out.reverse();
+            }
+            Ok(out)
+        })
+        .validating(|_| Ok(ValidateResult::Valid));
+
+    let outcome = verify_case(
+        &mut fake,
+        &case(ConformanceProperty::StateIdempotence, &[&[1u8, 2, 3]]),
+    );
+
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!("a permuting merge still breaks idempotence and must be reported: {outcome:?}");
+    };
+    assert!(
+        v.detail.contains("ENCODING is not canonical"),
+        "a reordering must be named as an encoding problem, or the author is sent \
+         to the install path when the fix is a deterministic encoding: {}",
+        v.detail
+    );
+}
+
 /// An idempotent contract still passes, with no finding at all.
 ///
 /// The floor under both tests above: if removing the fixpoint gate had made

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -894,21 +894,27 @@ fn a_never_settling_contract_is_flagged_as_never_settling() {
     );
 }
 
-/// A settling classification that differs between runs is NOT reported as
-/// reproduced.
+/// A classification that flaps between runs keeps the violation and reports
+/// `Indeterminate`.
 ///
-/// The verifier re-runs a failing case and requires the same failure before
-/// asserting it. That check compared only the digests, so a contract could produce
-/// identical `merge(A, A)` bytes on both runs — reproducing by that measure —
-/// while its settling classification differed. The field the whole change exists
-/// to carry, and the one an enforcement policy branches on, would then be reported
-/// as though it had reproduced when it had not.
+/// The violation itself DID reproduce: same inputs, same outputs, both runs.
+/// Only the settling class differed, and that class is data about the finding
+/// rather than the finding. Discarding the violation because the data was
+/// unstable would throw away a reproduced defect — the exact failure this
+/// change exists to remove.
 ///
-/// A contract whose settling varies IS non-deterministic, and the existing
-/// escalation names that under the property which describes it rather than
-/// asserting a classification we did not observe twice.
+/// This test used to assert the opposite, and that is worth recording. It
+/// checked only `!matches!(outcome, Violated(_))`, which was satisfied equally
+/// by "named under `UpdateDeterminism`" and by "dropped on the floor", so it
+/// could not tell the intended behaviour from the bug — and its doc claimed an
+/// escalation that cannot fire here at all, since `escalate_to_determinism`
+/// needs two states and an idempotence case carries one.
+///
+/// The deeper point, which two reviewers reached independently: an ERRORING
+/// classification and a FLAPPING one are the same epistemic situation. Handling
+/// them in opposite directions in one file was the defect.
 #[test]
-fn settling_must_reproduce_or_the_finding_is_not_reproducible() {
+fn a_flapping_classification_keeps_the_violation_as_indeterminate() {
     use std::sync::atomic::{AtomicUsize, Ordering};
     let b_merges = Arc::new(AtomicUsize::new(0));
     let seen = Arc::clone(&b_merges);
@@ -936,10 +942,19 @@ fn settling_must_reproduce_or_the_finding_is_not_reproducible() {
         &case(ConformanceProperty::StateIdempotence, &[&[1u8]]),
     );
 
-    assert!(
-        !matches!(outcome, PropertyOutcome::Violated(_)),
-        "the digests reproduced but the settling classification did not, so the \
-         finding must not be asserted as reproduced: {outcome:?}"
+    let PropertyOutcome::Violated(v) = outcome else {
+        panic!(
+            "the violation reproduced — same inputs, same outputs, twice — and \
+                 must not be discarded because its classification was unstable: \
+                 {outcome:?}"
+        );
+    };
+    assert_eq!(v.severity, Severity::Violation);
+    assert_eq!(
+        v.settling,
+        Some(IdempotenceSettling::Indeterminate),
+        "a class observed differently on each run is unknown, not whichever \
+             the second run happened to produce"
     );
 }
 

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -18,7 +18,8 @@ use freenet_stdlib::prelude::{RelatedContracts, State, StateDelta, UpdateData, V
 
 use super::oracle::{ConformanceOracle, OracleError, OracleErrorKind};
 use super::property::{
-    ConformanceProperty, Inconclusive, OutputDigest, PropertyOutcome, Violation,
+    ConformanceProperty, IdempotenceSettling, Inconclusive, OutputDigest, PropertyOutcome,
+    Violation,
 };
 
 /// Shared, cheaply-clonable input bytes.
@@ -235,38 +236,79 @@ fn run<O: ConformanceOracle + ?Sized>(
 
     match case.property {
         ConformanceProperty::StateIdempotence => {
-            // Iterate to a fixpoint rather than demanding `merge(A, A) == A` on the
-            // first try.
+            // `merge(A, A) != A` is reported. The fixpoint iteration below
+            // CLASSIFIES the finding; it does not decide whether there is one.
             //
-            // A correct CANONICALIZING contract fails a single-apply check for a
-            // reason that is not a defect: the PUT install path stores the client's
-            // raw bytes without ever running `update_state`, so the state a peer
-            // holds may not be canonical yet, and the first merge rewrites it into
-            // canonical form. That first change is real. What matters is whether it
-            // then STABILIZES. The in-tree probe already learned this the hard way
-            // and iterates for exactly this reason — see the rustdoc on
-            // `executor_impl::probe_identical_input_idempotency`, which says
-            // flagging on the first change alone "would false-flag every such
-            // contract".
+            // It used to decide. The loop returned `Holds` if the state settled
+            // within `MAX_CANONICALIZATION_APPLIES`, which silently merged two very
+            // different outcomes into a pass. The reasoning was that a correct
+            // CANONICALIZING contract fails a single-apply check for a reason that
+            // is not its fault: the PUT install path stores the client's raw bytes
+            // without ever running `update_state`, so a peer can hold a
+            // non-canonical state and the first merge legitimately rewrites it.
             //
-            // So a violation here means the state never settles: every re-apply
-            // changes it again, which is genuine non-idempotence and does diverge
-            // under at-least-once delivery.
-            let a = &case.states[0];
-            let mut current = a.to_vec();
-            for _ in 0..MAX_CANONICALIZATION_APPLIES {
+            // That reasoning is true and it does not license a pass. Two peers
+            // handed the same updates then hold different bytes — permanently, not
+            // until some deadline, but until unrelated traffic happens to arrive —
+            // and their summaries differ, so anti-entropy fires over a difference
+            // carrying no information. That is idempotence broken on any honest
+            // reading, and the loop was suppressing a true finding.
+            //
+            // The choice looked binary — flag every canonicalizing contract as
+            // removal-eligible, or suppress — and it is not. The distinction is
+            // kept as DATA on the finding ([`IdempotenceSettling`]) rather than as
+            // a severity fork, so an eventual removal policy can branch on it
+            // without the verifier having pre-decided the answer. Bending the
+            // classification to soften an enforcement consequence is the specific
+            // mistake this replaced (#5462).
+            //
+            // Sequencing note: canonicalising at install removes the benign class
+            // entirely, and is what makes this honest report safe to enforce on
+            // later. Until then, expect `SettledAfter(1)` findings against correct
+            // contracts and read them as "the install path has not been fixed yet",
+            // not as "this contract is broken".
+            let a: &[u8] = &case.states[0];
+            let once = merge(oracle, a, a)?;
+            if once == a {
+                return Ok(PropertyOutcome::Holds);
+            }
+
+            // Idempotence is already broken. Everything below only decides WHICH
+            // kind, and must never turn the finding back into a pass.
+            let mut current = once.clone();
+            let mut rewrites: u32 = 1;
+            let mut settling = IdempotenceSettling::NeverSettled;
+            // One merge is already spent above, so the remaining budget is
+            // `MAX_CANONICALIZATION_APPLIES - 1` and the total is unchanged.
+            for _ in 1..MAX_CANONICALIZATION_APPLIES {
                 let merged = merge(oracle, &current, &current)?;
                 if merged == current {
-                    return Ok(PropertyOutcome::Holds);
+                    settling = IdempotenceSettling::SettledAfter(rewrites);
+                    break;
                 }
                 current = merged;
+                rewrites += 1;
             }
-            Ok(violation(
+
+            let detail = match settling {
+                IdempotenceSettling::SettledAfter(n) => format!(
+                    "merge(A, A) != A: the state was rewritten {n} time(s) and then \
+                     stopped changing. Idempotence is broken either way; a \
+                     canonicalizing contract lands here because the install path \
+                     stores raw client bytes without running update_state"
+                ),
+                IdempotenceSettling::NeverSettled => format!(
+                    "merge(A, A) != A and no fixpoint within \
+                     {MAX_CANONICALIZATION_APPLIES} applies: the state changes on \
+                     every re-apply, so redelivery of the same state keeps mutating it"
+                ),
+            };
+            Ok(idempotence_violation(
                 case.property,
-                &current,
+                &once,
                 a,
-                "merge(A, A) never reached a fixpoint: the state changes on every \
-                 re-apply, so redelivery of the same state keeps mutating it",
+                &detail,
+                settling,
             ))
         }
 
@@ -328,6 +370,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                     right: OutputDigest::of(a),
                     detail: "update_state emitted a state the contract rejects as invalid"
                         .to_string(),
+                    settling: None,
                 })),
             }
         }
@@ -346,6 +389,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                         right: OutputDigest::of(&again),
                         detail: "merge(A, B) returned different bytes on repeated identical calls"
                             .to_string(),
+                        settling: None,
                     }));
                 }
             }
@@ -366,6 +410,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                         right: OutputDigest::of(&again),
                         detail: "summarize_state returned different bytes for the same state"
                             .to_string(),
+                        settling: None,
                     }));
                 }
             }
@@ -394,6 +439,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                         right: OutputDigest::of(&again),
                         detail: "get_state_delta returned different bytes for the same inputs"
                             .to_string(),
+                        settling: None,
                     }));
                 }
             }
@@ -454,6 +500,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                         "delta against an exact summary of the same state is {} bytes, not empty",
                         delta.len()
                     ),
+                    settling: None,
                 }))
             }
         }
@@ -484,6 +531,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                         delta.len(),
                         a.len()
                     ),
+                    settling: None,
                 }))
             }
         }
@@ -778,6 +826,7 @@ fn reconciliation_cycle<O: ConformanceOracle + ?Sized>(
                 detail: "two valid states revisited an exact state pair while still divergent: \
                      reconciliation cannot converge"
                     .to_string(),
+                settling: None,
             }));
         }
     }
@@ -971,5 +1020,30 @@ fn violation(
         left: OutputDigest::of(left),
         right: OutputDigest::of(right),
         detail: detail.to_string(),
+        settling: None,
+    })
+}
+
+/// [`violation`] plus the settling classification, for
+/// [`ConformanceProperty::StateIdempotence`].
+///
+/// Separate constructor rather than an extra parameter on `violation`, so the
+/// other six properties cannot accidentally acquire a field that means nothing
+/// for them, and so the severity stays `property.severity()` for both — the
+/// settling data must not reach into the severity.
+fn idempotence_violation(
+    property: ConformanceProperty,
+    left: &[u8],
+    right: &[u8],
+    detail: &str,
+    settling: IdempotenceSettling,
+) -> PropertyOutcome {
+    PropertyOutcome::Violated(Violation {
+        property,
+        severity: property.severity(),
+        left: OutputDigest::of(left),
+        right: OutputDigest::of(right),
+        detail: detail.to_string(),
+        settling: Some(settling),
     })
 }

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -205,8 +205,18 @@ fn reproduced_identically(first: &Violation, second: &Violation) -> bool {
         ConformanceProperty::UpdateDeterminism
         | ConformanceProperty::SummaryDeterminism
         | ConformanceProperty::DeltaDeterminism => true,
-        ConformanceProperty::StateIdempotence
-        | ConformanceProperty::StateCommutativity
+        // `settling` too, not just the digests. It is decision-relevant data — the
+        // whole point of carrying it is that an enforcement policy branches on it —
+        // so a classification that differs between runs must not be reported as
+        // though it had reproduced. A contract whose settling varies IS
+        // non-deterministic, and falling through to `escalate_to_determinism` names
+        // that under the property which describes it.
+        ConformanceProperty::StateIdempotence => {
+            first.left == second.left
+                && first.right == second.right
+                && first.settling == second.settling
+        }
+        ConformanceProperty::StateCommutativity
         | ConformanceProperty::StateAssociativity
         | ConformanceProperty::EmittedStateValidity
         | ConformanceProperty::DeltaIdempotence
@@ -262,6 +272,19 @@ fn run<O: ConformanceOracle + ?Sized>(
             // classification to soften an enforcement consequence is the specific
             // mistake this replaced (#5462).
             //
+            // DELIBERATE DIVERGENCE from the executor's in-tree probe — do NOT
+            // "reconcile" them without reading both. `probe_identical_input_idempotency`
+            // (contract/executor/runtime/executor_impl.rs) still returns WITHOUT
+            // flagging when the state settles after a rewrite, and its rustdoc says
+            // flagging on the first change alone "would false-flag every such
+            // contract". That is correct FOR THAT MECHANISM and must stay: it has
+            // teeth today, suppressing commit, broadcast and full-state egress, so a
+            // false flag there degrades a live node. This is a REPORT, acted on by
+            // nobody, so it can afford to be honest and carry the distinction as
+            // data. The two answer the same question differently on purpose, and the
+            // direction a future reader picks decides whether a live egress
+            // suppression starts firing on canonicalizing contracts (#5462).
+            //
             // Sequencing note: canonicalising at install removes the benign class
             // entirely, and is what makes this honest report safe to enforce on
             // later. Until then, expect `SettledAfter(1)` findings against correct
@@ -281,7 +304,19 @@ fn run<O: ConformanceOracle + ?Sized>(
             // One merge is already spent above, so the remaining budget is
             // `MAX_CANONICALIZATION_APPLIES - 1` and the total is unchanged.
             for _ in 1..MAX_CANONICALIZATION_APPLIES {
-                let merged = merge(oracle, &current, &current)?;
+                // Deliberately NOT `?`. Propagating here would return
+                // `Inconclusive` from the whole check and DISCARD the violation
+                // established above — reporting "we could not tell" about a
+                // contract already caught. The never-settling class grows its
+                // state on every apply, so it is the likeliest to hit a fuel or
+                // size ceiling on exactly these follow-up merges: the class
+                // enforcement can act on would be the one that silently
+                // disappeared, and a contract could arrange that in one line by
+                // trapping on the second identical merge.
+                let Ok(merged) = merge(oracle, &current, &current) else {
+                    settling = IdempotenceSettling::Indeterminate;
+                    break;
+                };
                 if merged == current {
                     settling = IdempotenceSettling::SettledAfter(rewrites);
                     break;
@@ -290,7 +325,7 @@ fn run<O: ConformanceOracle + ?Sized>(
                 rewrites += 1;
             }
 
-            let detail = match settling {
+            let mut detail = match settling {
                 IdempotenceSettling::SettledAfter(n) => format!(
                     "merge(A, A) != A: the state was rewritten {n} time(s) and then \
                      stopped changing. Idempotence is broken either way; a \
@@ -302,7 +337,30 @@ fn run<O: ConformanceOracle + ?Sized>(
                      {MAX_CANONICALIZATION_APPLIES} applies: the state changes on \
                      every re-apply, so redelivery of the same state keeps mutating it"
                 ),
+                IdempotenceSettling::Indeterminate => {
+                    "merge(A, A) != A; the contract then errored or was refused \
+                     during classification, so whether it settles is unknown. The \
+                     violation stands on the merge that succeeded"
+                        .to_string()
+                }
             };
+            // Name a reordering as an ENCODING problem, the way every
+            // `compare`-based property does. Without this the detail above sends the
+            // author to the PUT install path when the real fix is a deterministic
+            // encoding — and a merge that only permutes bytes (a HashMap serialized
+            // in iteration order, the #4295 shape) settles after one apply, so it
+            // lands squarely in the `SettledAfter` arm. The commutativity path
+            // already carries a test against exactly this misdiagnosis.
+            if is_reordering(&once, a) {
+                detail.push_str(
+                    ". NOTE: the rewritten state holds exactly the same bytes in a \
+                     different order, so the merge agreed on content and the ENCODING \
+                     is not canonical (e.g. a HashMap serialized in iteration order). \
+                     Peers compare state by hash, so this still prevents convergence, \
+                     but the fix is a deterministic encoding rather than a change to \
+                     the merge",
+                );
+            }
             Ok(idempotence_violation(
                 case.property,
                 &once,
@@ -578,7 +636,13 @@ fn run<O: ConformanceOracle + ?Sized>(
             // first time it is merged — the PUT install path stores the client's raw
             // bytes without ever running `update_state` — so the state a peer holds
             // may not be canonical yet. Comparing against the raw bytes would report
-            // that rewrite as a merge-law break. `StateIdempotence` iterates for the
+            // that rewrite as a merge-law break. NOTE: `StateIdempotence` no longer
+            // iterates for this reason — since #5462 it reports the break and uses the
+            // iteration only to CLASSIFY it. This arm still normalizes, which leaves
+            // issue #5462's item 4 ("apply canonicalization uniformly or not at all")
+            // open; the decision recorded on that issue covers `StateIdempotence`
+            // only. Kept as-is here deliberately rather than changed in passing.
+            // Historically both iterated for the
             // same reason and to the same budget.
             let mut settled = result.to_vec();
             let mut reached_fixpoint = false;

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -339,6 +339,7 @@ fn run<O: ConformanceOracle + ?Sized>(
             let mut current = once.clone();
             let mut rewrites: u32 = 1;
             let mut settling = IdempotenceSettling::NeverSettled;
+            let mut classification_failure: Option<Inconclusive> = None;
             // One merge is already spent above, so the remaining budget is
             // `MAX_CANONICALIZATION_APPLIES - 1` and the total is unchanged.
             for _ in 1..MAX_CANONICALIZATION_APPLIES {
@@ -351,9 +352,21 @@ fn run<O: ConformanceOracle + ?Sized>(
                 // enforcement can act on would be the one that silently
                 // disappeared, and a contract could arrange that in one line by
                 // trapping on the second identical merge.
-                let Ok(merged) = merge(oracle, &current, &current) else {
-                    settling = IdempotenceSettling::Indeterminate;
-                    break;
+                let merged = match merge(oracle, &current, &current) {
+                    Ok(merged) => merged,
+                    Err(reason) => {
+                        // BIND the reason; do not discard it. A `let`-else here threw
+                        // the `Inconclusive` away unread, collapsing a RUNTIME trap
+                        // and a CONTRACT rejection into one indistinguishable
+                        // outcome — destroying the only signal that would tell us the
+                        // harness has a bug rather than the contract. That
+                        // distinction is the whole point of #5509/#5517, whose own
+                        // rustdoc says a runtime failure must never wear a contract
+                        // error's label.
+                        settling = IdempotenceSettling::Indeterminate;
+                        classification_failure = Some(reason);
+                        break;
+                    }
                 };
                 if merged == current {
                     settling = IdempotenceSettling::SettledAfter(rewrites);
@@ -376,10 +389,21 @@ fn run<O: ConformanceOracle + ?Sized>(
                      every re-apply, so redelivery of the same state keeps mutating it"
                 ),
                 IdempotenceSettling::Indeterminate => {
-                    "merge(A, A) != A; the contract then errored or was refused \
-                     during classification, so whether it settles is unknown. The \
-                     violation stands on the merge that succeeded"
-                        .to_string()
+                    // Name WHICH side failed. Saying "the contract errored" when the
+                    // cause was a runtime trap accuses the wrong party, and this
+                    // report is the one that would otherwise carry the harness-bug
+                    // signal (#5509).
+                    let cause = classification_failure
+                        .as_ref()
+                        .map_or_else(|| "cause not recorded".to_string(), |r| format!("{r}"));
+                    format!(
+                        "merge(A, A) != A; classification could not complete \
+                         ({cause}), so whether it settles is unknown. The violation \
+                         stands on the merge that succeeded. If that cause is a \
+                         runtime or harness failure rather than the contract's own \
+                         rejection, the unknown classification is OURS, not the \
+                         contract's"
+                    )
                 }
             };
             // Name a reordering as an ENCODING problem, the way every

--- a/crates/core/src/conformance/verifier.rs
+++ b/crates/core/src/conformance/verifier.rs
@@ -150,10 +150,48 @@ pub fn verify_case<O: ConformanceOracle + ?Sized>(
             {
                 second
             }
-            // Disagreed with itself. The contract is nondeterministic, which is its
-            // own defect with its own property, and is emphatically not proof of the
-            // law this case was checking. Say so under the right name if we can:
-            // reporting nothing at all would turn a real defect into a silent miss.
+            // The violation reproduced; only its CLASSIFICATION did not.
+            //
+            // Same inputs, same outputs, both runs — `merge(A, A) != A` was
+            // established twice. What flapped is the settling class, which this
+            // change insists is DATA about the finding and not the finding itself.
+            // Discarding the violation because the data was unstable would throw
+            // away a reproduced defect, which is the exact failure this whole
+            // change exists to remove.
+            //
+            // Marked `Indeterminate` rather than reported as either class, because
+            // asserting a classification observed once is the other half of the
+            // same mistake. That is the identical treatment an ERRORING
+            // classification already gets a few lines up in `run`: "we could not
+            // determine the class" is one situation and it must not be handled two
+            // ways in one file.
+            //
+            // A clock-reading contract straddling a TTL boundary between the two
+            // runs is the ordinary way to reach here, not a contrived one.
+            (PropertyOutcome::Violated(a), PropertyOutcome::Violated(b))
+                if a.property == b.property
+                    && a.left == b.left
+                    && a.right == b.right
+                    && a.settling != b.settling =>
+            {
+                let PropertyOutcome::Violated(mut v) = second else {
+                    unreachable!("matched on Violated above")
+                };
+                v.settling = Some(IdempotenceSettling::Indeterminate);
+                PropertyOutcome::Violated(v)
+            }
+            // Disagreed with itself on the OUTPUTS. The contract is
+            // nondeterministic, which is its own defect with its own property, and
+            // is emphatically not proof of the law this case was checking. Say so
+            // under the right name if we can: reporting nothing at all would turn a
+            // real defect into a silent miss.
+            //
+            // Note for `StateIdempotence` specifically: this escalation cannot
+            // name it. `escalate_to_determinism` returns early unless the case has
+            // enough states for `UpdateDeterminism` (arity 2), and an idempotence
+            // case carries one. So the outcome here is always `NotReproducible` for
+            // that property, which is why the settling-flap arm above must keep the
+            // violation rather than fall through to this.
             _ => escalate_to_determinism(oracle, case),
         };
     }

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4139,6 +4139,18 @@ mod tests {
             "a Violation must be explained, not just labelled with the bare \
              enum name — got:\n{panel}"
         );
+        // The negative half, and the reason it is needed: `merge_panel` slices the
+        // WHOLE card, so the legend explaining the pill is inside the string this
+        // assertion inspects. Checking only that the new wording is present passed
+        // happily while the legend two lines below still explained it with the old
+        // claim — the page contradicting itself, in a commit titled "stop the
+        // strings lying".
+        assert!(
+            !panel.contains("cannot converge"),
+            "the card still claims every Violation cannot converge; since #5462 a \
+             settling idempotence finding converges and is still a Violation — \
+             got:\n{panel}"
+        );
         assert!(
             panel.contains("legal but wasteful"),
             "a Diagnostic must be visibly distinguished from a Violation, \

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4026,11 +4026,16 @@ mod tests {
     /// State 4: checked, with findings — the state the whole card exists for.
     ///
     /// Each finding must show its property, and a `Violation` must read as
-    /// visibly more serious than a `Diagnostic`: the former means the
-    /// contract cannot converge (peers disagree and retry indefinitely), the
-    /// latter is legal but wasteful. A panel that only printed the bare enum
-    /// name would satisfy "shows severity" without making the distinction an
-    /// operator actually needs.
+    /// visibly more serious than a `Diagnostic`: the former is removal-eligible
+    /// under enforcement, the latter is legal but wasteful. A panel that only
+    /// printed the bare enum name would satisfy "shows severity" without making
+    /// the distinction an operator actually needs.
+    ///
+    /// This asserted the panel said "cannot converge" until #5462. That stopped
+    /// being true of every `Violation`: `state_idempotence` now reports a
+    /// canonicalizing contract, which breaks idempotence and still converges. The
+    /// assertion is retargeted rather than dropped, because the property it
+    /// guards — an explanation rather than a bare enum name — is unchanged.
     #[test]
     fn merge_card_lists_findings_with_severity_and_removal_distinguished() {
         use freenet_stdlib::prelude::ContractInstanceId;
@@ -4048,12 +4053,14 @@ mod tests {
                         contract: key_id,
                         property: "state_commutativity",
                         severity: Severity::Violation,
+                        settling: None,
                         would_remove: true,
                     },
                     MergeFinding {
                         contract: key_id,
                         property: "self_delta_empty",
                         severity: Severity::Diagnostic,
+                        settling: None,
                         would_remove: false,
                     },
                 ],
@@ -4072,7 +4079,7 @@ mod tests {
             "both findings for this contract must be listed — got:\n{panel}"
         );
         assert!(
-            panel.contains("cannot converge"),
+            panel.contains("removal-eligible"),
             "a Violation must be explained, not just labelled with the bare \
              enum name — got:\n{panel}"
         );
@@ -4155,6 +4162,7 @@ mod tests {
                     contract: key_id,
                     property: "state_commutativity",
                     severity: Severity::Violation,
+                    settling: None,
                     would_remove: true,
                 }],
             )],
@@ -4173,6 +4181,7 @@ mod tests {
                         contract: other,
                         property: "state_idempotence",
                         severity: Severity::Violation,
+                        settling: None,
                         would_remove: true,
                     }],
                 )],
@@ -4341,6 +4350,7 @@ mod tests {
                     contract: key_id,
                     property: "state_commutativity",
                     severity: Severity::Violation,
+                    settling: None,
                     would_remove: true,
                 }],
             )],

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -4023,6 +4023,62 @@ mod tests {
         );
     }
 
+    /// A converging idempotence finding must not read the same as a
+    /// non-convergent one.
+    ///
+    /// Severity cannot separate them — since #5462 both are `Severity::Violation`,
+    /// deliberately — so the panel has to read `settling`. For a whole review round
+    /// `MergeFinding` carried that field while the only code that tells an operator
+    /// what a row means ignored it, and the field's own rustdoc said to consult it.
+    /// A test asserting the field is populated would have passed throughout; this
+    /// asserts what the operator actually sees.
+    #[test]
+    fn the_panel_separates_a_settling_finding_from_a_non_convergent_one() {
+        use crate::conformance::property::IdempotenceSettling;
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let rendered = |settling| {
+            let key_id = ContractInstanceId::new([7u8; 32]);
+            let key = key_id.to_string();
+            let mut status = MergeCheckStatus::default();
+            status.record(
+                [checked_record(
+                    key_id,
+                    40,
+                    0,
+                    vec![MergeFinding {
+                        contract: key_id,
+                        property: "state_idempotence",
+                        severity: Severity::Violation,
+                        settling,
+                        would_remove: true,
+                    }],
+                )],
+                1,
+                0,
+                tokio::time::Instant::now(),
+            );
+            let snap = hosted_snap(&key);
+            let view = merge_view(&status, &key_id);
+            let html = contract_detail_html_from(&Some(snap), &key, true, Some(&view));
+            merge_panel(&html)
+        };
+
+        let settled = rendered(Some(IdempotenceSettling::SettledAfter(1)));
+        let never = rendered(Some(IdempotenceSettling::NeverSettled));
+
+        assert_ne!(
+            settled, never,
+            "a contract that converges after one rewrite and one that never settles \
+             must not render identically — that is the misreading #5462 exists to \
+             prevent:\nsettled:\n{settled}\nnever:\n{never}"
+        );
+        assert!(
+            settled.contains("converges"),
+            "the settling case must say so in words the operator reads:\n{settled}"
+        );
+    }
+
     /// State 4: checked, with findings — the state the whole card exists for.
     ///
     /// Each finding must show its property, and a `Violation` must read as

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -5,7 +5,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use super::assets::{CSS, JS, PEER_CSS};
 use super::cards::format_bytes;
 use super::*;
-use crate::conformance::property::Severity;
+use crate::conformance::property::{IdempotenceSettling, Severity};
 use crate::conformance::status;
 
 // ─── Contract detail page ────────────────────────────────────────────────────
@@ -435,9 +435,26 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
     } else {
         let mut rows = String::new();
         for f in record.findings() {
-            let (pill_class, label) = match f.severity {
-                Severity::Violation => ("fresh-stale", "Violation — removal-eligible"),
-                Severity::Diagnostic => ("use-idle", "Diagnostic — legal but wasteful"),
+            // Severity alone cannot describe a `state_idempotence` row since
+            // #5462: a canonicalizing contract breaks the law and still converges,
+            // so it carries the same `Violation` as one that never settles. The
+            // settling class is what separates "waiting on the install-path fix"
+            // from "genuinely non-convergent", and showing the first as though it
+            // were the second is the misreading this whole change exists to
+            // prevent.
+            let (pill_class, label) = match (f.severity, f.settling) {
+                (Severity::Violation, Some(IdempotenceSettling::SettledAfter(_))) => (
+                    "fresh-stale",
+                    "Violation — settles after a rewrite (converges)",
+                ),
+                (Severity::Violation, Some(IdempotenceSettling::NeverSettled)) => {
+                    ("fresh-stale", "Violation — never settles")
+                }
+                (Severity::Violation, Some(IdempotenceSettling::Indeterminate)) => {
+                    ("fresh-stale", "Violation — settling unknown")
+                }
+                (Severity::Violation, _) => ("fresh-stale", "Violation — removal-eligible"),
+                (Severity::Diagnostic, _) => ("use-idle", "Diagnostic — legal but wasteful"),
             };
             rows.push_str(&format!(
                 r#"<tr><td>{property}</td><td><span class="fresh-pill {pill_class}">{label}</span></td><td class="right">{would_remove}</td></tr>"#,

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -436,7 +436,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
         let mut rows = String::new();
         for f in record.findings() {
             let (pill_class, label) = match f.severity {
-                Severity::Violation => ("fresh-stale", "Violation — cannot converge"),
+                Severity::Violation => ("fresh-stale", "Violation — removal-eligible"),
                 Severity::Diagnostic => ("use-idle", "Diagnostic — legal but wasteful"),
             };
             rows.push_str(&format!(
@@ -538,6 +538,7 @@ mod tests {
             contract: checked,
             property: PROPERTY,
             severity: Severity::Violation,
+            settling: None,
             would_remove: false,
         });
         status::publish([record], 1, 0, tokio::time::Instant::now());

--- a/crates/core/src/server/home_page/contract_detail.rs
+++ b/crates/core/src/server/home_page/contract_detail.rs
@@ -469,7 +469,7 @@ fn merge_law_card(merge_enabled: bool, merge_view: Option<&status::MergeCheckVie
                 <div class="info-grid" style="margin-top:0.75rem">
                     {cases_row}
                 </div>
-                <p class="empty" style="margin-top:0.75rem"><strong>Violation</strong> means the contract cannot converge: peers holding it disagree and retry indefinitely. <strong>Diagnostic</strong> is legal but wasteful — it never justifies removal on its own.</p>
+                <p class="empty" style="margin-top:0.75rem"><strong>Violation</strong> means the contract broke an algebraic law and is removal-eligible under enforcement. Most do not converge, but not all: a contract that normalises a stored state once and then holds still breaks idempotence and still agrees with its peers — those rows say <em>settles after a rewrite</em>. <strong>Diagnostic</strong> is legal but wasteful — it never justifies removal on its own.</p>
                 {note}
             </div>"#,
             rows = rows,

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -79,7 +79,7 @@ pub enum SubCommand {
     /// merging is order-independent, groups the same way whichever pairing is used,
     /// and applying the same change twice does nothing the second time.
     ///
-    /// A contract that breaks these cannot converge — two peers given the same
+    /// A contract that breaks these usually cannot converge — two peers given the same
     /// updates in different orders end up with different state, never agree, and
     /// retry indefinitely. That is what this looks for.
     ///

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -3890,7 +3890,7 @@ mod tests {
                 left: digest(),
                 right: digest(),
                 detail: "merge(A, A) != A".to_string(),
-                settling: Some(IdempotenceSettling::SettledAfter(1)),
+                settling: Some(IdempotenceSettling::NeverSettled),
             }),
         )];
         let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
@@ -3900,9 +3900,19 @@ mod tests {
             json.contains("\"settling\""),
             "the settling field never reached --json: {json}"
         );
+        // `NeverSettled` deliberately, and asserting the OTHER variant is absent.
+        // Found by mutation: with a `SettledAfter` fixture, hardcoding the forwarded
+        // value to `SettledAfter(1)` passed — the test proved the field was present,
+        // not that it carried what the verifier decided. `NeverSettled` is also the
+        // classification an enforcement policy can act on, so silently substituting
+        // the benign one is the direction that matters.
         assert!(
-            json.contains("SettledAfter"),
-            "--json carries the field but not which classification: {json}"
+            json.contains("NeverSettled"),
+            "--json must forward the classification the verifier made: {json}"
+        );
+        assert!(
+            !json.contains("SettledAfter"),
+            "a classification the verifier did not make must not appear: {json}"
         );
     }
 

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -1,6 +1,6 @@
 //! `fdev verify-merge`: check a contract's merge laws offline (RFC #5320).
 //!
-//! A contract that breaks them cannot converge — peers given the same updates
+//! A contract that breaks them usually cannot converge — peers given the same updates
 //! in different orders end up with different state and never agree.
 //!
 //! This is a thin CLI wrapper around `freenet::conformance` and does not
@@ -3879,20 +3879,41 @@ mod tests {
     /// handed, which is the defect #5461 fixed one field over.
     #[test]
     fn the_json_report_carries_the_settling_classification() {
-        let outcomes = vec![(
-            ConformanceCase::new(
-                ConformanceProperty::StateIdempotence,
-                vec![Bytes::from(vec![1u8])],
+        let outcomes = vec![
+            (
+                ConformanceCase::new(
+                    ConformanceProperty::StateIdempotence,
+                    vec![Bytes::from(vec![1u8])],
+                ),
+                PropertyOutcome::Violated(Violation {
+                    property: ConformanceProperty::StateIdempotence,
+                    severity: Severity::Violation,
+                    left: digest(),
+                    right: digest(),
+                    detail: "merge(A, A) != A".to_string(),
+                    settling: Some(IdempotenceSettling::NeverSettled),
+                }),
             ),
-            PropertyOutcome::Violated(Violation {
-                property: ConformanceProperty::StateIdempotence,
-                severity: Severity::Violation,
-                left: digest(),
-                right: digest(),
-                detail: "merge(A, A) != A".to_string(),
-                settling: Some(IdempotenceSettling::NeverSettled),
-            }),
-        )];
+            (
+                ConformanceCase::new(
+                    ConformanceProperty::StateIdempotence,
+                    vec![Bytes::from(vec![2u8])],
+                ),
+                PropertyOutcome::Violated(Violation {
+                    property: ConformanceProperty::StateIdempotence,
+                    severity: Severity::Violation,
+                    left: digest(),
+                    right: digest(),
+                    detail: "merge(A, A) != A, settles".to_string(),
+                    // A SECOND finding with a DIFFERENT class. One fixture value can
+                    // always be satisfied by hardcoding that value: this test used
+                    // `SettledAfter` until a mutation hardcoded `SettledAfter`, and
+                    // switching to `NeverSettled` only moved which constant passed.
+                    // Two classes in one report mean no constant can.
+                    settling: Some(IdempotenceSettling::SettledAfter(1)),
+                }),
+            ),
+        ];
         let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
         let json = serde_json::to_string(&report).expect("the report must serialize");
 
@@ -3911,8 +3932,9 @@ mod tests {
             "--json must forward the classification the verifier made: {json}"
         );
         assert!(
-            !json.contains("SettledAfter"),
-            "a classification the verifier did not make must not appear: {json}"
+            json.contains("SettledAfter"),
+            "the second finding's class must be forwarded too — with a single \
+             class in the fixture, hardcoding that class passes: {json}"
         );
     }
 

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -33,9 +33,9 @@ use freenet::conformance::host_clock;
 use freenet::conformance::verifier::Bytes;
 use freenet::conformance::{
     ConformanceCase, ConformanceEvidence, ConformanceProperty, EVIDENCE_SCHEMA_VERSION,
-    EvidenceRejected, GeneratorConfig, Inconclusive, MinimizeConfig, OracleBuildError,
-    PropertyOutcome, ReplayBundle, RuntimeOracle, Severity, Transition, generate_cases, minimize,
-    verify_case,
+    EvidenceRejected, GeneratorConfig, IdempotenceSettling, Inconclusive, MinimizeConfig,
+    OracleBuildError, PropertyOutcome, ReplayBundle, RuntimeOracle, Severity, Transition,
+    generate_cases, minimize, verify_case,
 };
 use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId, State, UpdateData};
 use serde::Serialize;
@@ -1302,6 +1302,15 @@ struct Finding {
     detail: String,
     left: String,
     right: String,
+    /// Machine-readable settling classification for `state_idempotence`; `null`
+    /// for every other property.
+    ///
+    /// `detail` states it in prose, but `Violation::detail` is documented as
+    /// diagnostic and never parsed, and this distinction is exactly what an
+    /// eventual removal policy branches on (#5462). Carrying it only as text
+    /// would leave the tool discarding structure it was handed — the defect
+    /// #5461 fixed, one field over.
+    settling: Option<IdempotenceSettling>,
 }
 
 /// How many distinct detail texts the HUMAN report shows per inconclusive reason.
@@ -1413,6 +1422,7 @@ impl Report {
                         detail: v.detail.clone(),
                         left: v.left.to_string(),
                         right: v.right.to_string(),
+                        settling: v.settling,
                     });
                 }
                 PropertyOutcome::Inconclusive(reason) => {
@@ -3318,6 +3328,7 @@ mod tests {
             left: digest(),
             right: digest(),
             detail: "test".to_string(),
+            settling: None,
         }
     }
 
@@ -3353,6 +3364,7 @@ mod tests {
             detail: detail.to_string(),
             left: left.to_string(),
             right: right.to_string(),
+            settling: None,
         }
     }
 
@@ -3851,6 +3863,43 @@ mod tests {
         assert!(
             resource_header < resource_text,
             "the resource-limit message is not under its heading:\n{rendered}"
+        );
+    }
+
+    /// `--json` must carry the settling classification, not just its prose.
+    ///
+    /// `Violation::detail` says the same thing in words, but it is documented as
+    /// diagnostic and never parsed, and this distinction is what an eventual
+    /// removal policy branches on (#5462): a contract that normalises once is a
+    /// different animal from one that mutates on every redelivery. Dropping the
+    /// structured field here would leave the tool discarding information it was
+    /// handed, which is the defect #5461 fixed one field over.
+    #[test]
+    fn the_json_report_carries_the_settling_classification() {
+        let outcomes = vec![(
+            ConformanceCase::new(
+                ConformanceProperty::StateIdempotence,
+                vec![Bytes::from(vec![1u8])],
+            ),
+            PropertyOutcome::Violated(Violation {
+                property: ConformanceProperty::StateIdempotence,
+                severity: Severity::Violation,
+                left: digest(),
+                right: digest(),
+                detail: "merge(A, A) != A".to_string(),
+                settling: Some(IdempotenceSettling::SettledAfter(1)),
+            }),
+        )];
+        let report = Report::build(&Corpus::default(), &outcomes, None, Vec::new());
+        let json = serde_json::to_string(&report).expect("the report must serialize");
+
+        assert!(
+            json.contains("\"settling\""),
+            "the settling field never reached --json: {json}"
+        );
+        assert!(
+            json.contains("SettledAfter"),
+            "--json carries the field but not which classification: {json}"
         );
     }
 

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -412,8 +412,11 @@ fn write_bundle(
 /// distinction CI needs and a single exit code cannot express.
 #[derive(Debug, thiserror::Error)]
 #[error(
-    "{count} merge-law violation(s) found: this contract cannot converge, so peers \
-     holding it will disagree and keep retrying"
+    "{count} merge-law violation(s) found. A violation is removal-eligible under \
+     enforcement; see each finding for what it means. NOTE: `state_idempotence` \
+     reporting `settled_after` is a real break whose harm is redundant anti-entropy \
+     rather than divergence \u{2014} expected against correct canonicalizing \
+     contracts until the PUT install path canonicalizes"
 )]
 pub struct ConformanceViolations {
     pub count: usize,

--- a/crates/fdev/src/main.rs
+++ b/crates/fdev/src/main.rs
@@ -237,7 +237,7 @@ mod tests {
     /// keep working — a rename that silently breaks a released command is worse than
     /// the naming it fixes. `verify-merge` is the name going forward because
     /// "conformance" never said what was being checked: it is the merge laws, and a
-    /// contract that breaks them cannot converge.
+    /// contract that breaks them usually cannot converge.
     #[test]
     fn both_the_new_and_released_subcommand_names_parse() {
         use clap::Parser;


### PR DESCRIPTION
## Problem

`StateIdempotence` iterated to a fixpoint and returned `Holds` if the state settled within `MAX_CANONICALIZATION_APPLIES`, which silently merged two very different outcomes into a pass.

The reasoning behind the loop was true. A correct **canonicalizing** contract fails a single-apply check for a reason that is not its fault: the PUT install path stores the client's raw bytes without ever running `update_state`, so a peer can hold a non-canonical state and the first merge legitimately rewrites it.

It does not license a pass. Two peers handed the same updates then hold different bytes — permanently, not until some deadline, but until unrelated traffic happens to arrive — and their summaries differ, so anti-entropy fires over a difference carrying no information. That is idempotence broken on any honest reading, and the loop was suppressing a true finding.

## Approach

The choice looked binary — flag every canonicalizing contract as removal-eligible, or suppress — and it is not. The fixpoint computation is kept, moved from **gate** to **classifier**, and the result is carried as data:

| | meaning |
|---|---|
| `SettledAfter(n)` | rewritten *n* times, then stable. A canonicalizing contract lands here with `n = 1`. Real, benign in effect until the install path is fixed. |
| `NeverSettled` | changes on every re-apply. Unambiguously non-convergent, and actionable without waiting on anything else. |

**Both are `Severity::Violation`.** Letting the settling behaviour pick the severity would repeat the original mistake in milder form — bending the *classification* to soften an *enforcement* consequence. That was proposed in the issue thread and rejected there.

It is carried **structurally** on `Violation` rather than folded into `detail`, because `detail` is documented as diagnostic and never parsed, while this distinction is exactly what an eventual removal policy branches on. `fdev` surfaces it in `--json` for the same reason: leaving it only in prose would have the tool discarding structure it was handed, which is the defect #5461 fixed one field over.

### Nothing is enforced by this

Phases 5 and 6 are unstarted. `Severity::Violation` marks a finding removal-**eligible** in a future where removal exists, not removal-pending today. That is what makes reporting this honestly costless now, and it is why the sequence is: report honestly → fix the install path → design enforcement against a corpus where the finding means what it says.

Expect `SettledAfter(1)` findings against correct contracts until the install path is canonicalized. That is the finding working, not a false positive, and the code says so where a reader will hit it.

### Evidence schema 1 → 2

For the new field. Evidence is not propagated to peers (phase 4 unstarted; `ConformanceEvidence` appears only within `conformance/`).

**Correction to an earlier version of this description.** It said `check_bounds` rejects an unsupported schema "at the front door, so an older file fails cleanly rather than mis-parsing". That is false, and a reviewer caught it. `bincode::deserialize` runs *before* the version check, and bincode is not self-describing, so a v1 file cannot reach the check at all: `Violation` gained a field mid-struct inside `observed`, which is followed by `runtime`, so the decode fails with an opaque error first. The version gate is unreachable for exactly the case it exists for.

The practical risk is nil — evidence is local-only, unpropagated, and these are developer artifacts — but the mechanism does not do what its own documentation claims, so it is filed separately rather than left as a claim I had not checked.

## Testing

**7 mutations, all killed:**

| Mutation | Result |
|---|---|
| The fixpoint loop gates the verdict again (the original defect) | killed |
| Settling softens the severity (the fork the decision rejected) | killed |
| Settling data dropped (everything reports `NeverSettled`) | killed |
| Never-settling misreported as settled | killed |
| Rewrite count stuck at 1 | killed |
| Idempotence reports on everything, including conforming contracts | killed |
| `fdev` drops the classification from its report | killed |

The rewrite-count mutation **survived the first round**, and it was a real gap rather than a bad mutation: every settling test used a contract that stabilises after exactly one rewrite, where a stuck counter and a correct one are indistinguishable. `the_settled_after_count_reports_the_actual_number_of_rewrites` uses a contract needing two.

`an_idempotent_contract_still_holds` is the floor under the others: without it, a change that made `StateIdempotence` report on *everything* would leave both new tests passing while the property became worthless.

`a_canonicalizing_contract_is_not_flagged` was **rewritten, not deleted** — it was correct for the policy it was written under, and the policy changed deliberately. Its replacement pins both halves of the new decision.

5,334 core tests pass; `fdev` green; fmt and clippy clean.

## Follow-up, sequenced deliberately

Canonicalizing at install (running `update_state` on the PUT path) removes the benign class entirely, at the cost of one extra WASM call per PUT. It is what makes this honest report safe to enforce on later. Filing separately rather than bundling: it changes the install path, this changes a report.

Closes #5462

[AI-assisted - Claude]

https://claude.ai/code/session_01K1tXeM2YX8Y9e7u4nALPva

