### PR TITLE
fix: repair broadcast drops swallowed by the resync throttle window, at the window's close

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4695,11 +4695,10 @@ impl GlobalTestMetrics {
 
     /// Returns the total number of ResyncRequests received since last reset.
     ///
-    /// This is the TOTAL across every cause. Since #5510 there are several — a
-    /// delta that failed to apply, a queue-full broadcast drop, and a
-    /// rate-limited broadcast drop (with a fourth, the trailing coalesced
-    /// repair, once #5525 lands) — so a test that means "no delta failed" must
-    /// use [`Self::delta_failure_resyncs`] instead.
+    /// This is the TOTAL across every cause. Since #5510 there are four — a
+    /// delta that failed to apply, a queue-full broadcast drop, a rate-limited
+    /// broadcast drop, and the trailing coalesced repair — so a test that means
+    /// "no delta failed" must use [`Self::delta_failure_resyncs`] instead.
     /// Asserting zero on this total makes any new, legitimate resync source
     /// look like the #2763 regression.
     pub fn resync_requests() -> u64 {

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1366,7 +1366,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                 return;
             }
         };
-    // Spawn BEFORE the blocking dispatch below — that ordering is load-bearing;
+    // Spawn BEFORE the blocking dispatch below; the order matters and is
     // see `spawn_resync_followups` (#4862 P2).
     spawn_resync_followups(
         op_manager,
@@ -1520,7 +1520,7 @@ async fn reserve_resync_emit(
     {
         op_manager
             .interest_manager
-            .note_resync_debt_on_held_reservation(&key, sender_addr);
+            .note_resync_debt_on_held_reservation(&key, sender_addr, reservation_deadline);
         // The COUNTER answers "how many repairs did the cap suppress" — one per
         // drop that wanted one — so a chain's own retries must not inflate it
         // (review round 3). One swallowed drop retried three times is ONE
@@ -1602,7 +1602,7 @@ async fn reserve_resync_emit(
 /// exits the first time a window closes with nothing swallowed, so a quiet
 /// contract costs one task for one window.
 ///
-/// # Ordering (#4862 P2), unchanged and still load-bearing
+/// # Ordering (#4862 P2), unchanged and still required
 ///
 /// The caller spawns this BEFORE its blocking `notify_node_event`, which can
 /// consume up to `NOTIFICATION_SEND_TIMEOUT` (30s) under backpressure. Spawning
@@ -1808,6 +1808,9 @@ fn spawn_resync_followups(
         };
         // Total loop passes, bounding a chain that only ever gets refused.
         let mut attempts: u32 = 0;
+        // Whether this chain has already spent its ONE speculative repair for an
+        // unknowable debt. See the `ResyncDebt::Unknown` arm below.
+        let mut repaired_unknown = false;
 
         loop {
             if deliver {
@@ -1869,13 +1872,44 @@ fn spawn_resync_followups(
             if !owed {
                 // `Unknown` (the reservation was evicted from the bounded LRU
                 // mid-window) counts as owed — see `ResyncDebt`. The chain
-                // cannot distinguish "nothing was swallowed" from "the record
-                // of what was swallowed is gone", and only one of those is safe
-                // to act on by exiting.
-                owed = op_mgr
-                    .interest_manager
-                    .take_resync_drop_during_window(&key, sender_addr, deadline)
-                    .is_owed();
+                // cannot distinguish "nothing was swallowed" from "the record of
+                // what was swallowed is gone", and only one of those is safe to
+                // act on by exiting.
+                //
+                // But it is LATCHED (review round 3, N2). The condition that
+                // produces `Unknown` is LRU pressure — more than
+                // RESYNC_THROTTLE_CACHE_SIZE pairs churning inside one window —
+                // and that condition persists, so an unlatched `Unknown` is
+                // reported again at every window close, so the chain runs to
+                // its served-window bound: 3 emits and ~90s of slot where one
+                // emit and ~30s was owed, on precisely the saturated node X1
+                // exists to protect. One speculative repair for an unknowable
+                // debt is proportionate; three is not.
+                //
+                // A genuine `Owed` is not latched and continues as before.
+                match op_mgr.interest_manager.take_resync_drop_during_window(
+                    &key,
+                    sender_addr,
+                    deadline,
+                ) {
+                    crate::ring::interest::ResyncDebt::Owed => owed = true,
+                    crate::ring::interest::ResyncDebt::Unknown if !repaired_unknown => {
+                        repaired_unknown = true;
+                        owed = true;
+                        tracing::debug!(
+                            tx = %incoming_tx,
+                            contract = %key,
+                            target = %sender_addr,
+                            event = "coalesced_resync_unknown_debt",
+                            "UPDATE relay: this pair's reservation was evicted \
+                             from the throttle LRU, so whether a drop was \
+                             swallowed is unknowable; repairing once \
+                             speculatively (#5510)"
+                        );
+                    }
+                    crate::ring::interest::ResyncDebt::Unknown
+                    | crate::ring::interest::ResyncDebt::None => {}
+                }
             }
             if !owed {
                 // Nothing was swallowed by this window. Usually that means the
@@ -1920,31 +1954,82 @@ fn spawn_resync_followups(
                 || attempts >= MAX_COALESCED_RESYNC_ATTEMPTS
             {
                 // The debt was CONSUMED into `owed` a few lines above, so
-                // returning here would abandon it silently (review round 3, X4):
-                // a drop swallowed late in the last served window would vanish
-                // at t=90 with nothing left holding the flag. Hand it back to
-                // the reservation instead, so the next drop on this pair — or a
-                // chain that later owns this window — still serves it.
+                // simply returning would abandon it silently: a drop swallowed
+                // late in the last served window would vanish at ~t=90.
                 //
-                // Handing back rather than emitting one more time keeps the
-                // bound meaning what it says. Emitting here would make the
-                // chain serve MAX+1 windows, and the bound exists to cap slot
-                // occupancy, not to cap repairs.
-                op_mgr
-                    .interest_manager
-                    .note_resync_debt_on_held_reservation(&key, sender_addr);
-                tracing::info!(
-                    tx = %incoming_tx,
-                    contract = %key,
-                    target = %sender_addr,
-                    windows_served,
-                    attempts,
-                    event = "coalesced_resync_chain_bound",
-                    "UPDATE relay: dropped-broadcast repair chain hit its bound \
-                     and is releasing its slot with a debt still owed; the debt \
-                     is left on the reservation, so a pair still dropping this \
-                     steadily repairs from its next reservation (#5510)"
-                );
+                // An earlier revision handed the debt back to the reservation
+                // instead of emitting. That was INERT (review round 3, N1), and
+                // instructively so: control only reaches here after
+                // `wait_until_reservation_close` returned true, i.e. `now >=
+                // deadline`, so the reservation being written to has ALREADY
+                // EXPIRED. Nothing can ever take that flag — the take requires a
+                // matching deadline and the only holder of it is this chain,
+                // which is leaving — and the next drop's grant `put`s a fresh
+                // entry with the flag cleared. The debt was written to a slot
+                // that had stopped being read, and the log beside it announced
+                // that the repair had been preserved.
+                //
+                // So EMIT, once, through the same gates as any other emit: gate
+                // B, the per-(contract, sender) throttle and the global
+                // per-contract cap all still apply, and `note_debt: true` hands
+                // the debt to a sibling if one now owns the window. The #4251
+                // bound is intact — still at most one request per window per
+                // pair — and the chain bound still does its real job, which is
+                // capping SLOT OCCUPANCY rather than capping repairs.
+                if op_mgr.ring.should_summarize_or_broadcast(&key) {
+                    match reserve_resync_emit(
+                        &op_mgr,
+                        key,
+                        sender_addr,
+                        incoming_tx,
+                        DroppedBroadcastReason::DroppedDuringThrottleWindow,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            dispatch_resync_request(&op_mgr, key, sender_addr, incoming_tx).await;
+                            tracing::info!(
+                                tx = %incoming_tx,
+                                contract = %key,
+                                target = %sender_addr,
+                                windows_served,
+                                attempts,
+                                event = "coalesced_resync_chain_bound",
+                                "UPDATE relay: dropped-broadcast repair chain hit \
+                                 its bound; emitted a final repair for the debt it \
+                                 was carrying and released its slot (#5510)"
+                            );
+                        }
+                        Err(refusal) => {
+                            tracing::info!(
+                                tx = %incoming_tx,
+                                contract = %key,
+                                target = %sender_addr,
+                                windows_served,
+                                attempts,
+                                refusal = ?refusal,
+                                event = "coalesced_resync_chain_bound_unrepaired",
+                                "UPDATE relay: dropped-broadcast repair chain hit \
+                                 its bound and its final repair was refused; the \
+                                 debt is handed to whichever reservation now holds \
+                                 this pair, or waits for the next drop (#5510)"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        windows_served,
+                        attempts,
+                        event = "coalesced_resync_chain_bound_unheld",
+                        "UPDATE relay: dropped-broadcast repair chain hit its \
+                         bound for a contract this node no longer holds; nothing \
+                         to repair (#5510)"
+                    );
+                }
                 return;
             }
 
@@ -5415,28 +5500,6 @@ mod tests {
              releases the window (so retrying can win it back), a sibling holds \
              it (so retrying cannot)"
         );
-        // #5510 review round 3 (X4): the bound's return must hand the debt back.
-        //
-        // The debt is CONSUMED into `owed` before the bound is checked, so a
-        // bare return abandons it — a drop swallowed late in the last served
-        // window would vanish at t=90 with nothing holding the flag. Handing it
-        // back rather than emitting one more time keeps the bound meaning what
-        // it says: it caps slot occupancy, not repairs.
-        let bound = body
-            .find("if windows_served >= MAX_COALESCED_RESYNC_WINDOWS")
-            .expect("the chain bound must exist");
-        let bound_end = body[bound..]
-            .find("\n            }")
-            .map(|i| bound + i)
-            .unwrap_or(body.len());
-        assert!(
-            body[bound..bound_end].contains("note_resync_debt_on_held_reservation"),
-            "the chain-bound return must hand the consumed debt back to the \
-             reservation; it was taken into `owed` before this check, so \
-             returning without it drops a real repair on the floor at the exact \
-             moment the chain stops looking (#5510 X4)"
-        );
-
         assert!(
             !arm_body.contains("note_resync_drop_during_window"),
             "the hand-over happens inside begin_resync_request_or_note_drop, \
@@ -5525,6 +5588,189 @@ mod tests {
             "retrying an unanswered repair must stay bounded by windows_served \
              and attempts — otherwise X2's fix trades a lost repair for a leaked \
              slot"
+        );
+    }
+
+    /// #5510 review round 3 (N2): an unknowable debt causes at most ONE
+    /// speculative repair, not one per window.
+    ///
+    /// `ResyncDebt::Unknown` means the pair's reservation was evicted from the
+    /// bounded LRU mid-window, so whether a drop was swallowed cannot be known.
+    /// Treating it as owed is right — a redundant full state costs one response,
+    /// a missed one costs a divergence that lasts until anti-entropy.
+    ///
+    /// Treating it as owed EVERY window is not. The condition that produces
+    /// `Unknown` is LRU pressure, and that persists, so an unlatched chain is
+    /// told "unknown" again at each close and walks to its served-window bound:
+    /// three emits and ~90s of a node-wide slot where one emit and ~30s was
+    /// owed — on precisely the saturated node the slot pool exists to protect.
+    ///
+    /// Here the entry is evicted before every window close, so `Unknown` is the
+    /// answer every time.
+    #[tokio::test(start_paused = true)]
+    async fn an_unknowable_debt_causes_one_speculative_repair_not_one_per_window() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("unknown-latch-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([95u8; 32]),
+            CodeHash::new([96u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:14200".parse().unwrap();
+
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        let _ = drain_resync_targets(&mut notification_rx, key);
+
+        // Discard the #4862 re-deliveries, which are not repairs and fire inside
+        // the first window regardless.
+        for _ in 0..56 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+
+        // From here, drop this pair's reservation before every window close, so
+        // the take can only ever answer `Unknown`.
+        //
+        // The correlation record is consumed on every tick, standing in for a
+        // responder that answers. Without that this test cannot see the latch at
+        // all: the X2 path keeps `owed` true while a request is unanswered, and
+        // in this harness nothing ever answers, so the chain runs to its bound
+        // for that reason instead — six emits, and not one of them attributable
+        // to `Unknown`. Consuming the record isolates the axis under test.
+        let mut emits = Vec::new();
+        for _ in 0..400 {
+            op_manager
+                .interest_manager
+                .cancel_resync_request(&key, target);
+            op_manager
+                .ring
+                .outstanding_resync_requests
+                .consume(*key.id(), target);
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            emits.extend(drain_resync_targets(&mut notification_rx, key));
+            if op_manager.interest_manager.outstanding_resync_retries() == 0 {
+                break;
+            }
+        }
+
+        assert!(
+            emits.len() <= 1,
+            "an unknowable debt must cause at most ONE speculative repair per \
+             chain. More means the latch is missing and sustained LRU pressure \
+             walks every chain to its full bound, holding node-wide slots on the \
+             busiest node. Got {emits:?}"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "and the chain must exit rather than keep re-reading Unknown"
+        );
+    }
+
+    /// #5510 review round 3 (N1): a chain that reaches its bound while still
+    /// owing a repair EMITS one, rather than returning quietly.
+    ///
+    /// The bound is checked after the window's debt has been consumed into
+    /// `owed`, so whatever the chain does there decides the fate of a real
+    /// swallowed drop. An earlier revision handed the debt back to the
+    /// reservation; that was inert, because control only reaches the bound once
+    /// `now >= deadline`, so the entry being written to had already expired —
+    /// no take could match its generation, and the next grant cleared the flag.
+    /// The drop was lost at ~t=90 while the log announced it had been preserved.
+    ///
+    /// Construction: the emit bucket is kept empty so every re-reservation is
+    /// refused and the chain climbs to its ATTEMPTS bound still owing, then the
+    /// draining stops so the final emit can be granted. Exactly one emit must
+    /// follow, and the chain must then exit.
+    #[tokio::test(start_paused = true)]
+    async fn a_chain_reaching_its_bound_while_owing_emits_a_final_repair() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("bound-final-emit-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([93u8; 32]),
+            CodeHash::new([94u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:14100".parse().unwrap();
+
+        for _ in 0..2 {
+            send_dropped_broadcast_resync_request(
+                &op_manager,
+                key,
+                target,
+                Transaction::new::<UpdateMsg>(),
+                DroppedBroadcastReason::RateLimited,
+            )
+            .await;
+        }
+        let _ = drain_resync_targets(&mut notification_rx, key);
+
+        // Phase 1: keep the bucket empty so every re-reservation is refused and
+        // the chain climbs toward its ATTEMPTS bound with the debt still owed.
+        // Stops at ~120s, comfortably before the attempts bound, so the bound
+        // itself is reached in phase 2 when tokens are available to serve it.
+        //
+        // Emissions here are discarded rather than asserted absent: the #4862
+        // re-deliveries re-send the already-authorized first request and do not
+        // consult the emit cap, so two of them fire inside the first window
+        // however empty the bucket is. They are not repairs.
+        for _ in 0..240 {
+            while op_manager
+                .ring
+                .resync_emit_limiter
+                .check_and_record(*key.id())
+            {}
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+        assert!(
+            op_manager.interest_manager.outstanding_resync_retries() > 0,
+            "precondition: the chain must still be alive and owing as it \
+             approaches its bound"
+        );
+
+        // Phase 2: stop draining. The chain's final act, at its bound, must be
+        // to emit the repair it has been carrying.
+        let mut after = Vec::new();
+        for _ in 0..400 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            after.extend(drain_resync_targets(&mut notification_rx, key));
+            if op_manager.interest_manager.outstanding_resync_retries() == 0 && !after.is_empty() {
+                break;
+            }
+        }
+
+        // Not an exact count, deliberately. How many of the remaining windows
+        // the chain SERVES before reaching its bound depends on when the emit
+        // bucket refills, which is not something this test should pin — and
+        // pinning it would make the test fail for reasons unrelated to N1. The
+        // defect N1 describes is the chain reaching its bound with a debt and
+        // emitting NOTHING, so zero is the failure this must catch. Termination
+        // is covered separately, by
+        // `a_chain_refused_on_every_attempt_terminates_and_frees_its_slot` and
+        // by the chain-bound pin.
+        assert!(
+            !after.is_empty(),
+            "the chain must emit the repair it carried to its bound rather than \
+             returning quietly: zero emits is the inert hand-back, where the debt \
+             was written to an already-expired reservation that nothing could \
+             read and the next grant then cleared"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "and the chain must then exit, releasing its node-wide slot"
         );
     }
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1277,6 +1277,30 @@ impl DroppedBroadcastReason {
             DroppedBroadcastReason::DroppedDuringThrottleWindow => "dropped_during_window",
         }
     }
+
+    /// Whether repairs originating from this drop are gated on the node still
+    /// holding the contract (#5510, review round 2).
+    ///
+    /// TRUE for the rate-limiter drop only, and that asymmetry is deliberate:
+    /// `node.rs` gates the rate-limited emit on
+    /// `should_summarize_or_broadcast`, so a chain descended from one must
+    /// re-check the same condition before each coalesced emit — it can live tens
+    /// of seconds and the contract may be evicted underneath it. The
+    /// pre-existing queue-full path (#4857) has NEVER been gated on hosting, and
+    /// adding the gate here would silently narrow it: a queue-full drop means
+    /// the executor was already applying the update locally, so the repair is
+    /// warranted whatever a later hosting read says. Widening #4857's gate is
+    /// out of scope for #5510 and would be a behaviour change with no evidence
+    /// behind it.
+    fn repair_is_hosting_gated(self) -> bool {
+        match self {
+            DroppedBroadcastReason::RateLimited => true,
+            DroppedBroadcastReason::QueueFull => false,
+            // The chain's own reason. Never the ORIGIN, so it is never the value
+            // asked here — the origin is threaded through separately.
+            DroppedBroadcastReason::DroppedDuringThrottleWindow => false,
+        }
+    }
 }
 
 /// On a DROPPED inbound broadcast, emit a RATE-LIMITED `ResyncRequest` to the
@@ -1329,11 +1353,42 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
     incoming_tx: Transaction,
     reason: DroppedBroadcastReason,
 ) {
-    let Some((reservation_deadline, correlated)) =
-        reserve_resync_emit(op_manager, key, sender_addr, incoming_tx, reason).await
-    else {
-        return;
-    };
+    // `note_debt: true` — this IS a genuine new drop, so if gate 1 refuses
+    // (a reservation is already held) the debt belongs on that reservation.
+    let (reservation_deadline, correlated) =
+        match reserve_resync_emit(op_manager, key, sender_addr, incoming_tx, reason, true).await {
+            Ok(reserved) => reserved,
+            Err(ReserveRefusal::WindowHeld) => {
+                // The held reservation's chain now owes this drop's repair and
+                // will emit it at the window's close. Nothing more to do.
+                return;
+            }
+            Err(ReserveRefusal::GlobalCap) => {
+                // Review round 2: this path used to simply return. The global
+                // cap `cancel`s the reservation, so NOTHING recorded the debt
+                // and NO follow-up existed to retry it — a one-off drop that
+                // happened to arrive as a contract's third repair in a minute
+                // was lost until anti-entropy, which is the very failure #5510
+                // exists to close. Spawn a follow-up that carries the debt and
+                // retries once the cap refills. It delivers nothing first
+                // (no request was authorized) and starts its wait from a fresh
+                // interval, since the reservation it would have anchored to was
+                // released.
+                let retry_deadline =
+                    op_manager.interest_manager.now() + RESYNC_REQUEST_MIN_INTERVAL;
+                spawn_resync_followups(
+                    op_manager,
+                    key,
+                    sender_addr,
+                    incoming_tx,
+                    FollowupStart::OwedOnly {
+                        retry_at: retry_deadline,
+                    },
+                    reason,
+                );
+                return;
+            }
+        };
     // Spawn BEFORE the blocking dispatch below — that ordering is load-bearing;
     // see `spawn_resync_followups` (#4862 P2).
     spawn_resync_followups(
@@ -1341,10 +1396,42 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
         key,
         sender_addr,
         incoming_tx,
-        reservation_deadline,
-        correlated,
+        FollowupStart::Reserved {
+            deadline: reservation_deadline,
+            correlated,
+        },
+        reason,
     );
     dispatch_resync_request(op_manager, key, sender_addr, incoming_tx).await;
+}
+
+/// How a follow-up chain begins, and the reservation state that goes with it.
+///
+/// The deadline and the correlation flag are carried IN the variant rather than
+/// passed alongside it, so `OwedOnly` cannot be handed a correlation flag it has
+/// no request to correlate — the illegal pairing is unrepresentable instead of
+/// merely unwritten. Same remedy as `.claude/rules/bug-prevention-patterns.md`
+/// prescribes for paired `Option` fields that must co-occur.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FollowupStart {
+    /// The caller holds a granted reservation and has dispatched its request.
+    /// The chain re-delivers that request, then sweeps at the window's close.
+    Reserved {
+        /// The granted reservation's close, on the throttle's own clock.
+        deadline: Instant,
+        /// Whether the correlation record was taken (#4864 round-8). Drives the
+        /// re-delivery's #4863 "did the first request already land" gate.
+        correlated: bool,
+    },
+    /// The caller was refused by the global emit cap, so nothing was emitted
+    /// and nothing is authorized. The chain owes a repair from the outset: it
+    /// delivers nothing, waits out an interval, and then tries to reserve.
+    /// There is no reservation to anchor to, hence a fresh interval and no
+    /// correlation flag.
+    OwedOnly {
+        /// When to make the first re-reservation attempt.
+        retry_at: Instant,
+    },
 }
 
 /// Take the two gates and record the correlation entry for ONE `ResyncRequest`,
@@ -1361,13 +1448,27 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
 ///
 /// Returns `None` when either gate refused, in which case NOTHING was emitted
 /// and no correlation entry exists.
+/// Which gate refused a reservation, for callers that must react differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReserveRefusal {
+    /// Gate 1: a reservation for this `(contract, sender)` is already held.
+    /// For the follow-up chain this means a SIBLING owns the window, so the
+    /// chain must stop rather than keep retrying against a reservation it does
+    /// not hold (review round 2).
+    WindowHeld,
+    /// Gate 2: the global per-contract emit cap. The window was released, so a
+    /// later attempt can take a fresh one — the debt is worth keeping.
+    GlobalCap,
+}
+
 async fn reserve_resync_emit(
     op_manager: &OpManager,
     key: ContractKey,
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
     reason: DroppedBroadcastReason,
-) -> Option<(Instant, bool)> {
+    note_debt: bool,
+) -> Result<(Instant, bool), ReserveRefusal> {
     // Gate 1 — per-(contract, sender)/30s throttle (#4857/#4862 + #4864 round-6).
     // RESERVE the window atomically (`begin` checks AND records under the
     // throttle's own lock) and return the reservation deadline on the throttle's
@@ -1385,9 +1486,16 @@ async fn reserve_resync_emit(
         // ResyncRequest when the window closes. One full-state ResyncResponse
         // restores every entry the window swallowed, so one flag covers any
         // number of drops and the #4251 amplification bound is untouched.
-        op_manager
-            .interest_manager
-            .note_resync_drop_during_window(&key, sender_addr);
+        // `note_debt` is false for the chain's own coalesced retry (review
+        // round 2). Without it the retry records debt against the reservation
+        // it is ALSO tracking in `owed`, so one swallowed drop is counted
+        // twice and the pair pays an extra full-state response per window.
+        // Only a genuine NEW drop may record debt.
+        if note_debt {
+            op_manager
+                .interest_manager
+                .note_resync_drop_during_window(&key, sender_addr);
+        }
         // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
             tx = %incoming_tx,
@@ -1397,7 +1505,7 @@ async fn reserve_resync_emit(
             reason = reason.as_str(),
             "UPDATE relay: dropped-broadcast ResyncRequest throttled (rate limit) to avoid amplification"
         );
-        return None;
+        return Err(ReserveRefusal::WindowHeld);
     };
 
     // ALSO subject to the GLOBAL per-contract emit cap (#4864 round-4 P1): the
@@ -1426,7 +1534,7 @@ async fn reserve_resync_emit(
             reason = reason.as_str(),
             "UPDATE relay: dropped-broadcast ResyncRequest suppressed by global per-contract cap"
         );
-        return None;
+        return Err(ReserveRefusal::GlobalCap);
     }
 
     // Both gates passed → the reservation stands (already recorded by `begin`).
@@ -1462,7 +1570,7 @@ async fn reserve_resync_emit(
         .outstanding_resync_requests
         .record(*key.id(), sender_addr);
 
-    Some((reservation_deadline, correlated))
+    Ok((reservation_deadline, correlated))
 }
 
 /// Spawn the follow-up task that owns everything this reservation still has to
@@ -1526,6 +1634,16 @@ async fn reserve_resync_emit(
 /// traffic STOPS right after a swallowed drop.
 const MAX_COALESCED_RESYNC_WINDOWS: u32 = 3;
 
+/// Maximum loop passes for one follow-up chain, however few are SERVED.
+///
+/// [`MAX_COALESCED_RESYNC_WINDOWS`] counts windows actually served, so a chain
+/// that is only ever refused would never reach it — the counters measure
+/// different things on purpose (review round 2: counting attempts as windows
+/// dropped the debt at t=90 after two refusals, having served none). This is the
+/// separate bound on attempts, so a pair whose contract is permanently over the
+/// global emit cap cannot hold its node-wide slot indefinitely.
+const MAX_COALESCED_RESYNC_ATTEMPTS: u32 = 6;
+
 /// Poll granularity for the trailing-edge wait (#5510).
 ///
 /// Deliberately coarser than [`QUEUE_FULL_RESYNC_RETRY_POLL_INTERVAL`]: the
@@ -1538,6 +1656,14 @@ const MAX_COALESCED_RESYNC_WINDOWS: u32 = 3;
 const COALESCED_RESYNC_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Throttle slot for the slot-cap log line (#5510, review finding 14).
+///
+/// Process-global, and stamped with `tokio::time::Instant`, so under
+/// `start_paused` it carries whichever test runtime touched it first. That is
+/// harmless for a log throttle — the worst case is one suppressed or one extra
+/// line — but do NOT write a test that asserts on this line's presence or
+/// absence without first moving the slot per-node. A test that did would be
+/// order-dependent in exactly the way `.claude/rules/testing.md` describes, and
+/// invisible under nextest.
 ///
 /// The condition fires once per repair attempt on a node that is by definition
 /// loaded enough to have exhausted 256 slots, so an unthrottled line there is a
@@ -1571,8 +1697,8 @@ fn spawn_resync_followups(
     key: ContractKey,
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
-    reservation_deadline: Instant,
-    correlated: bool,
+    start: FollowupStart,
+    origin: DroppedBroadcastReason,
 ) {
     let Some(slot) = op_manager.interest_manager.try_reserve_resync_retry_slot() else {
         // #5510: at the node-wide cap NOTHING is spawned, so this reservation
@@ -1601,24 +1727,43 @@ fn spawn_resync_followups(
     let op_mgr = op_manager.clone();
     GlobalExecutor::spawn(async move {
         let _slot = slot; // frees the node-wide slot on task exit
-        let mut deadline = reservation_deadline;
-        let mut correlated = correlated;
+        let (mut deadline, mut correlated) = match start {
+            FollowupStart::Reserved {
+                deadline,
+                correlated,
+            } => (deadline, correlated),
+            FollowupStart::OwedOnly { retry_at } => (retry_at, false),
+        };
         // The caller dispatches ITS window's request itself, concurrently with
         // this spawn (#4862 P2), so the first pass only re-delivers.
         let mut dispatch_pending = false;
-        // Whether this pass should re-deliver at all. False only after a gate
-        // refused a coalesced emit: there is then no newly-authorized request to
+        // Whether this pass should re-deliver at all. False after a gate refused
+        // a coalesced emit — there is then no newly-authorized request to
         // re-deliver, and re-delivering the previous window's would be an emit
-        // outside any reservation — the #4251 bound.
-        let mut deliver = true;
+        // outside any reservation, the #4251 bound — and false from the outset
+        // for a chain that starts owing (the caller was capped and emitted
+        // nothing).
+        let mut deliver = matches!(start, FollowupStart::Reserved { .. });
         // A repair is owed but not yet authorized. Held ACROSS iterations
         // because the flag is consumed at the window's close, before the gates
         // run: a refusal after that point would otherwise drop the repair
         // silently, and if that was the last message on the pair the divergence
         // would persist to anti-entropy (review finding 16).
-        let mut owed = false;
-        // Windows this chain has served, INCLUDING the caller's.
-        let mut windows_used: u32 = 1;
+        let mut owed = matches!(start, FollowupStart::OwedOnly { .. });
+        // Windows this chain has SERVED — reservations actually granted and
+        // emitted on, including the caller's when it had one. Deliberately NOT
+        // a count of attempts (review round 2): incrementing on a refusal meant
+        // that with the emit cap refilling once per 60s against a 30s
+        // re-reservation, two refused attempts exhausted the bound and the debt
+        // was dropped at t=90 having never been served once. Attempts are
+        // bounded separately, by `attempts` below and by the tokio backstop
+        // inside the wait.
+        let mut windows_served: u32 = match start {
+            FollowupStart::Reserved { .. } => 1,
+            FollowupStart::OwedOnly { .. } => 0,
+        };
+        // Total loop passes, bounding a chain that only ever gets refused.
+        let mut attempts: u32 = 0;
 
         loop {
             if deliver {
@@ -1661,26 +1806,56 @@ fn spawn_resync_followups(
             if !wait_until_reservation_close(&op_mgr, key, incoming_tx, deadline).await {
                 return;
             }
+            attempts += 1;
             if !owed {
-                owed = op_mgr
-                    .interest_manager
-                    .take_resync_drop_during_window(&key, sender_addr);
+                owed = op_mgr.interest_manager.take_resync_drop_during_window(
+                    &key,
+                    sender_addr,
+                    deadline,
+                );
             }
             if !owed {
                 // The window closed with nothing swallowed: the chain has done
                 // its job and the slot goes back.
                 return;
             }
-            if windows_used >= MAX_COALESCED_RESYNC_WINDOWS {
+            if windows_served >= MAX_COALESCED_RESYNC_WINDOWS
+                || attempts >= MAX_COALESCED_RESYNC_ATTEMPTS
+            {
                 tracing::info!(
                     tx = %incoming_tx,
                     contract = %key,
                     target = %sender_addr,
-                    windows = windows_used,
+                    windows_served,
+                    attempts,
                     event = "coalesced_resync_chain_bound",
-                    "UPDATE relay: dropped-broadcast repair chain hit its window \
-                     bound and is releasing its slot; a pair still dropping this \
+                    "UPDATE relay: dropped-broadcast repair chain hit its bound \
+                     and is releasing its slot; a pair still dropping this \
                      steadily repairs from its next immediate reservation (#5510)"
+                );
+                return;
+            }
+
+            // Re-check the hosting gate before EACH coalesced emit (review
+            // round 2). A chain can live for tens of seconds, and the contract
+            // may have been evicted underneath it; without this the chain would
+            // keep asking a peer to full-state us a contract we no longer hold.
+            // Cheap: `should_summarize_or_broadcast` is in-memory plus a redb
+            // point lookup, and it short-circuits for an unheld key.
+            //
+            // Scoped to the ORIGIN, not applied unconditionally: only the
+            // rate-limiter emit is gated on hosting at its source, so gating a
+            // queue-full chain here would narrow #4857's pre-existing behaviour
+            // as a side effect of #5510. See `repair_is_hosting_gated`.
+            if origin.repair_is_hosting_gated() && !op_mgr.ring.should_summarize_or_broadcast(&key)
+            {
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    target = %sender_addr,
+                    event = "coalesced_resync_no_longer_held",
+                    "UPDATE relay: contract no longer held; abandoning the \
+                     trailing coalesced repair (#5510)"
                 );
                 return;
             }
@@ -1691,30 +1866,56 @@ fn spawn_resync_followups(
                 sender_addr,
                 incoming_tx,
                 DroppedBroadcastReason::DroppedDuringThrottleWindow,
+                // NOT a genuine new drop: this chain already tracks the debt in
+                // `owed`, so recording it again would double-count one drop and
+                // buy the pair a second full-state response (review round 2).
+                false,
             )
             .await
             {
-                Some((next_deadline, next_correlated)) => {
+                Ok((next_deadline, next_correlated)) => {
                     owed = false;
                     deadline = next_deadline;
                     correlated = next_correlated;
                     dispatch_pending = true;
                     deliver = true;
+                    windows_served += 1;
                 }
-                None => {
-                    // A gate refused, realistically the global per-contract emit
-                    // cap: it refills 1/60s while re-reservation runs 1/30s, so
-                    // this is the common case rather than a corner. KEEP `owed`
-                    // and wait one more interval — the cap's `cancel` released
-                    // the window, so the next attempt can take a fresh one.
-                    // Do NOT re-deliver in the meantime (nothing new is
-                    // authorized), and stay under the chain bound.
+                Err(ReserveRefusal::WindowHeld) => {
+                    // A SIBLING took the reservation for this pair (review
+                    // round 2). Its chain now owns the window and will serve the
+                    // debt we just recorded on it; continuing would mean
+                    // retrying against a reservation this chain does not hold,
+                    // burning its slot to do nothing. Hand the debt over and
+                    // exit. `note_debt` was false above, so re-record it here —
+                    // deliberately, because ownership is moving.
+                    op_mgr
+                        .interest_manager
+                        .note_resync_drop_during_window(&key, sender_addr);
+                    tracing::debug!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        event = "coalesced_resync_handed_to_sibling",
+                        "UPDATE relay: another reservation now holds this pair's \
+                         window; handing the debt to it and releasing this slot \
+                         (#5510)"
+                    );
+                    return;
+                }
+                Err(ReserveRefusal::GlobalCap) => {
+                    // The global per-contract cap refused; it refills 1/60s
+                    // against a 1/30s re-reservation, so this is the common case
+                    // rather than a corner. KEEP `owed` and wait one more
+                    // interval — the cap's `cancel` released the window, so the
+                    // next attempt can take a fresh one. Do NOT re-deliver in
+                    // the meantime (nothing new is authorized), and do NOT count
+                    // this as a served window.
                     deadline = op_mgr.interest_manager.now() + RESYNC_REQUEST_MIN_INTERVAL;
                     dispatch_pending = false;
                     deliver = false;
                 }
             }
-            windows_used += 1;
         }
     });
 }
@@ -4474,19 +4675,33 @@ mod tests {
         rx: &mut crate::node::EventLoopNotificationsReceiver,
         key: ContractKey,
     ) -> Vec<SocketAddr> {
-        let mut targets = Vec::new();
+        drain_resync_events(rx)
+            .into_iter()
+            .filter_map(|(k, target)| (k == key).then_some(target))
+            .collect()
+    }
+
+    /// Drain every emitted `ResyncRequest`, KEEPING its contract key.
+    ///
+    /// [`drain_resync_targets`] filters to one key and discards the rest, which
+    /// is fine for a single-contract test and a trap for any test watching two:
+    /// draining the first key silently eats the second key's events, and the
+    /// second assertion then reads an empty vector as "it did not emit". Use
+    /// this whenever more than one contract is in play.
+    fn drain_resync_events(
+        rx: &mut crate::node::EventLoopNotificationsReceiver,
+    ) -> Vec<(ContractKey, SocketAddr)> {
+        let mut events = Vec::new();
         while let Ok(ev) = rx.notifications_receiver.try_recv() {
             if let Either::Right(NodeEvent::SendInterestMessage {
                 target,
-                message: InterestMessage::ResyncRequest { key: k },
+                message: InterestMessage::ResyncRequest { key },
             }) = ev
             {
-                if k == key {
-                    targets.push(target);
-                }
+                events.push((key, target));
             }
         }
-        targets
+        events
     }
 
     /// Build a minimal real OpManager wired to a contract-handler stand-in that
@@ -4920,33 +5135,71 @@ mod tests {
             .collect();
 
         assert!(
-            body.contains("letmutwindows_used:u32=1;"),
-            "the chain must COUNT the windows it has served, starting at 1 for the \
-             caller's own window — starting at 0 would silently grant one extra"
+            body.contains(
+                "letmutwindows_served:u32=matchstart{FollowupStart::Reserved{..}=>1,\
+                 FollowupStart::OwedOnly{..}=>0,};"
+                    .replace(' ', "")
+                    .as_str()
+            ),
+            "the chain must COUNT the windows it has SERVED, starting at 1 only \
+             when the caller holds a granted reservation — a chain that starts \
+             owing has served none, and starting it at 1 would spend a window it \
+             never got"
         );
         let compare = body
-            .find("ifwindows_used>=MAX_COALESCED_RESYNC_WINDOWS{")
+            .find(
+                "ifwindows_served>=MAX_COALESCED_RESYNC_WINDOWS||\
+                 attempts>=MAX_COALESCED_RESYNC_ATTEMPTS{"
+                    .replace(' ', "")
+                    .as_str(),
+            )
             .expect(
-                "the chain must compare its window count against \
-                 MAX_COALESCED_RESYNC_WINDOWS — without it the chain re-reserves \
-                 without limit and holds its node-wide slot forever (#5510 \
-                 finding 1)",
+                "the chain must bound BOTH its served windows and its total \
+                 attempts — without the first it re-reserves without limit and \
+                 holds its node-wide slot forever (#5510 finding 1); without the \
+                 second a chain that is only ever refused never reaches the \
+                 window bound at all, and holds the slot just as long (review \
+                 round 2)",
             );
         assert!(
             body[compare..].contains("return;"),
-            "reaching the window bound must RETURN, so the slot guard drops and \
-             the slot goes back to the node-wide pool"
+            "reaching a bound must RETURN, so the slot guard drops and the slot \
+             goes back to the node-wide pool"
         );
-        let increment = body.find("windows_used+=1;").expect(
-            "the window count must be incremented, or the comparison above can \
-             never fire",
+
+        let grant = body
+            .find("Ok((next_deadline,next_correlated))=>{")
+            .expect("the coalesced re-reservation must match on its Result");
+        let window_held = body
+            .find("Err(ReserveRefusal::WindowHeld)=>{")
+            .expect("a sibling-held window must be a distinct arm");
+        let increment = body
+            .find("windows_served+=1;")
+            .expect("the window count must be incremented, or the bound can never fire");
+        assert!(
+            increment > grant && increment < window_held,
+            "the increment ({increment}) must sit INSIDE the granted arm \
+             ({grant}..{window_held}) — counting a REFUSAL as a served window is \
+             the review-round-2 defect: the global emit cap refills once per 60s \
+             against a 30s re-reservation, so two refusals exhausted a bound of 3 \
+             and the debt was dropped at t=90 having never been served once"
+        );
+        assert_eq!(
+            body.matches("windows_served+=1;").count(),
+            1,
+            "exactly one increment: a second one on a refusal path would \
+             reintroduce the same defect"
         );
         assert!(
             increment > compare,
             "the increment ({increment}) must come AFTER the bound check \
              ({compare}) — incrementing first would let the chain serve one fewer \
-             window than the constant names, which is a quieter bug than the one \
-             this pin is for but still a mismatch between code and doc"
+             window than the constant names"
+        );
+        assert!(
+            body.contains("attempts+=1;"),
+            "the attempt count must be incremented every pass, or its bound can \
+             never fire on a chain that is only ever refused"
         );
     }
 
@@ -4956,6 +5209,148 @@ mod tests {
     ///
     /// This is the path finding 16 made non-trivial. The flag is consumed at the
     /// window's close, BEFORE the gates run, so a naive implementation that
+    /// #5510 review round 2: the trailing coalesced emit re-checks the HOSTING
+    /// gate, and does so only for chains descended from a rate-limiter drop.
+    ///
+    /// `node.rs` emits the rate-limited repair only when
+    /// `should_summarize_or_broadcast` holds, because asking a peer to
+    /// full-state us a contract we do not hold is pure waste — it costs the
+    /// peer a WASM summarize and us the transfer, and we discard the result.
+    /// A chain lives for tens of seconds across several windows, so a contract
+    /// evicted after the first emit would otherwise keep being requested by a
+    /// gate that ran once, long ago.
+    ///
+    /// The pre-existing queue-full path (#4857) has never carried that gate, and
+    /// this test is written as a DISCRIMINATING pair for exactly that reason: two
+    /// senders on one node, one driven with each origin, identical in every other
+    /// respect. If the re-check were applied unconditionally both would fall
+    /// silent and #5510 would have quietly narrowed #4857; if it were absent
+    /// both would emit and the gate would be doing nothing. Only the intended
+    /// behaviour produces one of each.
+    #[tokio::test(start_paused = true)]
+    async fn the_coalesced_emit_rechecks_hosting_for_a_rate_limited_origin_only() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("coalesced-hosting-recheck-5510").await;
+        // A contract EACH, not two senders on one: the global per-contract emit
+        // cap is `EMIT_BURST` 2, which one immediate plus one coalesced emit
+        // exactly exhausts. Sharing a contract between the two arms starves the
+        // second coalesced emit on the cap, and the test then reads that as the
+        // hosting gate — passing for entirely the wrong reason on the arm that
+        // is supposed to stay silent.
+        let key_gated = ContractKey::from_id_and_code(
+            ContractInstanceId::new([71u8; 32]),
+            CodeHash::new([72u8; 32]),
+        );
+        let key_ungated = ContractKey::from_id_and_code(
+            ContractInstanceId::new([73u8; 32]),
+            CodeHash::new([74u8; 32]),
+        );
+        let target: SocketAddr = "127.0.0.1:13400".parse().unwrap();
+
+        // The premise, asserted rather than assumed: this node holds NEITHER
+        // contract. Without these the test would pass just as happily on a node
+        // that does, having exercised nothing.
+        for key in [key_gated, key_ungated] {
+            assert!(
+                !op_manager.ring.should_summarize_or_broadcast(&key),
+                "fixture premise: the node must not hold {key}, or the re-check \
+                 under test never fires"
+            );
+        }
+
+        // First drop on each pair: both reserve and emit immediately. The entry
+        // point is deliberately NOT gated — `node.rs` already decided.
+        // Two drops on each pair. The first reserves and emits immediately — the
+        // entry point is deliberately NOT gated, because `node.rs` already
+        // decided. The second is refused by the held window and records the debt
+        // the chain serves at its close.
+        for _ in 0..2 {
+            for (key, reason) in [
+                (key_gated, DroppedBroadcastReason::RateLimited),
+                (key_ungated, DroppedBroadcastReason::QueueFull),
+            ] {
+                send_dropped_broadcast_resync_request(
+                    &op_manager,
+                    key,
+                    target,
+                    Transaction::new::<UpdateMsg>(),
+                    reason,
+                )
+                .await;
+            }
+        }
+        let immediate = drain_resync_events(&mut notification_rx);
+        assert_eq!(
+            immediate,
+            vec![(key_gated, target), (key_ungated, target)],
+            "each pair must emit exactly its immediate request, in call order: \
+             the hosting re-check belongs to the trailing emit, not the entry \
+             point, and the second drop is inside the held window"
+        );
+
+        // Cross the reservation deadline, discarding the #4862 re-deliveries
+        // that fire before it — those are unrelated machinery and fire for both
+        // pairs alike.
+        for _ in 0..58 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_events(&mut notification_rx);
+        }
+        let mut at_deadline = Vec::new();
+        for _ in 0..4 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            at_deadline.extend(drain_resync_events(&mut notification_rx));
+        }
+        let gated_emits: Vec<_> = at_deadline
+            .iter()
+            .filter(|(k, _)| *k == key_gated)
+            .collect();
+        let ungated_emits: Vec<_> = at_deadline
+            .iter()
+            .filter_map(|(k, t)| (*k == key_ungated).then_some(*t))
+            .collect();
+
+        assert!(
+            gated_emits.is_empty(),
+            "the rate-limiter-origin chain must re-check hosting and abandon its \
+             coalesced emit for a contract this node no longer holds, got \
+             {gated_emits:?}"
+        );
+        assert_eq!(
+            ungated_emits,
+            vec![target],
+            "the queue-full chain must STILL emit: #4857 has never been gated on \
+             hosting, and narrowing it here would be a behaviour change #5510 has \
+             no evidence for"
+        );
+    }
+
+    /// #5510 review round 2 companion: the gating decision lives on the ORIGIN
+    /// reason, and the chain's own reason must never be the one consulted.
+    ///
+    /// `DroppedDuringThrottleWindow` is what every coalesced emit carries, so if
+    /// the re-check ever read the chain's current reason instead of the reason it
+    /// descended from, the gate would evaluate to `false` for every chain and the
+    /// test above would keep passing on its queue-full half alone. This pins the
+    /// mapping directly.
+    #[test]
+    fn only_the_rate_limited_origin_gates_its_repair_on_hosting() {
+        assert!(
+            DroppedBroadcastReason::RateLimited.repair_is_hosting_gated(),
+            "node.rs gates the rate-limited emit on hosting, so its chain must too"
+        );
+        assert!(
+            !DroppedBroadcastReason::QueueFull.repair_is_hosting_gated(),
+            "#4857 has never been hosting-gated; gating it here would narrow it"
+        );
+        assert!(
+            !DroppedBroadcastReason::DroppedDuringThrottleWindow.repair_is_hosting_gated(),
+            "the chain's own reason is never an ORIGIN, so it must not be the \
+             value that decides gating"
+        );
+    }
+
     /// returned on refusal would drop the repair silently — and it is not a
     /// corner: the emit cap refills once per 60s while re-reservation runs once
     /// per 30s, so refusal is the common case. The chain therefore keeps the
@@ -7349,11 +7744,23 @@ mod tests {
         );
 
         // The deadline is threaded into the follow-ups so the burst is anchored
-        // to THIS reservation window (review P2-A).
+        // to THIS reservation window (review P2-A). It rides INSIDE
+        // `FollowupStart::Reserved` (review round 2, so a chain that owes a
+        // repair cannot be handed a reservation it does not hold), so the pin
+        // reads the threading at the entry point where it is decided rather than
+        // looking for a bare parameter name in the helper.
         assert!(
-            helper.contains("reservation_deadline"),
-            "the follow-up spawn must thread the reservation deadline from \
-             begin_resync_request into the retry (anchor to the window, P2-A)"
+            entry.contains("deadline: reservation_deadline"),
+            "the entry point must thread the reservation deadline from \
+             begin_resync_request into FollowupStart::Reserved (anchor to the \
+             window, P2-A)"
+        );
+        assert!(
+            helper.contains("FollowupStart::Reserved {")
+                && helper.contains("FollowupStart::OwedOnly {"),
+            "the follow-up chain must take its starting deadline from the \
+             variant it was given — reading a deadline from anywhere else would \
+             detach the burst from the reservation window it is bounded by"
         );
 
         // (1d) #4863: the correlation record MUST be written BEFORE the spawn.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1277,30 +1277,6 @@ impl DroppedBroadcastReason {
             DroppedBroadcastReason::DroppedDuringThrottleWindow => "dropped_during_window",
         }
     }
-
-    /// Whether repairs originating from this drop are gated on the node still
-    /// holding the contract (#5510, review round 2).
-    ///
-    /// TRUE for the rate-limiter drop only, and that asymmetry is deliberate:
-    /// `node.rs` gates the rate-limited emit on
-    /// `should_summarize_or_broadcast`, so a chain descended from one must
-    /// re-check the same condition before each coalesced emit — it can live tens
-    /// of seconds and the contract may be evicted underneath it. The
-    /// pre-existing queue-full path (#4857) has NEVER been gated on hosting, and
-    /// adding the gate here would silently narrow it: a queue-full drop means
-    /// the executor was already applying the update locally, so the repair is
-    /// warranted whatever a later hosting read says. Widening #4857's gate is
-    /// out of scope for #5510 and would be a behaviour change with no evidence
-    /// behind it.
-    fn repair_is_hosting_gated(self) -> bool {
-        match self {
-            DroppedBroadcastReason::RateLimited => true,
-            DroppedBroadcastReason::QueueFull => false,
-            // The chain's own reason. Never the ORIGIN, so it is never the value
-            // asked here — the origin is threaded through separately.
-            DroppedBroadcastReason::DroppedDuringThrottleWindow => false,
-        }
-    }
 }
 
 /// On a DROPPED inbound broadcast, emit a RATE-LIMITED `ResyncRequest` to the
@@ -1363,7 +1339,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                 // will emit it at the window's close. Nothing more to do.
                 return;
             }
-            Err(ReserveRefusal::GlobalCap) => {
+            Err(ReserveRefusal::GlobalCap { deadline }) => {
                 // Review round 2: this path used to simply return. The global
                 // cap `cancel`s the reservation, so NOTHING recorded the debt
                 // and NO follow-up existed to retry it — a one-off drop that
@@ -1371,11 +1347,13 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                 // was lost until anti-entropy, which is the very failure #5510
                 // exists to close. Spawn a follow-up that carries the debt and
                 // retries once the cap refills. It delivers nothing first
-                // (no request was authorized) and starts its wait from a fresh
-                // interval, since the reservation it would have anchored to was
-                // released.
-                let retry_deadline =
-                    op_manager.interest_manager.now() + RESYNC_REQUEST_MIN_INTERVAL;
+                // (no request was authorized) and anchors on the reservation
+                // it actually holds (X1) rather than an approximation of it: the
+                // window is what bounds the chain, and waiting on a different
+                // instant than the one the flag lives on means either waking
+                // early to find nothing or waking late and holding the slot past
+                // the window.
+                let retry_deadline = deadline;
                 spawn_resync_followups(
                     op_manager,
                     key,
@@ -1384,7 +1362,6 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                     FollowupStart::OwedOnly {
                         retry_at: retry_deadline,
                     },
-                    reason,
                 );
                 return;
             }
@@ -1400,7 +1377,6 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
             deadline: reservation_deadline,
             correlated,
         },
-        reason,
     );
     dispatch_resync_request(op_manager, key, sender_addr, incoming_tx).await;
 }
@@ -1456,9 +1432,13 @@ pub(crate) enum ReserveRefusal {
     /// chain must stop rather than keep retrying against a reservation it does
     /// not hold (review round 2).
     WindowHeld,
-    /// Gate 2: the global per-contract emit cap. The window was released, so a
-    /// later attempt can take a fresh one — the debt is worth keeping.
-    GlobalCap,
+    /// Gate 2: the global per-contract emit cap. The window is KEPT and its
+    /// dropped-during-window flag set (review round 3, X1), so the chain that
+    /// owns it serves the debt at the close and later drops on the pair are
+    /// throttled into that same chain rather than each spawning one. Carries
+    /// the held reservation's deadline so the chain anchors on the real window
+    /// rather than an approximation of it.
+    GlobalCap { deadline: Instant },
 }
 
 async fn reserve_resync_emit(
@@ -1476,9 +1456,11 @@ async fn reserve_resync_emit(
     // callbacks for the same (contract, sender) cannot both pass. If the global
     // cap below then rejects, we `cancel` the reservation so the window is
     // released (not burned).
-    let Some(reservation_deadline) = op_manager
+    let crate::ring::interest::ResyncGrant::Granted {
+        deadline: reservation_deadline,
+    } = op_manager
         .interest_manager
-        .begin_resync_request(&key, sender_addr)
+        .begin_resync_request_or_note_drop(&key, sender_addr, note_debt)
     else {
         // #5510: this drop's repair is being refused, and BEFORE this change
         // nothing ever re-sent it — the throttle simply returned. Mark the held
@@ -1486,16 +1468,17 @@ async fn reserve_resync_emit(
         // ResyncRequest when the window closes. One full-state ResyncResponse
         // restores every entry the window swallowed, so one flag covers any
         // number of drops and the #4251 amplification bound is untouched.
+        // The debt was recorded INSIDE the call above, under the throttle's own
+        // lock, when `note_debt` is set — never as a second lock acquisition
+        // here. See `begin_resync_request_or_note_drop` for why the two-step
+        // has a TOCTOU hole the generation check does not close.
+        //
         // `note_debt` is false for the chain's own coalesced retry (review
         // round 2). Without it the retry records debt against the reservation
         // it is ALSO tracking in `owed`, so one swallowed drop is counted
         // twice and the pair pays an extra full-state response per window.
         // Only a genuine NEW drop may record debt.
-        if note_debt {
-            op_manager
-                .interest_manager
-                .note_resync_drop_during_window(&key, sender_addr);
-        }
+        //
         // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
             tx = %incoming_tx,
@@ -1515,8 +1498,21 @@ async fn reserve_resync_emit(
     // emission. (This is NOT a mirror of the delta-failure path — that path is
     // global-cap-only, with no per-sender throttle. The global suppression records
     // the same `record_resync_request_suppressed` metric node.rs does.) On
-    // suppression, CANCEL the reservation so the per-sender window is released and
-    // the sender retries as soon as global tokens refill.
+    // suppression, KEEP the reservation and mark it as owing a repair.
+    //
+    // This used to `cancel`, releasing the window so the sender could retry as
+    // soon as tokens refilled. That was wrong once a follow-up chain existed
+    // (#5510 review round 3, X1): with the window released, EVERY later drop on
+    // the pair also reaches the cap, also gets refused, and also spawns its own
+    // chain — so one hot pair could take slot after slot, in seconds, all of
+    // them waiting on the same empty per-contract bucket. Keeping the window
+    // makes those later drops `WindowHeld` instead, so they hand their debt to
+    // the one chain already carrying it. One chain per pair per window, the
+    // same bound gate 1 already gives every other path.
+    //
+    // Note this is not a lost repair: the reservation is retained WITH its
+    // dropped-during-window flag set, so the chain that owns it serves the debt
+    // at the window's close, once tokens have refilled.
     if !op_manager
         .ring
         .resync_emit_limiter
@@ -1524,17 +1520,34 @@ async fn reserve_resync_emit(
     {
         op_manager
             .interest_manager
-            .cancel_resync_request(&key, sender_addr);
-        crate::config::GlobalTestMetrics::record_resync_request_suppressed();
+            .note_resync_debt_on_held_reservation(&key, sender_addr);
+        // The COUNTER answers "how many repairs did the cap suppress" — one per
+        // drop that wanted one — so a chain's own retries must not inflate it
+        // (review round 3). One swallowed drop retried three times is ONE
+        // suppressed repair, not three; counting each attempt would make the
+        // metric drift with chain length rather than with the thing an operator
+        // is asking about, and it would grow precisely when the cap is busiest.
+        let is_chain_retry = matches!(reason, DroppedBroadcastReason::DroppedDuringThrottleWindow);
+        if !is_chain_retry {
+            crate::config::GlobalTestMetrics::record_resync_request_suppressed();
+        }
         tracing::debug!(
             tx = %incoming_tx,
             contract = %key,
             sender = %sender_addr,
-            event = "queue_full_resync_suppressed_global",
+            // Distinct event for a chain retry, so the log and the counter
+            // agree about what each is describing.
+            event = if is_chain_retry {
+                "coalesced_resync_suppressed_global"
+            } else {
+                "queue_full_resync_suppressed_global"
+            },
             reason = reason.as_str(),
             "UPDATE relay: dropped-broadcast ResyncRequest suppressed by global per-contract cap"
         );
-        return Err(ReserveRefusal::GlobalCap);
+        return Err(ReserveRefusal::GlobalCap {
+            deadline: reservation_deadline,
+        });
     }
 
     // Both gates passed → the reservation stands (already recorded by `begin`).
@@ -1698,8 +1711,17 @@ fn spawn_resync_followups(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
     start: FollowupStart,
-    origin: DroppedBroadcastReason,
 ) {
+    // ONE pool, because X1 removed the reason for two. An earlier round gave
+    // owing chains their own smaller pool, on the grounds that a contract with
+    // N dropping senders could spawn N of them per window and starve the #4862
+    // re-delivery. That explosion was real, but its cause was the cap path
+    // CANCELLING the reservation: with the window released, every later drop on
+    // the pair was refused afresh and spawned a chain of its own. X1 keeps the
+    // window, so those drops are `WindowHeld` and hand their debt to the chain
+    // already carrying it — one chain per pair per window, the same bound gate 1
+    // gives every other path. A second pool would now cap a symptom that no
+    // longer occurs, at the cost of a bound nobody can reason about.
     let Some(slot) = op_manager.interest_manager.try_reserve_resync_retry_slot() else {
         // #5510: at the node-wide cap NOTHING is spawned, so this reservation
         // gets neither the #4862 re-delivery nor the trailing coalesced repair.
@@ -1717,8 +1739,10 @@ fn spawn_resync_followups(
                 event = "resync_retry_slot_cap_reached",
                 "UPDATE relay: at the node-wide resync-retry slot cap; immediate \
                  ResyncRequests still send, but reservations are getting no \
-                 re-delivery and no trailing coalesced repair. Throttled to one \
-                 line per minute (#4862 P1/#5510)"
+                 re-delivery and no trailing coalesced repair. A repair already \
+                 owed on a held window waits for the next drop on that pair or \
+                 for anti-entropy. Throttled to one line per minute \
+                 (#4862 P1/#5510)"
             );
         }
         return;
@@ -1804,24 +1828,91 @@ fn spawn_resync_followups(
             // window regardless, because a drop swallowed AFTER that response is
             // exactly the case this exists for.
             if !wait_until_reservation_close(&op_mgr, key, incoming_tx, deadline).await {
+                // The backstop fired or the wait was cancelled. If a repair was
+                // owed, it dies here — name it (review round 3), because a
+                // silent exit makes an unrepaired drop indistinguishable from a
+                // chain that simply had nothing to do.
+                if owed {
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        contract = %key,
+                        target = %sender_addr,
+                        event = "coalesced_resync_abandoned_at_backstop",
+                        "UPDATE relay: dropped-broadcast repair abandoned with a \
+                         debt still owed; that drop now waits for the next drop \
+                         on this pair or for anti-entropy (#5510)"
+                    );
+                }
                 return;
             }
             attempts += 1;
             if !owed {
-                owed = op_mgr.interest_manager.take_resync_drop_during_window(
-                    &key,
-                    sender_addr,
-                    deadline,
-                );
+                // `Unknown` (the reservation was evicted from the bounded LRU
+                // mid-window) counts as owed — see `ResyncDebt`. The chain
+                // cannot distinguish "nothing was swallowed" from "the record
+                // of what was swallowed is gone", and only one of those is safe
+                // to act on by exiting.
+                owed = op_mgr
+                    .interest_manager
+                    .take_resync_drop_during_window(&key, sender_addr, deadline)
+                    .is_owed();
             }
             if !owed {
-                // The window closed with nothing swallowed: the chain has done
-                // its job and the slot goes back.
-                return;
+                // Nothing was swallowed by this window. Usually that means the
+                // chain is done — but not if the request it emitted was never
+                // ANSWERED (review round 3, X2).
+                //
+                // The responder runs its own 30s `resync_response_limiter` per
+                // (contract, peer). If the initial request was delayed by the
+                // blocking `notify_node_event` and landed late, the coalesced
+                // request and its short retries can all arrive inside that one
+                // responder window and be rejected before the responder clears
+                // its cached summary of us. Nothing is swallowed here, because
+                // nothing new was dropped — and yet the divergence this chain
+                // exists to repair is still there.
+                //
+                // Our correlation record is consumed when a matching
+                // ResyncResponse arrives, so a record still outstanding means no
+                // response has landed. Keep going in that case, so the next
+                // served window retries after the responder's window has passed.
+                // Bounded exactly as before by `windows_served` and `attempts`,
+                // so this cannot become a spin.
+                let unanswered = correlated
+                    && op_mgr
+                        .ring
+                        .outstanding_resync_requests
+                        .is_outstanding(*key.id(), sender_addr);
+                if !unanswered {
+                    return;
+                }
+                owed = true;
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    target = %sender_addr,
+                    event = "coalesced_resync_unanswered_retry",
+                    "UPDATE relay: the emitted repair has had no ResyncResponse, \
+                     so the responder's own throttle may have rejected it; \
+                     retrying in the next window (#5510)"
+                );
             }
             if windows_served >= MAX_COALESCED_RESYNC_WINDOWS
                 || attempts >= MAX_COALESCED_RESYNC_ATTEMPTS
             {
+                // The debt was CONSUMED into `owed` a few lines above, so
+                // returning here would abandon it silently (review round 3, X4):
+                // a drop swallowed late in the last served window would vanish
+                // at t=90 with nothing left holding the flag. Hand it back to
+                // the reservation instead, so the next drop on this pair — or a
+                // chain that later owns this window — still serves it.
+                //
+                // Handing back rather than emitting one more time keeps the
+                // bound meaning what it says. Emitting here would make the
+                // chain serve MAX+1 windows, and the bound exists to cap slot
+                // occupancy, not to cap repairs.
+                op_mgr
+                    .interest_manager
+                    .note_resync_debt_on_held_reservation(&key, sender_addr);
                 tracing::info!(
                     tx = %incoming_tx,
                     contract = %key,
@@ -1830,8 +1921,9 @@ fn spawn_resync_followups(
                     attempts,
                     event = "coalesced_resync_chain_bound",
                     "UPDATE relay: dropped-broadcast repair chain hit its bound \
-                     and is releasing its slot; a pair still dropping this \
-                     steadily repairs from its next immediate reservation (#5510)"
+                     and is releasing its slot with a debt still owed; the debt \
+                     is left on the reservation, so a pair still dropping this \
+                     steadily repairs from its next reservation (#5510)"
                 );
                 return;
             }
@@ -1843,12 +1935,16 @@ fn spawn_resync_followups(
             // Cheap: `should_summarize_or_broadcast` is in-memory plus a redb
             // point lookup, and it short-circuits for an unheld key.
             //
-            // Scoped to the ORIGIN, not applied unconditionally: only the
-            // rate-limiter emit is gated on hosting at its source, so gating a
-            // queue-full chain here would narrow #4857's pre-existing behaviour
-            // as a side effect of #5510. See `repair_is_hosting_gated`.
-            if origin.repair_is_hosting_gated() && !op_mgr.ring.should_summarize_or_broadcast(&key)
-            {
+            // Applied to EVERY coalesced emit, whatever the origin (review
+            // round 3, correcting round 2). The "#4857 has never been
+            // hosting-gated" argument is true of the IMMEDIATE queue-full emit
+            // and does not extend to this chain, which is NEW code: it can
+            // re-emit across up to MAX_COALESCED_RESYNC_WINDOWS served windows,
+            // roughly 180s, for a contract that may have been evicted in the
+            // meantime. Carrying a pre-existing exemption into new code that
+            // spans three minutes is not preserving behaviour, it is inventing
+            // a new one. The immediate queue-full emit stays ungated.
+            if !op_mgr.ring.should_summarize_or_broadcast(&key) {
                 tracing::debug!(
                     tx = %incoming_tx,
                     contract = %key,
@@ -1866,10 +1962,15 @@ fn spawn_resync_followups(
                 sender_addr,
                 incoming_tx,
                 DroppedBroadcastReason::DroppedDuringThrottleWindow,
-                // NOT a genuine new drop: this chain already tracks the debt in
-                // `owed`, so recording it again would double-count one drop and
-                // buy the pair a second full-state response (review round 2).
-                false,
+                // TRUE, and the reason is subtle. This chain holds a debt in
+                // `owed`. If its re-reservation is refused because a SIBLING
+                // now owns the window, that debt must move to the sibling's
+                // reservation or it dies with this chain — and the only
+                // TOCTOU-free moment to move it is inside that same locked
+                // check. On the granted path nothing is recorded (there is no
+                // held window to record against), so this cannot double-count:
+                // the flag is set only on the refusal this chain exits on.
+                true,
             )
             .await
             {
@@ -1882,16 +1983,18 @@ fn spawn_resync_followups(
                     windows_served += 1;
                 }
                 Err(ReserveRefusal::WindowHeld) => {
-                    // A SIBLING took the reservation for this pair (review
-                    // round 2). Its chain now owns the window and will serve the
-                    // debt we just recorded on it; continuing would mean
-                    // retrying against a reservation this chain does not hold,
-                    // burning its slot to do nothing. Hand the debt over and
-                    // exit. `note_debt` was false above, so re-record it here —
-                    // deliberately, because ownership is moving.
-                    op_mgr
-                        .interest_manager
-                        .note_resync_drop_during_window(&key, sender_addr);
+                    // A SIBLING took the reservation for this pair. Its chain
+                    // now owns the window and will serve the debt; continuing
+                    // would mean retrying against a reservation this chain does
+                    // not hold, burning its slot to do nothing.
+                    //
+                    // The hand-over happens INSIDE the call above, because this
+                    // arm passes `note_debt: true` — that is the whole reason
+                    // the chain's retry sets it. An earlier version passed
+                    // `false` and re-noted here on a second lock acquisition,
+                    // which made `note_debt` unobservable (both values behaved
+                    // identically) and reopened the TOCTOU hole the atomic
+                    // method exists to close. Do not re-add a note here.
                     tracing::debug!(
                         tx = %incoming_tx,
                         contract = %key,
@@ -1903,7 +2006,7 @@ fn spawn_resync_followups(
                     );
                     return;
                 }
-                Err(ReserveRefusal::GlobalCap) => {
+                Err(ReserveRefusal::GlobalCap { deadline: held }) => {
                     // The global per-contract cap refused; it refills 1/60s
                     // against a 1/30s re-reservation, so this is the common case
                     // rather than a corner. KEEP `owed` and wait one more
@@ -1911,7 +2014,7 @@ fn spawn_resync_followups(
                     // next attempt can take a fresh one. Do NOT re-deliver in
                     // the meantime (nothing new is authorized), and do NOT count
                     // this as a served window.
-                    deadline = op_mgr.interest_manager.now() + RESYNC_REQUEST_MIN_INTERVAL;
+                    deadline = held;
                     dispatch_pending = false;
                     deliver = false;
                 }
@@ -4543,6 +4646,17 @@ mod tests {
                 "\npub async fn ",
                 "\npub fn ",
                 "\npub(",
+                // Item openers, not just fn openers (review round 3, C4).
+                // `reserve_resync_emit` is followed by `const
+                // MAX_COALESCED_RESYNC_*` and `static SLOT_CAP_LOG` before the
+                // next `fn`, so a fn-only terminator ran the slice straight
+                // through their DOC COMMENTS — and a pin asserting on a
+                // mechanism could then be satisfied by prose describing it
+                // rather than by the code.
+                "\nconst ",
+                "\nstatic ",
+                "\npub(crate) const ",
+                "\npub(crate) static ",
             ]
             .iter()
             .filter_map(|kw| after.find(kw))
@@ -4637,9 +4751,11 @@ mod tests {
         // same point in the sequence and is what authorizes the response, so it
         // is the tighter anchor of the two.
         let helper = fn_body("async fn reserve_resync_emit(");
-        let per_sender = helper.find(".begin_resync_request(").expect(
+        let per_sender = helper.find(".begin_resync_request_or_note_drop(").expect(
             "helper must RESERVE the per-sender throttle atomically via \
-             begin_resync_request (#4864 round-6 item 2)",
+             begin_resync_request_or_note_drop (#4864 round-6 item 2; renamed in \
+             #5510 round 3 when the refusal and the debt-note became one \
+             critical section)",
         );
         // Anchor on the CALL, not the bare identifier — a comment earlier in the
         // helper mentions `resync_emit_limiter` before the real gate (#4864 round-6
@@ -4651,9 +4767,25 @@ mod tests {
         let emit = helper.find("outstanding_resync_requests").expect(
             "helper must record the outstanding request that authorizes the heal (#4857/#4864)",
         );
-        let cancel = helper.find(".cancel_resync_request(").expect(
-            "helper must CANCEL the reservation when the global cap rejects, so the \
-             window is released (#4864 round-6 item 2)",
+        // #5510 review round 3 (X1) REVERSED this. The helper used to `cancel`
+        // the reservation on a global-cap rejection, releasing the window so the
+        // sender could retry once tokens refilled. Correct before a follow-up
+        // chain existed; wrong after. With the window released, every later drop
+        // on the pair is refused afresh and spawns a chain of its own, so a hot
+        // pair drains the node-wide slot pool in seconds. The reservation is now
+        // KEPT with its dropped-during-window flag set, which throttles those
+        // later drops into the one chain already carrying the debt.
+        let keep = helper
+            .find(".note_resync_debt_on_held_reservation(")
+            .expect(
+                "helper must KEEP the reservation on a global-cap rejection and mark \
+             it as owing a repair — releasing the window lets every later drop \
+             on the pair spawn its own chain (#5510 X1)",
+            );
+        assert!(
+            !helper.contains(".cancel_resync_request("),
+            "helper must NOT cancel the reservation on a global-cap rejection; \
+             that is the pre-X1 behaviour whose slot-drain this replaced"
         );
         assert!(
             per_sender < emit && global_cap < emit,
@@ -4662,15 +4794,51 @@ mod tests {
              so an unthrottled emission cannot re-open the #4251 storm"
         );
         assert!(
-            per_sender < global_cap && global_cap < cancel && cancel < emit,
-            "the cancel ({cancel}) MUST be in the global-cap reject branch — after the \
-             reservation ({per_sender}) and the global cap ({global_cap}), before the \
-             emit ({emit}) — so a global-cap suppression releases the window (#4864 round-6)"
+            per_sender < global_cap && global_cap < keep && keep < emit,
+            "the debt-mark ({keep}) MUST be in the global-cap reject branch — after \
+             the reservation ({per_sender}) and the global cap ({global_cap}), before \
+             the emit ({emit}) — so a suppressed repair is remembered on the window \
+             it is owed against rather than dropped (#4864 round-6, #5510 X1)"
         );
     }
 
     /// Drain the event-loop notification channel (non-blocking) and return the
     /// targets of every `ResyncRequest(key)` emitted since the last drain.
+    /// Make `op_manager` genuinely HOLD `keys`, so gate B does not suppress the
+    /// chain's coalesced emit (#5510, review round 3).
+    ///
+    /// `should_summarize_or_broadcast` is `(is_hosting_contract ||
+    /// contract_in_use) && contract_state_present`: a local client subscription
+    /// supplies the first, stored state the second. Both are needed, and the
+    /// caller asserts the predicate afterwards — a test of the repair that runs
+    /// on a node holding nothing passes against the GATE rather than against the
+    /// repair, which is a vacuous pass in the direction that looks like success.
+    ///
+    /// Returns the tempdir guard; keep it alive for the test's duration.
+    async fn hold_contracts(op_manager: &OpManager, keys: &[ContractKey]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = crate::contract::storages::Storage::new(dir.path())
+            .await
+            .expect("storage");
+        for key in keys {
+            storage
+                .store_state_sync(key, WrappedState::new(vec![1u8, 2, 3]))
+                .expect("store state");
+        }
+        op_manager.ring.set_hosting_storage(storage);
+        for key in keys {
+            op_manager
+                .ring
+                .add_client_subscription(key.id(), crate::client_events::ClientId::FIRST);
+            assert!(
+                op_manager.ring.should_summarize_or_broadcast(key),
+                "precondition: the node must HOLD {key}, or gate B suppresses the \
+                 coalesced emit and the test passes for the wrong reason"
+            );
+        }
+        dir
+    }
+
     fn drain_resync_targets(
         rx: &mut crate::node::EventLoopNotificationsReceiver,
         key: ContractKey,
@@ -4889,6 +5057,595 @@ mod tests {
         );
     }
 
+    /// #5510 review round 3 (S1): a chain that starts OWING a repair — because
+    /// the global emit cap refused the immediate one — actually retries and
+    /// emits once the cap refills.
+    ///
+    /// This path had no behavioural test, and the gap was not benign: reverting
+    /// the `Err(ReserveRefusal::GlobalCap)` spawn to a bare `return` left the
+    /// whole suite green, because the existing pins anchor on
+    /// `spawn_resync_followups`'s own match arm, which survives deleting the
+    /// CALL SITE. A pin on the callee cannot see a caller that stopped calling.
+    ///
+    /// Before this path existed, a drop whose repair the cap refused recorded
+    /// nothing and retried never: the cap `cancel`s the reservation, so there
+    /// was not even a window to hang the debt on. With `EMIT_BURST` 2 against a
+    /// 30s re-reservation, that is a routine case, not a corner.
+    #[tokio::test(start_paused = true)]
+    async fn a_cap_refused_immediate_repair_still_emits_once_the_cap_refills() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("owed-only-chain-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([81u8; 32]),
+            CodeHash::new([82u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:13600".parse().unwrap();
+
+        // Drain this contract's emit tokens BEFORE any drop, so the very first
+        // repair attempt is refused by the global cap rather than granted.
+        for _ in 0..(crate::ring::resync_rate_limit::EMIT_BURST as usize) {
+            assert!(
+                op_manager
+                    .ring
+                    .resync_emit_limiter
+                    .check_and_record(*key.id()),
+                "draining the burst must succeed while tokens remain"
+            );
+        }
+        assert!(
+            !op_manager
+                .ring
+                .resync_emit_limiter
+                .check_and_record(*key.id()),
+            "precondition: the contract's emit bucket must be empty, or this \
+             test exercises the granted path instead of the refused one"
+        );
+
+        let before = op_manager.interest_manager.outstanding_resync_retries();
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "the cap refused the emit, so nothing may go out now"
+        );
+        assert!(
+            op_manager.interest_manager.outstanding_resync_retries() > before,
+            "an owing chain must have been spawned to carry the debt; without it \
+             this drop is simply lost, which is the #5510 failure"
+        );
+
+        // Advance past the cap's refill. The chain re-reserves and emits ONE
+        // coalesced request for the drop it has been carrying.
+        let mut emitted = Vec::new();
+        for _ in 0..200 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            emitted.extend(drain_resync_targets(&mut notification_rx, key));
+            if !emitted.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(
+            emitted,
+            vec![target],
+            "once the cap refills, the owing chain must emit exactly one repair \
+             for the drop it carried"
+        );
+    }
+
+    /// #5510 review round 3 (T1): when a SIBLING takes the window at the
+    /// boundary, the old chain hands its debt over and exits rather than
+    /// retrying against a reservation it does not hold.
+    ///
+    /// The map is keyed by `(contract, target)` alone, so at a window boundary
+    /// two chains can briefly both believe they are the owner. Exactly one
+    /// repair must result: the sibling's. Without the hand-over the debt dies
+    /// with the departing chain and the drop is never repaired — the silent
+    /// loss #5510 exists to close, reintroduced one layer up.
+    ///
+    /// The hand-over happens inside `begin_resync_request_or_note_drop` under
+    /// one lock, which is what makes it safe; a second note here would be both
+    /// redundant and a TOCTOU hole.
+    ///
+    /// # What this test does and does not establish
+    ///
+    /// It covers the OBSERVABLE requirement at a window boundary: exactly one
+    /// repair crosses it, and no chain keeps a node-wide slot afterwards. It
+    /// does NOT force the A-vs-B race itself. I tried, and measured that it
+    /// does not: with `start_paused`, a drop issued before the boundary is
+    /// refused (A still owns the window) and one issued after finds A has
+    /// already re-reserved, so the `WindowHeld` arm is never entered — I
+    /// confirmed that by collapsing that arm into a plain retry, which this
+    /// test still passed. Winning the race needs the sibling to reserve in the
+    /// instant between A's timer firing and A's task being polled, which the
+    /// runtime does not let a test schedule.
+    ///
+    /// So the arm's own behaviour is pinned by
+    /// `the_window_held_arm_exits_rather_than_retrying`, and the generational
+    /// half by
+    /// `a_stale_chain_cannot_consume_a_newer_reservations_swallowed_drop` in
+    /// `ring::interest`. Recording this rather than leaving the mutation gap
+    /// silent, because a behavioural test that cannot fail for the reason it
+    /// names is worse than an honest pin.
+    #[tokio::test(start_paused = true)]
+    async fn a_sibling_taking_the_window_inherits_the_debt_and_the_old_chain_exits() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("sibling-takeover-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([85u8; 32]),
+            CodeHash::new([86u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:13800".parse().unwrap();
+
+        // Chain A: granted, holds a slot, then a second drop inside its window
+        // leaves it owing a repair.
+        for _ in 0..2 {
+            send_dropped_broadcast_resync_request(
+                &op_manager,
+                key,
+                target,
+                Transaction::new::<UpdateMsg>(),
+                DroppedBroadcastReason::RateLimited,
+            )
+            .await;
+        }
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![target],
+            "only the FIRST drop may emit; the second is inside A's window"
+        );
+        let slots_with_a = op_manager.interest_manager.outstanding_resync_retries();
+        assert!(slots_with_a > 0, "precondition: chain A must hold a slot");
+
+        // Run to just BEFORE A's window closes, discarding the #4862
+        // re-deliveries. Those re-send the request A already emitted, so they
+        // are not repairs and counting them would drown the signal.
+        for _ in 0..58 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+
+        // A genuine new drop right at the boundary. Whether it is refused (A
+        // still owns the window and inherits this drop too) or granted (it
+        // becomes sibling B and A must hand its debt over and exit), the
+        // observable requirement is the same and is what this asserts.
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+
+        // Cross the boundary. Stop 1s past it: a fresh reservation taken here
+        // has its first #4862 retry >= 1.6s out, so it cannot contaminate the
+        // count — the same narrow window the deadline test relies on.
+        let mut emitted = Vec::new();
+        for _ in 0..4 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            emitted.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "exactly ONE repair may cross the window boundary, whichever chain \
+             ends up owning the reservation. Two would be the #4251 \
+             amplification the throttle exists to bound — the shape a hand-over \
+             that ALSO left the old chain emitting would produce. Zero would be \
+             the silent loss #5510 exists to close, which is what a hand-over \
+             that dropped the debt would produce. Got {emitted:?}"
+        );
+
+        // And the chains must drain: nothing may hold a node-wide slot forever
+        // because it lost a race for a reservation.
+        let mut ticks = 0;
+        while op_manager.interest_manager.outstanding_resync_retries() > 0 && ticks < 2000 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+            ticks += 1;
+        }
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "every chain must eventually release its slot; a chain that lost the \
+             window to a sibling must exit rather than retry against a \
+             reservation it does not hold"
+        );
+    }
+
+    /// #5510 review round 3 (T3): the tokio liveness backstop fires when the
+    /// injected clock never advances.
+    ///
+    /// `wait_until_reservation_close` loops on the THROTTLE's clock, which a
+    /// node can be configured to drive from an injected `TimeSource`. If that
+    /// clock stalls — a frozen mock, a suspended host, a DST discontinuity —
+    /// the loop's own condition can never become true, and without a second
+    /// clock to bound it the task would poll forever while holding one of the
+    /// 256 node-wide slots. The backstop measures `tokio::time::Instant`
+    /// instead, which is a different clock on purpose.
+    ///
+    /// Frozen throttle clock, advancing tokio clock: the wait must give up
+    /// within the backstop rather than spin.
+    #[tokio::test(start_paused = true)]
+    async fn the_wait_gives_up_when_the_injected_clock_never_advances() {
+        let (op_manager, _notification_rx, _guard) = build_queue_full_test_node_with_clock(
+            "coalesced-backstop-5510",
+            Some(
+                Arc::new(crate::util::time_source::SharedMockTimeSource::new())
+                    as crate::util::time_source::DynTimeSource,
+            ),
+        )
+        .await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([87u8; 32]),
+            CodeHash::new([88u8; 32]),
+        );
+
+        // A deadline the frozen clock can never reach.
+        let unreachable = op_manager.interest_manager.now() + Duration::from_secs(3600);
+        let waiter = tokio::spawn({
+            let op_manager = op_manager.clone();
+            async move {
+                wait_until_reservation_close(
+                    &op_manager,
+                    key,
+                    Transaction::new::<UpdateMsg>(),
+                    unreachable,
+                )
+                .await
+            }
+        });
+
+        // Advance tokio's clock only. The throttle's clock stays frozen, so the
+        // loop condition never clears and only the backstop can end this.
+        for _ in 0..80 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            if waiter.is_finished() {
+                break;
+            }
+        }
+
+        assert!(
+            waiter.is_finished(),
+            "the wait must give up on the tokio backstop rather than poll \
+             forever against a stalled injected clock — otherwise a frozen \
+             clock leaks node-wide slots one chain at a time"
+        );
+        assert!(
+            !waiter.await.expect("waiter must not panic"),
+            "giving up must report FALSE, so the caller abandons the coalesced \
+             emit instead of emitting against a window it never observed close"
+        );
+    }
+
+    /// #5510 review round 3 (T1, pin): the `WindowHeld` arm must EXIT, not
+    /// retry.
+    ///
+    /// A chain whose re-reservation is refused because a sibling now owns the
+    /// window holds nothing. Retrying would burn one of the 256 node-wide slots
+    /// waiting on a reservation it does not own, and the sibling — which does
+    /// own it, and has the debt — is the one that will serve the repair. So the
+    /// arm must return.
+    ///
+    /// This is a source pin because the race it describes cannot be scheduled
+    /// from a test; see
+    /// `a_sibling_taking_the_window_inherits_the_debt_and_the_old_chain_exits`
+    /// for the measurement behind that claim.
+    #[test]
+    fn the_window_held_arm_exits_rather_than_retrying() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("fn spawn_resync_followups(")
+            .expect("spawn_resync_followups not found");
+        let rest = &src[start + 1..];
+        let end = [
+            "\nasync fn ",
+            "\nfn ",
+            "\npub async fn ",
+            "\npub fn ",
+            "\npub(",
+            "\nconst ",
+            "\nstatic ",
+            "\npub(crate) const ",
+            "\npub(crate) static ",
+        ]
+        .iter()
+        .filter_map(|kw| rest.find(kw))
+        .min()
+        .unwrap_or(rest.len());
+        let body = &src[start..start + 1 + end];
+
+        let arm = body
+            .find("Err(ReserveRefusal::WindowHeld) => {")
+            .expect("the sibling-held refusal must be its own arm, so it can be handled");
+        // No closing paren: the variant carries a field now, so the old exact
+        // match silently failed and ran `arm_body` to the end of the function.
+        let arm_end = body[arm..]
+            .find("Err(ReserveRefusal::GlobalCap")
+            .map(|i| arm + i)
+            .unwrap_or(body.len());
+        let arm_body = &body[arm..arm_end];
+
+        assert!(
+            arm_body.contains("return;"),
+            "the WindowHeld arm must RETURN: a sibling owns the window and holds \
+             the debt, so retrying only burns a node-wide slot waiting on a \
+             reservation this chain does not own"
+        );
+        assert!(
+            !arm_body.contains("deliver = false;") && !arm_body.contains("dispatch_pending"),
+            "the WindowHeld arm must not fall through into the retry shape used \
+             by the GlobalCap arm — those are different situations: the cap \
+             releases the window (so retrying can win it back), a sibling holds \
+             it (so retrying cannot)"
+        );
+        // #5510 review round 3 (X4): the bound's return must hand the debt back.
+        //
+        // The debt is CONSUMED into `owed` before the bound is checked, so a
+        // bare return abandons it — a drop swallowed late in the last served
+        // window would vanish at t=90 with nothing holding the flag. Handing it
+        // back rather than emitting one more time keeps the bound meaning what
+        // it says: it caps slot occupancy, not repairs.
+        let bound = body
+            .find("if windows_served >= MAX_COALESCED_RESYNC_WINDOWS")
+            .expect("the chain bound must exist");
+        let bound_end = body[bound..]
+            .find("\n            }")
+            .map(|i| bound + i)
+            .unwrap_or(body.len());
+        assert!(
+            body[bound..bound_end].contains("note_resync_debt_on_held_reservation"),
+            "the chain-bound return must hand the consumed debt back to the \
+             reservation; it was taken into `owed` before this check, so \
+             returning without it drops a real repair on the floor at the exact \
+             moment the chain stops looking (#5510 X4)"
+        );
+
+        assert!(
+            !arm_body.contains("note_resync_drop_during_window"),
+            "the hand-over happens inside begin_resync_request_or_note_drop, \
+             under the same lock as the refusal. A second note here would be a \
+             TOCTOU hole AND would make `note_debt` unobservable, which is how \
+             the round-2 version hid this arm from testing entirely"
+        );
+    }
+
+    /// #5510 review round 3 (X2): a chain whose request went unanswered keeps
+    /// trying rather than exiting on "nothing swallowed".
+    ///
+    /// The responder runs its own 30s `resync_response_limiter` per (contract,
+    /// peer). If our request lands late — the enqueue is a blocking
+    /// `notify_node_event` — the coalesced request and its short retries can all
+    /// fall inside ONE responder window and be rejected before the responder
+    /// clears its cached summary of us. From this side nothing new is swallowed,
+    /// so the old code exited satisfied while the divergence remained.
+    ///
+    /// The correlation record is consumed when a matching ResyncResponse
+    /// arrives, so a record still outstanding means nothing came back. This
+    /// harness never answers, so the record stays outstanding throughout, and
+    /// the chain must keep going to its bound rather than stopping at the first
+    /// window that swallowed nothing.
+    #[tokio::test(start_paused = true)]
+    async fn an_unanswered_repair_keeps_retrying_instead_of_exiting_satisfied() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("unanswered-retry-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([91u8; 32]),
+            CodeHash::new([92u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:14000".parse().unwrap();
+
+        // One drop only. Nothing further is swallowed, so a chain that judged
+        // solely on the flag would exit at the first window close.
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![target],
+            "the drop must emit its immediate request"
+        );
+        assert!(
+            op_manager
+                .ring
+                .outstanding_resync_requests
+                .is_outstanding(*key.id(), target),
+            "precondition: the correlation record must be outstanding, or there \
+             is no 'unanswered' signal for the chain to read"
+        );
+
+        // Past the first window close. The chain must still be alive: no
+        // response has arrived, so its repair has not landed.
+        for _ in 0..64 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+        }
+        assert!(
+            op_manager.interest_manager.outstanding_resync_retries() > 0,
+            "the chain must NOT have exited at the first window close: its \
+             request was never answered, so the divergence it exists to repair \
+             is still there and the responder's own 30s throttle is the likely \
+             reason (#5510 X2)"
+        );
+
+        // And it must still terminate — retrying is bounded, not indefinite.
+        let mut ticks = 0;
+        while op_manager.interest_manager.outstanding_resync_retries() > 0 && ticks < 4000 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+            ticks += 1;
+        }
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "retrying an unanswered repair must stay bounded by windows_served \
+             and attempts — otherwise X2's fix trades a lost repair for a leaked \
+             slot"
+        );
+    }
+
+    /// #5510 review round 3 (X1): a pair whose contract is over the global emit
+    /// cap spawns ONE chain, not one per drop.
+    ///
+    /// The cap path used to `cancel` the per-pair reservation, releasing the
+    /// window. That looked like the considerate thing to do — the sender could
+    /// then retry as soon as tokens refilled — and it was, right up until a
+    /// follow-up chain existed. With the window released, every later drop on
+    /// the pair reaches the cap afresh, is refused afresh, and spawns a chain of
+    /// its own, so one hot pair drains the 256 node-wide slots in seconds while
+    /// all of them wait on the same empty bucket.
+    ///
+    /// Keeping the reservation makes those later drops `WindowHeld`, so they
+    /// hand their debt to the chain already carrying it. This asserts the slot
+    /// count, because that is the resource the old shape exhausted.
+    #[tokio::test(start_paused = true)]
+    async fn a_capped_pair_spawns_one_chain_however_many_drops_arrive() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("capped-pair-one-chain-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([89u8; 32]),
+            CodeHash::new([90u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:13900".parse().unwrap();
+
+        // Empty the contract's emit bucket so every repair attempt is refused.
+        while op_manager
+            .ring
+            .resync_emit_limiter
+            .check_and_record(*key.id())
+        {}
+
+        let before = op_manager.interest_manager.outstanding_resync_retries();
+        for _ in 0..12 {
+            send_dropped_broadcast_resync_request(
+                &op_manager,
+                key,
+                target,
+                Transaction::new::<UpdateMsg>(),
+                DroppedBroadcastReason::RateLimited,
+            )
+            .await;
+            tokio::task::yield_now().await;
+        }
+
+        let spawned = op_manager.interest_manager.outstanding_resync_retries() - before;
+        assert_eq!(
+            spawned, 1,
+            "twelve drops on one capped pair must produce ONE chain, not one \
+             each: gate 1 is per (contract, sender), and keeping the reservation \
+             on a cap refusal is what makes the later drops hit it. Got \
+             {spawned} chains, which is the slot-drain shape X1 removed"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "and nothing may be emitted while the cap refuses"
+        );
+    }
+
+    /// #5510 review round 3 (T2): a chain that is refused on every attempt
+    /// still terminates and gives its slot back.
+    ///
+    /// [`MAX_COALESCED_RESYNC_WINDOWS`] counts SERVED windows, so a chain that
+    /// never serves one would never reach it — that is exactly why
+    /// [`MAX_COALESCED_RESYNC_ATTEMPTS`] exists as a separate bound. Without it
+    /// a pair whose contract sits permanently over the global emit cap holds one
+    /// of the 256 node-wide slots indefinitely, which is the refreshable-cap
+    /// shape `.claude/rules/code-style.md` forbids.
+    ///
+    /// The cap is kept drained for the whole run, so every re-reservation is
+    /// refused and `windows_served` never advances past its starting value.
+    #[tokio::test(start_paused = true)]
+    async fn a_chain_refused_on_every_attempt_terminates_and_frees_its_slot() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("attempts-bound-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([83u8; 32]),
+            CodeHash::new([84u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:13700".parse().unwrap();
+
+        // First drop: granted, spawns a chain holding a #4862 slot.
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![target],
+            "the first drop must emit immediately"
+        );
+        assert!(
+            op_manager.interest_manager.outstanding_resync_retries() > 0,
+            "precondition: a chain must be holding a slot"
+        );
+
+        // A second drop inside the window records the debt the chain will try,
+        // and keep trying, to serve.
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+
+        // Keep the bucket empty for the whole run so every re-reservation is
+        // refused. Draining on each tick is what makes this a test of the
+        // ATTEMPTS bound rather than of the window bound.
+        let mut ticks = 0;
+        while op_manager.interest_manager.outstanding_resync_retries() > 0 && ticks < 4000 {
+            while op_manager
+                .ring
+                .resync_emit_limiter
+                .check_and_record(*key.id())
+            {}
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            let _ = drain_resync_targets(&mut notification_rx, key);
+            ticks += 1;
+        }
+
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "a chain refused on every attempt MUST still terminate and return its \
+             node-wide slot; without the attempts bound it re-reserves forever, \
+             and 256 such pairs starve every later pair of both the #4862 \
+             re-delivery and the trailing repair"
+        );
+    }
+
     /// #5510 trailing edge, the case the throttle used to swallow silently.
     ///
     /// Sequence, all on one `(contract, sender)`:
@@ -4918,6 +5675,9 @@ mod tests {
             ContractInstanceId::new([21u8; 32]),
             CodeHash::new([22u8; 32]),
         );
+        // The chain's coalesced emit is gated on holding the contract, so the
+        // node must actually hold it or this measures the gate, not the repair.
+        let _held = hold_contracts(&op_manager, &[key]).await;
         let sender_addr: SocketAddr = "127.0.0.1:12400".parse().unwrap();
 
         let drop_once = |bytes: Vec<u8>| {
@@ -5124,6 +5884,13 @@ mod tests {
             "\npub async fn ",
             "\npub fn ",
             "\npub(",
+            // Item openers too (review round 3, C4): consts and statics sit
+            // between these fns, and their doc comments would otherwise fall
+            // inside the slice.
+            "\nconst ",
+            "\nstatic ",
+            "\npub(crate) const ",
+            "\npub(crate) static ",
         ]
         .iter()
         .filter_map(|kw| rest.find(kw))
@@ -5220,15 +5987,21 @@ mod tests {
     /// evicted after the first emit would otherwise keep being requested by a
     /// gate that ran once, long ago.
     ///
-    /// The pre-existing queue-full path (#4857) has never carried that gate, and
-    /// this test is written as a DISCRIMINATING pair for exactly that reason: two
-    /// senders on one node, one driven with each origin, identical in every other
-    /// respect. If the re-check were applied unconditionally both would fall
-    /// silent and #5510 would have quietly narrowed #4857; if it were absent
-    /// both would emit and the gate would be doing nothing. Only the intended
-    /// behaviour produces one of each.
+    /// The split under test is IMMEDIATE vs CHAIN, not one origin vs the other
+    /// (review round 3, correcting round 2). The immediate queue-full emit
+    /// (#4857) has never been hosting-gated and still is not — that argument is
+    /// about a path that predates this PR. It does not extend to the chain,
+    /// which is new code with a ~180s lifetime, so EVERY coalesced emit is
+    /// gated whatever it descended from.
+    ///
+    /// Written as a discriminating pair for that reason: two contracts, one
+    /// driven with each origin, identical otherwise, on a node that holds
+    /// neither. Both must emit immediately and neither must emit at the
+    /// window's close. If the gate were absent, both would emit twice; if it
+    /// were (wrongly) moved onto the immediate emit as well, neither would emit
+    /// at all. Only the intended split produces one emit each.
     #[tokio::test(start_paused = true)]
-    async fn the_coalesced_emit_rechecks_hosting_for_a_rate_limited_origin_only() {
+    async fn the_coalesced_emit_rechecks_hosting_for_every_origin() {
         let (op_manager, mut notification_rx, _guard) =
             build_queue_full_test_node("coalesced-hosting-recheck-5510").await;
         // A contract EACH, not two senders on one: the global per-contract emit
@@ -5304,7 +6077,7 @@ mod tests {
         }
         let gated_emits: Vec<_> = at_deadline
             .iter()
-            .filter(|(k, _)| *k == key_gated)
+            .filter_map(|(k, t)| (*k == key_gated).then_some(*t))
             .collect();
         let ungated_emits: Vec<_> = at_deadline
             .iter()
@@ -5314,40 +6087,16 @@ mod tests {
         assert!(
             gated_emits.is_empty(),
             "the rate-limiter-origin chain must re-check hosting and abandon its \
-             coalesced emit for a contract this node no longer holds, got \
+             coalesced emit for a contract this node does not hold, got \
              {gated_emits:?}"
         );
-        assert_eq!(
-            ungated_emits,
-            vec![target],
-            "the queue-full chain must STILL emit: #4857 has never been gated on \
-             hosting, and narrowing it here would be a behaviour change #5510 has \
-             no evidence for"
-        );
-    }
-
-    /// #5510 review round 2 companion: the gating decision lives on the ORIGIN
-    /// reason, and the chain's own reason must never be the one consulted.
-    ///
-    /// `DroppedDuringThrottleWindow` is what every coalesced emit carries, so if
-    /// the re-check ever read the chain's current reason instead of the reason it
-    /// descended from, the gate would evaluate to `false` for every chain and the
-    /// test above would keep passing on its queue-full half alone. This pins the
-    /// mapping directly.
-    #[test]
-    fn only_the_rate_limited_origin_gates_its_repair_on_hosting() {
         assert!(
-            DroppedBroadcastReason::RateLimited.repair_is_hosting_gated(),
-            "node.rs gates the rate-limited emit on hosting, so its chain must too"
-        );
-        assert!(
-            !DroppedBroadcastReason::QueueFull.repair_is_hosting_gated(),
-            "#4857 has never been hosting-gated; gating it here would narrow it"
-        );
-        assert!(
-            !DroppedBroadcastReason::DroppedDuringThrottleWindow.repair_is_hosting_gated(),
-            "the chain's own reason is never an ORIGIN, so it must not be the \
-             value that decides gating"
+            ungated_emits.is_empty(),
+            "the QUEUE-FULL chain must abandon its coalesced emit too. #4857's \
+             hosting exemption covers its IMMEDIATE emit, which this test already \
+             observed firing; extending that exemption to a chain that re-emits \
+             for ~180s would be inventing a new behaviour, not preserving an old \
+             one. Got {ungated_emits:?}"
         );
     }
 
@@ -5366,6 +6115,7 @@ mod tests {
             ContractInstanceId::new([63u8; 32]),
             CodeHash::new([64u8; 32]),
         );
+        let _held = hold_contracts(&op_manager, &[key]).await;
         let sender_addr: SocketAddr = "127.0.0.1:13100".parse().unwrap();
 
         // Drop 1: takes the reservation, spends one of the contract's two emit
@@ -6354,6 +7104,17 @@ mod tests {
                 "\npub async fn ",
                 "\npub fn ",
                 "\npub(",
+                // Item openers, not just fn openers (review round 3, C4).
+                // `reserve_resync_emit` is followed by `const
+                // MAX_COALESCED_RESYNC_*` and `static SLOT_CAP_LOG` before the
+                // next `fn`, so a fn-only terminator ran the slice straight
+                // through their DOC COMMENTS — and a pin asserting on a
+                // mechanism could then be satisfied by prose describing it
+                // rather than by the code.
+                "\nconst ",
+                "\nstatic ",
+                "\npub(crate) const ",
+                "\npub(crate) static ",
             ]
             .iter()
             .filter_map(|kw| prod[..pos].rfind(kw))
@@ -6405,6 +7166,17 @@ mod tests {
                 "\npub async fn ",
                 "\npub fn ",
                 "\npub(",
+                // Item openers, not just fn openers (review round 3, C4).
+                // `reserve_resync_emit` is followed by `const
+                // MAX_COALESCED_RESYNC_*` and `static SLOT_CAP_LOG` before the
+                // next `fn`, so a fn-only terminator ran the slice straight
+                // through their DOC COMMENTS — and a pin asserting on a
+                // mechanism could then be satisfied by prose describing it
+                // rather than by the code.
+                "\nconst ",
+                "\nstatic ",
+                "\npub(crate) const ",
+                "\npub(crate) static ",
             ]
             .iter()
             .filter_map(|kw| rest.find(kw))
@@ -6465,6 +7237,17 @@ mod tests {
                 "\npub async fn ",
                 "\npub fn ",
                 "\npub(",
+                // Item openers, not just fn openers (review round 3, C4).
+                // `reserve_resync_emit` is followed by `const
+                // MAX_COALESCED_RESYNC_*` and `static SLOT_CAP_LOG` before the
+                // next `fn`, so a fn-only terminator ran the slice straight
+                // through their DOC COMMENTS — and a pin asserting on a
+                // mechanism could then be satisfied by prose describing it
+                // rather than by the code.
+                "\nconst ",
+                "\nstatic ",
+                "\npub(crate) const ",
+                "\npub(crate) static ",
             ]
             .iter()
             .filter_map(|kw| prod[..pos].rfind(kw))
@@ -7651,6 +8434,17 @@ mod tests {
                 "\npub async fn ",
                 "\npub fn ",
                 "\npub(",
+                // Item openers, not just fn openers (review round 3, C4).
+                // `reserve_resync_emit` is followed by `const
+                // MAX_COALESCED_RESYNC_*` and `static SLOT_CAP_LOG` before the
+                // next `fn`, so a fn-only terminator ran the slice straight
+                // through their DOC COMMENTS — and a pin asserting on a
+                // mechanism could then be satisfied by prose describing it
+                // rather than by the code.
+                "\nconst ",
+                "\nstatic ",
+                "\npub(crate) const ",
+                "\npub(crate) static ",
             ]
             .iter()
             .filter_map(|kw| after.find(kw))
@@ -7685,9 +8479,32 @@ mod tests {
         );
 
         let helper = fn_body("async fn reserve_resync_emit(");
-        let gate = helper
-            .find(".begin_resync_request(")
-            .expect("helper must gate on begin_resync_request (per-sender throttle, #4251)");
+        let gate = helper.find(".begin_resync_request_or_note_drop(").expect(
+            "helper must gate on begin_resync_request_or_note_drop (per-sender \
+             throttle, #4251)",
+        );
+
+        // #5510 round 3: the refusal and the debt-note must be ONE call.
+        //
+        // The two-step (`begin_resync_request` -> `None`, then a separate
+        // `note_resync_drop_during_window`) has a TOCTOU hole that the
+        // generation check does NOT close: between the two lock acquisitions
+        // the owning chain can reach its deadline, take the flag, read false,
+        // conclude nothing is owed, and free its slot — after which the note
+        // lands on an entry nobody is watching and the drop is never repaired.
+        // Silently, which is the exact failure #5510 exists to close.
+        assert!(
+            !helper.contains(".begin_resync_request("),
+            "reserve_resync_emit must NOT call the two-step begin_resync_request; \
+             the atomic begin_resync_request_or_note_drop exists because the \
+             two-step loses a swallowed drop under a multi-thread runtime"
+        );
+        assert!(
+            !helper.contains("note_resync_drop_during_window"),
+            "reserve_resync_emit must NOT note the debt as a separate lock \
+             acquisition — the note belongs inside the same critical section as \
+             the refusal that caused it"
+        );
         let global_cap = helper
             .find("resync_emit_limiter")
             .expect("helper must gate on the global per-contract emit cap (#4864)");

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1259,6 +1259,12 @@ pub(crate) enum DroppedBroadcastReason {
     /// Refused by the per-(sender, contract) UPDATE dispatch rate limiter
     /// in `node.rs` before any driver ran (#5510).
     RateLimited,
+    /// The trailing-edge coalesced repair (#5510): one or more drops were
+    /// swallowed by a held throttle window, and this is the single request
+    /// emitted at that window's close to cover all of them. The original cause
+    /// of those drops is deliberately not carried — a window can swallow both
+    /// kinds, and one full-state response repairs either.
+    DroppedDuringThrottleWindow,
 }
 
 impl DroppedBroadcastReason {
@@ -1268,6 +1274,7 @@ impl DroppedBroadcastReason {
         match self {
             DroppedBroadcastReason::QueueFull => "queue_full",
             DroppedBroadcastReason::RateLimited => "rate_limited",
+            DroppedBroadcastReason::DroppedDuringThrottleWindow => "dropped_during_window",
         }
     }
 }
@@ -1322,6 +1329,45 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
     incoming_tx: Transaction,
     reason: DroppedBroadcastReason,
 ) {
+    let Some((reservation_deadline, correlated)) =
+        reserve_resync_emit(op_manager, key, sender_addr, incoming_tx, reason).await
+    else {
+        return;
+    };
+    // Spawn BEFORE the blocking dispatch below — that ordering is load-bearing;
+    // see `spawn_resync_followups` (#4862 P2).
+    spawn_resync_followups(
+        op_manager,
+        key,
+        sender_addr,
+        incoming_tx,
+        reservation_deadline,
+        correlated,
+    );
+    dispatch_resync_request(op_manager, key, sender_addr, incoming_tx).await;
+}
+
+/// Take the two gates and record the correlation entry for ONE `ResyncRequest`,
+/// returning the reservation deadline and whether the request is correlated.
+///
+/// Split out of [`send_dropped_broadcast_resync_request`] so the #5510
+/// trailing-edge sweep can emit a NEW request without re-entering that function.
+/// Calling it recursively is not an option: `send_...` spawns a task whose
+/// future would then have to prove itself `Send` in terms of itself, and rustc
+/// rejects that cycle outright. Sharing this function rather than hand-inlining
+/// the gates is what stops the two emit paths drifting — the failure shape
+/// `.claude/rules/bug-prevention-patterns.md` calls "manually-inlined originator
+/// side effects".
+///
+/// Returns `None` when either gate refused, in which case NOTHING was emitted
+/// and no correlation entry exists.
+async fn reserve_resync_emit(
+    op_manager: &OpManager,
+    key: ContractKey,
+    sender_addr: SocketAddr,
+    incoming_tx: Transaction,
+    reason: DroppedBroadcastReason,
+) -> Option<(Instant, bool)> {
     // Gate 1 — per-(contract, sender)/30s throttle (#4857/#4862 + #4864 round-6).
     // RESERVE the window atomically (`begin` checks AND records under the
     // throttle's own lock) and return the reservation deadline on the throttle's
@@ -1333,6 +1379,15 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
         .interest_manager
         .begin_resync_request(&key, sender_addr)
     else {
+        // #5510: this drop's repair is being refused, and BEFORE this change
+        // nothing ever re-sent it — the throttle simply returned. Mark the held
+        // reservation so the trailing-edge sweep emits ONE coalesced
+        // ResyncRequest when the window closes. One full-state ResyncResponse
+        // restores every entry the window swallowed, so one flag covers any
+        // number of drops and the #4251 amplification bound is untouched.
+        op_manager
+            .interest_manager
+            .note_resync_drop_during_window(&key, sender_addr);
         // Per-(contract, sender)/30s throttle (existing #4857 bound).
         tracing::debug!(
             tx = %incoming_tx,
@@ -1342,7 +1397,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
             reason = reason.as_str(),
             "UPDATE relay: dropped-broadcast ResyncRequest throttled (rate limit) to avoid amplification"
         );
-        return;
+        return None;
     };
 
     // ALSO subject to the GLOBAL per-contract emit cap (#4864 round-4 P1): the
@@ -1371,7 +1426,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
             reason = reason.as_str(),
             "UPDATE relay: dropped-broadcast ResyncRequest suppressed by global per-contract cap"
         );
-        return;
+        return None;
     }
 
     // Both gates passed → the reservation stands (already recorded by `begin`).
@@ -1407,52 +1462,177 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
         .outstanding_resync_requests
         .record(*key.id(), sender_addr);
 
-    // #4862 (P2): the immediate ResyncRequest below rides a LOSSY path
-    // (`notify_node_event` → event loop → `P2pBridge::try_send`), which can drop
-    // it under the SAME backpressure that caused the queue-full drop. If dropped,
-    // the sender never clears its poisoned summary and a one-off change diverges
-    // until the ~5-min heartbeat. Schedule a BOUNDED trailing re-dispatch so the
-    // resync gets more chances to land — well before the heartbeat.
-    //
-    // Spawn CONCURRENTLY, BEFORE the blocking immediate enqueue below (#4862 P2):
-    // `notify_node_event(...).await` can consume up to NOTIFICATION_SEND_TIMEOUT
-    // (30s) under backpressure; spawning after it would let the task start with
-    // the window already gone (`now >= reservation_deadline`) and do nothing. The
-    // first attempt is a jittered delay out (never t=0), so it does not duplicate
-    // the immediate send, and it stays anchored to `reservation_deadline` (the
-    // throttle's own clock) so it can NEVER spill into a new reservation. The
-    // retries re-deliver the ONE already-authorized emit, so they do NOT
-    // re-consult the per-sender throttle or the global emit cap and do NOT
-    // re-record the correlation entry recorded above.
-    //
-    // #4863: each attempt is CONDITIONAL on that correlation entry still being
-    // outstanding, so a retry fires only while the first request is NOT observed
-    // to have landed.
-    //
-    // #4862 P1: gate the spawn on a node-wide retry-task slot so the throttle LRU
-    // evicting active reservations under key churn cannot spawn unbounded
-    // overlapping tasks. At cap ONLY the retry is skipped; the immediate send
-    // below still fires. Fire-and-forget; the slot guard frees on completion.
-    if let Some(slot) = op_manager.interest_manager.try_reserve_resync_retry_slot() {
-        let op_mgr = op_manager.clone();
-        GlobalExecutor::spawn(async move {
-            let _slot = slot; // frees the node-wide retry slot on task exit
+    Some((reservation_deadline, correlated))
+}
+
+/// Spawn the follow-up task that owns everything this reservation still has to
+/// do: the #4862 re-delivery burst, then the #5510 trailing-edge sweep, then —
+/// if that sweep found a swallowed drop — the next reservation's burst and
+/// sweep, and so on.
+///
+/// # Why it is ONE looping task
+///
+/// The obvious shape is for the sweep to call
+/// [`send_dropped_broadcast_resync_request`] again. It does not compile, and the
+/// reason is worth recording so nobody re-tries it: that function spawns a task,
+/// so proving the spawned future `Send` would require already knowing whether it
+/// is `Send`, and rustc rejects the cycle rather than resolving it. Looping in
+/// one task removes the recursion entirely and is a better fit anyway — the loop
+/// exits the first time a window closes with nothing swallowed, so a quiet
+/// contract costs one task for one window.
+///
+/// # Ordering (#4862 P2), unchanged and still load-bearing
+///
+/// The caller spawns this BEFORE its blocking `notify_node_event`, which can
+/// consume up to `NOTIFICATION_SEND_TIMEOUT` (30s) under backpressure. Spawning
+/// after it would let the task start with the window already gone and do
+/// nothing. The correlation entry is recorded before this too (in
+/// `reserve_resync_emit`), so the #4863 gate can never read a not-yet-written
+/// record and mistake it for "landed".
+///
+/// # Bounds
+///
+/// One node-wide slot per chain ([`crate::ring::interest::
+/// MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]), held for as long as the chain
+/// runs, and the chain only continues while drops keep being swallowed. Each
+/// iteration emits at most `1 + QUEUE_FULL_RESYNC_MAX_RETRIES` re-deliveries of
+/// one authorized request plus at most one NEW request, per (contract, sender)
+/// per window — the #4251 bound.
+fn spawn_resync_followups(
+    op_manager: &OpManager,
+    key: ContractKey,
+    sender_addr: SocketAddr,
+    incoming_tx: Transaction,
+    reservation_deadline: Instant,
+    correlated: bool,
+) {
+    let Some(slot) = op_manager.interest_manager.try_reserve_resync_retry_slot() else {
+        // #5510: at the node-wide cap NOTHING is spawned, so this reservation
+        // gets neither the #4862 re-delivery nor the trailing coalesced repair.
+        // A drop the window then swallows waits for the next drop after it
+        // closes. `info!` rather than `debug!` because `release_max_level_info`
+        // compiles `debug!` out — the very reason #5510 was invisible in the
+        // field — and because this is the one path where the repair silently
+        // does less than the code promises.
+        tracing::info!(
+            tx = %incoming_tx,
+            contract = %key,
+            target = %sender_addr,
+            cap = crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES,
+            event = "resync_retry_slot_cap_reached",
+            "UPDATE relay: at the node-wide resync-retry slot cap; the immediate \
+             ResyncRequest still sends, but this reservation gets no re-delivery \
+             and no trailing coalesced repair (#4862 P1/#5510)"
+        );
+        return;
+    };
+
+    let op_mgr = op_manager.clone();
+    GlobalExecutor::spawn(async move {
+        let _slot = slot; // frees the node-wide slot on task exit
+        let mut deadline = reservation_deadline;
+        let mut correlated = correlated;
+        loop {
             resend_dropped_broadcast_resync_request(
                 &op_mgr,
                 key,
                 sender_addr,
                 incoming_tx,
-                reservation_deadline,
+                deadline,
                 correlated,
             )
             .await;
-        });
-    }
 
-    // Immediate (first) ResyncRequest — blocking best-effort enqueue. The
-    // #4862 trailing retry above re-sends the SAME request and relies on the ONE
-    // correlation record made before the spawn — see
-    // `resend_dropped_broadcast_resync_request`.
+            // #5510. The re-delivery above can return EARLY (its #4863 gate
+            // stops it once the first response lands); this waits out the rest
+            // of the window regardless, because a drop swallowed AFTER that
+            // response is exactly the case this exists for.
+            if !wait_for_reservation_close(&op_mgr, key, sender_addr, incoming_tx, deadline).await {
+                return;
+            }
+
+            tracing::info!(
+                tx = %incoming_tx,
+                contract = %key,
+                target = %sender_addr,
+                event = "coalesced_resync_window_closed",
+                "UPDATE relay: a broadcast repair was swallowed by the throttle \
+                 window; emitting one coalesced ResyncRequest now that it has \
+                 closed (#5510)"
+            );
+
+            let Some((next_deadline, next_correlated)) = reserve_resync_emit(
+                &op_mgr,
+                key,
+                sender_addr,
+                incoming_tx,
+                DroppedBroadcastReason::DroppedDuringThrottleWindow,
+            )
+            .await
+            else {
+                // A gate refused the coalesced request (the global per-contract
+                // emit cap is the realistic one). Stop: the next real drop takes
+                // its own reservation, and looping here would spin on a cap.
+                return;
+            };
+            dispatch_resync_request(&op_mgr, key, sender_addr, incoming_tx).await;
+            deadline = next_deadline;
+            correlated = next_correlated;
+        }
+    });
+}
+
+/// Wait out the rest of a reservation window, then report whether a broadcast
+/// repair was swallowed by it (#5510).
+///
+/// Polls the throttle's OWN clock — the injected `hosting_time_source_override`
+/// in sims, the wall clock in prod — so sim pacing stays deterministic, with the
+/// same tokio-time liveness backstop the #4862 re-delivery uses: a decoupled
+/// injected clock that FREEZES before its deadline would otherwise spin this
+/// forever. The backstop is measured from the start of THIS wait, so under a
+/// frozen injected clock a chain iteration can burn up to two reservation
+/// intervals of tokio time rather than one. That is immaterial (the bound exists
+/// only to stop an unbounded spin) and is stated rather than left to be
+/// discovered.
+///
+/// Consuming the flag rather than peeking it is what bounds the trailing emit to
+/// one per window even if two waiters ever reach the same deadline.
+async fn wait_for_reservation_close(
+    op_manager: &OpManager,
+    key: ContractKey,
+    sender_addr: SocketAddr,
+    incoming_tx: Transaction,
+    reservation_deadline: Instant,
+) -> bool {
+    let started = tokio::time::Instant::now();
+    while op_manager.interest_manager.now() < reservation_deadline {
+        if started.elapsed() >= RESYNC_REQUEST_MIN_INTERVAL {
+            tracing::debug!(
+                tx = %incoming_tx,
+                contract = %key,
+                event = "coalesced_resync_backstop",
+                "UPDATE relay: tokio liveness backstop elapsed (injected clock \
+                 stalled), abandoning the trailing coalesced ResyncRequest (#5510)"
+            );
+            return false;
+        }
+        tokio::time::sleep(QUEUE_FULL_RESYNC_RETRY_POLL_INTERVAL).await;
+    }
+    op_manager
+        .interest_manager
+        .take_resync_drop_during_window(&key, sender_addr)
+}
+
+/// Enqueue one `ResyncRequest` to `sender_addr`.
+///
+/// Blocking best-effort: the path is lossy (`notify_node_event` -> event loop ->
+/// `P2pBridge::try_send`), which is what the #4862 re-delivery exists to cover.
+async fn dispatch_resync_request(
+    op_manager: &OpManager,
+    key: ContractKey,
+    sender_addr: SocketAddr,
+    incoming_tx: Transaction,
+) {
     if let Err(e) = op_manager
         .notify_node_event(NodeEvent::SendInterestMessage {
             target: sender_addr,
@@ -4106,7 +4286,15 @@ mod tests {
         // lock) then RELEASED (`cancel`) if the global cap rejects (#4864 round-6
         // item 2), so concurrent callbacks can't both pass and a globally
         // suppressed emit does not burn the window.
-        let helper = fn_body("async fn send_dropped_broadcast_resync_request(");
+        // #5510 re-anchor: the gates now live in `reserve_resync_emit`, which
+        // `send_dropped_broadcast_resync_request` calls before anything else.
+        // The property is unchanged — nothing is emitted until both gates pass —
+        // and it is now checked where the gates actually are. The `emit` anchor
+        // is the correlation record rather than the wire message, because the
+        // enqueue moved to `dispatch_resync_request`; the record is made at the
+        // same point in the sequence and is what authorizes the response, so it
+        // is the tighter anchor of the two.
+        let helper = fn_body("async fn reserve_resync_emit(");
         let per_sender = helper.find(".begin_resync_request(").expect(
             "helper must RESERVE the per-sender throttle atomically via \
              begin_resync_request (#4864 round-6 item 2)",
@@ -4118,16 +4306,16 @@ mod tests {
             "helper must ALSO gate on the global per-contract emit cap \
              (resync_emit_limiter.check_and_record, #4864 round-4)",
         );
-        let emit = helper
-            .find("InterestMessage::ResyncRequest")
-            .expect("helper must emit InterestMessage::ResyncRequest (heal, #4857)");
+        let emit = helper.find("outstanding_resync_requests").expect(
+            "helper must record the outstanding request that authorizes the heal (#4857/#4864)",
+        );
         let cancel = helper.find(".cancel_resync_request(").expect(
             "helper must CANCEL the reservation when the global cap rejects, so the \
              window is released (#4864 round-6 item 2)",
         );
         assert!(
             per_sender < emit && global_cap < emit,
-            "the ResyncRequest emit ({emit}) MUST come AFTER both the per-sender \
+            "the authorized emit ({emit}) MUST come AFTER both the per-sender \
              throttle reservation ({per_sender}) and the global emit cap ({global_cap}), \
              so an unthrottled emission cannot re-open the #4251 storm"
         );
@@ -4342,6 +4530,168 @@ mod tests {
             drain_resync_targets(&mut notification_rx, key).is_empty(),
             "a second queue-full drop within the throttle window MUST NOT emit \
              another ResyncRequest (bounds #4251 amplification)"
+        );
+    }
+
+    /// #5510 trailing edge, the case the throttle used to swallow silently.
+    ///
+    /// Sequence, all on one `(contract, sender)`:
+    ///
+    /// 1. a drop emits the immediate `ResyncRequest`;
+    /// 2. a SECOND drop inside the window emits nothing at the time — that is the
+    ///    #4251 bound working as designed, and before this change it was also the
+    ///    end of the story: nothing ever re-sent it;
+    /// 3. at the reservation deadline exactly ONE coalesced `ResyncRequest` fires.
+    ///
+    /// The count is taken in two windows rather than as a single total, and that
+    /// is what makes it a real test of the DEADLINE rather than of the emit. A
+    /// total-only assertion passes just as happily if the trailing emit fires
+    /// immediately. Verified against the mutation: deleting the
+    /// `while ... < reservation_deadline` wait makes this FAIL, because the sweep
+    /// then consumes the flag before step 2 has set it and no fourth request ever
+    /// appears.
+    ///
+    /// The 2 requests counted before the deadline are the #4862 retry's, which is
+    /// unrelated machinery: no `ResyncResponse` can arrive in this harness, so its
+    /// correlation gate never trips and it uses its full budget.
+    #[tokio::test(start_paused = true)]
+    async fn drop_swallowed_by_throttle_window_emits_one_coalesced_resync_at_the_deadline() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("coalesced-resync-5510-deadline").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([21u8; 32]),
+            CodeHash::new([22u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12400".parse().unwrap();
+
+        let drop_once = |bytes: Vec<u8>| {
+            drive_relay_broadcast_to(
+                &op_manager,
+                Transaction::new::<UpdateMsg>(),
+                key,
+                DeltaOrFullState::Delta(bytes),
+                Vec::new(),
+                sender_addr,
+                crate::ring::broadcast_coverage::CoveredPeers::empty(),
+            )
+        };
+
+        // (1) First drop → the immediate ResyncRequest.
+        let r1 = drop_once(vec![1, 2, 3]).await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "the first drop must emit its immediate ResyncRequest"
+        );
+
+        // (2) Second drop, different bytes so it is not a dedup hit, inside the
+        //     held window → refused by the throttle, nothing emitted NOW.
+        let r2 = drop_once(vec![4, 5, 6]).await;
+        assert!(
+            r2.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "second broadcast should still hit queue-full, got {r2:?}"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "a second drop inside the throttle window MUST NOT emit immediately — \
+             that is the #4251 amplification bound"
+        );
+
+        // Run to just BEFORE the reservation deadline. Only the #4862 retries
+        // may fire in here; the trailing sweep must not have run yet.
+        let mut before_deadline = Vec::new();
+        for _ in 0..58 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            before_deadline.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert_eq!(
+            before_deadline.len(),
+            QUEUE_FULL_RESYNC_MAX_RETRIES as usize,
+            "before the deadline only the #4862 retries may fire ({} of them); the \
+             coalesced repair must WAIT for the window to close, got {:?}",
+            QUEUE_FULL_RESYNC_MAX_RETRIES,
+            before_deadline
+        );
+
+        // (3) Cross the deadline. Stop 1s past it: a fresh reservation is taken
+        //     by the coalesced emit, and ITS first retry is >= 1.6s out, so it
+        //     cannot contaminate this count.
+        let mut at_deadline = Vec::new();
+        for _ in 0..4 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            at_deadline.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert_eq!(
+            at_deadline,
+            vec![sender_addr],
+            "exactly ONE coalesced ResyncRequest must fire when the window closes \
+             — one full-state response repairs every drop the window swallowed, so \
+             one request covers any number of them (#5510)"
+        );
+    }
+
+    /// #5510 negative control for the test above: with NO drop swallowed by the
+    /// window, nothing extra fires when it closes.
+    ///
+    /// Without this, the deadline test would still pass if the sweep emitted
+    /// unconditionally — which would be a new unthrottled emission per window per
+    /// pair, exactly the #4251 shape the throttle exists to prevent.
+    #[tokio::test(start_paused = true)]
+    async fn no_drop_during_the_window_emits_nothing_when_it_closes() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("coalesced-resync-5510-control").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([23u8; 32]),
+            CodeHash::new([24u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12500".parse().unwrap();
+
+        // ONE drop only. No second broadcast, so the window swallows nothing.
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "the drop must emit its immediate ResyncRequest"
+        );
+
+        // Run past the reservation deadline.
+        let mut emitted = Vec::new();
+        for _ in 0..64 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            emitted.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert_eq!(
+            emitted.len(),
+            QUEUE_FULL_RESYNC_MAX_RETRIES as usize,
+            "with nothing swallowed by the window, the ONLY additional requests \
+             may be the #4862 retries — a sweep that emits unconditionally would \
+             be a new per-window unthrottled emission (#4251), got {emitted:?}"
         );
     }
 
@@ -5042,9 +5392,13 @@ mod tests {
     #[test]
     fn queue_full_resync_helper_goes_through_global_emit_cap() {
         let src = include_str!("op_ctx_task.rs");
+        // #5510: the gates moved into `reserve_resync_emit`, the one function
+        // both emit paths (the initial drop and the trailing coalesced repair)
+        // go through. Pinning it there is what stops a second emit path being
+        // hand-inlined without the cap.
         let start = src
-            .find("async fn send_dropped_broadcast_resync_request(")
-            .expect("send_dropped_broadcast_resync_request not found");
+            .find("async fn reserve_resync_emit(")
+            .expect("reserve_resync_emit not found");
         let after = &src[start + 1..];
         let end = after
             .find("\nasync fn ")
@@ -5095,13 +5449,38 @@ mod tests {
                 .find("\nasync fn ")
                 .unwrap_or(prod.len() - retry_start - 1);
 
+        // ALSO exempt `dispatch_resync_request` (#5510). It is the shared
+        // enqueue, split out so the initial drop and the trailing coalesced
+        // repair send through one body instead of two hand-inlined copies. It
+        // holds no gate and makes no decision: every caller reaches it only
+        // after `reserve_resync_emit` has taken both gates AND made the
+        // `outstanding_resync_requests.record(...)` this pin is about. The
+        // guarantee is therefore intact — it has just moved one call up.
+        //
+        // The exemption is narrow ON PURPOSE: it is keyed to this function's
+        // name, so a NEW emit site elsewhere is still caught. Before adding
+        // another exemption, check that the record really is made on every path
+        // that reaches it — an emit whose response is dropped unapplied by the
+        // #4864 gate is a silently useless repair, which is the failure this
+        // pin exists to prevent.
+        let dispatch_start = prod
+            .find("async fn dispatch_resync_request(")
+            .expect("dispatch_resync_request (the #5510 shared enqueue) not found");
+        let dispatch_end = dispatch_start
+            + 1
+            + prod[dispatch_start + 1..]
+                .find("\nasync fn ")
+                .unwrap_or(prod.len() - dispatch_start - 1);
+
         let mut emits = 0usize;
         let mut cursor = 0usize;
         while let Some(rel) = prod[cursor..].find("message: InterestMessage::ResyncRequest") {
             let pos = cursor + rel;
             cursor = pos + 1;
-            // Skip the exempt retry re-delivery (see above).
-            if (retry_start..retry_end).contains(&pos) {
+            // Skip the exempt retry re-delivery and the shared enqueue (see above).
+            if (retry_start..retry_end).contains(&pos)
+                || (dispatch_start..dispatch_end).contains(&pos)
+            {
                 continue;
             }
             emits += 1;
@@ -5150,10 +5529,53 @@ mod tests {
                  receive arm would drop its response as unsolicited (#4864 round-8)"
             );
         }
+        // #5510: `dispatch_resync_request` is now the shared enqueue, so its CALL
+        // SITES are emit sites for this pin's purposes and must carry the same
+        // guarantee. Each must be preceded, in its own enclosing fn, by the
+        // `reserve_resync_emit(` that takes both gates AND makes the record.
+        //
+        // Without this the exemption above would be a hole: a new caller could
+        // enqueue a ResyncRequest with no record at all and the loop would never
+        // see it, because the only literal emit lives in the exempt function.
+        let mut dispatches = 0usize;
+        let mut cursor = 0usize;
+        while let Some(rel) = prod[cursor..].find("dispatch_resync_request(") {
+            let pos = cursor + rel;
+            cursor = pos + 1;
+            // Skip the definition itself.
+            if (dispatch_start..dispatch_end).contains(&pos) {
+                continue;
+            }
+            dispatches += 1;
+            let fn_start = [
+                "\nasync fn ",
+                "\nfn ",
+                "\npub async fn ",
+                "\npub fn ",
+                "\npub(",
+            ]
+            .iter()
+            .filter_map(|kw| prod[..pos].rfind(kw))
+            .max()
+            .unwrap_or(0);
+            let window: String = prod[fn_start..pos]
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect();
+            assert!(
+                window.contains("reserve_resync_emit("),
+                "a dispatch_resync_request call at byte {pos} is NOT preceded by a \
+                 reserve_resync_emit(...) in the same fn — it would enqueue a \
+                 ResyncRequest with no gates and no correlation record, and the \
+                 receive arm would drop its response unapplied (#4864 round-8/#5510)"
+            );
+        }
+
         assert!(
-            emits >= 2,
-            "expected at least the queue-full-helper and delta-failure ResyncRequest \
-             emit sites in production ({emits} found) — has the emit path moved?"
+            emits + dispatches >= 2,
+            "expected at least the dropped-broadcast and delta-failure ResyncRequest \
+             emit sites in production ({emits} literal + {dispatches} via the shared \
+             enqueue) — has the emit path moved?"
         );
     }
 
@@ -5885,11 +6307,25 @@ mod tests {
              — each redundant request costs another full-state ResyncResponse \
              onto a just-saturated receiver (#4863). Got {retries:?}"
         );
+        // #5510 changed WHEN the slot is released, not whether. The task now also
+        // owns the trailing-edge sweep, so it holds the slot until the
+        // reservation window closes rather than returning as soon as the retry
+        // burst is skipped. Assert the property that actually matters — the slot
+        // is never LEAKED — by running past the deadline and requiring it back.
+        // Nothing was swallowed by this window, so the chain ends there.
+        for _ in 0..70 {
+            if op_manager.interest_manager.outstanding_resync_retries() == 0 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+        }
         assert_eq!(
             op_manager.interest_manager.outstanding_resync_retries(),
             0,
-            "skipping the retry must RELEASE the node-wide retry slot (the task \
-             returns and its RAII guard drops), never burn it (#4862 P1)"
+            "the follow-up task must free its node-wide slot once the reservation \
+             window closes with nothing swallowed — a slot held forever would \
+             starve the node-wide cap (#4862 P1/#5510)"
         );
     }
 
@@ -5971,10 +6407,21 @@ mod tests {
             "once the response lands mid-burst, every REMAINING attempt must be \
              skipped — the gate is re-evaluated per attempt (#4863). Got {retries:?}"
         );
+        // #5510: as above, the slot is now held until the window closes rather
+        // than until the retry burst ends. Run past the deadline and require it
+        // back; nothing was swallowed here, so the chain ends.
+        for _ in 0..70 {
+            if op_manager.interest_manager.outstanding_resync_retries() == 0 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+        }
         assert_eq!(
             op_manager.interest_manager.outstanding_resync_retries(),
             0,
-            "the retry task must exit and free its node-wide slot (#4862 P1)"
+            "the follow-up task must exit and free its node-wide slot once the \
+             reservation window closes (#4862 P1/#5510)"
         );
     }
 
@@ -6304,33 +6751,56 @@ mod tests {
         // per-(contract, sender) throttle reservation (`begin_resync_request`) and
         // the global per-contract emit cap (`resync_emit_limiter`, #4864) — so it
         // never runs on a throttled or globally-suppressed drop.
-        let helper = fn_body("async fn send_dropped_broadcast_resync_request(");
+        // #5510 re-anchor. The gates are in `reserve_resync_emit` and the spawn
+        // is in `spawn_resync_followups`, so the ordering is now checked in two
+        // steps: the entry point calls reserve BEFORE spawn, and reserve holds
+        // both gates. That is the same guarantee — nothing is scheduled on a
+        // throttled or globally-suppressed drop — expressed against the current
+        // shape.
+        let entry = fn_body("async fn send_dropped_broadcast_resync_request(");
+        let reserve = entry
+            .find("reserve_resync_emit(")
+            .expect("the entry point must take the gates via reserve_resync_emit (#4251/#4864)");
+        let followups = entry
+            .find("spawn_resync_followups(")
+            .expect("the entry point must schedule the follow-ups (heal #4857 P2 / #5510)");
+        assert!(
+            reserve < followups,
+            "the gates ({reserve}) MUST be taken before the follow-up task is \
+             spawned ({followups}), so a throttled or globally-suppressed drop \
+             schedules nothing"
+        );
+
+        let helper = fn_body("async fn reserve_resync_emit(");
         let gate = helper
             .find(".begin_resync_request(")
             .expect("helper must gate on begin_resync_request (per-sender throttle, #4251)");
         let global_cap = helper
             .find("resync_emit_limiter")
             .expect("helper must gate on the global per-contract emit cap (#4864)");
+        let record = helper
+            .find("outstanding_resync_requests")
+            .expect("helper must record the outstanding request the follow-ups rely on");
+        assert!(
+            gate < record && global_cap < record,
+            "the correlation record MUST come AFTER both the begin_resync_request \
+             reservation and the global emit-cap gate, so the follow-ups only run \
+             within a granted, globally-authorized reservation (never on a \
+             throttled or suppressed drop)"
+        );
+        // #5510: the spawn itself moved to `spawn_resync_followups`, which the
+        // entry point calls only after the gates (asserted above). The slot and
+        // Drop-guard assertions below therefore read that function.
+        let helper = fn_body("fn spawn_resync_followups(");
         let spawn = helper
-            .find("resend_dropped_broadcast_resync_request(")
-            .expect("helper must schedule the trailing retry (heal #4857 P2)");
-        assert!(
-            gate < spawn && global_cap < spawn,
-            "the trailing-retry spawn MUST come AFTER both the begin_resync_request \
-             reservation and the global emit-cap gate, so retries only run within a \
-             granted, globally-authorized reservation (never on a throttled or \
-             suppressed drop)"
-        );
-        assert!(
-            helper.contains("GlobalExecutor::spawn("),
-            "the trailing retry must be a spawned background task"
-        );
+            .find("GlobalExecutor::spawn(")
+            .expect("the follow-ups must be a spawned background task");
 
-        // (1a) The retry spawn is gated on a node-wide slot (#4862 P1) so LRU
-        // churn cannot spawn unbounded overlapping retry tasks, and the slot is
-        // moved INTO the task (freed on completion via its Drop guard).
+        // (1a) The spawn is gated on a node-wide slot (#4862 P1) so LRU churn
+        // cannot spawn unbounded overlapping tasks, and the slot is moved INTO
+        // the task (freed on completion via its Drop guard).
         let reserve = helper.find("try_reserve_resync_retry_slot(").expect(
-            "retry spawn must be gated on interest_manager.try_reserve_resync_retry_slot() (#4862 P1)",
+            "the spawn must be gated on interest_manager.try_reserve_resync_retry_slot() (#4862 P1)",
         );
         assert!(
             reserve < spawn,
@@ -6343,41 +6813,44 @@ mod tests {
              on task completion (#4862 P1)"
         );
 
-        // (1b) The retry is spawned CONCURRENTLY, BEFORE the blocking immediate
-        // enqueue (#4862 P2), so its timer runs DURING a backpressured send —
-        // otherwise a send that consumed the whole window would leave the task
-        // starting past the deadline with zero retries.
-        let immediate_send = helper
-            .find(".notify_node_event(")
-            .expect("helper must perform the immediate (blocking) ResyncRequest enqueue");
+        // (1b) The follow-ups are spawned CONCURRENTLY, BEFORE the blocking
+        // immediate enqueue (#4862 P2), so the retry timer runs DURING a
+        // backpressured send — otherwise a send that consumed the whole window
+        // would leave the task starting past the deadline with zero retries.
+        // #5510: the enqueue moved into `dispatch_resync_request`, so the
+        // ordering is now read off the entry point's call sequence, which is
+        // where it is actually decided.
+        let immediate_send = entry
+            .find("dispatch_resync_request(")
+            .expect("the entry point must perform the immediate (blocking) enqueue");
         assert!(
-            spawn < immediate_send,
-            "the retry spawn MUST come BEFORE the blocking .notify_node_event() \
-             immediate send (#4862 P2), so the retry timer runs during a \
-             backpressured enqueue"
+            followups < immediate_send,
+            "the follow-up spawn ({followups}) MUST come BEFORE the blocking \
+             dispatch_resync_request ({immediate_send}) (#4862 P2), so the retry \
+             timer runs during a backpressured enqueue"
         );
 
-        // The helper passes the reservation deadline into the retry so the burst
-        // is anchored to THIS reservation window (review P2-A).
+        // The deadline is threaded into the follow-ups so the burst is anchored
+        // to THIS reservation window (review P2-A).
         assert!(
             helper.contains("reservation_deadline"),
-            "the helper must thread the reservation deadline from \
+            "the follow-up spawn must thread the reservation deadline from \
              begin_resync_request into the retry (anchor to the window, P2-A)"
         );
 
-        // (1d) #4863: the correlation record MUST be written BEFORE the retry
-        // spawn. The retry's conditional gate READS that record to decide whether
-        // the first request already landed; a task spawned before the record
-        // exists could observe "absent", conclude "landed", and skip the heal.
-        let record = helper.find(".record(*key.id(), sender_addr)").expect(
-            "helper must record the outstanding request for receive-arm \
-             correlation (#4864 round-8)",
-        );
+        // (1d) #4863: the correlation record MUST be written BEFORE the spawn.
+        // The retry's conditional gate READS that record to decide whether the
+        // first request already landed; a task spawned before the record exists
+        // could observe "absent", conclude "landed", and skip the heal. #5510:
+        // the record is in `reserve_resync_emit` (asserted present above), and
+        // the entry point calls it before the spawn — asserted as
+        // `reserve < followups` at the top of this test. Re-state it here with
+        // the record's own anchor so deleting the record is caught too.
         assert!(
-            record < spawn,
-            "the outstanding-request record ({record}) MUST precede the retry \
-             spawn ({spawn}) — the retry's #4863 conditional gate reads it, and a \
-             task that could observe a not-yet-written record would skip the heal"
+            fn_body("async fn reserve_resync_emit(").contains(".record(*key.id(), sender_addr)"),
+            "reserve_resync_emit must record the outstanding request for \
+             receive-arm correlation (#4864 round-8), and it must do so there \
+             because the entry point calls it before spawning the follow-ups"
         );
 
         // (2) The retry body RE-DELIVERS the one already-authorized emit: it must

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1645,6 +1645,26 @@ async fn reserve_resync_emit(
 /// fresh immediate reservation from each new real drop, so the trailing repair
 /// is marginal there; its value is concentrated in the case it exists for, where
 /// traffic STOPS right after a swallowed drop.
+///
+/// # The resulting bound, stated in one place
+///
+/// **One chain per `(contract, sender)` pair per window**, because gate 1 is per
+/// pair and a global-cap refusal now KEEPS the window rather than releasing it
+/// (X1) — so later drops on the pair are `WindowHeld` and hand their debt to the
+/// chain already carrying it, instead of each spawning one of their own.
+///
+/// Node-wide, chains are bounded by
+/// [`crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`] (256)
+/// slots, shared with the #4862 re-delivery. Each chain lives at most
+/// `MAX_COALESCED_RESYNC_WINDOWS` served windows (3) or
+/// [`MAX_COALESCED_RESYNC_ATTEMPTS`] passes (6), whichever comes first, plus the
+/// tokio backstop inside the wait.
+///
+/// There is deliberately no SECOND pool for chains that start owing a repair. An
+/// earlier revision added one, to bound a case where a contract with N dropping
+/// senders spawned N such chains per window. X1 removed the cause of that rather
+/// than capping its effect, so a second pool would now bound something that
+/// cannot happen, at the cost of a limit nobody can reason about.
 const MAX_COALESCED_RESYNC_WINDOWS: u32 = 3;
 
 /// Maximum loop passes for one follow-up chain, however few are SERVED.

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1493,11 +1493,79 @@ async fn reserve_resync_emit(
 /// # Bounds
 ///
 /// One node-wide slot per chain ([`crate::ring::interest::
-/// MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]), held for as long as the chain
-/// runs, and the chain only continues while drops keep being swallowed. Each
-/// iteration emits at most `1 + QUEUE_FULL_RESYNC_MAX_RETRIES` re-deliveries of
-/// one authorized request plus at most one NEW request, per (contract, sender)
-/// per window — the #4251 bound.
+/// MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]), and the chain only continues
+/// while drops keep being swallowed. Each iteration emits at most
+/// `1 + QUEUE_FULL_RESYNC_MAX_RETRIES` re-deliveries of one authorized request
+/// plus at most one NEW request, per (contract, sender) per window — the #4251
+/// bound.
+///
+/// **The slot is held for as long as a repair is OWED, not merely for one
+/// window.** When a gate refuses a coalesced emit the chain keeps the debt and
+/// waits another interval rather than dropping it, so the slot stays occupied
+/// across that wait. [`MAX_COALESCED_RESYNC_WINDOWS`] is what makes that
+/// bounded: the debt can survive at most that many windows, after which the
+/// chain gives up and the guard drops. Without the window cap, "hold the slot
+/// while debt is owed" and "re-arm the debt on every swallowed drop" would
+/// together be an unbounded hold — which is the shape
+/// `.claude/rules/code-style.md` forbids, and the reason the two were designed
+/// together rather than separately.
+/// Maximum consecutive reservation windows one follow-up chain will serve
+/// (#5510, review finding 1).
+///
+/// Without a bound the chain re-reserves for as long as each window keeps
+/// swallowing a drop, so a pair under sustained drops holds its node-wide slot
+/// forever. 256 such pairs — reachable by legitimately busy traffic, not only by
+/// an attacker — would then permanently starve every later pair of BOTH the
+/// #4862 re-delivery and the trailing repair. That is the refreshable-cap shape
+/// `.claude/rules/code-style.md` forbids: an exemption that renews without limit
+/// is not a bound.
+///
+/// Three is generous. A pair that keeps dropping every window is also taking a
+/// fresh immediate reservation from each new real drop, so the trailing repair
+/// is marginal there; its value is concentrated in the case it exists for, where
+/// traffic STOPS right after a swallowed drop.
+const MAX_COALESCED_RESYNC_WINDOWS: u32 = 3;
+
+/// Poll granularity for the trailing-edge wait (#5510).
+///
+/// Deliberately coarser than [`QUEUE_FULL_RESYNC_RETRY_POLL_INTERVAL`]: the
+/// #4862 retry polls at 100 ms because it aims at jittered sub-second targets
+/// inside the window, whereas this wait only has to NOTICE a 30 s deadline. At
+/// 100 ms that was ~300 wakeups per repair, and at the 256-slot cap ~2,500
+/// wakeups/s on exactly the node already loaded enough to saturate it. One
+/// second keeps the worst case ~250/s and still lands the emit within a second
+/// of the window closing, which is nothing against a 30 s window.
+const COALESCED_RESYNC_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Throttle slot for the slot-cap log line (#5510, review finding 14).
+///
+/// The condition fires once per repair attempt on a node that is by definition
+/// loaded enough to have exhausted 256 slots, so an unthrottled line there is a
+/// log storm on the worst possible node. Same reasoning and interval as
+/// `update_rate_limit`'s three throttled signals.
+static SLOT_CAP_LOG: std::sync::Mutex<Option<tokio::time::Instant>> = std::sync::Mutex::new(None);
+
+/// One minute, matching `update_rate_limit::EVICTION_LOG_INTERVAL`.
+const SLOT_CAP_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Whether the slot-cap line is due, stamping the slot when it is.
+fn slot_cap_log_due(now: tokio::time::Instant) -> bool {
+    let mut last = match SLOT_CAP_LOG.lock() {
+        Ok(guard) => guard,
+        // Poisoned only if a previous holder panicked while formatting a log
+        // line. Losing the throttle is not worth propagating a panic here.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let due = match *last {
+        Some(prev) => now.saturating_duration_since(prev) >= SLOT_CAP_LOG_INTERVAL,
+        None => true,
+    };
+    if due {
+        *last = Some(now);
+    }
+    due
+}
+
 fn spawn_resync_followups(
     op_manager: &OpManager,
     key: ContractKey,
@@ -1514,16 +1582,19 @@ fn spawn_resync_followups(
         // compiles `debug!` out — the very reason #5510 was invisible in the
         // field — and because this is the one path where the repair silently
         // does less than the code promises.
-        tracing::info!(
-            tx = %incoming_tx,
-            contract = %key,
-            target = %sender_addr,
-            cap = crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES,
-            event = "resync_retry_slot_cap_reached",
-            "UPDATE relay: at the node-wide resync-retry slot cap; the immediate \
-             ResyncRequest still sends, but this reservation gets no re-delivery \
-             and no trailing coalesced repair (#4862 P1/#5510)"
-        );
+        if slot_cap_log_due(tokio::time::Instant::now()) {
+            tracing::info!(
+                tx = %incoming_tx,
+                contract = %key,
+                target = %sender_addr,
+                cap = crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES,
+                event = "resync_retry_slot_cap_reached",
+                "UPDATE relay: at the node-wide resync-retry slot cap; immediate \
+                 ResyncRequests still send, but reservations are getting no \
+                 re-delivery and no trailing coalesced repair. Throttled to one \
+                 line per minute (#4862 P1/#5510)"
+            );
+        }
         return;
     };
 
@@ -1532,36 +1603,89 @@ fn spawn_resync_followups(
         let _slot = slot; // frees the node-wide slot on task exit
         let mut deadline = reservation_deadline;
         let mut correlated = correlated;
-        loop {
-            resend_dropped_broadcast_resync_request(
-                &op_mgr,
-                key,
-                sender_addr,
-                incoming_tx,
-                deadline,
-                correlated,
-            )
-            .await;
+        // The caller dispatches ITS window's request itself, concurrently with
+        // this spawn (#4862 P2), so the first pass only re-delivers.
+        let mut dispatch_pending = false;
+        // Whether this pass should re-deliver at all. False only after a gate
+        // refused a coalesced emit: there is then no newly-authorized request to
+        // re-deliver, and re-delivering the previous window's would be an emit
+        // outside any reservation — the #4251 bound.
+        let mut deliver = true;
+        // A repair is owed but not yet authorized. Held ACROSS iterations
+        // because the flag is consumed at the window's close, before the gates
+        // run: a refusal after that point would otherwise drop the repair
+        // silently, and if that was the last message on the pair the divergence
+        // would persist to anti-entropy (review finding 16).
+        let mut owed = false;
+        // Windows this chain has served, INCLUDING the caller's.
+        let mut windows_used: u32 = 1;
 
-            // #5510. The re-delivery above can return EARLY (its #4863 gate
-            // stops it once the first response lands); this waits out the rest
-            // of the window regardless, because a drop swallowed AFTER that
-            // response is exactly the case this exists for.
-            if !wait_for_reservation_close(&op_mgr, key, sender_addr, incoming_tx, deadline).await {
+        loop {
+            if deliver {
+                if dispatch_pending {
+                    // CONCURRENT, not sequential. `dispatch_resync_request`
+                    // blocks on `notify_node_event`, which is a `send().await`
+                    // under NOTIFICATION_SEND_TIMEOUT (30s) — the whole window.
+                    // Run sequentially, the re-delivery below would start with
+                    // its deadline already gone and retry nothing. This is the
+                    // same hazard, and the same fix, as the caller spawning
+                    // before its own blocking dispatch (#4862 P2).
+                    tokio::join!(
+                        dispatch_resync_request(&op_mgr, key, sender_addr, incoming_tx),
+                        resend_dropped_broadcast_resync_request(
+                            &op_mgr,
+                            key,
+                            sender_addr,
+                            incoming_tx,
+                            deadline,
+                            correlated,
+                        ),
+                    );
+                } else {
+                    resend_dropped_broadcast_resync_request(
+                        &op_mgr,
+                        key,
+                        sender_addr,
+                        incoming_tx,
+                        deadline,
+                        correlated,
+                    )
+                    .await;
+                }
+            }
+
+            // #5510. The re-delivery can return EARLY (its #4863 gate stops it
+            // once the first response lands); this waits out the rest of the
+            // window regardless, because a drop swallowed AFTER that response is
+            // exactly the case this exists for.
+            if !wait_until_reservation_close(&op_mgr, key, incoming_tx, deadline).await {
+                return;
+            }
+            if !owed {
+                owed = op_mgr
+                    .interest_manager
+                    .take_resync_drop_during_window(&key, sender_addr);
+            }
+            if !owed {
+                // The window closed with nothing swallowed: the chain has done
+                // its job and the slot goes back.
+                return;
+            }
+            if windows_used >= MAX_COALESCED_RESYNC_WINDOWS {
+                tracing::info!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    target = %sender_addr,
+                    windows = windows_used,
+                    event = "coalesced_resync_chain_bound",
+                    "UPDATE relay: dropped-broadcast repair chain hit its window \
+                     bound and is releasing its slot; a pair still dropping this \
+                     steadily repairs from its next immediate reservation (#5510)"
+                );
                 return;
             }
 
-            tracing::info!(
-                tx = %incoming_tx,
-                contract = %key,
-                target = %sender_addr,
-                event = "coalesced_resync_window_closed",
-                "UPDATE relay: a broadcast repair was swallowed by the throttle \
-                 window; emitting one coalesced ResyncRequest now that it has \
-                 closed (#5510)"
-            );
-
-            let Some((next_deadline, next_correlated)) = reserve_resync_emit(
+            match reserve_resync_emit(
                 &op_mgr,
                 key,
                 sender_addr,
@@ -1569,38 +1693,53 @@ fn spawn_resync_followups(
                 DroppedBroadcastReason::DroppedDuringThrottleWindow,
             )
             .await
-            else {
-                // A gate refused the coalesced request (the global per-contract
-                // emit cap is the realistic one). Stop: the next real drop takes
-                // its own reservation, and looping here would spin on a cap.
-                return;
-            };
-            dispatch_resync_request(&op_mgr, key, sender_addr, incoming_tx).await;
-            deadline = next_deadline;
-            correlated = next_correlated;
+            {
+                Some((next_deadline, next_correlated)) => {
+                    owed = false;
+                    deadline = next_deadline;
+                    correlated = next_correlated;
+                    dispatch_pending = true;
+                    deliver = true;
+                }
+                None => {
+                    // A gate refused, realistically the global per-contract emit
+                    // cap: it refills 1/60s while re-reservation runs 1/30s, so
+                    // this is the common case rather than a corner. KEEP `owed`
+                    // and wait one more interval — the cap's `cancel` released
+                    // the window, so the next attempt can take a fresh one.
+                    // Do NOT re-deliver in the meantime (nothing new is
+                    // authorized), and stay under the chain bound.
+                    deadline = op_mgr.interest_manager.now() + RESYNC_REQUEST_MIN_INTERVAL;
+                    dispatch_pending = false;
+                    deliver = false;
+                }
+            }
+            windows_used += 1;
         }
     });
 }
 
-/// Wait out the rest of a reservation window, then report whether a broadcast
-/// repair was swallowed by it (#5510).
+/// Wait out the rest of a reservation window (#5510).
+///
+/// Returns `false` only when the tokio liveness backstop fired, i.e. a decoupled
+/// injected clock froze before its deadline and the caller should give up.
 ///
 /// Polls the throttle's OWN clock — the injected `hosting_time_source_override`
-/// in sims, the wall clock in prod — so sim pacing stays deterministic, with the
-/// same tokio-time liveness backstop the #4862 re-delivery uses: a decoupled
-/// injected clock that FREEZES before its deadline would otherwise spin this
-/// forever. The backstop is measured from the start of THIS wait, so under a
-/// frozen injected clock a chain iteration can burn up to two reservation
-/// intervals of tokio time rather than one. That is immaterial (the bound exists
-/// only to stop an unbounded spin) and is stated rather than left to be
-/// discovered.
+/// in sims, the wall clock in prod — so sim pacing stays deterministic, at
+/// [`COALESCED_RESYNC_POLL_INTERVAL`] rather than the #4862 retry's finer step
+/// (see that constant for the wakeup arithmetic). The backstop is measured from
+/// the start of THIS wait, so under a frozen injected clock one chain iteration
+/// can burn up to two reservation intervals of tokio time rather than one. That
+/// is immaterial — the bound exists only to stop an unbounded spin — and is
+/// stated rather than left to be discovered.
 ///
-/// Consuming the flag rather than peeking it is what bounds the trailing emit to
-/// one per window even if two waiters ever reach the same deadline.
-async fn wait_for_reservation_close(
+/// Deliberately does NOT take the swallowed-drop flag. The caller takes it,
+/// because it must survive a gate refusal that happens after the window closes
+/// (review finding 16); consuming it here would lose the repair in exactly the
+/// case the chain exists to cover.
+async fn wait_until_reservation_close(
     op_manager: &OpManager,
     key: ContractKey,
-    sender_addr: SocketAddr,
     incoming_tx: Transaction,
     reservation_deadline: Instant,
 ) -> bool {
@@ -1616,11 +1755,9 @@ async fn wait_for_reservation_close(
             );
             return false;
         }
-        tokio::time::sleep(QUEUE_FULL_RESYNC_RETRY_POLL_INTERVAL).await;
+        tokio::time::sleep(COALESCED_RESYNC_POLL_INTERVAL).await;
     }
-    op_manager
-        .interest_manager
-        .take_resync_drop_during_window(&key, sender_addr)
+    true
 }
 
 /// Enqueue one `ResyncRequest` to `sender_addr`.
@@ -1873,11 +2010,14 @@ async fn resend_dropped_broadcast_resync_request(
         // make the real response look unsolicited (dropped without applying).
         //
         // Return, don't continue: once the heal has landed every REMAINING
-        // attempt is redundant too, and returning frees the node-wide retry slot
-        // (#4862 P1) via its RAII guard instead of holding it for the rest of the
-        // window. The residual case this cannot cover is a request that landed but
-        // whose response is still in flight — bounded by the same `1 + MAX` cap as
-        // before, never worse than the blind retry it replaces.
+        // attempt is redundant too. NOTE (#5510): returning no longer frees the
+        // node-wide slot — the guard now lives in `spawn_resync_followups`, which
+        // holds it until the reservation window closes and, if drops keep being
+        // swallowed, until the chain's window bound. This return ends the
+        // RE-DELIVERY only; the caller then waits out the window. The residual
+        // case this cannot cover is a request that landed but whose response is
+        // still in flight — bounded by the same `1 + MAX` cap as before, never
+        // worse than the blind retry it replaces.
         if correlated
             && !op_manager
                 .ring
@@ -4186,15 +4326,16 @@ mod tests {
             let start = src.find(name).unwrap_or_else(|| panic!("{name} not found"));
             let after = &src[start + 1..];
             // Terminate on ANY fn opener, not just `async fn` (review finding
-            // 19). Plain `fn`s sit between the async ones this pin slices —
-            // `jittered_resync_retry_delay` between the two resync fns,
-            // `seed_sender_summary_from_broadcast` before the broadcast driver
-            // — so an `async fn`-only terminator ran a slice straight through
-            // them into the NEXT async fn, and a gate deleted from the sliced
-            // function would still satisfy the pin as long as the same
-            // identifier appeared anywhere downstream. Taking the MINIMUM
-            // rather than the first match matters: the openers are not in
-            // source order.
+            // 19). Several plain `fn`s sit between the async ones this pin
+            // slices: `jittered_resync_retry_delay` between the two resync
+            // fns, `seed_sender_summary_from_broadcast` before the broadcast
+            // driver, and — added by this PR — `spawn_resync_followups`
+            // between `reserve_resync_emit` and the next async fn. With an
+            // `async fn`-only terminator a slice ran straight through them,
+            // and a gate deleted from the sliced function would still satisfy
+            // the pin as long as the same identifier appeared anywhere
+            // downstream. Taking the MINIMUM rather than the first match
+            // matters: the openers are not in source order.
             let end = [
                 "\nasync fn ",
                 "\nfn ",
@@ -4637,6 +4778,317 @@ mod tests {
             "exactly ONE coalesced ResyncRequest must fire when the window closes \
              — one full-state response repairs every drop the window swallowed, so \
              one request covers any number of them (#5510)"
+        );
+    }
+
+    /// #5510 review finding 10: at the node-wide slot cap the immediate
+    /// `ResyncRequest` still goes out and NO follow-up task is spawned.
+    ///
+    /// The primitive (`try_reserve_resync_retry_slot` returning `None` at cap)
+    /// has its own test; this covers the BRANCH that reads it, which is where a
+    /// mistake would matter — an early `return` moved above the immediate
+    /// dispatch would silently drop the repair entirely on exactly the loaded
+    /// node that needs it most, and the primitive's test would stay green.
+    #[tokio::test(start_paused = true)]
+    async fn at_the_slot_cap_the_immediate_resync_still_sends_and_nothing_spawns() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("slot-cap-branch-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([61u8; 32]),
+            CodeHash::new([62u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:12900".parse().unwrap();
+
+        // Hold every slot, so the branch under test is the one taken.
+        let held: Vec<_> = (0..crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES)
+            .map(|_| {
+                op_manager
+                    .interest_manager
+                    .try_reserve_resync_retry_slot()
+                    .expect("slots must be available up to the cap")
+            })
+            .collect();
+        assert!(
+            op_manager
+                .interest_manager
+                .try_reserve_resync_retry_slot()
+                .is_none(),
+            "precondition: the cap must now refuse"
+        );
+        let at_cap = op_manager.interest_manager.outstanding_resync_retries();
+
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error from the stand-in handler, got {r1:?}"
+        );
+
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "at the slot cap the IMMEDIATE ResyncRequest must still be sent — the \
+             cap withholds the follow-ups, never the repair itself"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            at_cap,
+            "no follow-up task may be spawned at the cap"
+        );
+
+        // Nothing further may appear: with no task there is no re-delivery and
+        // no trailing sweep. Run well past a full reservation window.
+        for _ in 0..70 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "with no follow-up task, neither the #4862 re-delivery nor the #5510 \
+             trailing sweep may fire"
+        );
+
+        drop(held);
+    }
+
+    /// #5510 review finding 1: the follow-up chain is bounded to
+    /// [`MAX_COALESCED_RESYNC_WINDOWS`] consecutive windows.
+    ///
+    /// Without the bound a chain re-reserves for as long as its windows keep
+    /// swallowing drops, so a pair under sustained load holds its node-wide slot
+    /// forever; 256 such pairs — reachable by legitimately busy traffic, not
+    /// only by an attacker — permanently starve every later pair of both the
+    /// #4862 re-delivery and the trailing repair. That is the refreshable-cap
+    /// shape `.claude/rules/code-style.md` forbids.
+    ///
+    /// # Why this is a source pin and not a behavioural test
+    ///
+    /// A behavioural test cannot reach the bound with today's constants, and I
+    /// measured that rather than assuming it. Two reasons, both structural:
+    ///
+    /// 1. Advancing a chain past a window needs a GRANTED coalesced emit, which
+    ///    needs a token from the global per-contract cap — `EMIT_BURST` 2,
+    ///    refilling once per `EMIT_REFILL_INTERVAL` (60s) against a 30s
+    ///    re-reservation. A chain therefore runs out of tokens long before three
+    ///    granted windows, and terminates on the cap instead.
+    /// 2. Feeding drops in to keep the flag set does not extend the existing
+    ///    chain: a drop that arrives when no reservation is held takes its own
+    ///    reservation and spawns a SEPARATE chain, so the injected traffic
+    ///    creates siblings rather than consecutive swallowed windows for one.
+    ///
+    /// So the bound is defence in depth — it binds only if the emit cap is ever
+    /// loosened or another caller reaches this loop — and a behavioural test
+    /// asserting termination would pass whether or not the bound existed. It did:
+    /// the first version of this test passed with `windows_used >= MAX` mutated
+    /// to `false`, which is exactly the vacuous pin this repo's testing rules
+    /// warn about. Pinning the mechanism is the honest alternative; deleting the
+    /// check fails this test.
+    ///
+    /// `a_cap_refused_coalesced_emit_keeps_its_debt_and_the_chain_terminates`
+    /// covers the termination that IS reachable today.
+    #[test]
+    fn the_followup_chain_is_bounded_by_a_window_count() {
+        let src = include_str!("op_ctx_task.rs");
+        let start = src
+            .find("fn spawn_resync_followups(")
+            .expect("spawn_resync_followups not found");
+        let rest = &src[start + 1..];
+        let end = [
+            "\nasync fn ",
+            "\nfn ",
+            "\npub async fn ",
+            "\npub fn ",
+            "\npub(",
+        ]
+        .iter()
+        .filter_map(|kw| rest.find(kw))
+        .min()
+        .unwrap_or(rest.len());
+        let body: String = src[start..start + 1 + end]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        assert!(
+            body.contains("letmutwindows_used:u32=1;"),
+            "the chain must COUNT the windows it has served, starting at 1 for the \
+             caller's own window — starting at 0 would silently grant one extra"
+        );
+        let compare = body
+            .find("ifwindows_used>=MAX_COALESCED_RESYNC_WINDOWS{")
+            .expect(
+                "the chain must compare its window count against \
+                 MAX_COALESCED_RESYNC_WINDOWS — without it the chain re-reserves \
+                 without limit and holds its node-wide slot forever (#5510 \
+                 finding 1)",
+            );
+        assert!(
+            body[compare..].contains("return;"),
+            "reaching the window bound must RETURN, so the slot guard drops and \
+             the slot goes back to the node-wide pool"
+        );
+        let increment = body.find("windows_used+=1;").expect(
+            "the window count must be incremented, or the comparison above can \
+             never fire",
+        );
+        assert!(
+            increment > compare,
+            "the increment ({increment}) must come AFTER the bound check \
+             ({compare}) — incrementing first would let the chain serve one fewer \
+             window than the constant names, which is a quieter bug than the one \
+             this pin is for but still a mismatch between code and doc"
+        );
+    }
+
+    /// #5510 review finding 11: when the GLOBAL per-contract emit cap refuses
+    /// the coalesced request, the chain gives up within its window bound and
+    /// releases its node-wide slot.
+    ///
+    /// This is the path finding 16 made non-trivial. The flag is consumed at the
+    /// window's close, BEFORE the gates run, so a naive implementation that
+    /// returned on refusal would drop the repair silently — and it is not a
+    /// corner: the emit cap refills once per 60s while re-reservation runs once
+    /// per 30s, so refusal is the common case. The chain therefore keeps the
+    /// debt and retries, which makes the WINDOW BOUND (finding 1) the thing that
+    /// has to stop it. Both properties are asserted here: nothing is emitted
+    /// while the cap refuses, and the slot comes back rather than being held for
+    /// the life of the node.
+    #[tokio::test(start_paused = true)]
+    async fn a_cap_refused_coalesced_emit_keeps_its_debt_and_the_chain_terminates() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("coalesced-cap-refused-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([63u8; 32]),
+            CodeHash::new([64u8; 32]),
+        );
+        let sender_addr: SocketAddr = "127.0.0.1:13100".parse().unwrap();
+
+        // Drop 1: takes the reservation, spends one of the contract's two emit
+        // tokens, and spawns the chain.
+        let r1 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![1, 2, 3]),
+            Vec::new(),
+            sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(
+            r1.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error, got {r1:?}"
+        );
+        assert_eq!(
+            drain_resync_targets(&mut notification_rx, key),
+            vec![sender_addr],
+            "the immediate ResyncRequest must fire"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            1,
+            "the chain must have taken a slot"
+        );
+
+        // Drain the contract's REMAINING emit token directly, so every later
+        // coalesced attempt is refused by the global cap on this frozen clock.
+        while op_manager
+            .ring
+            .resync_emit_limiter
+            .check_and_record(*key.id())
+        {}
+
+        // Drop 2 inside the held window: throttled, flag set, nothing emitted.
+        let r2 = drive_relay_broadcast_to(
+            &op_manager,
+            Transaction::new::<UpdateMsg>(),
+            key,
+            DeltaOrFullState::Delta(vec![4, 5, 6]),
+            Vec::new(),
+            sender_addr,
+            crate::ring::broadcast_coverage::CoveredPeers::empty(),
+        )
+        .await;
+        assert!(
+            r2.as_ref()
+                .err()
+                .is_some_and(|e| e.is_contract_queue_full()),
+            "expected a queue-full error, got {r2:?}"
+        );
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "a second drop inside the window must not emit immediately"
+        );
+
+        // Phase 1 — the first window closes at t=30s and the coalesced emit is
+        // refused, because the contract has no emit token. Nothing may go out
+        // between the close and the cap's 60s refill: an emit past the cap is
+        // the #4251 storm the cap exists to bound.
+        //
+        // The two emits before t=30s are the #4862 re-deliveries of the ALREADY
+        // authorized initial request, which deliberately consult no gate; they
+        // are drained here so the phase-2 assertion sees only new emits.
+        for _ in 0..64 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            drain_resync_targets(&mut notification_rx, key);
+        }
+        let mut during_refusal = Vec::new();
+        for _ in 0..50 {
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            during_refusal.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert!(
+            during_refusal.is_empty(),
+            "while the global emit cap refuses, the chain must emit NOTHING. \
+             Got {during_refusal:?}"
+        );
+        assert!(
+            op_manager.interest_manager.outstanding_resync_retries() > 0,
+            "and it must still be HOLDING its debt rather than having given up — \
+             consuming the flag at the window close and returning on the refusal \
+             would lose the repair, and with the cap refusing 1/60s against a \
+             1/30s re-reservation that is the common case, not a corner (#5510 \
+             finding 16)"
+        );
+
+        // Phase 2 — the cap refills at t=60s and the remembered debt is finally
+        // paid: the coalesced request goes out, and the chain then terminates
+        // and gives its node-wide slot back.
+        let mut after_refill = Vec::new();
+        for _ in 0..200 {
+            if op_manager.interest_manager.outstanding_resync_retries() == 0 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(500)).await;
+            tokio::task::yield_now().await;
+            after_refill.extend(drain_resync_targets(&mut notification_rx, key));
+        }
+        assert!(
+            !after_refill.is_empty(),
+            "once the cap refills, the debt remembered across the refusal MUST be \
+             paid — otherwise a drop swallowed by a window whose coalesced emit \
+             was capped is lost to anti-entropy (#5510 finding 16)"
+        );
+        assert_eq!(
+            op_manager.interest_manager.outstanding_resync_retries(),
+            0,
+            "the chain MUST terminate within MAX_COALESCED_RESYNC_WINDOWS and \
+             release its node-wide slot — holding it indefinitely is how 256 \
+             pairs would starve every later pair (#5510 finding 1)"
         );
     }
 
@@ -5537,13 +5989,78 @@ mod tests {
         // Without this the exemption above would be a hole: a new caller could
         // enqueue a ResyncRequest with no record at all and the loop would never
         // see it, because the only literal emit lives in the exempt function.
+        // `spawn_resync_followups` is the one call site where the ordering is
+        // LOOP-CARRIED rather than textual: its dispatch fires only when
+        // `dispatch_pending` is set, and that flag is set ONLY on the `Some(..)`
+        // arm of `reserve_resync_emit`, one iteration earlier. A positional
+        // check cannot see that, so the mechanism is asserted directly below and
+        // the fn is skipped in the positional scan. Weakening the scan to "the
+        // identifier appears somewhere in the fn" instead would have accepted a
+        // dispatch that no reserve gates at all.
+        let followups = {
+            let start = prod
+                .find("fn spawn_resync_followups(")
+                .expect("spawn_resync_followups not found");
+            let rest = &prod[start + 1..];
+            // Terminate on ANY fn opener, not just `async fn` — the sibling
+            // below this one is a plain `fn` (review finding 19).
+            let end = [
+                "\nasync fn ",
+                "\nfn ",
+                "\npub async fn ",
+                "\npub fn ",
+                "\npub(",
+            ]
+            .iter()
+            .filter_map(|kw| rest.find(kw))
+            .min()
+            .unwrap_or(rest.len());
+            &prod[start..start + 1 + end]
+        };
+        let reserve_in_followups = followups.find("reserve_resync_emit(").expect(
+            "spawn_resync_followups must gate its dispatch on reserve_resync_emit \
+             (#4864 round-8/#5510)",
+        );
+        assert!(
+            followups.contains("let mut dispatch_pending = false;"),
+            "the loop's dispatch flag must start FALSE — the caller dispatches \
+             its own window's request, so a chain that started with it true would \
+             double-send (#4862 P2/#5510)"
+        );
+        let set_pending = followups.find("dispatch_pending = true;").expect(
+            "spawn_resync_followups must set dispatch_pending after a granted \
+             reservation",
+        );
+        assert!(
+            reserve_in_followups < set_pending,
+            "dispatch_pending ({set_pending}) may only be set AFTER \
+             reserve_resync_emit ({reserve_in_followups}) — it is what makes the \
+             loop's dispatch correspond to a granted, correlated reservation"
+        );
+        assert_eq!(
+            followups.matches("dispatch_pending = true;").count(),
+            1,
+            "exactly one site may arm the loop's dispatch; a second one could arm \
+             it without a reservation"
+        );
+        assert!(
+            followups.contains("if dispatch_pending {"),
+            "the loop's dispatch must be guarded by dispatch_pending"
+        );
+        let followups_start = prod
+            .find("fn spawn_resync_followups(")
+            .expect("spawn_resync_followups not found");
+        let followups_end = followups_start + 1 + followups.len();
+
         let mut dispatches = 0usize;
         let mut cursor = 0usize;
         while let Some(rel) = prod[cursor..].find("dispatch_resync_request(") {
             let pos = cursor + rel;
             cursor = pos + 1;
-            // Skip the definition itself.
-            if (dispatch_start..dispatch_end).contains(&pos) {
+            // Skip the definition itself and the loop-carried site above.
+            if (dispatch_start..dispatch_end).contains(&pos)
+                || (followups_start..followups_end).contains(&pos)
+            {
                 continue;
             }
             dispatches += 1;
@@ -6723,15 +7240,16 @@ mod tests {
             let start = src.find(name).unwrap_or_else(|| panic!("{name} not found"));
             let after = &src[start + 1..];
             // Terminate on ANY fn opener, not just `async fn` (review finding
-            // 19). Plain `fn`s sit between the async ones this pin slices —
-            // `jittered_resync_retry_delay` between the two resync fns,
-            // `seed_sender_summary_from_broadcast` before the broadcast driver
-            // — so an `async fn`-only terminator ran a slice straight through
-            // them into the NEXT async fn, and a gate deleted from the sliced
-            // function would still satisfy the pin as long as the same
-            // identifier appeared anywhere downstream. Taking the MINIMUM
-            // rather than the first match matters: the openers are not in
-            // source order.
+            // 19). Several plain `fn`s sit between the async ones this pin
+            // slices: `jittered_resync_retry_delay` between the two resync
+            // fns, `seed_sender_summary_from_broadcast` before the broadcast
+            // driver, and — added by this PR — `spawn_resync_followups`
+            // between `reserve_resync_emit` and the next async fn. With an
+            // `async fn`-only terminator a slice ran straight through them,
+            // and a gate deleted from the sliced function would still satisfy
+            // the pin as long as the same identifier appeared anywhere
+            // downstream. Taking the MINIMUM rather than the first match
+            // matters: the openers are not in source order.
             let end = [
                 "\nasync fn ",
                 "\nfn ",

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -1354,7 +1354,7 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                 // early to find nothing or waking late and holding the slot past
                 // the window.
                 let retry_deadline = deadline;
-                spawn_resync_followups(
+                if !spawn_resync_followups(
                     op_manager,
                     key,
                     sender_addr,
@@ -1362,13 +1362,33 @@ pub(crate) async fn send_dropped_broadcast_resync_request(
                     FollowupStart::OwedOnly {
                         retry_at: retry_deadline,
                     },
-                );
+                ) {
+                    // No slot, so no chain will ever serve the debt just
+                    // recorded — and the window is held with the flag set
+                    // (#5510 N4). Left alone, every drop for the next 30s is
+                    // WindowHeld and emits nothing, and the first drop after the
+                    // window clears the flag on its way past, so the repair is
+                    // stranded for a full window and then forgotten.
+                    //
+                    // Release the reservation so a later drop inside this same
+                    // window can take a fresh one and win a refilled emit token.
+                    // This is the ONE branch where cancelling is right: nothing
+                    // was emitted, so releasing cannot produce a second request
+                    // for one window, and no chain exists to be confused by it.
+                    op_manager
+                        .interest_manager
+                        .cancel_resync_request(&key, sender_addr);
+                }
                 return;
             }
         };
     // Spawn BEFORE the blocking dispatch below; the order matters and is
     // see `spawn_resync_followups` (#4862 P2).
-    spawn_resync_followups(
+    // Deliberately ignored here, unlike the owing path above. A request WAS
+    // emitted for this reservation, so the window must stay held whether or not
+    // a chain got a slot — releasing it would let a second request go out inside
+    // one window, which is the #4251 bound.
+    let _spawned = spawn_resync_followups(
         op_manager,
         key,
         sender_addr,
@@ -1395,9 +1415,13 @@ enum FollowupStart {
     Reserved {
         /// The granted reservation's close, on the throttle's own clock.
         deadline: Instant,
-        /// Whether the correlation record was taken (#4864 round-8). Drives the
-        /// re-delivery's #4863 "did the first request already land" gate.
-        correlated: bool,
+        /// The correlation record's GENERATION (#4864 round-8, #5510 N7), or
+        /// `None` when the strict cap refused it. Drives the re-delivery's
+        /// #4863 "did the first request already land" gate, and the chain's X2
+        /// "was mine answered" check — which asks about THIS generation, not
+        /// about the pair, so a late response to an earlier window cannot be
+        /// mistaken for an answer to this one.
+        correlated: Option<u64>,
     },
     /// The caller was refused by the global emit cap, so nothing was emitted
     /// and nothing is authorized. The chain owes a repair from the outset: it
@@ -1448,7 +1472,7 @@ async fn reserve_resync_emit(
     incoming_tx: Transaction,
     reason: DroppedBroadcastReason,
     note_debt: bool,
-) -> Result<(Instant, bool), ReserveRefusal> {
+) -> Result<(Instant, Option<u64>), ReserveRefusal> {
     // Gate 1 — per-(contract, sender)/30s throttle (#4857/#4862 + #4864 round-6).
     // RESERVE the window atomically (`begin` checks AND records under the
     // throttle's own lock) and return the reservation deadline on the throttle's
@@ -1578,12 +1602,12 @@ async fn reserve_resync_emit(
     // full. A re-dispatch still heals when uncorrelated — the responder clears
     // its cached summary on the ResyncRequest itself (#4857), independently of
     // our correlation record; only the full-state ResyncResponse needs it.
-    let correlated = op_manager
+    let generation = op_manager
         .ring
         .outstanding_resync_requests
-        .record(*key.id(), sender_addr);
+        .record_generation(*key.id(), sender_addr);
 
-    Ok((reservation_deadline, correlated))
+    Ok((reservation_deadline, generation))
 }
 
 /// Spawn the follow-up task that owns everything this reservation still has to
@@ -1731,7 +1755,7 @@ fn spawn_resync_followups(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
     start: FollowupStart,
-) {
+) -> bool {
     // ONE pool, because X1 removed the reason for two. An earlier round gave
     // owing chains their own smaller pool, on the grounds that a contract with
     // N dropping senders could spawn N of them per window and starve the #4862
@@ -1765,7 +1789,7 @@ fn spawn_resync_followups(
                  (#4862 P1/#5510)"
             );
         }
-        return;
+        return false;
     };
 
     let op_mgr = op_manager.clone();
@@ -1776,7 +1800,7 @@ fn spawn_resync_followups(
                 deadline,
                 correlated,
             } => (deadline, correlated),
-            FollowupStart::OwedOnly { retry_at } => (retry_at, false),
+            FollowupStart::OwedOnly { retry_at } => (retry_at, None),
         };
         // The caller dispatches ITS window's request itself, concurrently with
         // this spawn (#4862 P2), so the first pass only re-delivers.
@@ -1931,11 +1955,19 @@ fn spawn_resync_followups(
                 // served window retries after the responder's window has passed.
                 // Bounded exactly as before by `windows_served` and `attempts`,
                 // so this cannot become a spin.
-                let unanswered = correlated
-                    && op_mgr
+                // OUR generation, not the pair's (#5510 N7). A response carries
+                // no request id, so `is_outstanding` for the pair can be
+                // answered `false` by a LATE reply to a previous window's
+                // request — generated before the drop being repaired, arriving
+                // after this request was recorded. The chain would then exit as
+                // though its own request had landed, and if that request was
+                // responder-throttled or lost the update waits for anti-entropy.
+                let unanswered = correlated.is_some_and(|generation| {
+                    op_mgr
                         .ring
                         .outstanding_resync_requests
-                        .is_outstanding(*key.id(), sender_addr);
+                        .is_generation_outstanding(*key.id(), sender_addr, generation)
+                });
                 if !unanswered {
                     return;
                 }
@@ -2126,6 +2158,7 @@ fn spawn_resync_followups(
             }
         }
     });
+    true
 }
 
 /// Wait out the rest of a reservation window (#5510).
@@ -2323,7 +2356,7 @@ async fn resend_dropped_broadcast_resync_request(
     sender_addr: SocketAddr,
     incoming_tx: Transaction,
     reservation_deadline: Instant,
-    correlated: bool,
+    correlated: Option<u64>,
 ) {
     // Tokio-clock liveness backstop (DST safety). The injected `reservation_deadline`
     // below is the PRIMARY stop, but if the injected clock is a DECOUPLED
@@ -2427,12 +2460,15 @@ async fn resend_dropped_broadcast_resync_request(
         // case this cannot cover is a request that landed but whose response is
         // still in flight — bounded by the same `1 + MAX` cap as before, never
         // worse than the blind retry it replaces.
-        if correlated
-            && !op_manager
+        // Asks about THIS request's generation, not the pair's (#5510 N7): a
+        // late response to a previous window's request would otherwise read as
+        // "ours landed" and cancel a re-delivery that was still needed.
+        if correlated.is_some_and(|generation| {
+            !op_manager
                 .ring
                 .outstanding_resync_requests
-                .is_outstanding(*key.id(), sender_addr)
-        {
+                .is_generation_outstanding(*key.id(), sender_addr, generation)
+        }) {
             // info!, not debug!: `release_max_level_info` compiles debug out of
             // release builds, and this is the ONLY field-visible signal of the
             // gate's decision. Both the benefit (fewer redundant full-state
@@ -4762,6 +4798,21 @@ mod tests {
                 "\nstatic ",
                 "\npub(crate) const ",
                 "\npub(crate) static ",
+                // Type and impl openers too (review round 3, N5). Measured
+                // overruns before this: the `send_dropped_broadcast_resync_request`
+                // slice ran 1325-1428 for a fn ending at 1381, and
+                // `reserve_resync_emit` ran 1444-1647 for one ending at 1587 —
+                // straight through the enum and impl blocks between them, so a
+                // pin could be satisfied by an identifier appearing in a type's
+                // doc comment rather than in the function under test.
+                "\nenum ",
+                "\nstruct ",
+                "\nimpl ",
+                "\n#[derive",
+                "\npub enum ",
+                "\npub struct ",
+                "\npub(crate) enum ",
+                "\npub(crate) struct ",
             ]
             .iter()
             .filter_map(|kw| after.find(kw))
@@ -5469,6 +5520,15 @@ mod tests {
             "\nstatic ",
             "\npub(crate) const ",
             "\npub(crate) static ",
+            // Type and impl openers too (review round 3, N5).
+            "\nenum ",
+            "\nstruct ",
+            "\nimpl ",
+            "\n#[derive",
+            "\npub enum ",
+            "\npub struct ",
+            "\npub(crate) enum ",
+            "\npub(crate) struct ",
         ]
         .iter()
         .filter_map(|kw| rest.find(kw))
@@ -5673,6 +5733,157 @@ mod tests {
             op_manager.interest_manager.outstanding_resync_retries(),
             0,
             "and the chain must exit rather than keep re-reading Unknown"
+        );
+    }
+
+    /// #5510 review round 3 (N4): at the node-wide slot cap, the owing path
+    /// RELEASES its reservation instead of holding a window nothing will serve.
+    ///
+    /// The cap-refused path notes the debt and keeps the window before it knows
+    /// whether a chain can be spawned. If no slot is free, the pair is left
+    /// holding a 30s window with the flag set and nothing watching it: every
+    /// drop inside that window is `WindowHeld` and emits nothing, and the first
+    /// drop after it clears the flag on its way past. The repair is stranded for
+    /// a window and then forgotten.
+    ///
+    /// Releasing lets a later drop inside the same window take a fresh
+    /// reservation and win a refilled token. Nothing was emitted, so releasing
+    /// cannot produce two requests for one window.
+    #[tokio::test(start_paused = true)]
+    async fn at_the_slot_cap_the_owing_path_releases_its_window() {
+        let (op_manager, mut notification_rx, _guard) =
+            build_queue_full_test_node("slot-cap-release-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([97u8; 32]),
+            CodeHash::new([98u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:14300".parse().unwrap();
+
+        // Hold every node-wide slot so no chain can be spawned.
+        let mut slots = Vec::new();
+        while let Some(slot) = op_manager.interest_manager.try_reserve_resync_retry_slot() {
+            slots.push(slot);
+        }
+        assert!(!slots.is_empty(), "precondition: slots must be reservable");
+
+        // Empty the emit bucket so the first drop takes the cap-refused path.
+        while op_manager
+            .ring
+            .resync_emit_limiter
+            .check_and_record(*key.id())
+        {}
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        assert!(
+            drain_resync_targets(&mut notification_rx, key).is_empty(),
+            "the cap refused, so nothing may be emitted"
+        );
+
+        // Probe the throttle directly, still INSIDE what would have been the
+        // first reservation's 30s window. This is the assertion that matters and
+        // it has to be made here: waiting for the window to expire would let a
+        // held reservation pass, since it would have lapsed on its own.
+        //
+        // A token cannot be made available inside the window either (the bucket
+        // refills once per 60s), so "can a later drop emit" is not directly
+        // observable. Whether the WINDOW is free is, and that is precisely what
+        // N4 is about.
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            op_manager
+                .interest_manager
+                .begin_resync_request(&key, target)
+                .is_some(),
+            "the reservation must have been RELEASED when no slot was available \
+             to spawn a chain: held, it would swallow every drop for the rest of \
+             the window while nothing anywhere was watching the flag, and the \
+             first drop after the window would clear it (#5510 N4)"
+        );
+
+        drop(slots);
+    }
+
+    /// #5510 review round 3 (N6): a chain retry refused by the global cap does
+    /// not inflate the suppression counter; an immediate refusal does.
+    ///
+    /// The counter answers "how many repairs did the cap suppress", one per drop
+    /// that wanted one. Counting a chain's retries would make it drift with
+    /// chain length rather than with the thing an operator is asking about, and
+    /// it would drift upward exactly when the cap is busiest.
+    #[tokio::test(start_paused = true)]
+    async fn the_suppression_metric_counts_drops_not_chain_retries() {
+        let (op_manager, _notification_rx, _guard) =
+            build_queue_full_test_node("suppression-metric-5510").await;
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([99u8; 32]),
+            CodeHash::new([100u8; 32]),
+        );
+        let _held = hold_contracts(&op_manager, &[key]).await;
+        let target: SocketAddr = "127.0.0.1:14400".parse().unwrap();
+
+        while op_manager
+            .ring
+            .resync_emit_limiter
+            .check_and_record(*key.id())
+        {}
+
+        let before = crate::config::GlobalTestMetrics::resync_requests_suppressed();
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::RateLimited,
+        )
+        .await;
+        let after_immediate = crate::config::GlobalTestMetrics::resync_requests_suppressed();
+        assert_eq!(
+            after_immediate,
+            before + 1,
+            "an IMMEDIATE repair refused by the cap is one suppressed repair and \
+             must be counted"
+        );
+
+        // Past the window, so gate 1 grants and the retry actually REACHES the
+        // cap. Without this the call is refused by the throttle first and never
+        // touches the counter, and the test passes whatever the guard does — it
+        // did, until the mutation showed it.
+        tokio::time::advance(RESYNC_REQUEST_MIN_INTERVAL + Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !op_manager
+                .ring
+                .resync_emit_limiter
+                .check_and_record(*key.id()),
+            "precondition: the emit bucket must still be empty, or the retry is \
+             granted instead of refused and the guard is never consulted"
+        );
+
+        // The chain's own retry carries DroppedDuringThrottleWindow, and must
+        // not count again: one swallowed drop retried is still one suppressed
+        // repair.
+        send_dropped_broadcast_resync_request(
+            &op_manager,
+            key,
+            target,
+            Transaction::new::<UpdateMsg>(),
+            DroppedBroadcastReason::DroppedDuringThrottleWindow,
+        )
+        .await;
+        assert_eq!(
+            crate::config::GlobalTestMetrics::resync_requests_suppressed(),
+            after_immediate,
+            "a CHAIN RETRY refused by the cap must not increment the counter: \
+             one swallowed drop retried three times is one suppressed repair, \
+             not three"
         );
     }
 
@@ -6157,6 +6368,15 @@ mod tests {
             "\nstatic ",
             "\npub(crate) const ",
             "\npub(crate) static ",
+            // Type and impl openers too (review round 3, N5).
+            "\nenum ",
+            "\nstruct ",
+            "\nimpl ",
+            "\n#[derive",
+            "\npub enum ",
+            "\npub struct ",
+            "\npub(crate) enum ",
+            "\npub(crate) struct ",
         ]
         .iter()
         .filter_map(|kw| rest.find(kw))
@@ -7381,6 +7601,21 @@ mod tests {
                 "\nstatic ",
                 "\npub(crate) const ",
                 "\npub(crate) static ",
+                // Type and impl openers too (review round 3, N5). Measured
+                // overruns before this: the `send_dropped_broadcast_resync_request`
+                // slice ran 1325-1428 for a fn ending at 1381, and
+                // `reserve_resync_emit` ran 1444-1647 for one ending at 1587 —
+                // straight through the enum and impl blocks between them, so a
+                // pin could be satisfied by an identifier appearing in a type's
+                // doc comment rather than in the function under test.
+                "\nenum ",
+                "\nstruct ",
+                "\nimpl ",
+                "\n#[derive",
+                "\npub enum ",
+                "\npub struct ",
+                "\npub(crate) enum ",
+                "\npub(crate) struct ",
             ]
             .iter()
             .filter_map(|kw| prod[..pos].rfind(kw))
@@ -7443,6 +7678,21 @@ mod tests {
                 "\nstatic ",
                 "\npub(crate) const ",
                 "\npub(crate) static ",
+                // Type and impl openers too (review round 3, N5). Measured
+                // overruns before this: the `send_dropped_broadcast_resync_request`
+                // slice ran 1325-1428 for a fn ending at 1381, and
+                // `reserve_resync_emit` ran 1444-1647 for one ending at 1587 —
+                // straight through the enum and impl blocks between them, so a
+                // pin could be satisfied by an identifier appearing in a type's
+                // doc comment rather than in the function under test.
+                "\nenum ",
+                "\nstruct ",
+                "\nimpl ",
+                "\n#[derive",
+                "\npub enum ",
+                "\npub struct ",
+                "\npub(crate) enum ",
+                "\npub(crate) struct ",
             ]
             .iter()
             .filter_map(|kw| rest.find(kw))
@@ -7514,6 +7764,21 @@ mod tests {
                 "\nstatic ",
                 "\npub(crate) const ",
                 "\npub(crate) static ",
+                // Type and impl openers too (review round 3, N5). Measured
+                // overruns before this: the `send_dropped_broadcast_resync_request`
+                // slice ran 1325-1428 for a fn ending at 1381, and
+                // `reserve_resync_emit` ran 1444-1647 for one ending at 1587 —
+                // straight through the enum and impl blocks between them, so a
+                // pin could be satisfied by an identifier appearing in a type's
+                // doc comment rather than in the function under test.
+                "\nenum ",
+                "\nstruct ",
+                "\nimpl ",
+                "\n#[derive",
+                "\npub enum ",
+                "\npub struct ",
+                "\npub(crate) enum ",
+                "\npub(crate) struct ",
             ]
             .iter()
             .filter_map(|kw| prod[..pos].rfind(kw))
@@ -8506,7 +8771,9 @@ mod tests {
                 sender_addr,
                 Transaction::new::<UpdateMsg>(),
                 reservation_deadline,
-                true,
+                // A correlated request, generation 0 — these tests drive the
+                // retry directly rather than through `reserve_resync_emit`.
+                Some(0),
             )
             .await;
         });
@@ -8640,7 +8907,9 @@ mod tests {
                 sender_addr,
                 Transaction::new::<UpdateMsg>(),
                 reservation_deadline,
-                true,
+                // A correlated request, generation 0 — these tests drive the
+                // retry directly rather than through `reserve_resync_emit`.
+                Some(0),
             )
             .await;
         });
@@ -8711,6 +8980,21 @@ mod tests {
                 "\nstatic ",
                 "\npub(crate) const ",
                 "\npub(crate) static ",
+                // Type and impl openers too (review round 3, N5). Measured
+                // overruns before this: the `send_dropped_broadcast_resync_request`
+                // slice ran 1325-1428 for a fn ending at 1381, and
+                // `reserve_resync_emit` ran 1444-1647 for one ending at 1587 —
+                // straight through the enum and impl blocks between them, so a
+                // pin could be satisfied by an identifier appearing in a type's
+                // doc comment rather than in the function under test.
+                "\nenum ",
+                "\nstruct ",
+                "\nimpl ",
+                "\n#[derive",
+                "\npub enum ",
+                "\npub struct ",
+                "\npub(crate) enum ",
+                "\npub(crate) struct ",
             ]
             .iter()
             .filter_map(|kw| after.find(kw))
@@ -8855,7 +9139,8 @@ mod tests {
         // `reserve < followups` at the top of this test. Re-state it here with
         // the record's own anchor so deleting the record is caught too.
         assert!(
-            fn_body("async fn reserve_resync_emit(").contains(".record(*key.id(), sender_addr)"),
+            fn_body("async fn reserve_resync_emit(")
+                .contains(".record_generation(*key.id(), sender_addr)"),
             "reserve_resync_emit must record the outstanding request for \
              receive-arm correlation (#4864 round-8), and it must do so there \
              because the entry point calls it before spawning the follow-ups"
@@ -8886,9 +9171,12 @@ mod tests {
         // still being present (read-only). A blind retry re-sends a request that
         // already landed, which makes the sender clear its summary and ship FULL
         // STATE again onto a receiver whose queue was just full.
-        let landed_gate = retry.find("is_outstanding(").expect(
+        let landed_gate = retry.find("is_generation_outstanding(").expect(
             "the retry must gate each re-dispatch on \
-             outstanding_resync_requests.is_outstanding(...) (#4863)",
+             outstanding_resync_requests.is_generation_outstanding(...) — its OWN \
+             generation, so a late response to an earlier window cannot read as \
+             \"ours landed\" and cancel a re-delivery still needed (#4863, \
+             #5510 N7)",
         );
         let retry_emit = retry
             .find("try_notify_node_event(")

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -307,6 +307,30 @@ const MISSING_SUMMARY_ACTIVE_SIZE: usize = 256;
 pub(crate) const FIRST_MISSING_SUMMARY_SEND_AGE_LABELS: [&str; 5] =
     ["lt_1s", "1_9s", "10_59s", "60_299s", "gte_300s"];
 
+/// One held `ResyncRequest` reservation for a `(contract, target)` pair.
+///
+/// The flag lives HERE, inside the throttle's own LRU value, rather than in a
+/// second map: the reservation is exactly the thing it qualifies, so it is
+/// bounded by [`RESYNC_THROTTLE_CACHE_SIZE`] for free, it is cleared for free
+/// whenever a fresh reservation overwrites the entry, and it cannot outlive the
+/// window it describes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResyncReservation {
+    /// When this reservation was granted, on the manager's `TimeSource`.
+    stamped: Instant,
+    /// A broadcast from `target` for `contract` was DROPPED while this
+    /// reservation was held, so the repair it needed was refused by the
+    /// throttle and nothing else will re-send it (#5510).
+    ///
+    /// Consumed at the window's close by
+    /// `operations::update::op_ctx_task::trailing_coalesced_resync_request`,
+    /// which emits ONE coalesced `ResyncRequest` covering every drop the window
+    /// swallowed. One flag rather than a count, because one full-state
+    /// `ResyncResponse` restores every lost entry at once: the repair does not
+    /// scale with the number of drops, so neither should the signal.
+    dropped_during_window: bool,
+}
+
 /// Node-wide cap on concurrently-outstanding queue-full-resync retry tasks
 /// (#4862 P1). The per-(contract, peer) throttle above is a bounded LRU; under
 /// saturation plus key churn (a peer cycling through more than
@@ -1229,7 +1253,7 @@ pub struct InterestManager<T: TimeSource> {
     /// (contract, target peer address). Bounded LRU so remote peers cannot grow
     /// it without bound. See [`InterestManager::begin_resync_request`] and
     /// issue #4857.
-    resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), Instant>>,
+    resync_request_throttle: Mutex<LruCache<(ContractKey, SocketAddr), ResyncReservation>>,
 
     /// Rotation cursor for the bounded periodic summary reply (#5155, extended
     /// to the digest form by #5238), keyed by the peer's stable transport
@@ -2332,13 +2356,67 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         let now = self.time_source.now();
         let key = (*contract, target);
         let mut throttle = self.resync_request_throttle.lock();
-        if let Some(&last) = throttle.get(&key) {
-            if now.duration_since(last) < RESYNC_REQUEST_MIN_INTERVAL {
+        if let Some(res) = throttle.get(&key) {
+            if now.duration_since(res.stamped) < RESYNC_REQUEST_MIN_INTERVAL {
                 return None;
             }
         }
-        throttle.put(key, now);
+        // Overwriting the entry clears `dropped_during_window` by construction.
+        // That is the ONLY thing keeping a stale flag from causing a spurious
+        // emit later: if the task that would have consumed it died (the
+        // node-wide retry-slot cap, a cancelled runtime), the next granted
+        // reservation drops it on the floor, and that drop is harmless because
+        // the very drop that would have set it again is about to emit anyway.
+        throttle.put(
+            key,
+            ResyncReservation {
+                stamped: now,
+                dropped_during_window: false,
+            },
+        );
         Some(now + RESYNC_REQUEST_MIN_INTERVAL)
+    }
+
+    /// Record that a broadcast repair was REFUSED because this `(contract,
+    /// target)` reservation window is already held (#5510).
+    ///
+    /// Called on the `begin_resync_request` -> `None` path. The flag is read
+    /// once at the window's close; see [`Self::take_resync_drop_during_window`].
+    /// A no-op when no reservation is held, which is correct: without one the
+    /// caller was not throttled and emitted its own request.
+    pub(crate) fn note_resync_drop_during_window(
+        &self,
+        contract: &ContractKey,
+        target: SocketAddr,
+    ) {
+        if let Some(res) = self
+            .resync_request_throttle
+            .lock()
+            .get_mut(&(*contract, target))
+        {
+            res.dropped_during_window = true;
+        }
+    }
+
+    /// Consume the "a drop was swallowed by this window" flag, returning whether
+    /// it was set (#5510).
+    ///
+    /// Consuming rather than peeking is what bounds the trailing emit to at most
+    /// one per window per pair even if two waiters somehow reach the deadline
+    /// for the same reservation.
+    pub(crate) fn take_resync_drop_during_window(
+        &self,
+        contract: &ContractKey,
+        target: SocketAddr,
+    ) -> bool {
+        let mut throttle = self.resync_request_throttle.lock();
+        match throttle.get_mut(&(*contract, target)) {
+            Some(res) => std::mem::replace(&mut res.dropped_during_window, false),
+            // The LRU evicted the reservation under key churn. Nothing to emit:
+            // an evicted reservation means the next drop takes a fresh one and
+            // repairs immediately, which is the stronger outcome anyway.
+            None => false,
+        }
     }
 
     /// Try to reserve a slot for a queue-full-resync retry task (#4862 P1).
@@ -4694,6 +4772,95 @@ mod tests {
     /// amplification); after the window elapses a fresh request is allowed
     /// again. The returned deadline is the reservation window close
     /// (`now + RESYNC_REQUEST_MIN_INTERVAL`) on the manager's clock (#4857 P2).
+    /// #5510: a fresh reservation CLEARS the "a drop was swallowed" flag.
+    ///
+    /// This is the invariant that makes a stale flag harmless, and it is the only
+    /// thing that does. The task that would consume the flag can fail to exist
+    /// (the node-wide retry-slot cap) or die (runtime shutdown, cancellation),
+    /// leaving the flag set with nobody to read it. Without this clearing, the
+    /// NEXT window's sweep would find that stale flag and emit a second, wholly
+    /// unmotivated `ResyncRequest` — one emit for the fresh drop, one for the
+    /// ghost. Overwriting the entry on every grant is what bounds it to one.
+    #[test]
+    fn a_fresh_reservation_clears_the_dropped_during_window_flag() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(7);
+        let addr: SocketAddr = "127.0.0.1:5101".parse().unwrap();
+
+        manager
+            .begin_resync_request(&contract, addr)
+            .expect("first reservation must be granted");
+
+        // A drop is swallowed by the held window, and nothing ever consumes the
+        // flag — the waiter was never spawned (slot cap) or did not survive.
+        manager.note_resync_drop_during_window(&contract, addr);
+
+        // The window closes and a later drop takes a FRESH reservation.
+        time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
+        manager
+            .begin_resync_request(&contract, addr)
+            .expect("a reservation after the window must be granted");
+
+        assert!(
+            !manager.take_resync_drop_during_window(&contract, addr),
+            "the fresh reservation must have cleared the stale flag: that drop is \
+             already repaired by the request this new reservation authorizes, so a \
+             sweep firing on the stale flag would be a SECOND emit for one drop"
+        );
+    }
+
+    /// #5510 companion: within ONE reservation the flag round-trips, and taking
+    /// it CONSUMES it.
+    ///
+    /// Consuming is what bounds the trailing emit to one per window even if two
+    /// waiters somehow reach the same deadline. Without it, the test above could
+    /// pass on an implementation that simply never sets the flag at all.
+    #[test]
+    fn taking_the_dropped_during_window_flag_consumes_it() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(8);
+        let addr: SocketAddr = "127.0.0.1:5102".parse().unwrap();
+
+        manager
+            .begin_resync_request(&contract, addr)
+            .expect("reservation must be granted");
+        assert!(
+            !manager.take_resync_drop_during_window(&contract, addr),
+            "no drop swallowed yet, so the flag must read false"
+        );
+
+        manager.note_resync_drop_during_window(&contract, addr);
+        assert!(
+            manager.take_resync_drop_during_window(&contract, addr),
+            "a swallowed drop must be recorded on the held reservation"
+        );
+        assert!(
+            !manager.take_resync_drop_during_window(&contract, addr),
+            "taking the flag must CONSUME it — two waiters at one deadline must \
+             not both emit"
+        );
+    }
+
+    /// #5510: with no reservation held, recording a swallowed drop is a no-op.
+    ///
+    /// The `None` arm is not defensive padding. `begin_resync_request` returning
+    /// `None` is the only path that records, so a caller that was NOT throttled
+    /// emitted its own request; and the LRU can evict a live reservation under key
+    /// churn. In both cases inventing an entry would resurrect a window that no
+    /// longer exists and hand out an emit nobody is owed.
+    #[test]
+    fn noting_a_swallowed_drop_without_a_reservation_is_a_no_op() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(9);
+        let addr: SocketAddr = "127.0.0.1:5103".parse().unwrap();
+
+        manager.note_resync_drop_during_window(&contract, addr);
+        assert!(
+            !manager.take_resync_drop_during_window(&contract, addr),
+            "with no reservation held there is nothing to flag, and nothing to emit"
+        );
+    }
+
     #[test]
     fn begin_resync_request_rate_limits_per_contract_peer() {
         let (manager, time) = make_manager();

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -334,6 +334,18 @@ pub(crate) struct ResyncReservation {
     dropped_during_window: bool,
 }
 
+impl ResyncReservation {
+    /// When this reservation's window closes, on the manager's `TimeSource`.
+    ///
+    /// This doubles as the reservation's GENERATION: every grant stamps a
+    /// distinct `stamped`, so two reservations for the same pair never share a
+    /// deadline. `take_resync_drop_during_window` compares it so a chain cannot
+    /// consume a debt recorded against a reservation it does not own.
+    fn deadline(&self) -> Instant {
+        self.stamped + RESYNC_REQUEST_MIN_INTERVAL
+    }
+}
+
 /// Node-wide cap on concurrently-outstanding queue-full-resync retry tasks
 /// (#4862 P1). The per-(contract, peer) throttle above is a bounded LRU; under
 /// saturation plus key churn (a peer cycling through more than
@@ -2411,10 +2423,23 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         &self,
         contract: &ContractKey,
         target: SocketAddr,
+        expected_deadline: Instant,
     ) -> bool {
         let mut throttle = self.resync_request_throttle.lock();
         match throttle.get_mut(&(*contract, target)) {
-            Some(res) => std::mem::replace(&mut res.dropped_during_window, false),
+            Some(res) if res.deadline() == expected_deadline => {
+                std::mem::replace(&mut res.dropped_during_window, false)
+            }
+            // A DIFFERENT reservation than the caller's now occupies this key
+            // (review round 2). The map is keyed by pair alone, so without this
+            // check a chain whose own reservation was LRU-evicted — or that
+            // simply outlived it — would reach its deadline and consume a
+            // SIBLING's freshly-recorded debt, emitting the sibling's repair on
+            // the sibling's behalf and leaving the sibling to find nothing.
+            // Comparing the reservation deadline makes the take generational:
+            // each grant stamps a distinct instant, so only the chain that owns
+            // the current reservation can consume its debt.
+            Some(_) => false,
             // The LRU evicted the reservation under key churn. Nothing to emit:
             // an evicted reservation means the next drop takes a fresh one and
             // repairs immediately, which is the stronger outcome anyway.
@@ -4793,12 +4818,12 @@ mod tests {
 
         // The window closes and a later drop takes a FRESH reservation.
         time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
-        manager
+        let fresh = manager
             .begin_resync_request(&contract, addr)
             .expect("a reservation after the window must be granted");
 
         assert!(
-            !manager.take_resync_drop_during_window(&contract, addr),
+            !manager.take_resync_drop_during_window(&contract, addr, fresh),
             "the fresh reservation must have cleared the stale flag: that drop is \
              already repaired by the request this new reservation authorizes, so a \
              sweep firing on the stale flag would be a SECOND emit for one drop"
@@ -4817,21 +4842,21 @@ mod tests {
         let contract = make_contract_key(8);
         let addr: SocketAddr = "127.0.0.1:5102".parse().unwrap();
 
-        manager
+        let deadline = manager
             .begin_resync_request(&contract, addr)
             .expect("reservation must be granted");
         assert!(
-            !manager.take_resync_drop_during_window(&contract, addr),
+            !manager.take_resync_drop_during_window(&contract, addr, deadline),
             "no drop swallowed yet, so the flag must read false"
         );
 
         manager.note_resync_drop_during_window(&contract, addr);
         assert!(
-            manager.take_resync_drop_during_window(&contract, addr),
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
             "a swallowed drop must be recorded on the held reservation"
         );
         assert!(
-            !manager.take_resync_drop_during_window(&contract, addr),
+            !manager.take_resync_drop_during_window(&contract, addr, deadline),
             "taking the flag must CONSUME it — two waiters at one deadline must \
              not both emit"
         );
@@ -4852,8 +4877,54 @@ mod tests {
 
         manager.note_resync_drop_during_window(&contract, addr);
         assert!(
-            !manager.take_resync_drop_during_window(&contract, addr),
+            !manager.take_resync_drop_during_window(
+                &contract,
+                addr,
+                manager.now() + RESYNC_REQUEST_MIN_INTERVAL,
+            ),
             "with no reservation held there is nothing to flag, and nothing to emit"
+        );
+    }
+
+    /// #5510 review round 2: the take is GENERATIONAL — a chain must not consume
+    /// a debt recorded against a DIFFERENT reservation for the same pair.
+    ///
+    /// The throttle map is keyed by `(contract, target)` alone, so a chain that
+    /// outlives its own reservation (its window closed and a sibling took a fresh
+    /// one) would otherwise reach its deadline, find the sibling's freshly-noted
+    /// drop, and emit the sibling's repair on the sibling's behalf. The sibling
+    /// then finds nothing and its own drop goes unrepaired — the exact silent
+    /// loss #5510 exists to close, reintroduced one layer up. Comparing the
+    /// reservation's deadline is what makes the take belong to one generation.
+    #[test]
+    fn a_stale_chain_cannot_consume_a_newer_reservations_swallowed_drop() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(10);
+        let addr: SocketAddr = "127.0.0.1:5104".parse().unwrap();
+
+        let stale = manager
+            .begin_resync_request(&contract, addr)
+            .expect("first reservation must be granted");
+
+        // The first window closes; a sibling takes a fresh reservation and a
+        // drop is swallowed by THAT window.
+        time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
+        let fresh = manager
+            .begin_resync_request(&contract, addr)
+            .expect("a reservation after the window must be granted");
+        assert_ne!(
+            stale, fresh,
+            "each grant must stamp a distinct deadline, or the generation check              cannot tell two reservations apart"
+        );
+        manager.note_resync_drop_during_window(&contract, addr);
+
+        assert!(
+            !manager.take_resync_drop_during_window(&contract, addr, stale),
+            "the STALE chain must not consume a debt owed to the newer              reservation; doing so emits the sibling's repair for it and leaves              the sibling's own drop unrepaired"
+        );
+        assert!(
+            manager.take_resync_drop_during_window(&contract, addr, fresh),
+            "and the debt must still be there for the reservation that owns it"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -344,8 +344,16 @@ pub(crate) enum ResyncDebt {
     /// The reservation is GONE — evicted from the bounded LRU under pair churn
     /// — so whether a drop was swallowed cannot be known. Treat as owed: a
     /// redundant full state costs one response, a missed one costs a divergence
-    /// that persists to anti-entropy. Still bounded by the emit cap and the
-    /// chain bound, so conservatism here cannot amplify.
+    /// that persists to anti-entropy.
+    ///
+    /// The caller must LATCH this to ONE speculative repair per chain (#5510
+    /// N2). The emit cap and the chain bound hold the emit RATE at one per
+    /// window per pair, so conservatism cannot amplify traffic — but they do not
+    /// bound SLOT OCCUPANCY, and the LRU pressure that produces `Unknown`
+    /// persists, so an unlatched chain is re-told "unknown" every window and
+    /// runs to its full served-window bound holding a node-wide slot throughout.
+    /// An earlier version of this comment said "cannot amplify" without that
+    /// distinction, which was true of the one axis and false of the other.
     Unknown,
 }
 
@@ -2374,14 +2382,22 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// has elapsed since the last such request (or none was ever sent), or
     /// `None` when still throttled.
     ///
-    /// The `begin`/[`Self::cancel_resync_request`] reservation-commit pair
-    /// restores atomicity under the double-gate (#4864 round-6 item 2): recording
-    /// under the lock means two concurrent queue-full callbacks for the same
-    /// (contract, target) cannot both pass, so they cannot both consume the global
-    /// burst and emit duplicates inside the window. If a later gate (the global
-    /// per-contract emit cap) then rejects, the caller `cancel`s the reservation
-    /// so the window is released — preserving the round-5 improvement that a
-    /// globally-suppressed emit does not burn the 30s window.
+    /// Recording under the lock is what restores atomicity under the double-gate
+    /// (#4864 round-6 item 2): two concurrent queue-full callbacks for the same
+    /// (contract, target) cannot both pass, so they cannot both consume the
+    /// global burst and emit duplicates inside the window.
+    ///
+    /// When a later gate (the global per-contract emit cap) rejects, the caller
+    /// **keeps** the reservation and marks it as owing a repair
+    /// ([`Self::note_resync_debt_on_held_reservation`]), rather than cancelling
+    /// it (#5510 X1). Cancelling released the window, which read as considerate
+    /// — the sender could retry as soon as tokens refilled — and was, until a
+    /// follow-up chain existed: with the window released, every later drop on
+    /// the pair was refused afresh and spawned a chain of its own, draining the
+    /// node-wide slot pool. Keeping it throttles those later drops into the one
+    /// chain already carrying the debt. The window is not burned either way: the
+    /// chain that owns it serves the debt at its close, and the attempt after
+    /// that takes a FRESH window, because this one has expired by then.
     ///
     /// The returned deadline lets a caller that performs a bounded retry burst
     /// (the UPDATE queue-full path, #4857/#4862 P2) anchor every retry to THIS
@@ -2488,13 +2504,24 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         &self,
         contract: &ContractKey,
         target: SocketAddr,
-    ) {
-        if let Some(res) = self
-            .resync_request_throttle
-            .lock()
-            .get_mut(&(*contract, target))
-        {
-            res.dropped_during_window = true;
+        expected_deadline: Instant,
+    ) -> bool {
+        let now = self.time_source.now();
+        let mut throttle = self.resync_request_throttle.lock();
+        match throttle.get_mut(&(*contract, target)) {
+            // Only a LIVE reservation of the caller's own generation can carry a
+            // debt (review round 3, N1). An unconditional set looked right and
+            // was inert: on an EXPIRED reservation nothing can ever take the
+            // flag — the take requires a matching deadline, and the only holder
+            // of that deadline is the chain that just gave up — and the next
+            // grant `put`s a fresh entry with the flag cleared. So the debt was
+            // written to a slot that had already stopped being read, and the log
+            // beside it claimed the repair had been preserved.
+            Some(res) if res.deadline() == expected_deadline && now < res.deadline() => {
+                res.dropped_during_window = true;
+                true
+            }
+            _ => false,
         }
     }
 
@@ -2576,12 +2603,23 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         self.resync_retry_slots.load(Ordering::Relaxed)
     }
 
-    /// Cancel a reservation made by [`Self::begin_resync_request`]: removes the
-    /// just-recorded throttle window for (contract, target) so the sender can
-    /// retry as soon as the OTHER gate (the global emit cap) refills, rather than
-    /// waiting out the full [`RESYNC_REQUEST_MIN_INTERVAL`] (#4864 round-6 item 2).
-    /// Call only after a `begin` that returned `true` whose send was then rejected
-    /// downstream.
+    /// Cancel a reservation: removes the just-recorded throttle window for
+    /// (contract, target) so the sender can retry immediately.
+    ///
+    /// **No production caller since #5510 X1.** The global-cap path used to call
+    /// this; it now keeps the reservation and marks it as owing a repair
+    /// instead, because releasing the window let every later drop on the pair
+    /// spawn its own follow-up chain. Kept, rather than deleted, only because
+    /// `begin_cancel_resync_request_reservation_semantics` pins the
+    /// reserve-then-release semantics of the throttle itself, which is worth
+    /// keeping testable independently of who calls it. If that test goes, this
+    /// goes with it — do NOT reintroduce a production caller without reading the
+    /// X1 note on `begin_resync_request` first.
+    /// Removes the just-recorded throttle window for (contract, target) so the
+    /// sender can retry as soon as the OTHER gate (the global emit cap) refills,
+    /// rather than waiting out the full [`RESYNC_REQUEST_MIN_INTERVAL`]
+    /// (#4864 round-6 item 2).
+    #[cfg(test)]
     pub fn cancel_resync_request(&self, contract: &ContractKey, target: SocketAddr) {
         self.resync_request_throttle
             .lock()
@@ -5003,6 +5041,58 @@ mod tests {
             ResyncDebt::None,
             "a granted reservation starts with no debt: the caller emits for \
              itself, so nothing is owed to a later sweep"
+        );
+    }
+
+    /// #5510 review round 3 (N1): the debt-note refuses an EXPIRED reservation.
+    ///
+    /// Without this, `note_resync_debt_on_held_reservation` was a set that
+    /// looked effective and was inert. A chain reaching its bound writes the
+    /// flag after `now >= deadline`, so the entry has expired: no take can match
+    /// its generation (the only holder is the chain now leaving), and the next
+    /// grant `put`s a fresh entry with the flag cleared. The debt went to a slot
+    /// that had stopped being read, while the log beside it claimed the repair
+    /// had been preserved.
+    ///
+    /// Refusing makes that visible to the caller, which is what lets the caller
+    /// do the right thing instead — emit.
+    #[test]
+    fn the_debt_note_refuses_an_expired_or_foreign_reservation() {
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(12);
+        let addr: SocketAddr = "127.0.0.1:5106".parse().unwrap();
+
+        let deadline = manager
+            .begin_resync_request(&contract, addr)
+            .expect("reservation must be granted");
+
+        assert!(
+            manager.note_resync_debt_on_held_reservation(&contract, addr, deadline),
+            "a LIVE reservation of the caller's own generation must accept the debt"
+        );
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
+            ResyncDebt::Owed,
+            "and that debt must be takeable by the chain that owns the window"
+        );
+
+        // A deadline that is not this reservation's.
+        assert!(
+            !manager.note_resync_debt_on_held_reservation(
+                &contract,
+                addr,
+                deadline + Duration::from_secs(1),
+            ),
+            "a note against a different generation must be refused rather than \
+             land on someone else's reservation"
+        );
+
+        // Now let the window expire, which is the case that made this inert.
+        time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
+        assert!(
+            !manager.note_resync_debt_on_held_reservation(&contract, addr, deadline),
+            "an EXPIRED reservation must refuse the debt: nothing can take a flag \
+             set on it, so accepting would report a repair that will never happen"
         );
     }
 

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -322,10 +322,13 @@ pub(crate) struct ResyncReservation {
     /// reservation was held, so the repair it needed was refused by the
     /// throttle and nothing else will re-send it (#5510).
     ///
-    /// Consumed at the window's close by
-    /// `operations::update::op_ctx_task::trailing_coalesced_resync_request`,
-    /// which emits ONE coalesced `ResyncRequest` covering every drop the window
-    /// swallowed. One flag rather than a count, because one full-state
+    /// The window's close is detected by
+    /// `operations::update::op_ctx_task::wait_until_reservation_close`, and the
+    /// flag is consumed by that function's caller — the follow-up chain in
+    /// `spawn_resync_followups`, which then emits ONE coalesced `ResyncRequest`
+    /// covering every drop the window swallowed. The chain takes it rather than
+    /// the wait helper so the debt survives a gate refusal that happens after
+    /// the window has closed. One flag rather than a count, because one full-state
     /// `ResyncResponse` restores every lost entry at once: the repair does not
     /// scale with the number of drops, so neither should the signal.
     dropped_during_window: bool,
@@ -4765,13 +4768,6 @@ mod tests {
         );
     }
 
-    /// Issue #4857: `begin_resync_request` must emit at most one
-    /// `ResyncRequest` per (contract, peer) per `RESYNC_REQUEST_MIN_INTERVAL`.
-    /// The first drop heals immediately (returning `Some(deadline)`); a burst of
-    /// further drops within the window is throttled (`None`, bounding the #4251
-    /// amplification); after the window elapses a fresh request is allowed
-    /// again. The returned deadline is the reservation window close
-    /// (`now + RESYNC_REQUEST_MIN_INTERVAL`) on the manager's clock (#4857 P2).
     /// #5510: a fresh reservation CLEARS the "a drop was swallowed" flag.
     ///
     /// This is the invariant that makes a stale flag harmless, and it is the only
@@ -4861,6 +4857,13 @@ mod tests {
         );
     }
 
+    /// Issue #4857: `begin_resync_request` must emit at most one
+    /// `ResyncRequest` per (contract, peer) per `RESYNC_REQUEST_MIN_INTERVAL`.
+    /// The first drop heals immediately (returning `Some(deadline)`); a burst of
+    /// further drops within the window is throttled (`None`, bounding the #4251
+    /// amplification); after the window elapses a fresh request is allowed
+    /// again. The returned deadline is the reservation window close
+    /// (`now + RESYNC_REQUEST_MIN_INTERVAL`) on the manager's clock (#4857 P2).
     #[test]
     fn begin_resync_request_rate_limits_per_contract_peer() {
         let (manager, time) = make_manager();

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -2606,20 +2606,19 @@ impl<T: TimeSource + Sync> InterestManager<T> {
     /// Cancel a reservation: removes the just-recorded throttle window for
     /// (contract, target) so the sender can retry immediately.
     ///
-    /// **No production caller since #5510 X1.** The global-cap path used to call
-    /// this; it now keeps the reservation and marks it as owing a repair
-    /// instead, because releasing the window let every later drop on the pair
-    /// spawn its own follow-up chain. Kept, rather than deleted, only because
-    /// `begin_cancel_resync_request_reservation_semantics` pins the
-    /// reserve-then-release semantics of the throttle itself, which is worth
-    /// keeping testable independently of who calls it. If that test goes, this
-    /// goes with it — do NOT reintroduce a production caller without reading the
-    /// X1 note on `begin_resync_request` first.
+    /// **Exactly one production caller** (#5510 N4): the owing path, when no
+    /// node-wide slot was available to spawn a chain. Nothing was emitted there,
+    /// so releasing the window cannot produce a second request inside one
+    /// window, and leaving it held would strand the debt for a full window and
+    /// then lose it.
+    ///
+    /// Do NOT restore the pre-X1 caller on the global-cap path: releasing the
+    /// window there let every later drop on the pair spawn a chain of its own.
+    /// Read the X1 note on `begin_resync_request` before adding any caller.
     /// Removes the just-recorded throttle window for (contract, target) so the
     /// sender can retry as soon as the OTHER gate (the global emit cap) refills,
     /// rather than waiting out the full [`RESYNC_REQUEST_MIN_INTERVAL`]
     /// (#4864 round-6 item 2).
-    #[cfg(test)]
     pub fn cancel_resync_request(&self, contract: &ContractKey, target: SocketAddr) {
         self.resync_request_throttle
             .lock()

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -334,6 +334,40 @@ pub(crate) struct ResyncReservation {
     dropped_during_window: bool,
 }
 
+/// What a window's close says about whether a repair is owed (#5510, X3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResyncDebt {
+    /// A drop was swallowed by this window and is owed a repair.
+    Owed,
+    /// The reservation is present and nothing was swallowed.
+    None,
+    /// The reservation is GONE — evicted from the bounded LRU under pair churn
+    /// — so whether a drop was swallowed cannot be known. Treat as owed: a
+    /// redundant full state costs one response, a missed one costs a divergence
+    /// that persists to anti-entropy. Still bounded by the emit cap and the
+    /// chain bound, so conservatism here cannot amplify.
+    Unknown,
+}
+
+impl ResyncDebt {
+    /// Whether the chain should emit. `Unknown` counts as owed; see the variant.
+    pub(crate) fn is_owed(self) -> bool {
+        matches!(self, ResyncDebt::Owed | ResyncDebt::Unknown)
+    }
+}
+
+/// Outcome of [`InterestManager::begin_resync_request_or_note_drop`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResyncGrant {
+    /// A fresh reservation was taken; its window closes at `deadline`.
+    Granted { deadline: Instant },
+    /// A reservation for this pair is already held, so no request is
+    /// authorized. When the caller passed `note_debt`, the swallowed drop was
+    /// recorded on the held reservation in the SAME critical section, so the
+    /// chain owning that window will serve it at the window's close.
+    WindowHeld,
+}
+
 impl ResyncReservation {
     /// When this reservation's window closes, on the manager's `TimeSource`.
     ///
@@ -2368,12 +2402,54 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         contract: &ContractKey,
         target: SocketAddr,
     ) -> Option<Instant> {
+        match self.begin_resync_request_or_note_drop(contract, target, false) {
+            ResyncGrant::Granted { deadline } => Some(deadline),
+            ResyncGrant::WindowHeld => None,
+        }
+    }
+
+    /// Take the per-`(contract, target)` reservation, or — if the window is
+    /// already held and `note_debt` is set — record the swallowed drop, ALL
+    /// under one acquisition of the throttle lock (#5510, review round 3).
+    ///
+    /// # Why this must be one critical section
+    ///
+    /// The obvious two-step (`begin_resync_request` returning `None`, then a
+    /// separate `note_resync_drop_during_window`) has a TOCTOU window, and the
+    /// generation check does not close it — that check guards against consuming
+    /// the WRONG generation's debt, not against consuming before the debt is
+    /// written. Between the two locks, on a multi-thread runtime, the owning
+    /// chain can observe `now >= deadline`, take the flag (reading `false`),
+    /// conclude nothing is owed, exit and free its node-wide slot. The refused
+    /// caller's note then lands on an entry no chain is watching, and the drop
+    /// it recorded is never repaired — silently, which is the exact failure
+    /// #5510 exists to close.
+    ///
+    /// Holding one lock across both makes the set and the take MUTUALLY
+    /// EXCLUSIVE by construction: the note happens only while
+    /// `now < deadline`, [`Self::take_resync_drop_during_window`] runs only
+    /// when the caller has reached `now >= deadline`, and both read the same
+    /// clock under the same lock. There is no interleaving in which a flag is
+    /// written after the only reader has decided to stop looking.
+    ///
+    /// Do NOT reintroduce the two-step by calling `begin_resync_request` and
+    /// then noting separately; pinned by
+    /// `reserve_resync_emit_takes_the_window_and_the_debt_atomically`.
+    pub(crate) fn begin_resync_request_or_note_drop(
+        &self,
+        contract: &ContractKey,
+        target: SocketAddr,
+        note_debt: bool,
+    ) -> ResyncGrant {
         let now = self.time_source.now();
         let key = (*contract, target);
         let mut throttle = self.resync_request_throttle.lock();
-        if let Some(res) = throttle.get(&key) {
+        if let Some(res) = throttle.get_mut(&key) {
             if now.duration_since(res.stamped) < RESYNC_REQUEST_MIN_INTERVAL {
-                return None;
+                if note_debt {
+                    res.dropped_during_window = true;
+                }
+                return ResyncGrant::WindowHeld;
             }
         }
         // Overwriting the entry clears `dropped_during_window` by construction.
@@ -2389,17 +2465,26 @@ impl<T: TimeSource + Sync> InterestManager<T> {
                 dropped_during_window: false,
             },
         );
-        Some(now + RESYNC_REQUEST_MIN_INTERVAL)
+        ResyncGrant::Granted {
+            deadline: now + RESYNC_REQUEST_MIN_INTERVAL,
+        }
     }
 
-    /// Record that a broadcast repair was REFUSED because this `(contract,
-    /// target)` reservation window is already held (#5510).
+    /// Mark the reservation this caller JUST took as owing a repair (#5510,
+    /// review round 3, X1).
     ///
-    /// Called on the `begin_resync_request` -> `None` path. The flag is read
-    /// once at the window's close; see [`Self::take_resync_drop_during_window`].
-    /// A no-op when no reservation is held, which is correct: without one the
-    /// caller was not throttled and emitted its own request.
-    pub(crate) fn note_resync_drop_during_window(
+    /// Used on the global-emit-cap refusal, where the per-pair window was
+    /// granted but no request is authorized. The reservation is deliberately
+    /// KEPT rather than cancelled — see the call site — so later drops on the
+    /// pair are throttled into the same chain instead of each spawning one of
+    /// their own. Setting the flag here is what stops that retention from
+    /// swallowing the drop: the chain owning the window serves it at the close.
+    ///
+    /// Distinct from the note inside
+    /// [`Self::begin_resync_request_or_note_drop`], which records a drop
+    /// REFUSED by someone else's window. This records one against a window the
+    /// caller holds.
+    pub(crate) fn note_resync_debt_on_held_reservation(
         &self,
         contract: &ContractKey,
         target: SocketAddr,
@@ -2424,12 +2509,26 @@ impl<T: TimeSource + Sync> InterestManager<T> {
         contract: &ContractKey,
         target: SocketAddr,
         expected_deadline: Instant,
-    ) -> bool {
+    ) -> ResyncDebt {
         let mut throttle = self.resync_request_throttle.lock();
         match throttle.get_mut(&(*contract, target)) {
             Some(res) if res.deadline() == expected_deadline => {
-                std::mem::replace(&mut res.dropped_during_window, false)
+                if std::mem::replace(&mut res.dropped_during_window, false) {
+                    ResyncDebt::Owed
+                } else {
+                    ResyncDebt::None
+                }
             }
+            // The chain's OWN reservation is gone from the map (review round 3,
+            // X3). The throttle is a bounded LRU, so under pair churn an entry
+            // can be evicted mid-window — taking any flag set on it with it. The
+            // chain cannot tell "no drop was swallowed" from "a drop was
+            // swallowed and the record was evicted", and those need opposite
+            // responses. Reporting it as `Unknown` lets the caller repair
+            // conservatively rather than exit on an absence it cannot interpret,
+            // which is the difference between one redundant full state and a
+            // silently unrepaired divergence.
+            None => ResyncDebt::Unknown,
             // A DIFFERENT reservation than the caller's now occupies this key
             // (review round 2). The map is keyed by pair alone, so without this
             // check a chain whose own reservation was LRU-evicted — or that
@@ -2439,11 +2538,7 @@ impl<T: TimeSource + Sync> InterestManager<T> {
             // Comparing the reservation deadline makes the take generational:
             // each grant stamps a distinct instant, so only the chain that owns
             // the current reservation can consume its debt.
-            Some(_) => false,
-            // The LRU evicted the reservation under key churn. Nothing to emit:
-            // an evicted reservation means the next drop takes a fresh one and
-            // repairs immediately, which is the stronger outcome anyway.
-            None => false,
+            Some(_) => ResyncDebt::None,
         }
     }
 
@@ -4814,7 +4909,11 @@ mod tests {
 
         // A drop is swallowed by the held window, and nothing ever consumes the
         // flag — the waiter was never spawned (slot cap) or did not survive.
-        manager.note_resync_drop_during_window(&contract, addr);
+        assert_eq!(
+            manager.begin_resync_request_or_note_drop(&contract, addr, true),
+            ResyncGrant::WindowHeld,
+            "a second drop inside the window must be refused"
+        );
 
         // The window closes and a later drop takes a FRESH reservation.
         time.advance_time(RESYNC_REQUEST_MIN_INTERVAL);
@@ -4822,8 +4921,9 @@ mod tests {
             .begin_resync_request(&contract, addr)
             .expect("a reservation after the window must be granted");
 
-        assert!(
-            !manager.take_resync_drop_during_window(&contract, addr, fresh),
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, fresh),
+            ResyncDebt::None,
             "the fresh reservation must have cleared the stale flag: that drop is \
              already repaired by the request this new reservation authorizes, so a \
              sweep firing on the stale flag would be a SECOND emit for one drop"
@@ -4845,18 +4945,26 @@ mod tests {
         let deadline = manager
             .begin_resync_request(&contract, addr)
             .expect("reservation must be granted");
-        assert!(
-            !manager.take_resync_drop_during_window(&contract, addr, deadline),
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
+            ResyncDebt::None,
             "no drop swallowed yet, so the flag must read false"
         );
 
-        manager.note_resync_drop_during_window(&contract, addr);
-        assert!(
-            manager.take_resync_drop_during_window(&contract, addr, deadline),
-            "a swallowed drop must be recorded on the held reservation"
+        assert_eq!(
+            manager.begin_resync_request_or_note_drop(&contract, addr, true),
+            ResyncGrant::WindowHeld,
+            "the window is held, so this drop must be refused"
         );
-        assert!(
-            !manager.take_resync_drop_during_window(&contract, addr, deadline),
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
+            ResyncDebt::Owed,
+            "a swallowed drop must be recorded on the held reservation, and it \
+             must be recorded by the SAME call that refused it"
+        );
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
+            ResyncDebt::None,
             "taking the flag must CONSUME it — two waiters at one deadline must \
              not both emit"
         );
@@ -4875,14 +4983,72 @@ mod tests {
         let contract = make_contract_key(9);
         let addr: SocketAddr = "127.0.0.1:5103".parse().unwrap();
 
-        manager.note_resync_drop_during_window(&contract, addr);
+        // No reservation held, so this GRANTS rather than refusing — there is
+        // no window to record a debt against, and inventing one would hand out
+        // an emit nobody is owed.
         assert!(
-            !manager.take_resync_drop_during_window(
+            matches!(
+                manager.begin_resync_request_or_note_drop(&contract, addr, true),
+                ResyncGrant::Granted { .. }
+            ),
+            "with no reservation held the caller is not throttled, so it takes \
+             the window and emits its own request"
+        );
+        assert_eq!(
+            manager.take_resync_drop_during_window(
                 &contract,
                 addr,
                 manager.now() + RESYNC_REQUEST_MIN_INTERVAL,
             ),
-            "with no reservation held there is nothing to flag, and nothing to emit"
+            ResyncDebt::None,
+            "a granted reservation starts with no debt: the caller emits for \
+             itself, so nothing is owed to a later sweep"
+        );
+    }
+
+    /// #5510 review round 3 (X3): an evicted reservation reads as UNKNOWN, not
+    /// as "nothing owed".
+    ///
+    /// The throttle is a bounded LRU. Under pair churn it can evict a live
+    /// reservation mid-window, taking any dropped-during-window flag with it.
+    /// The chain then cannot distinguish "no drop was swallowed" from "a drop
+    /// was swallowed and the record is gone" — and those need opposite
+    /// responses. Reporting a bare `false` made the chain exit, so the drop went
+    /// unrepaired until anti-entropy, silently.
+    ///
+    /// The conservative reading costs at most one redundant full state, and is
+    /// still bounded by the emit cap and the chain bound. The other error is
+    /// unbounded in time.
+    #[test]
+    fn an_evicted_reservation_reads_as_unknown_rather_than_unowed() {
+        let (manager, _time) = make_manager();
+        let contract = make_contract_key(11);
+        let addr: SocketAddr = "127.0.0.1:5105".parse().unwrap();
+
+        let deadline = manager
+            .begin_resync_request(&contract, addr)
+            .expect("first reservation must be granted");
+        manager.begin_resync_request_or_note_drop(&contract, addr, true);
+
+        // Churn the LRU past its capacity so this pair's entry is evicted.
+        for i in 0..(RESYNC_THROTTLE_CACHE_SIZE + 16) {
+            let other = make_contract_key((i % 200) as u8);
+            let other_addr: SocketAddr =
+                format!("127.0.0.2:{}", 1024 + (i % 60000)).parse().unwrap();
+            manager.begin_resync_request(&other, other_addr);
+        }
+
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, deadline),
+            ResyncDebt::Unknown,
+            "an evicted reservation must read as Unknown: the debt it carried is \
+             unknowable, and reporting it as 'nothing owed' loses a real drop \
+             silently — the exact failure #5510 exists to close"
+        );
+        assert!(
+            ResyncDebt::Unknown.is_owed(),
+            "and Unknown must be treated as owed, or distinguishing it changes \
+             nothing"
         );
     }
 
@@ -4916,14 +5082,21 @@ mod tests {
             stale, fresh,
             "each grant must stamp a distinct deadline, or the generation check              cannot tell two reservations apart"
         );
-        manager.note_resync_drop_during_window(&contract, addr);
+        assert_eq!(
+            manager.begin_resync_request_or_note_drop(&contract, addr, true),
+            ResyncGrant::WindowHeld,
+            "the sibling's window is held, so this drop is refused and its debt \
+             lands on the sibling's reservation"
+        );
 
-        assert!(
-            !manager.take_resync_drop_during_window(&contract, addr, stale),
+        assert_eq!(
+            manager.take_resync_drop_during_window(&contract, addr, stale),
+            ResyncDebt::None,
             "the STALE chain must not consume a debt owed to the newer              reservation; doing so emits the sibling's repair for it and leaves              the sibling's own drop unrepaired"
         );
-        assert!(
+        assert_eq!(
             manager.take_resync_drop_during_window(&contract, addr, fresh),
+            ResyncDebt::Owed,
             "and the debt must still be there for the reservation that owns it"
         );
     }

--- a/crates/core/src/ring/resync_rate_limit.rs
+++ b/crates/core/src/ring/resync_rate_limit.rs
@@ -44,6 +44,7 @@
 //! not a correctness bug. This matches the `UpdateRateLimiter` precedent, which
 //! also relies on the TTL sweep rather than disconnect hooks.
 
+use std::collections::VecDeque;
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -292,6 +293,22 @@ pub(crate) fn new_response_global_limiter(
 /// anti-entropy heartbeat instead of executing a full-state WASM merge.
 pub(crate) const OUTSTANDING_RESYNC_TTL: Duration = Duration::from_secs(60);
 
+/// One outstanding `ResyncRequest` we emitted (#5510 N7).
+#[derive(Debug, Clone, Copy)]
+struct OutstandingRequest {
+    /// Identifies THIS request among the pair's outstanding ones.
+    generation: u64,
+    /// When it was emitted, for the TTL.
+    emitted: Instant,
+}
+
+/// Per-pair cap on concurrently-outstanding requests.
+///
+/// The chain bound already keeps a well-behaved pair far below this. The cap is
+/// here because a pair is not obliged to be well-behaved, and without it one
+/// pair could occupy the whole map's budget and push every other pair out.
+const MAX_OUTSTANDING_PER_PAIR: usize = 8;
+
 /// Correlation map for outstanding `ResyncRequest`s (#4864 round-8, Codex P1).
 ///
 /// A received `ResyncResponse` triggers a full-state WASM merge on the resync
@@ -315,9 +332,26 @@ pub(crate) const OUTSTANDING_RESYNC_TTL: Duration = Duration::from_secs(60);
 /// cap + reaper TTL sweep) so a request storm can't grow the map without bound.
 pub(crate) struct OutstandingResyncRequests {
     /// `(contract, peer)` → the time we emitted the request.
-    entries: DashMap<(ContractInstanceId, SocketAddr), Instant>,
+    /// One entry per PAIR, holding every outstanding request for that pair
+    /// oldest-first (#5510 N7).
+    ///
+    /// A single `Instant` per pair was wrong in a narrow but real way. A
+    /// `ResyncResponse` carries no request id, so the only thing that can match
+    /// it to a request is arrival order. With one slot, a late response to the
+    /// PREVIOUS window's request — generated before the drop that is now being
+    /// repaired, arriving after the next request was recorded — overwrote or
+    /// consumed the record for the CURRENT request, and the chain's "did mine
+    /// land?" check then read false and exited as though answered. If the
+    /// current request had in fact been throttled by the responder or lost, the
+    /// update waited for anti-entropy.
+    entries: DashMap<(ContractInstanceId, SocketAddr), VecDeque<OutstandingRequest>>,
+    /// Total outstanding REQUESTS, not pairs, so the cap bounds memory.
     size: AtomicUsize,
     max_tracked: usize,
+    /// Source of generation ids. A counter rather than the emit `Instant`,
+    /// because two records can share an instant under an injected clock and two
+    /// generations must never be confused for one.
+    next_generation: AtomicU64,
     ttl: Duration,
     time_source: Arc<dyn TimeSource + Send + Sync>,
 }
@@ -326,6 +360,7 @@ impl OutstandingResyncRequests {
     pub fn new(time_source: Arc<dyn TimeSource + Send + Sync>) -> Self {
         Self {
             entries: DashMap::new(),
+            next_generation: AtomicU64::new(0),
             size: AtomicUsize::new(0),
             max_tracked: MAX_TRACKED_KEYS,
             ttl: OUTSTANDING_RESYNC_TTL,
@@ -346,23 +381,42 @@ impl OutstandingResyncRequests {
     /// "did it land?" signal MUST NOT treat that absence as "landed" (#4863).
     #[must_use]
     pub fn record(&self, contract: ContractInstanceId, target: SocketAddr) -> bool {
+        self.record_generation(contract, target).is_some()
+    }
+
+    /// As [`Self::record`], but returns the GENERATION of the request recorded,
+    /// so a caller can later ask whether ITS OWN request is still outstanding
+    /// rather than whether any request for the pair is (#5510 N7).
+    ///
+    /// `None` means the strict cap rejected it and nothing was stored; the
+    /// request is UNCORRELATED and [`Self::is_outstanding`] will read `false`
+    /// for it forever, which must not be taken as "landed" (#4863).
+    #[must_use]
+    pub fn record_generation(
+        &self,
+        contract: ContractInstanceId,
+        target: SocketAddr,
+    ) -> Option<u64> {
         let now = self.time_source.now();
-        use dashmap::mapref::entry::Entry;
-        match self.entries.entry((contract, target)) {
-            Entry::Occupied(mut occ) => {
-                *occ.get_mut() = now;
-                true
-            }
-            Entry::Vacant(vac) => {
-                let prev = self.size.fetch_add(1, Ordering::Relaxed);
-                if prev >= self.max_tracked {
-                    self.size.fetch_sub(1, Ordering::Relaxed);
-                    return false;
-                }
-                vac.insert(now);
-                true
-            }
+        let prev = self.size.fetch_add(1, Ordering::Relaxed);
+        if prev >= self.max_tracked {
+            self.size.fetch_sub(1, Ordering::Relaxed);
+            return None;
         }
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let mut queue = self.entries.entry((contract, target)).or_default();
+        // Per-pair cap. The chain bound already keeps this small, but a pair is
+        // not obliged to be well-behaved: without a cap one pair could hold the
+        // whole map's budget.
+        if queue.len() >= MAX_OUTSTANDING_PER_PAIR {
+            queue.pop_front();
+            self.size.fetch_sub(1, Ordering::Relaxed);
+        }
+        queue.push_back(OutstandingRequest {
+            generation,
+            emitted: now,
+        });
+        Some(generation)
     }
 
     /// Require-and-consume a matching outstanding entry for a received
@@ -372,13 +426,32 @@ impl OutstandingResyncRequests {
     /// finds nothing and is rejected.
     pub fn consume(&self, contract: ContractInstanceId, source: SocketAddr) -> bool {
         let now = self.time_source.now();
-        match self.entries.remove(&(contract, source)) {
-            Some((_, emitted)) => {
-                self.size.fetch_sub(1, Ordering::Relaxed);
-                now.saturating_duration_since(emitted) <= self.ttl
+        let mut empty = false;
+        let matched = match self.entries.get_mut(&(contract, source)) {
+            Some(mut queue) => {
+                // OLDEST first. A response carries no request id, so arrival
+                // order is the only correspondence available, and the oldest
+                // outstanding request is the one a response most plausibly
+                // answers. Consuming the newest instead would let a late reply
+                // to an old request cancel the correlation of the request
+                // currently being retried.
+                let front = queue.pop_front();
+                empty = queue.is_empty();
+                match front {
+                    Some(req) => {
+                        self.size.fetch_sub(1, Ordering::Relaxed);
+                        now.saturating_duration_since(req.emitted) <= self.ttl
+                    }
+                    None => false,
+                }
             }
             None => false,
+        };
+        if empty {
+            self.entries
+                .remove_if(&(contract, source), |_, q| q.is_empty());
         }
+        matched
     }
 
     /// Read-only: is there a NON-EXPIRED outstanding request for
@@ -418,11 +491,44 @@ impl OutstandingResyncRequests {
     /// fail (including with another `ContractQueueFull`). Absence therefore
     /// means "the response arrived and we authorized it", not "the state
     /// merged".
+    ///
+    /// **No production caller since #5510 N7**, which moved both the chain's X2
+    /// check and the #4863 re-delivery gate onto
+    /// [`Self::is_generation_outstanding`]. Kept because the pair-level question
+    /// is still the right one for a test to ask — "is anything outstanding for
+    /// this pair" — and because a future caller that genuinely wants the
+    /// aggregate should find it here rather than reinvent it. Anything asking
+    /// "did MY request land" must use the generation form: this one answers
+    /// `false` as soon as any response retires any generation.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn is_outstanding(&self, contract: ContractInstanceId, peer: SocketAddr) -> bool {
         let now = self.time_source.now();
-        self.entries
-            .get(&(contract, peer))
-            .is_some_and(|emitted| now.saturating_duration_since(*emitted) <= self.ttl)
+        self.entries.get(&(contract, peer)).is_some_and(|queue| {
+            queue
+                .iter()
+                .any(|req| now.saturating_duration_since(req.emitted) <= self.ttl)
+        })
+    }
+
+    /// Is the request with THIS generation still outstanding (#5510 N7)?
+    ///
+    /// The distinction from [`Self::is_outstanding`] is the whole point: a
+    /// chain asking "did any request for this pair go unanswered" gets the
+    /// wrong answer when a late response to an earlier window consumed an
+    /// entry. Asking about its own generation cannot be confused that way.
+    pub fn is_generation_outstanding(
+        &self,
+        contract: ContractInstanceId,
+        peer: SocketAddr,
+        generation: u64,
+    ) -> bool {
+        let now = self.time_source.now();
+        self.entries.get(&(contract, peer)).is_some_and(|queue| {
+            queue.iter().any(|req| {
+                req.generation == generation
+                    && now.saturating_duration_since(req.emitted) <= self.ttl
+            })
+        })
     }
 
     /// Drop entries older than the TTL. Call from the Ring reaper so a burst of
@@ -431,13 +537,11 @@ impl OutstandingResyncRequests {
         let now = self.time_source.now();
         let ttl = self.ttl;
         let mut removed = 0usize;
-        self.entries.retain(|_, emitted| {
-            if now.saturating_duration_since(*emitted) > ttl {
-                removed += 1;
-                false
-            } else {
-                true
-            }
+        self.entries.retain(|_, queue| {
+            let before = queue.len();
+            queue.retain(|req| now.saturating_duration_since(req.emitted) <= ttl);
+            removed += before - queue.len();
+            !queue.is_empty()
         });
         if removed > 0 {
             self.size.fetch_sub(removed, Ordering::Relaxed);
@@ -497,6 +601,76 @@ mod tests {
         assert!(
             !m.consume(c, peer),
             "a replayed/duplicate response must be rejected after the first consume"
+        );
+    }
+
+    /// #5510 N7: a LATE response to an earlier window must not cancel the
+    /// correlation of the request currently outstanding.
+    ///
+    /// A `ResyncResponse` carries no request id, so nothing in the message says
+    /// which request it answers. With one slot per pair, a response generated
+    /// before the swallowed broadcast and arriving after the next request was
+    /// recorded consumed that next request's record. The chain's "did mine
+    /// land?" check then read false and it exited as though answered — and if
+    /// its request had in fact been throttled by the responder or lost, the
+    /// update waited for anti-entropy.
+    ///
+    /// Generations make the question answerable: consumption is oldest-first,
+    /// so a late reply retires the request it plausibly answers, and the chain
+    /// asks about ITS OWN generation rather than about the pair.
+    ///
+    /// This is the out-of-order case `.claude/rules/testing.md` asks to cover.
+    #[test]
+    fn a_late_response_to_an_earlier_window_does_not_retire_the_current_request() {
+        let ts = SharedMockTimeSource::new();
+        let m = new_outstanding_resync_requests(Arc::new(ts.clone()));
+        let c = mk_contract(7);
+        let peer = mk_peer(7);
+
+        // Window 1's request.
+        let first = m
+            .record_generation(c, peer)
+            .expect("first record must correlate under the cap");
+
+        // The window closes and the chain records window 2's request. Both are
+        // now outstanding; the responder has answered neither.
+        ts.advance_time(Duration::from_secs(30));
+        let second = m
+            .record_generation(c, peer)
+            .expect("second record must correlate");
+        assert_ne!(
+            first, second,
+            "each record must take a distinct generation, or the two requests \
+             cannot be told apart at all"
+        );
+
+        // NOW window 1's response arrives, late. It retires window 1's request,
+        // oldest-first, and must leave window 2's alone.
+        assert!(
+            m.consume(c, peer),
+            "the late response is still within the TTL, so it authorizes"
+        );
+        assert!(
+            !m.is_generation_outstanding(c, peer, first),
+            "the response must retire the OLDEST outstanding request, which is \
+             the one it plausibly answers"
+        );
+        assert!(
+            m.is_generation_outstanding(c, peer, second),
+            "and the CURRENT request must remain outstanding: nothing has \
+             answered it. Retiring it here is what made a chain exit believing \
+             its own repair had landed (#5510 N7)"
+        );
+
+        // A second response retires window 2's request in turn.
+        assert!(m.consume(c, peer), "the second response authorizes too");
+        assert!(
+            !m.is_generation_outstanding(c, peer, second),
+            "and now nothing is outstanding for the pair"
+        );
+        assert!(
+            !m.is_outstanding(c, peer),
+            "the pair-level view must agree once every generation is retired"
         );
     }
 

--- a/crates/core/src/ring/update_rate_limit.rs
+++ b/crates/core/src/ring/update_rate_limit.rs
@@ -389,15 +389,24 @@ pub(crate) const MIN_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 ///
 /// # Tuning this back toward 100ms is not free
 ///
-/// The obvious "safer" move is the wrong one. Raising the interval raises
-/// drop pressure, and the repair cannot absorb the extra drops: it allows
-/// one `ResyncRequest` per `(contract, sender)` per 30s, so the SECOND and
-/// later drops inside a window are refused and, on this branch, nothing
-/// re-sends them — they wait for the next drop after the window closes, or
-/// for the ~5-minute anti-entropy heartbeat. A higher interval therefore
-/// buys drops that land squarely in the repair's blind spot. #5525 closes
-/// that spot with a trailing coalesced repair; until it lands, treat every
-/// drop beyond the first per window as unrepaired.
+/// The obvious "safer" move is the wrong one, and the coupling is not
+/// visible from this constant alone. Raising the interval raises drop
+/// pressure. Every drop is repaired — a drop that takes a fresh
+/// reservation emits its own `ResyncRequest`, and a drop swallowed by a
+/// held window is repaired by the trailing coalesced request at that
+/// window's close — but the repair's COST scales with drop pressure while
+/// its rate does not: still at most one extra request per window per pair,
+/// and one full-state `ResyncResponse` per request.
+///
+/// What actually binds is slots. Each repair chain holds one of the
+/// [`crate::ring::interest::MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES`]
+/// (256) node-wide follow-up slots for up to
+/// `MAX_COALESCED_RESYNC_WINDOWS` served windows (3 x 30s) plus its
+/// attempts bound, and gate 1 is per `(contract, sender)`, so a contract
+/// with N dropping senders can want N chains per window. A higher interval
+/// therefore thins the very backstop meant to catch the extra drops it
+/// creates, and does so exactly when the node is busiest. Widening and
+/// narrowing this number are NOT symmetric.
 ///
 /// On the adversarial side, do not lean on the #4997 per-sender budget
 /// here: it charges a token only for a pair the limiter is not currently

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2186,10 +2186,9 @@ fn test_full_state_send_no_incorrect_caching() {
     // #5510 made this assertion specific rather than total. It used to assert
     // `resync_requests() == 0`, using "no resyncs at all" as a proxy for "no
     // delta failed". That proxy held only while a delta failure was the ONLY
-    // thing that emitted a ResyncRequest. It no longer is: a queue-full drop
-    // and a rate-limited broadcast drop both emit one too (and #5525 adds a
-    // third, the trailing coalesced repair), all of them healthy behaviour.
-    // This test began failing on
+    // thing that emitted a ResyncRequest. It no longer is: a queue-full drop,
+    // a rate-limited broadcast drop, and the trailing coalesced repair all emit
+    // one too, and all three are healthy behaviour. This test began failing on
     // exactly that — `delta_sends: 0, full_state_sends: 11, resync_requests: 1`
     // with everything converged — where the single resync was a broadcast
     // repair and no delta had failed at all.


### PR DESCRIPTION
## Follows #5515, which has now merged

This was stacked on #5515 while that was in flight. #5515 merged as `93bf3c57b`,
and this branch has been rebased onto `main` and retargeted, so it now stands on
its own: the diff is its own three commits, two files, and there is no merge
ordering left to respect.

#5515 closed the four root causes of #5510. This closes the residual that
review surfaced while checking whether the queue-full repair's trailing-edge
retry was engaged: it was, but only for the reservation that WINS the
throttle. A drop refused *inside* a held window still had nothing that ever
re-sent it, which is the issue's own "nothing ever re-sends them" for that
case.

## Problem

`begin_resync_request` grants at most one `ResyncRequest` per `(contract,
sender)` per 30s — the #4251 amplification bound, and correct. Before this
change, a broadcast drop that arrived while a reservation was held was simply
returned on: nothing recorded it, and the reservation's own follow-up chain
had no idea it had happened.

That matters because of #5464 true-diff deltas. The sender refreshes its
cached summary of us when it *enqueues* a broadcast, not when we acknowledge
one, so a dropped broadcast leaves the sender believing we hold an entry we
never received. Every later delta is computed against that wrong belief, so
the lost entry is excluded permanently. It comes back only at the ~5-minute
InterestSync anti-entropy heartbeat, and only if the pair is still connected
and the contract still in that round's rotating window.

A second refusal path had the same hole: the global per-contract emit cap
(`EMIT_BURST` 2, refilling once per 60s) `cancel`s the reservation, so a drop
refused there recorded nothing either. With re-reservation running every 30s
against a 60s refill, that is the common case rather than a corner.

## Approach

One flag on the reservation, consumed at the window's close, emitting ONE
coalesced `ResyncRequest` that covers every drop the window swallowed. One
full-state `ResyncResponse` restores every lost entry at once, so the repair
does not scale with the number of drops and neither does the signal. The
#4251 bound is untouched: still at most one emit per pair per window.

The chain that serves it is bounded on three independent axes, because a
chain that re-reserves for as long as its windows keep swallowing drops would
hold one of the 256 node-wide retry slots indefinitely — the refreshable-cap
shape `.claude/rules/code-style.md` forbids:

- `MAX_COALESCED_RESYNC_WINDOWS` (3) bounds windows actually SERVED;
- `MAX_COALESCED_RESYNC_ATTEMPTS` (6) bounds total passes, so a chain that is
  only ever refused still terminates;
- the existing tokio backstop inside the wait.

Two axes rather than one is a review-round-2 correction, and the reason is
worth stating: counting a refusal as a served window meant that with the emit
cap refilling once per 60s against a 30s re-reservation, two refusals
exhausted a bound of three and the debt was dropped at t=90 having never been
served once.

The take is generational. The throttle map is keyed by pair alone, so a chain
that outlived its own reservation could consume a *sibling's* freshly-recorded
debt, emit the sibling's repair for it, and leave the sibling to find
nothing — the silent loss this PR exists to close, reintroduced one layer up.
`ResyncReservation::deadline()` is the generation token.

### The hosting re-check applies to every coalesced emit; the split is immediate vs chain

Gate B (`should_summarize_or_broadcast`) is re-checked before **every** coalesced
emit, whatever drop the chain descended from. A chain can live across three
served windows — roughly 180s — and the contract can be evicted underneath it,
so a gate that ran once at the start is not a gate.

The **immediate** queue-full emit stays ungated, and that is the whole of the
#4857 exemption. An earlier revision of this PR scoped the chain's re-check to
rate-limiter origins on the argument that #4857 has never been hosting-gated.
Review round 3 corrected it, and the correction is the right one: that argument
is about a path which predates this PR, and the chain is new code. Carrying a
pre-existing exemption into new code that re-emits for three minutes is not
preserving behaviour, it is inventing a new one. `repair_is_hosting_gated` and
its origin-mapping pin were deleted along with the scoping.

Applying the gate to the chain exposed something worth naming: **two** tests
written earlier in this PR had fixtures that never actually held the contract, so
they had been passing against the gate rather than against the repair
(`drop_swallowed_by_throttle_window_emits_one_coalesced_resync_at_the_deadline`
and `a_cap_refused_coalesced_emit_keeps_its_debt_and_the_chain_terminates`).
Both now hold it, via a `hold_contracts` helper that asserts the precondition so
the vacuous pass cannot come back. The helper's other five call sites are in
tests added in this round, which use it from the start.

A previous revision of this section said four. That was miscounted: four tests
went red when the gate was applied, but two of them failed on pins asserting the
pre-rename `begin_resync_request`, which is the atomic-method change and has
nothing to do with the hosting gate.

The re-check costs an in-memory hosting lookup plus a redb point lookup for
`contract_state_present`, on a path that runs at most a handful of times per
chain. That is negligible against the WASM summarize plus full-state transfer
it avoids asking a peer for.

## Testing

All behavioural where the behaviour is reachable, and each mutation-checked —
I verified the test FAILS with the mechanism removed rather than assuming it
would:

- `drop_swallowed_by_throttle_window_emits_one_coalesced_resync_at_the_deadline` —
  counts emissions in two windows rather than as a total, which is what makes
  it a test of the DEADLINE and not merely of the emit. Deleting the wait
  makes it fail.
- `the_coalesced_emit_rechecks_hosting_for_every_origin` — two contracts on one
  node, one driven with each origin, identical otherwise, on a node holding
  neither. Both must emit immediately and neither at the window's close, which
  is the immediate-vs-chain split stated as an assertion. Fails under BOTH the
  no-gate mutation (both would emit twice) and the gate-the-immediate-emit-too
  mutation (neither would emit at all), so it cannot pass by accident in either
  direction. A contract each rather than two senders on one is load-bearing: the
  emit cap is per contract, and sharing one starves the second coalesced emit on
  the cap, which the test would then have read as the hosting gate.
- `a_stale_chain_cannot_consume_a_newer_reservations_swallowed_drop` — the
  generational take.
- `a_cap_refused_coalesced_emit_keeps_its_debt_and_the_chain_terminates` — the
  cap-refusal path keeps its debt and still terminates.

### One source pin, and why it is not a behavioural test

`the_followup_chain_is_bounded_by_a_window_count` pins source text. I measured
rather than assumed that a behavioural test cannot reach the bound with
today's constants, for two structural reasons: advancing past a window needs a
granted emit, and the global cap refills once per 60s against a 30s
re-reservation, so a chain runs out of tokens first; and feeding drops in does
not extend the existing chain, because a drop arriving with no reservation
held takes its own and spawns a SIBLING.

So the bound is defence in depth, and a behavioural test asserting termination
would pass whether or not the bound existed. It did: the first version of this
test passed with `windows_used >= MAX` mutated to `false` — exactly the
vacuous pin this repo's testing rules warn about. Pinning the mechanism is the
honest alternative, and the pin fails under both the dropped-attempts-bound
and the increment-on-refusal mutations. No production test hook was added for
it.

Full core lib suite: 5352 passed, 0 failed, under plain `cargo test` (not just
nextest — see `.claude/rules/testing.md` on process-global state).

## Follow-ups

- **#5526** — `ResyncRequest` carries no reason, so the repairs this PR emits are
  attributed at the sender as delta-incompatibility evidence. Pre-existing shape
  (#4857 has it too); needs a version-gated wire append, out of scope here.
- **#5523** — deterministic simulation coverage for rate-limiter refusals. The
  existing harness cannot drive co-host fan-out above the broadcast budget, so
  there is no sim-level test of this path.
- **Sender-side pacing off the broadcast-queue drain** — complementary to the
  receive-side budget; would reduce the refusals rather than widen the allowance.
  Held by the issue filer until this lands.

### Slot occupancy, stated plainly

A coalesced chain holds its node-wide slot longer than a bare #4862 retry does.
The retry burst ends within one reservation window; a chain can live up to
`MAX_COALESCED_RESYNC_WINDOWS` served windows (3 x 30s) plus its attempts bound.
Gate 1 is per `(contract, sender)`, so a contract with N dropping senders can
want N chains per window, against 256 node-wide slots.

There is **one pool, not two**, and the reason is worth recording because an
earlier round of this PR had two. The concern was real: a contract with N
dropping senders could spawn N chains that had nothing authorized to send, and
starve the #4862 re-delivery of chains protecting a request already on the wire.
The fix that round was a separate smaller pool for them.

That was capping a symptom. The actual cause was that the global-cap path
**cancelled** the per-pair reservation, releasing the window — so every later
drop on the pair was refused afresh and spawned a chain of its own. Keeping the
reservation instead (with its debt flag set) makes those later drops
`WindowHeld`, handing their debt to the one chain already carrying it. That is
one chain per pair per window, the same bound gate 1 gives every other path, and
it removes the need for a second pool entirely. Measured: twelve drops on a
capped pair now produce **one** chain; restoring the cancel produces **twelve**.

So the bound, in full: **one chain per `(contract, sender)` pair per window**,
node-wide at most the 256 `MAX_OUTSTANDING_QUEUE_FULL_RESYNC_RETRIES` slots
(shared with the #4862 re-delivery), each chain living at most 3 served windows
or 6 attempts, whichever comes first, plus the tokio backstop inside the wait.
The same statement is on `MAX_COALESCED_RESYNC_WINDOWS` so it does not live only
in a PR description.

Closes #5510. #5515 fixes the four root causes; this closes the residual the
issue also names — the drops a held throttle window swallows, which are its own
"nothing ever re-sends them" for that case, and #5515 (now merged) fixed the
other four.

https://claude.ai/code/session_01XpSr7Uomp7TUw5RH1KqV6Z

[AI-assisted - Claude]
