### PR TITLE
fix(ci): verify companion units after a gateway update

### DIFF
--- a/scripts/gateway-auto-update.sh
+++ b/scripts/gateway-auto-update.sh
@@ -435,8 +435,52 @@ deploy_update() {
 # a missing unit, or a non-systemd host returns non-zero. `systemctl is-active`
 # is a read-only query and needs no root. Mirrors the release-agent's
 # version.rs::query_service_active so the script-side and HTTP-side gates agree.
+# Verify the deployed unit AND every companion unit configured to start with it.
+#
+# `WantedBy=` pulls a companion up when the primary starts, but systemd does NOT
+# propagate the companion's START FAILURE back to the primary — so a companion
+# that fails to come up leaves the primary active and this check green while a
+# gateway is silently down. Same shape as the v0.2.71 incident this function
+# exists for.
+#
+# nova runs exactly that: freenet-gateway-2 is a second gateway process with
+# `WantedBy=freenet-gateway.service` and no release-agent of its own.
+#
+# Companions are read from the `.wants` SYMLINKS on disk, deliberately NOT from
+# `systemctl show -p ConsistsOf`. ConsistsOf reflects the LOADED unit graph and
+# comes back EMPTY once the companion is stopped — so a ConsistsOf-based check
+# finds nothing to verify at exactly the moment it is needed and passes. That
+# was measured, not assumed. The symlinks are static configuration and are
+# present whether or not the unit is running.
+#
+# Reading from disk also survives the release-agent's `sudo` call, which strips
+# the environment — the same reason SERVICE_NAME forwarding is still unsolved
+# (see the note at the top of this file).
 verify_service_active() {
     local service_arg="$1"
+
+    # Search roots are overridable ONLY so the test harness can point them at a
+    # fixture; production never sets this. Without it the companion branch is
+    # untestable and would ship unexercised, which is how the gap this function
+    # closes got in.
+    local -a unit_roots
+    IFS=: read -r -a unit_roots <<< "${SYSTEMD_UNIT_ROOTS:-/etc/systemd/system:/usr/lib/systemd/system}"
+
+    local root wants_dir companion cstate cname
+    for root in "${unit_roots[@]}"; do
+        wants_dir="$root/$service_arg.service.wants"
+        [[ -d "$wants_dir" ]] || continue
+        for companion in "$wants_dir"/*.service; do
+            [[ -e "$companion" ]] || continue
+            cname=$(basename "$companion")
+            cstate=$(systemctl is-active "$cname" 2>/dev/null || true)
+            if [[ "$cstate" != "active" ]]; then
+                log ERROR "Companion unit '$cname' of '$service_arg' is '$cstate', not active; treating the update as failed"
+                return 1
+            fi
+            log INFO "Companion unit '$cname' is active"
+        done
+    done
 
     # Only systemd is supported by the automated update path (nova/vega). On a
     # host without systemctl we cannot confirm liveness; fail closed so a

--- a/scripts/release-agent/gateway-auto-update_test.sh
+++ b/scripts/release-agent/gateway-auto-update_test.sh
@@ -50,7 +50,15 @@ cat > "$TMP/bin/systemctl" <<EOF
 #!/bin/bash
 case "\$1" in
   is-active)
-    state="\$(cat "$TMP/service-state" 2>/dev/null || echo unknown)"
+    # Per-unit state file if present, else the shared default. Lets a companion
+    # be down while the primary is up, which is the case the companion check
+    # exists for.
+    unit="\${2%.service}"
+    if [[ -f "$TMP/state-\$unit" ]]; then
+      state="\$(cat "$TMP/state-\$unit")"
+    else
+      state="\$(cat "$TMP/service-state" 2>/dev/null || echo unknown)"
+    fi
     echo "\$state"
     [[ "\$state" == "active" ]] && exit 0 || exit 3
     ;;
@@ -133,6 +141,64 @@ if deploy_update "$TMP/fake-binary" 2>/dev/null; then
 else
     pass "deploy_update: dead service caught despite deploy script exiting 0"
 fi
+
+# ── companion units (WantedBy=) ──────────────────────────────────────
+#
+# nova runs a SECOND gateway process, freenet-gateway-2, with
+# `WantedBy=freenet-gateway.service` and no release-agent of its own. systemd
+# does NOT propagate a wanted unit's START FAILURE back to the primary, so
+# without this check the primary comes up, the update reports success, and the
+# second gateway is silently down — the v0.2.71 failure class again.
+#
+# SYSTEMD_UNIT_ROOTS points the lookup at a fixture instead of /etc/systemd.
+
+export SYSTEMD_UNIT_ROOTS="$TMP/units"
+WANTS="$TMP/units/freenet-gateway.service.wants"
+mkdir -p "$WANTS" || { echo "FAIL: could not create $WANTS" >&2; exit 1; }
+
+echo "active" > "$TMP/service-state"
+
+# (1) No companions: the loop must fall through, not fail.
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: none configured -> 0"
+else
+    fail "companions: an empty wants dir must not fail the update"
+fi
+
+# (2) Companion present and active.
+touch "$WANTS/freenet-gateway-2.service"
+echo "active" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: active companion -> 0"
+else
+    fail "companions: an active companion must not fail the update"
+fi
+
+# (3) THE CASE THIS EXISTS FOR: primary active, companion down. Must fail.
+echo "inactive" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "companions: primary active + companion INACTIVE must NOT return 0 (silent gateway outage)"
+else
+    pass "companions: inactive companion -> non-zero"
+fi
+
+# (4) A failed companion is equally unacceptable.
+echo "failed" > "$TMP/state-freenet-gateway-2"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    fail "companions: primary active + companion FAILED must NOT return 0"
+else
+    pass "companions: failed companion -> non-zero"
+fi
+
+# (5) A wants dir that does not exist must not fail (hosts without companions).
+rm -f "$TMP/state-freenet-gateway-2"
+export SYSTEMD_UNIT_ROOTS="$TMP/no-such-root"
+if verify_service_active "freenet-gateway" 2>/dev/null; then
+    pass "companions: missing wants root -> 0"
+else
+    fail "companions: a missing wants root must not fail the update"
+fi
+unset SYSTEMD_UNIT_ROOTS
 
 # Same deploy script, but now the service is genuinely active → success.
 echo "active" > "$TMP/service-state"


### PR DESCRIPTION
## Problem

**A gateway that fails to start is currently reported as a successful update.**

`WantedBy=` pulls a companion unit up when the primary starts, but systemd does **not** propagate the companion's *start failure* back to the primary. The primary comes up, `verify_service_active` sees it active and returns 0, and a gateway process is silently down — the same failure class as v0.2.71, which is why this function exists at all.

This is live on nova today: `freenet-gateway-2` is a second gateway process carrying `WantedBy=freenet-gateway.service`, with no release-agent of its own, and nothing verified it.

## Approach

`verify_service_active` now also checks every companion in the primary's `.wants` directories and fails the update if one is not active.

Read from the **`.wants` symlinks**, deliberately not `systemctl show -p ConsistsOf`. ConsistsOf reflects the *loaded* unit graph and returns **empty** once the companion is stopped — so a ConsistsOf-based check finds nothing to verify at exactly the moment it matters, and passes. I implemented it that way first and caught it only by testing the failure case: a check that could not go red, inside a fix for a check that could not go red. The symlinks are static configuration, present whether or not the unit is running.

Reading from disk also survives the release-agent's `sudo` call, which strips the environment — the same constraint that leaves `SERVICE_NAME` forwarding unsolved.

## Testing

Five cases in the existing harness, which previously never created a `.wants` fixture and would have let this ship unexercised:

| case | expected |
|---|---|
| no companions configured | 0 |
| companion active | 0 |
| **primary active, companion INACTIVE** | **non-zero** |
| primary active, companion FAILED | non-zero |
| wants root does not exist | 0 |

Case 3 is the defect. `SYSTEMD_UNIT_ROOTS` makes the lookup roots overridable so the harness can point at a fixture; production never sets it, and without it the branch is untestable.

Also verified in production: on the v0.2.132 release the journal shows `freenet-gateway-2` stopped at 12:22:33 and started again at 12:22:39 with no manual intervention, confirming the `WantedBy=` edge works — this PR is about detecting when it *doesn't*.

## Why this is separate

Split out of #5513 on review. That PR retires an AWS gateway; this is an independent safety fix that happens to have been motivated by the same work. It should stand or fall on its own, and #5513 should not carry a new mechanism inside an infrastructure chore.

[AI-assisted - Claude]
