### PR TITLE
fix(conformance): frame evidence and check schema before decode

### DIFF
--- a/crates/core/src/conformance.rs
+++ b/crates/core/src/conformance.rs
@@ -123,7 +123,10 @@ mod wasm_tests;
 
 pub use bundle::{ReplayBundle, Transition};
 pub use capture::{CaptureHandle, Observation};
-pub use evidence::{ConformanceEvidence, EVIDENCE_SCHEMA_VERSION, EvidenceId, EvidenceRejected};
+pub use evidence::{
+    ConformanceEvidence, EVIDENCE_MAGIC, EVIDENCE_SCHEMA_VERSION, EvidenceError, EvidenceId,
+    EvidenceRejected,
+};
 pub use focus::FocusSelector;
 pub use generator::{GeneratorConfig, generate_cases};
 pub use host_clock::{

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -38,6 +38,21 @@ use super::verifier::ConformanceCase;
 /// reproducer is exactly how a false positive would spread.
 pub const EVIDENCE_SCHEMA_VERSION: u16 = 2;
 
+/// Magic prefix so a truncated, raw, or unrelated file fails fast with a clear message
+/// rather than as a confusing deserialization error deep in bincode.
+pub const EVIDENCE_MAGIC: &[u8; 8] = b"FRNTEVD1";
+
+/// Errors encountered when encoding or decoding conformance evidence.
+#[derive(Debug, thiserror::Error)]
+pub enum EvidenceError {
+    #[error("not conformance evidence (bad magic)")]
+    BadMagic,
+    #[error("evidence uses schema version {found}, this build understands {supported}")]
+    UnsupportedSchema { found: u16, supported: u16 },
+    #[error("decode: {0}")]
+    Decode(String),
+}
+
 /// Hard ceiling on one evidence object's input bytes.
 ///
 /// Chosen so that verifying evidence is unambiguously cheaper than the update
@@ -353,6 +368,35 @@ impl ConformanceEvidence {
             summary: self.summary.as_ref().map(|s| Arc::from(s.as_slice())),
             related,
         })
+    }
+
+    /// Encode with framing: 8-byte magic (`FRNTEVD1`), 2-byte schema version (LE),
+    /// followed by the bincode-serialized payload.
+    pub fn encode(&self) -> Result<Vec<u8>, EvidenceError> {
+        let mut out = Vec::with_capacity(self.input_bytes() + 128);
+        out.extend_from_slice(EVIDENCE_MAGIC);
+        out.extend_from_slice(&self.schema_version.to_le_bytes());
+        let body = bincode::serialize(self).map_err(|e| EvidenceError::Decode(e.to_string()))?;
+        out.extend_from_slice(&body);
+        Ok(out)
+    }
+
+    /// Decode an evidence file, verifying magic and schema version *before*
+    /// attempting bincode deserialization.
+    pub fn decode(bytes: &[u8]) -> Result<Self, EvidenceError> {
+        if bytes.len() < EVIDENCE_MAGIC.len() + 2
+            || &bytes[..EVIDENCE_MAGIC.len()] != EVIDENCE_MAGIC
+        {
+            return Err(EvidenceError::BadMagic);
+        }
+        let version = u16::from_le_bytes([bytes[8], bytes[9]]);
+        if version != EVIDENCE_SCHEMA_VERSION {
+            return Err(EvidenceError::UnsupportedSchema {
+                found: version,
+                supported: EVIDENCE_SCHEMA_VERSION,
+            });
+        }
+        bincode::deserialize(&bytes[10..]).map_err(|e| EvidenceError::Decode(e.to_string()))
     }
 }
 

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -2809,6 +2809,65 @@ fn unsupported_schema_is_rejected() {
     ));
 }
 
+#[test]
+fn a_foreign_file_is_not_mistaken_for_evidence() {
+    use super::evidence::{ConformanceEvidence, EvidenceError};
+    assert!(matches!(
+        ConformanceEvidence::decode(b"definitely not evidence"),
+        Err(EvidenceError::BadMagic)
+    ));
+    assert!(matches!(
+        ConformanceEvidence::decode(b"FRNT"),
+        Err(EvidenceError::BadMagic)
+    ));
+    assert!(matches!(
+        ConformanceEvidence::decode(b""),
+        Err(EvidenceError::BadMagic)
+    ));
+}
+
+#[test]
+fn an_evidence_from_an_unsupported_schema_is_refused_before_bincode() {
+    use super::evidence::{ConformanceEvidence, EVIDENCE_SCHEMA_VERSION, EvidenceError};
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    let mut encoded = evidence.encode().expect("encode");
+
+    // Bump the version in the 10-byte header, leaving the magic intact.
+    let bumped = EVIDENCE_SCHEMA_VERSION + 1;
+    encoded[8..10].copy_from_slice(&bumped.to_le_bytes());
+    // Corrupt the body so that bincode would error if deserialization ran first.
+    encoded[10..].fill(0xff);
+
+    match ConformanceEvidence::decode(&encoded) {
+        Err(EvidenceError::UnsupportedSchema { found, supported }) => {
+            assert_eq!(found, bumped);
+            assert_eq!(supported, EVIDENCE_SCHEMA_VERSION);
+        }
+        other => panic!("expected an unsupported-schema refusal, got {other:?}"),
+    }
+
+    // Also verify schema version 1 (older version) is refused without entering bincode.
+    encoded[8..10].copy_from_slice(&1u16.to_le_bytes());
+    match ConformanceEvidence::decode(&encoded) {
+        Err(EvidenceError::UnsupportedSchema { found, supported }) => {
+            assert_eq!(found, 1);
+            assert_eq!(supported, EVIDENCE_SCHEMA_VERSION);
+        }
+        other => panic!("expected schema 1 refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn evidence_encode_decode_roundtrip() {
+    use super::evidence::ConformanceEvidence;
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let bytes = evidence.encode().expect("encode");
+    let decoded = ConformanceEvidence::decode(&bytes).expect("decode");
+    assert_eq!(decoded, evidence);
+}
+
 // ----------------------------------------------------------------------- generator
 
 #[test]

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -32,10 +32,9 @@ use freenet::conformance::generator::Corpus;
 use freenet::conformance::host_clock;
 use freenet::conformance::verifier::Bytes;
 use freenet::conformance::{
-    ConformanceCase, ConformanceEvidence, ConformanceProperty, EVIDENCE_SCHEMA_VERSION,
-    EvidenceRejected, GeneratorConfig, IdempotenceSettling, Inconclusive, MinimizeConfig,
-    OracleBuildError, PropertyOutcome, ReplayBundle, RuntimeOracle, Severity, Transition,
-    generate_cases, minimize, verify_case,
+    ConformanceCase, ConformanceEvidence, ConformanceProperty, EvidenceRejected, GeneratorConfig,
+    IdempotenceSettling, Inconclusive, MinimizeConfig, OracleBuildError, PropertyOutcome,
+    ReplayBundle, RuntimeOracle, Severity, Transition, generate_cases, minimize, verify_case,
 };
 use freenet_stdlib::prelude::{CodeHash, ContractCode, ContractInstanceId, State, UpdateData};
 use serde::Serialize;
@@ -476,18 +475,8 @@ fn parse_properties(names: &[String]) -> anyhow::Result<Vec<ConformanceProperty>
 /// differ, and both are worth knowing.
 async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::Result<()> {
     let bytes = read_file(path)?;
-    let evidence: ConformanceEvidence = bincode::deserialize(&bytes)
+    let evidence = ConformanceEvidence::decode(&bytes)
         .with_context(|| format!("decoding evidence {}", path.display()))?;
-
-    // Refuse a schema this build does not know, rather than reading fields that may
-    // have changed meaning. Silently misreading evidence is worse than declining.
-    if evidence.schema_version != EVIDENCE_SCHEMA_VERSION {
-        anyhow::bail!(
-            "evidence uses schema version {}, this build understands {}",
-            evidence.schema_version,
-            EVIDENCE_SCHEMA_VERSION
-        );
-    }
 
     // Bounds-check with the same function a receiving peer uses, so this command
     // never accepts evidence the network itself would reject, and do it BEFORE
@@ -1056,8 +1045,9 @@ fn write_evidence<O: ConformanceOracle + ?Sized>(
         if !written.insert(id) {
             continue;
         }
-        let bytes =
-            bincode::serialize(&evidence).with_context(|| format!("encoding evidence {id}"))?;
+        let bytes = evidence
+            .encode()
+            .with_context(|| format!("encoding evidence {id}"))?;
         let path = dir.join(format!("{id}.bin"));
         std::fs::write(&path, bytes)
             .with_context(|| format!("writing evidence to {}", path.display()))?;
@@ -3050,11 +3040,8 @@ mod tests {
 
         let dir = tempfile::tempdir().expect("temp dir");
         let evidence_path = dir.path().join("evidence.bin");
-        std::fs::write(
-            &evidence_path,
-            bincode::serialize(&evidence).expect("encode evidence"),
-        )
-        .expect("write evidence");
+        std::fs::write(&evidence_path, evidence.encode().expect("encode evidence"))
+            .expect("write evidence");
 
         let store_file = dir.path().join("contract.wasm");
         let encoded = ContractCode::from(code.clone())
@@ -3106,11 +3093,8 @@ mod tests {
 
         let dir = tempfile::tempdir().expect("temp dir");
         let evidence_path = dir.path().join("evidence.bin");
-        std::fs::write(
-            &evidence_path,
-            bincode::serialize(&evidence).expect("encode evidence"),
-        )
-        .expect("write evidence");
+        std::fs::write(&evidence_path, evidence.encode().expect("encode evidence"))
+            .expect("write evidence");
 
         let store_file = dir.path().join("contract.wasm");
         let encoded = ContractCode::from(wrong_code.clone())
@@ -3128,6 +3112,59 @@ mod tests {
             err.to_string().contains(&inner_hash),
             "the error must name the INNER code hash so an operator can compare \
              it against store filenames; got: {err}"
+        );
+    }
+
+    /// An evidence file from an unsupported schema version must be refused politely
+    /// with an explicit version message rather than an opaque deserialization error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_evidence_rejects_unsupported_schema_politely() {
+        let code = minimal_contract_wasm(1);
+        let params = Vec::new();
+        let instance = ContractInstanceId::from_params_and_code(
+            freenet_stdlib::prelude::Parameters::from(params.clone()),
+            ContractCode::from(code.clone()),
+        );
+        let case = ConformanceCase::new(
+            ConformanceProperty::StateIdempotence,
+            vec![Bytes::from(vec![1u8, 2, 3])],
+        );
+        let evidence = ConformanceEvidence::new(instance, params, &case, None);
+        let mut bytes = evidence.encode().expect("encode");
+
+        // Set the schema version to 1 in the framing header.
+        bytes[8..10].copy_from_slice(&1u16.to_le_bytes());
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let evidence_path = dir.path().join("evidence.bin");
+        std::fs::write(&evidence_path, &bytes).expect("write evidence");
+
+        let config = wasm_only_config(None);
+        let err = verify_evidence(&config, &evidence_path)
+            .await
+            .expect_err("unsupported schema must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("evidence uses schema version 1, this build understands 2"),
+            "error should state schema version mismatch cleanly; got: {msg}"
+        );
+    }
+
+    /// A file with bad magic is rejected fast as not conformance evidence.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_evidence_rejects_bad_magic() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let evidence_path = dir.path().join("evidence.bin");
+        std::fs::write(&evidence_path, b"not evidence content here").expect("write file");
+
+        let config = wasm_only_config(None);
+        let err = verify_evidence(&config, &evidence_path)
+            .await
+            .expect_err("bad magic must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not conformance evidence (bad magic)"),
+            "error should indicate bad magic; got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Problem

`ConformanceEvidence` had no framing header: `bincode::deserialize` ran before the schema version was consulted. For the common case (`observed: Some(..)`), deserialization failed inside bincode with an opaque decode error instead of the intended clean schema-version rejection, making the version guard unreachable in practice.

## Solution

Mirrored the framing pattern established in `ReplayBundle`:
- Prepend a 10-byte framing header (`EVIDENCE_MAGIC` [8 bytes] + `schema_version` [2 bytes, LE u16]).
- Implement `encode()` / `decode()` methods on `ConformanceEvidence` that check magic bytes and reject unsupported schema versions before any bincode deserialization occurs.
- Update `fdev`'s `write_evidence` and `verify_evidence` commands to use the new `encode()` and `decode()` methods.

## Testing

- Added regression tests in `crates/core/src/conformance/tests.rs`:
  - `decode_evidence_rejects_unsupported_version_before_bincode`: Confirms schema version rejection triggers even with corrupt/truncated payload before bincode is entered.
  - `decode_evidence_round_trip`: Verifies round-trip encoding and decoding with the 10-byte framing header.
- Verified test suite passes.

## Fixes

Closes #5520
