### PR TITLE
ci: make the anonymous pull the Docker publish's public-ness test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -429,14 +429,44 @@ jobs:
       - name: The published package is publicly pullable
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          IMAGE: ghcr.io/${{ github.repository }}
         run: |
           set -euo pipefail
           visibility=$(gh api "orgs/${{ github.repository_owner }}/packages/container/freenet-core" \
             --jq '.visibility' 2>/dev/null || echo unknown)
           echo "package visibility: ${visibility}"
 
-          if [ "$visibility" = public ]; then
+          # The authoritative test is an ANONYMOUS pull, because that is
+          # literally what a user does. It needs no API permission, so unlike
+          # the visibility field it cannot come back "unknown".
+          #
+          # DOCKER_CONFIG is pointed at an empty directory on purpose: the
+          # smoke job logged in to ghcr.io above, and without this the check
+          # would reuse those credentials and pass on a private package.
+          anon_ok=0
+          anon_home=$(mktemp -d)
+          if DOCKER_CONFIG="$anon_home" docker manifest inspect "${IMAGE}:${RELEASE_TAG}" >/dev/null 2>&1; then
+            anon_ok=1
+          fi
+          rm -rf "$anon_home"
+          echo "anonymous manifest fetch: ${anon_ok}"
+
+          if [ "$anon_ok" = 1 ]; then
+            # Public in the only sense that matters. Note a disagreeing
+            # visibility field rather than failing on it.
+            if [ "$visibility" != public ] && [ "$visibility" != unknown ]; then
+              echo "::warning::Anonymous pull works, but the package visibility field reads '${visibility}'. Worth a look, but not a broken release."
+            fi
             exit 0
+          fi
+
+          if [ "$visibility" = unknown ]; then
+            # GITHUB_TOKEN cannot always read org package metadata, so treat a
+            # failed lookup as "could not tell", never as "not public" — a
+            # release job that goes red on every run stops being read at all.
+            echo "::error::Could not pull ${IMAGE}:${RELEASE_TAG} anonymously, and could not read the package visibility either (the API lookup failed — GITHUB_TOKEN may lack read access to org packages). Most likely the GHCR package is still private. Check https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/freenet-core and see docs/RELEASING.md, 'One-time setup: GHCR package visibility'."
+            exit 1
           fi
 
           echo "::error::The image published, but the GHCR package is '${visibility}', so nobody outside the org can pull it. GitHub creates a new package private and offers no API to change it, so this needs one manual change, once, ever: open https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/freenet-core, go to package settings, and set visibility to Public. Then re-run this workflow with: gh workflow run docker-publish.yml --field tag=${{ github.event.release.tag_name || inputs.tag }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -395,7 +395,7 @@ jobs:
       # (`unauthorized` on a manifest HEAD) looks like a broken image rather
       # than a settings problem. That happened on v0.2.133, the release that
       # introduced this workflow.
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -421,7 +421,18 @@ jobs:
             test "$expected" = "$actual"
           done
 
-      # Checked separately from the pull above, and stated as its own failure,
+  # Its OWN job, not a step of `smoke`, so the two failures stay distinguishable.
+  # A `smoke` failure means the image is broken; this failing means the image is
+  # fine and a registry SETTING is wrong. `notify-publish-failure` says "latest
+  # is now stale", which is true of the first and false of the second — folding
+  # them together would send whoever reads the alert to look at the publish job.
+  public-pull:
+    name: The published package is publicly pullable
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Checked separately from the smoke pull, and stated as its own failure,
       # because a working image nobody can download is still a broken release
       # from a user's point of view. GitHub exposes no API to change this
       # (PATCH on the package route is 404), so it cannot be automated and the
@@ -431,24 +442,42 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           IMAGE: ghcr.io/${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          visibility=$(gh api "orgs/${{ github.repository_owner }}/packages/container/freenet-core" \
-            --jq '.visibility' 2>/dev/null || echo unknown)
+          # `.visibility // empty` because the API can return 200 without the
+          # field, and `--jq '.visibility'` then prints the literal "null",
+          # which the `|| echo unknown` guard would not catch.
+          visibility=$(gh api "orgs/${REPO_OWNER}/packages/container/${PACKAGE}" \
+            --jq '.visibility // empty' 2>/dev/null || true)
+          visibility=${visibility:-unknown}
           echo "package visibility: ${visibility}"
 
           # The authoritative test is an ANONYMOUS pull, because that is
           # literally what a user does. It needs no API permission, so unlike
           # the visibility field it cannot come back "unknown".
           #
-          # DOCKER_CONFIG is pointed at an empty directory on purpose: the
-          # smoke job logged in to ghcr.io above, and without this the check
-          # would reuse those credentials and pass on a private package.
+          # DOCKER_CONFIG points at an empty directory on purpose: the smoke job
+          # logged in to ghcr.io, and that file also selects the credential
+          # HELPER, so an empty config dir removes both the stored token and any
+          # pointer to a helper. Verified against an instrumented helper: with
+          # the default config it is invoked, with an empty DOCKER_CONFIG it is
+          # never invoked at all.
+          #
+          # Retried, because this is now the whole gate and it is one
+          # unauthenticated call from a shared runner IP moments after a push.
+          # A transient 5xx or an anonymous rate limit must not turn a healthy
+          # release red — a release check that fails on a blip stops being read.
           anon_ok=0
           anon_home=$(mktemp -d)
-          if DOCKER_CONFIG="$anon_home" docker manifest inspect "${IMAGE}:${RELEASE_TAG}" >/dev/null 2>&1; then
-            anon_ok=1
-          fi
+          for attempt in 1 2 3; do
+            if DOCKER_CONFIG="$anon_home" docker manifest inspect "${IMAGE}:${RELEASE_TAG}" >/dev/null 2>&1; then
+              anon_ok=1
+              break
+            fi
+            [ "$attempt" = 3 ] || sleep 10
+          done
           rm -rf "$anon_home"
           echo "anonymous manifest fetch: ${anon_ok}"
 
@@ -461,16 +490,49 @@ jobs:
             exit 0
           fi
 
-          if [ "$visibility" = unknown ]; then
-            # GITHUB_TOKEN cannot always read org package metadata, so treat a
-            # failed lookup as "could not tell", never as "not public" — a
-            # release job that goes red on every run stops being read at all.
-            echo "::error::Could not pull ${IMAGE}:${RELEASE_TAG} anonymously, and could not read the package visibility either (the API lookup failed — GITHUB_TOKEN may lack read access to org packages). Most likely the GHCR package is still private. Check https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/freenet-core and see docs/RELEASING.md, 'One-time setup: GHCR package visibility'."
+          if [ "$visibility" = public ]; then
+            # Do NOT print the set-it-public message here: it would tell the
+            # maintainer to make a change that is already made, on a release
+            # that is probably fine.
+            echo "::error::The package visibility field reads 'public', but an anonymous manifest fetch of ${IMAGE}:${RELEASE_TAG} failed three times. This is NOT the private-package case — suspect a transient GHCR failure or an anonymous rate limit, and re-run this workflow. If it persists, check the package page: https://github.com/orgs/${REPO_OWNER}/packages/container/package/${PACKAGE}"
             exit 1
           fi
 
-          echo "::error::The image published, but the GHCR package is '${visibility}', so nobody outside the org can pull it. GitHub creates a new package private and offers no API to change it, so this needs one manual change, once, ever: open https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/freenet-core, go to package settings, and set visibility to Public. Then re-run this workflow with: gh workflow run docker-publish.yml --field tag=${{ github.event.release.tag_name || inputs.tag }}"
+          if [ "$visibility" = unknown ]; then
+            # GITHUB_TOKEN cannot always read org package metadata, so treat a
+            # failed lookup as "could not tell", never as "not public".
+            echo "::error::Could not pull ${IMAGE}:${RELEASE_TAG} anonymously, and could not read the package visibility either (the API lookup failed — GITHUB_TOKEN may lack read access to org packages). Most likely the GHCR package is still private. Check https://github.com/orgs/${REPO_OWNER}/packages/container/package/${PACKAGE} and see docs/RELEASING.md, 'One-time setup: GHCR package visibility'."
+            exit 1
+          fi
+
+          echo "::error::The image published, but the GHCR package is '${visibility}', so nobody outside the org can pull it. GitHub creates a new package private and offers no API to change it, so this needs one manual change, once, ever: open https://github.com/orgs/${REPO_OWNER}/packages/container/package/${PACKAGE}, go to package settings, and set visibility to Public. Then re-run this workflow with: gh workflow run docker-publish.yml --field tag=\"${RELEASE_TAG}\". See docs/RELEASING.md, 'One-time setup: GHCR package visibility'."
           exit 1
+
+  # `public-pull` is deliberately NOT in notify-publish-failure's `needs`, because
+  # that alert says `latest` is now stale — true when the publish broke, false
+  # when the image is fine and only the registry visibility is wrong. This is
+  # that second alert, so the failure is still announced rather than sitting
+  # unread as a red tick in the Actions tab, but announced accurately.
+  notify-not-public:
+    name: Notify dev room if the published image is not publicly pullable
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [public-pull]
+    if: |
+      always() &&
+      (github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
+      (needs.public-pull.result == 'failure' || needs.public-pull.result == 'cancelled')
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - id: notify-not-public
+        uses: ./.github/actions/river-dev-notify
+        with:
+          message: "🐳 The Docker image for ${{ github.event.release.tag_name || inputs.tag }} published FINE, but it could not be pulled anonymously — so `docker pull ghcr.io/freenet/freenet-core` fails for everyone outside the org. The image is NOT stale and running containers are unaffected; this is a registry visibility setting, and GitHub offers no API to change it. Fix once at ${{ github.server_url }}/orgs/${{ github.repository_owner }}/packages/container/package/${{ github.event.repository.name }} (package settings -> visibility -> Public), then re-run. See docs/RELEASING.md, 'One-time setup: GHCR package visibility'. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          bot-config: ${{ secrets.RIVER_DEV_BOT_CONFIG }}
+          room-id: ${{ secrets.RIVER_DEV_ROOM_ID }}
+          gateway-url: ${{ secrets.RIVER_GATEWAY_URL }}
 
   # Without this a failed publish leaves `latest` stale and says so nowhere but
   # a red tick in the Actions tab. Existing containers keep self-updating, so

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -469,10 +469,20 @@ jobs:
           # unauthenticated call from a shared runner IP moments after a push.
           # A transient 5xx or an anonymous rate limit must not turn a healthy
           # release red — a release check that fails on a blip stops being read.
+          # DOCKER_CLI_EXPERIMENTAL is belt-and-braces. `docker manifest` was
+          # historically gated by the `experimental` key in the CLI config, and
+          # emptying DOCKER_CONFIG removes that key along with the credentials —
+          # which would fail every invocation and be indistinguishable from
+          # "package is private", reintroducing the false failure this job
+          # exists to remove. Measured on Docker CLI 28.5.1 the gate is gone (it
+          # was dropped in CLI 23, and runners are well past that), so this is
+          # insurance rather than a fix. It is free, and the step cannot be
+          # exercised in CI before a real release, so take the insurance.
           anon_ok=0
           anon_home=$(mktemp -d)
           for attempt in 1 2 3; do
-            if DOCKER_CONFIG="$anon_home" docker manifest inspect "${IMAGE}:${RELEASE_TAG}" >/dev/null 2>&1; then
+            if DOCKER_CONFIG="$anon_home" DOCKER_CLI_EXPERIMENTAL=enabled \
+              docker manifest inspect "${IMAGE}:${RELEASE_TAG}" >/dev/null 2>&1; then
               anon_ok=1
               break
             fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -486,7 +486,11 @@ jobs:
               anon_ok=1
               break
             fi
-            [ "$attempt" = 3 ] || sleep 10
+            # Jittered. A fixed backoff against a rate-limited third-party
+            # endpoint puts every retrying job at the same offset after
+            # publish; the point of retrying is to miss the thing that
+            # produced the first failure.
+            [ "$attempt" = 3 ] || sleep $(( 10 + RANDOM % 5 ))
           done
           rm -rf "$anon_home"
           echo "anonymous manifest fetch: ${anon_ok}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -384,6 +384,23 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v3
 
+      # Authenticated on purpose. This step's job is "does the published image
+      # run on both architectures", and pulling anonymously conflates that with
+      # "is the package public", which is a separate property checked below.
+      #
+      # Without the login, the FIRST publish of a package always fails here and
+      # every later one passes, because GHCR creates a package private and only
+      # a human can change that. An asymmetry that fires exactly once reads as a
+      # flake forever afterwards, and the failure it produced
+      # (`unauthorized` on a manifest HEAD) looks like a broken image rather
+      # than a settings problem. That happened on v0.2.133, the release that
+      # introduced this workflow.
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       # Pulls what was actually published, per architecture, and runs the
       # binary. Publishing an arm64 manifest that cannot execute is otherwise
       # invisible until a user on a Raspberry Pi reports it.
@@ -403,6 +420,27 @@ jobs:
             echo "expected ${expected}, image ships ${actual}"
             test "$expected" = "$actual"
           done
+
+      # Checked separately from the pull above, and stated as its own failure,
+      # because a working image nobody can download is still a broken release
+      # from a user's point of view. GitHub exposes no API to change this
+      # (PATCH on the package route is 404), so it cannot be automated and the
+      # message has to be good enough to act on without further digging.
+      - name: The published package is publicly pullable
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          visibility=$(gh api "orgs/${{ github.repository_owner }}/packages/container/freenet-core" \
+            --jq '.visibility' 2>/dev/null || echo unknown)
+          echo "package visibility: ${visibility}"
+
+          if [ "$visibility" = public ]; then
+            exit 0
+          fi
+
+          echo "::error::The image published, but the GHCR package is '${visibility}', so nobody outside the org can pull it. GitHub creates a new package private and offers no API to change it, so this needs one manual change, once, ever: open https://github.com/orgs/${{ github.repository_owner }}/packages/container/package/freenet-core, go to package settings, and set visibility to Public. Then re-run this workflow with: gh workflow run docker-publish.yml --field tag=${{ github.event.release.tag_name || inputs.tag }}"
+          exit 1
 
   # Without this a failed publish leaves `latest` stale and says so nowhere but
   # a red tick in the Actions tab. Existing containers keep self-updating, so

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,6 +86,37 @@ To validate `FREENET_RELEASE_SIGNING_KEY` without cutting a release, run the
 `verify-signing-key` job derives the public key from the secret, asserts it
 matches the key baked into the binary, and does a sign/verify round-trip.
 
+### One-time setup: GHCR package visibility
+
+`docker-publish.yml` pushes `ghcr.io/freenet/freenet-core`. GitHub creates a new
+package as **private**, so until its visibility is set to public once, every
+`docker pull` in the Docker README fails for everyone except maintainers, and
+the error reads as a missing image rather than a permissions problem.
+
+This is needed once, not per release, and it cannot be automated: there is no
+REST API for it (`PATCH` on the package route returns 404), so it is a manual
+change in the web UI.
+
+    https://github.com/orgs/freenet/packages/container/package/freenet-core
+    -> package settings -> visibility -> Public
+
+**This happened on v0.2.133**, the release that introduced the workflow. The
+image published correctly and the `smoke` job failed with
+
+    Head "https://ghcr.io/v2/freenet/freenet-core/manifests/v0.2.133": unauthorized
+
+which looks like a broken image and is actually the package being private. The
+smoke job now authenticates its pull, so it tests whether the image runs rather
+than whether the package is public, and checks visibility as a separate step
+whose error message names this section. If you see that error on a future
+release, the package visibility has been reset rather than the image being bad.
+
+After changing it, re-run the publish for that tag:
+
+```bash
+gh workflow run docker-publish.yml --field tag=vX.Y.Z
+```
+
 ### Windows code signing (Authenticode)
 
 `freenet.exe` and `fdev.exe` are Authenticode-signed in

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -107,13 +107,23 @@ image published correctly and the `smoke` job failed with
 
 which looks like a broken image and is actually the package being private. The
 smoke job now authenticates its pull, so it tests whether the image runs rather
-than whether the package is public. Public-ness is checked as a separate step,
-and what that step actually tests is an anonymous `docker manifest inspect` —
-the thing a user does — rather than the package's `visibility` field, because
-`GITHUB_TOKEN` cannot always read org package metadata and a lookup that fails
-must read as "could not tell", never as "not public". Its error message names
-this section. If you see that error on a future
-release, the package visibility has been reset rather than the image being bad.
+than whether the package is public.
+
+Public-ness is a separate job, `public-pull`, and what it actually tests is an
+anonymous `docker manifest inspect` — the thing a user does — rather than the
+package's `visibility` field, because `GITHUB_TOKEN` cannot always read org
+package metadata and a lookup that fails must read as "could not tell", never
+as "not public". It is a separate job rather than a step of `smoke` so that
+"the image is broken" and "a registry setting is wrong" stay distinguishable:
+the dev-room alert for a `smoke` failure says `latest` is now stale, which is
+true of the first and false of the second.
+
+The anonymous fetch is retried three times before failing. It is one
+unauthenticated call from a shared runner IP moments after a push, and a
+release gate that goes red on a network blip stops being read. If the
+`visibility` field says `public` but the anonymous fetch still fails, the job
+says so specifically rather than telling you to set a flag that is already
+set.
 
 After changing it, re-run the publish for that tag:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -107,8 +107,12 @@ image published correctly and the `smoke` job failed with
 
 which looks like a broken image and is actually the package being private. The
 smoke job now authenticates its pull, so it tests whether the image runs rather
-than whether the package is public, and checks visibility as a separate step
-whose error message names this section. If you see that error on a future
+than whether the package is public. Public-ness is checked as a separate step,
+and what that step actually tests is an anonymous `docker manifest inspect` —
+the thing a user does — rather than the package's `visibility` field, because
+`GITHUB_TOKEN` cannot always read org package metadata and a lookup that fails
+must read as "could not tell", never as "not public". Its error message names
+this section. If you see that error on a future
 release, the package visibility has been reset rather than the image being bad.
 
 After changing it, re-run the publish for that tag:


### PR DESCRIPTION
## Problem

v0.2.133 published its Docker image correctly and the `smoke` job failed anyway:

```
Head "https://ghcr.io/v2/freenet/freenet-core/manifests/v0.2.133": unauthorized
```

The image was fine. GHCR creates a new package **private**, the smoke step pulled anonymously, and the pull was refused. Changing visibility is manual and cannot be automated (GitHub exposes no REST API for it; `PATCH` on the package route returns 404), so it cannot possibly happen before a step in the same workflow run.

The ordering is only half of it. Because a package is private exactly once, this step fails on the **first** publish of any package and passes on every one after. A check that fails once and then never again is indistinguishable from a flake by the time someone reads it, and the error it produced points at a manifest rather than at a settings page. A future reader would see a red `docker-publish` on the release that introduced it and nothing explaining why.

## Fix

These were two properties wearing one assertion, so they are now two steps.

**The smoke pull authenticates.** Its job is "does the published image run on both architectures". Pulling anonymously conflated that with "is the package public".

**Visibility is checked on its own**, because an image nobody can download is still a broken release from a user's point of view. It fails with the exact package URL and the re-run command, so it is actionable without digging:

```
::error::The image published, but the GHCR package is 'private', so nobody
outside the org can pull it. GitHub creates a new package private and offers no
API to change it, so this needs one manual change, once, ever: open
https://github.com/orgs/freenet/packages/container/package/freenet-core, go to
package settings, and set visibility to Public. Then re-run this workflow with:
gh workflow run docker-publish.yml --field tag=v0.2.133
```

`docs/RELEASING.md` records what actually happened on v0.2.133, including the error text, so someone meeting it on a later release reads it as "visibility was reset" rather than "the image is broken".

## Testing

Verified against the live package after it was made public. Logged out of ghcr.io first, so these are what an unauthenticated stranger gets:

```
anonymous manifest fetch                          HTTP 200
docker run --platform linux/amd64 ... :v0.2.133   Freenet version: 0.2.133 (d6f099508f36)
docker run --platform linux/arm64 ... :v0.2.133   Freenet version: 0.2.133 (d6f099508f36)
docker run                        ... :latest     Freenet version: 0.2.133 (d6f099508f36)
```

The commit hash matches the v0.2.133 release commit.

The workflow's own `verify` job exercises this file on every change to it, and `docker-publish.yml` was re-fired for v0.2.133 to confirm the smoke job passes now that the package is public.

Credit to the release agent for spotting the asymmetry rather than treating the red run as a one-off.

[AI-assisted - Claude]

https://claude.ai/code/session_01W2mLM7JF3KC6UfTB4Zqwf6
