### PR TITLE
fix(delegates): park delegates off the serial loop instead of blocking it (#5544)

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -289,10 +289,23 @@ MUST:
 
 - Off-loop deferral (#4391): there are now TWO entry points into the
   bridged upsert.
-  * The NON-deferrable path (`upsert_contract_state`, used by
-    delegate-driven PUTs and direct callers) keeps the INLINE
+  * The NON-deferrable path (`upsert_contract_state`) keeps the INLINE
     `start_sub_op_get` escalation described above — it awaits the
     network GET in place, bounded by RELATED_FETCH_TIMEOUT.
+    Used by direct callers, and as a FALLBACK only: the delegate path
+    reaches it when there is no parking context (direct unit-test calls)
+    or when a park was refused at the node-wide cap. Falling back means
+    accepting the loop stall the deferral exists to remove, which is the
+    deliberate trade at that cap — losing a user's prompt or a delegate's
+    write would be worse.
+  * DELEGATE-DRIVEN PUTs AND UPDATEs USE THE DEFERRABLE PATH (#5544).
+    They used to be listed above as non-deferrable, and were: the delegate
+    arms called `upsert_contract_state` directly, so a related-contract
+    miss awaited a network GET on the serial loop for up to
+    RELATED_FETCH_TIMEOUT. That was one of the two stalls #5544 removes.
+    Past `MAX_DEFERRED_UPSERTS_PER_PARK` the excess REFUSES with
+    `MissingRelated` rather than falling back inline, because nothing caps
+    how many upserts one `process()` may emit.
   * The DEFERRABLE path (`upsert_contract_state_deferrable`, used by the
     serial `contract_handling` loop) resolves related contracts
     LOCAL-ONLY first. On a local miss it does NOT await the network GET

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -109,6 +109,12 @@ WHEN a timing assertion cannot be made decisive in your harness:
   → Do not leave a reader to assume the timeout is the guard
 ```
 
+Running the falsification is itself governed by "Deliberately breaking code to
+verify a test: mark it `MUTATION_APPLIED`" above — commit before you mutate,
+mark the broken line with that exact token, and grep it clean before you
+commit. This section says a "does not block" test MUST be falsified; that one
+says how to falsify without leaving the break behind.
+
 **Known-vacuous, do not trust (audited 2026-09-04):** `#4391`'s
 `deferred_related_fetch_does_not_block_local_get` and
 `same_key_get_during_deferred_put_runs_promptly` both PASS with the deferral

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -67,6 +67,59 @@ WHEN writing tests for any behavioral change:
     fn test_send_packet_after_recovery() { ... }
 ```
 
+### A "does not block" test is only as good as whether the counterfactual actually blocks
+
+```
+WHEN writing a test that asserts work X proceeds while slow work Y is in flight
+  ("does not block", "runs promptly", "no head-of-line blocking"):
+
+  → The assertion is meaningless unless Y REALLY HANGS in that harness
+  → RUN THE FALSIFICATION: disable the fix, re-run, confirm the test FAILS
+  → If it still passes, the test is vacuous — it is passing for a reason
+    unrelated to the fix, and it will not notice the regression it names
+```
+
+The trap is that these tests look strong. They drive the real loop, they use a
+gate, they assert a tight timeout — and they can still be measuring nothing,
+because the mock the test builds cannot perform the slow operation at all.
+
+**Worked example (#5544).** `deferred_delegate_upsert_does_not_block_the_loop`
+gated the OFF-LOOP related-contract fetch and asserted an unrelated local GET
+stayed prompt. It passed with the deferral disabled. `build_handler` constructs
+its executor with **no `op_manager`**, so the INLINE fetch fails immediately
+instead of hanging — the GET was prompt either way. The assertion held for a
+reason that had nothing to do with the change.
+
+Contrast the sibling test in the same commit,
+`parked_delegate_prompt_does_not_block_the_loop`, which IS decisive: it gates
+`prompter.prompt()`, which is pure async and genuinely hangs inline, so removing
+the fix really does stall the loop and really does fail the test.
+
+The distinction is not "integration vs unit" or "real loop vs mock". It is
+whether the specific slow operation you gated can block in the harness you built.
+
+Fix for a vacuous one: assert the MECHANISM alongside the emergent property —
+that the off-loop path was actually taken (a call counter on the stub), and that
+the operation is genuinely suspended (`!task.is_finished()` while gated). Both
+fail when the fix is removed; the timing assertion stays as corroboration.
+
+```
+WHEN a timing assertion cannot be made decisive in your harness:
+  → SAY SO IN A COMMENT ON THE TEST, naming what does carry the weight
+  → Do not leave a reader to assume the timeout is the guard
+```
+
+**Known-vacuous, do not trust (audited 2026-09-04):** `#4391`'s
+`deferred_related_fetch_does_not_block_local_get` and
+`same_key_get_during_deferred_put_runs_promptly` both PASS with the deferral
+removed, for exactly this reason. #4391's deferral IS covered — three tests
+(`deferred_related_fetch_success_resumes_and_completes`,
+`second_related_request_after_resume_does_not_defer_again`,
+`update_path_deferral_resumes_and_applies`) do fail when it is removed — but they
+cover that the deferral EXISTS, not the head-of-line-blocking property it exists
+to provide. A regression where the deferral still happens but blocks anyway would
+be caught by nothing.
+
 ## Trigger-Action Rules
 
 ### When writing new code in `crates/core/`

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -666,11 +666,13 @@ async fn run_user_input_prompts<P>(
     delegate_key: &DelegateKey,
     delegate_key_str: &str,
     caller: CallerIdentity,
-) -> Vec<InboundDelegateMsg<'static>>
-where
+    // Answers are appended AS THEY ARRIVE rather than returned at the end, so a
+    // caller whose overall budget expires mid-sequence still keeps the ones a
+    // human already answered (#5544 S6).
+    sink: &std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>,
+) where
     P: UserInputPrompter,
 {
-    let mut out = Vec::with_capacity(requests.len());
     for req in requests {
         let request_id = req.request_id;
         let response = match prompter
@@ -689,16 +691,17 @@ where
                 ClientResponse::new(Vec::new())
             }
         };
-        out.push(InboundDelegateMsg::UserResponse(UserInputResponse {
-            request_id,
-            response,
-            // UserInputRequest has no context field, so we use default.
-            // The delegate's actual context is maintained separately in
-            // the process_outbound loop in delegate.rs.
-            context: DelegateContext::default(),
-        }));
+        sink.lock()
+            .unwrap()
+            .push(InboundDelegateMsg::UserResponse(UserInputResponse {
+                request_id,
+                response,
+                // UserInputRequest has no context field, so we use default.
+                // The delegate's actual context is maintained separately in
+                // the process_outbound loop in delegate.rs.
+                context: DelegateContext::default(),
+            }));
     }
-    out
 }
 
 /// Loop-side context that lets a delegate run PARK instead of blocking.
@@ -717,6 +720,20 @@ struct ParkingCtx<'a> {
     /// new continuation, and if it completes the caller reads what is left here
     /// and answers the client. A fresh run passes `&mut None`.
     carried_responder: &'a mut Option<StashedResponder>,
+}
+
+/// State carried into a delegate run that is continuing an earlier one.
+///
+/// Bundled rather than passed as two more positional arguments to a function
+/// that already carries an `allow(too_many_arguments)`.
+#[derive(Default)]
+struct RunSeed {
+    /// Messages this delegate emitted BEFORE an earlier park, so a round-trip
+    /// that parks more than once still yields one complete response.
+    accumulated: Vec<OutboundDelegateMsg>,
+    /// Iterations already consumed, so `MAX_CONTRACT_REQUEST_ITERATIONS`
+    /// bounds the whole round-trip and a park cannot reset it (#5544 S1).
+    iterations: usize,
 }
 
 /// Outcome of one delegate run.
@@ -767,10 +784,9 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     delegate_key: &DelegateKey,
     prompter: &std::sync::Arc<P>,
     mut parking: Option<ParkingCtx<'_>>,
-    // Messages this delegate emitted BEFORE an earlier park, carried in so a
-    // round-trip that parks more than once still yields one complete response.
-    // `Vec::new()` for a fresh run; `continuation.accumulated` for a resume.
-    seed_accumulated: Vec<OutboundDelegateMsg>,
+    // State carried in from an earlier leg of this round-trip. `RunSeed::
+    // default()` for a fresh run; built from the continuation for a resume.
+    seed: RunSeed,
 ) -> DelegateRunOutcome
 where
     CH: ContractHandler + Send + 'static,
@@ -812,9 +828,11 @@ where
 
     let mut current_req = initial_req;
     let current_params = initial_params;
-    let mut iterations = 0;
     // Accumulate non-contract-request messages across iterations
-    let mut accumulated_messages: Vec<OutboundDelegateMsg> = seed_accumulated;
+    let RunSeed {
+        accumulated: mut accumulated_messages,
+        mut iterations,
+    } = seed;
 
     loop {
         iterations += 1;
@@ -992,7 +1010,11 @@ where
 
                 let result = match outcome {
                     Ok(UpsertOutcome::Completed(r)) => Ok(r),
-                    Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                    Ok(UpsertOutcome::DeferRelated(missing))
+                        if parking.is_some()
+                            && deferred_upserts.len()
+                                < delegate_park::MAX_DEFERRED_UPSERTS_PER_PARK =>
+                    {
                         deferred_upserts.push(delegate_park::PendingUpsert {
                             key: contract_key,
                             update,
@@ -1168,7 +1190,11 @@ where
                             .await;
                         match outcome {
                             Ok(UpsertOutcome::Completed(r)) => Ok(r),
-                            Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                            Ok(UpsertOutcome::DeferRelated(missing))
+                                if parking.is_some()
+                                    && deferred_upserts.len()
+                                        < delegate_park::MAX_DEFERRED_UPSERTS_PER_PARK =>
+                            {
                                 deferred_upserts.push(delegate_park::PendingUpsert {
                                     key: full_key,
                                     update: update_value,
@@ -1527,6 +1553,9 @@ where
                     inter_delegate,
                     accumulated: std::mem::take(&mut accumulated_messages),
                     inbound_so_far: std::mem::take(&mut inbound_responses),
+                    // Carry the count so the cap bounds the ROUND-TRIP, not
+                    // each leg (#5544 S1).
+                    iterations,
                     // Attached by the caller right after we return `Parked` (it
                     // owns the channel), or carried straight through if this run
                     // is itself a resume that is parking again.
@@ -1560,6 +1589,21 @@ where
                         // this task the handler. See `delegate_park`'s module
                         // docs, "What parking does NOT relax".
                         GlobalExecutor::spawn(async move {
+                            // Results land in these as they complete, so a
+                            // budget expiry keeps what is already done (#5544
+                            // S6). Discarding on timeout would throw away
+                            // prompt answers a HUMAN has already given, and
+                            // prompts run sequentially, so two slow ones can
+                            // exceed the budget with the first already
+                            // answered.
+                            let answers_sink: std::sync::Arc<
+                                std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>,
+                            > = Default::default();
+                            let fetch_sink: std::sync::Arc<
+                                std::sync::Mutex<Vec<delegate_park::ResolvedUpsert>>,
+                            > = Default::default();
+                            let answers_out = answers_sink.clone();
+                            let fetch_out = fetch_sink.clone();
                             // Prompts and fetches run CONCURRENTLY, and the whole
                             // body is capped by PARK_WORK_BUDGET. Sequentially
                             // they could sum past PARK_TTL, at which point the
@@ -1570,29 +1614,32 @@ where
                             let fetches = async {
                                 futures::future::join_all(upserts.into_iter().map(|pending| {
                                     let op_manager = op_manager.clone();
+                                    let sink = fetch_sink.clone();
                                     async move {
                                         let fetched = fetch_related_off_loop(
                                             op_manager,
                                             pending.missing.clone(),
                                         )
                                         .await;
-                                        delegate_park::ResolvedUpsert { pending, fetched }
+                                        sink.lock().unwrap().push(delegate_park::ResolvedUpsert {
+                                            pending,
+                                            fetched,
+                                        });
                                     }
                                 }))
-                                .await
+                                .await;
                             };
                             let answers = async {
-                                if prompts.is_empty() {
-                                    Vec::new()
-                                } else {
+                                if !prompts.is_empty() {
                                     run_user_input_prompts(
                                         prompter.as_ref(),
                                         prompts,
                                         &key,
                                         &delegate_key_str,
                                         caller,
+                                        &answers_sink,
                                     )
-                                    .await
+                                    .await;
                                 }
                             };
                             let done =
@@ -1600,17 +1647,25 @@ where
                                     tokio::join!(answers, fetches)
                                 })
                                 .await;
-                            match done {
-                                Ok((responses, resolved)) => guard.send(responses, resolved),
-                                Err(_) => {
-                                    tracing::warn!(
-                                        delegate = %key,
-                                        "Off-loop delegate work exceeded PARK_WORK_BUDGET; \
-                                         resuming empty so the round-trip terminates"
-                                    );
-                                    guard.send(Vec::new(), Vec::new());
-                                }
+                            // Either way, resume with whatever completed. On
+                            // expiry that is a PARTIAL result rather than
+                            // nothing, so answers the user already gave are not
+                            // thrown away; the delegate sees responses for the
+                            // requests that finished and none for those that
+                            // did not, which is the same shape as a denied
+                            // prompt.
+                            let responses = std::mem::take(&mut *answers_out.lock().unwrap());
+                            let resolved = std::mem::take(&mut *fetch_out.lock().unwrap());
+                            if done.is_err() {
+                                tracing::warn!(
+                                    delegate = %key,
+                                    kept_answers = responses.len(),
+                                    kept_fetches = resolved.len(),
+                                    "Off-loop delegate work exceeded PARK_WORK_BUDGET; \
+                                     resuming with what completed"
+                                );
                             }
+                            guard.send(responses, resolved);
                         });
                         return DelegateRunOutcome::Parked;
                     }
@@ -1623,6 +1678,7 @@ where
                         let continuation = *continuation;
                         accumulated_messages = continuation.accumulated;
                         inbound_responses = continuation.inbound_so_far;
+                        iterations = continuation.iterations;
                         *ctx.carried_responder = continuation.responder;
                     }
                 }
@@ -1634,16 +1690,17 @@ where
                 inbound_responses.push(run_deferred_upsert_inline(contract_handler, pending).await);
             }
             if !user_input_requests.is_empty() {
-                inbound_responses.extend(
-                    run_user_input_prompts(
-                        prompter.as_ref(),
-                        std::mem::take(&mut user_input_requests),
-                        delegate_key,
-                        &delegate_key_str,
-                        caller,
-                    )
-                    .await,
-                );
+                let sink = std::sync::Mutex::new(Vec::new());
+                run_user_input_prompts(
+                    prompter.as_ref(),
+                    std::mem::take(&mut user_input_requests),
+                    delegate_key,
+                    &delegate_key_str,
+                    caller,
+                    &sink,
+                )
+                .await;
+                inbound_responses.extend(sink.into_inner().unwrap());
             }
         }
 
@@ -1806,11 +1863,21 @@ where
         // iteration for the same reason as the deferred-upsert drain — each
         // resume re-enters WASM — and interleaved with the fair queue so
         // resumes cannot head-of-line-block ordinary contract ops.
-        for _ in 0..MAX_RESUME_DRAIN_BATCH {
+        let mut resume_budget = MAX_RESUME_DRAIN_BATCH;
+        while resume_budget > 0 {
             match delegate_resume_rx.try_recv() {
                 Ok(resume) => {
-                    handle_delegate_resume(&mut contract_handler, &mut park_ctx, &prompter, resume)
-                        .await;
+                    // Spend the WHOLE cost, including the pending requests
+                    // drained behind the park — each is a full delegate run
+                    // (#5544 S5).
+                    let runs = handle_delegate_resume(
+                        &mut contract_handler,
+                        &mut park_ctx,
+                        &prompter,
+                        resume,
+                    )
+                    .await;
+                    resume_budget = resume_budget.saturating_sub(runs.max(1));
                 }
                 Err(_) => break,
             }
@@ -1824,7 +1891,7 @@ where
                 delegate = %delegate_key,
                 "Delegate park exceeded PARK_TTL — force-resuming"
             );
-            handle_delegate_resume(
+            let _ = handle_delegate_resume(
                 &mut contract_handler,
                 &mut park_ctx,
                 &prompter,
@@ -1965,7 +2032,7 @@ where
                 // iteration, so there is exactly one sweep implementation.
             }
             Some(delegate_resume) = delegate_resume_rx.recv() => {
-                handle_delegate_resume(
+                let _ = handle_delegate_resume(
                     &mut contract_handler,
                     &mut park_ctx,
                     &prompter,
@@ -2789,7 +2856,7 @@ async fn handle_delegate_notification<CH, P>(
             delivery: delegate_park::Delivery::Apps,
             carried_responder: &mut no_responder,
         }),
-        Vec::new(),
+        RunSeed::default(),
     )
     .await;
 
@@ -2947,7 +3014,7 @@ async fn dispatch_delegate_request<CH, P>(
             &delegate_key,
             prompter,
             None,
-            Vec::new(),
+            RunSeed::default(),
         )
         .await;
         let response = match outcome {
@@ -3038,7 +3105,7 @@ async fn dispatch_delegate_request<CH, P>(
             delivery: delegate_park::Delivery::Client,
             carried_responder: &mut carried_responder,
         }),
-        Vec::new(),
+        RunSeed::default(),
     )
     .await;
 
@@ -3092,12 +3159,21 @@ async fn send_delegate_response<CH>(
 /// Runs ON the serial loop (the delegate's WASM must stay serial); only the
 /// WAIT happened off it. This is the counterpart to #4391's
 /// `handle_deferred_resume`.
+///
+/// Returns the number of delegate runs performed, INCLUDING the pending
+/// requests drained behind the park. The loop spends that against its
+/// `MAX_RESUME_DRAIN_BATCH` budget (#5544 S5): each drained request is a full
+/// delegate run, so an unaccounted drain could do
+/// `MAX_RESUME_DRAIN_BATCH x MAX_PENDING_PER_DELEGATE` runs before the fair
+/// queue got a single turn — exactly the head-of-line blocking the batch cap
+/// exists to prevent.
 async fn handle_delegate_resume<CH, P>(
     contract_handler: &mut CH,
     park: &mut delegate_park::DelegateParkCtx,
     prompter: &std::sync::Arc<P>,
     resume: delegate_park::DelegateResume,
-) where
+) -> usize
+where
     CH: ContractHandler + Send + 'static,
     P: UserInputPrompter + 'static,
 {
@@ -3115,8 +3191,10 @@ async fn handle_delegate_resume<CH, P>(
             delegate = %delegate_key,
             "Resume for a delegate that is not parked — dropping"
         );
-        return;
+        return 0;
     };
+    // The resumed run itself, plus one per pending request drained below.
+    let mut runs = 1usize;
 
     if cause == delegate_park::ResumeCause::TimedOut {
         tracing::warn!(
@@ -3128,6 +3206,7 @@ async fn handle_delegate_resume<CH, P>(
     }
 
     let delegate_park::Continuation {
+        iterations,
         params,
         origin_contract,
         connection_scope,
@@ -3179,7 +3258,10 @@ async fn handle_delegate_resume<CH, P>(
             // run parks AGAIN it lands in the new continuation. Appending to the
             // `Completed` arm only — as this did — silently dropped every
             // pre-park message on the second park.
-            accumulated,
+            RunSeed {
+                accumulated,
+                iterations,
+            },
         )
         .await
     };
@@ -3230,6 +3312,7 @@ async fn handle_delegate_resume<CH, P>(
     // every item: the resumed run (or an earlier drained request) may have
     // parked this delegate again, and exclusion must still hold.
     for queued in pending {
+        runs += 1;
         match queued {
             delegate_park::PendingRun::Client {
                 id,
@@ -3268,6 +3351,7 @@ async fn handle_delegate_resume<CH, P>(
             }
         }
     }
+    runs
 }
 
 /// Re-run a notification-driven delegate invocation that had been queued behind
@@ -3322,7 +3406,7 @@ async fn run_queued_notification<CH, P>(
             delivery: delegate_park::Delivery::Apps,
             carried_responder: &mut no_responder,
         }),
-        Vec::new(),
+        RunSeed::default(),
     )
     .await;
 
@@ -6907,6 +6991,60 @@ mod hol_4391_tests {
         );
     }
 
+    /// S1: the iteration cap must bound the whole ROUND-TRIP, not each leg.
+    ///
+    /// `iterations` used to be a call-frame local, so every park reset it. A
+    /// delegate that emits `RequestUserInput` on every re-entry then loops
+    /// park -> resume -> park without limit, holding its per-delegate exclusion
+    /// open the entire time so every other request for it queues and is then
+    /// refused. Before parking existed the same delegate stopped after
+    /// `MAX_CONTRACT_REQUEST_ITERATIONS`.
+    ///
+    /// FALSIFY by dropping `iterations` from the `Continuation` (or seeding it
+    /// as 0 in `handle_delegate_resume`): the run then consumes the whole
+    /// script instead of stopping at the cap.
+    #[tokio::test]
+    async fn the_iteration_cap_bounds_the_round_trip_not_each_park() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        let calls = handler.runtime_mut().delegate_calls.clone();
+
+        // A delegate that prompts EVERY time it is entered. More entries than
+        // the cap, so "ran out of script" cannot be mistaken for "hit the cap".
+        let scripted = MAX_CONTRACT_REQUEST_ITERATIONS + 50;
+        for _ in 0..scripted {
+            script.lock().unwrap().push_back(prompt_outbound().into());
+        }
+
+        let send = Arc::new(send);
+        // Answer every prompt immediately; the point here is the loop count,
+        // not the wait.
+        let gate = Arc::new(tokio::sync::Semaphore::new(scripted + 10));
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        let resp = tokio::time::timeout(
+            Duration::from_secs(10),
+            send.send_to_handler(delegate_event(&test_delegate_key())),
+        )
+        .await
+        .expect("a delegate that prompts forever must still terminate (#5544 S1)");
+        assert!(resp.is_ok(), "the client must be answered, got {resp:?}");
+
+        let entered = calls.lock().unwrap().len();
+        assert!(
+            entered <= MAX_CONTRACT_REQUEST_ITERATIONS + 1,
+            "the cap must bound the whole round-trip across parks: entered the \
+             delegate {entered} times, cap is {MAX_CONTRACT_REQUEST_ITERATIONS} \
+             (#5544 S1)"
+        );
+
+        handle.abort();
+    }
+
     /// B2 via the context model: an inter-delegate message must not re-enter a
     /// parked TARGET delegate.
     ///
@@ -6996,6 +7134,7 @@ mod hol_4391_tests {
     /// A continuation standing in for a delegate parked on a prompt.
     fn parked_continuation() -> delegate_park::Continuation {
         delegate_park::Continuation {
+            iterations: 0,
             params: Parameters::from(Vec::new()),
             origin_contract: None,
             connection_scope: crate::client_events::ConnectionScope::Local,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -610,10 +610,42 @@ where
                     freenet_stdlib::prelude::State::from(state.as_ref().to_vec()),
                 );
             }
-            contract_handler
+            // DEFERRABLE, not the plain upsert (#5544 B4).
+            //
+            // This runs from `handle_delegate_resume`, ON the serial loop. If
+            // the contract asks for a SECOND or DIFFERENT related contract now
+            // that the first set is injected, the plain `upsert_contract_state`
+            // would do that network GET inline and re-create the exact
+            // node-wide stall this change removes.
+            //
+            // A repeated `DeferRelated` becomes `MissingRelated` rather than
+            // deferring again: the same depth=1 / one-deferral cap
+            // `handle_deferred_resume` applies on the client path, and the
+            // pattern `contracts.md` requires for work on the serial loop.
+            // Without the cap a contract could defer indefinitely and hold this
+            // delegate's exclusion open.
+            let outcome = contract_handler
                 .executor()
-                .upsert_contract_state(pending.key, pending.update, related_contracts, pending.code)
-                .await
+                .upsert_contract_state_deferrable(
+                    pending.key,
+                    pending.update,
+                    related_contracts,
+                    pending.code,
+                )
+                .await;
+            match outcome {
+                Ok(UpsertOutcome::Completed(r)) => Ok(r),
+                Ok(UpsertOutcome::DeferRelated(missing)) => {
+                    let id = missing.first().copied().unwrap_or(contract_id);
+                    tracing::warn!(
+                        contract = %contract_id,
+                        "Resumed delegate upsert requested a further related \
+                         contract; refusing to defer twice (depth=1 cap)"
+                    );
+                    Err(ExecutorError::missing_related(id))
+                }
+                Err(err) => Err(err),
+            }
         }
         // The fetch failed or timed out: surface it to the delegate rather than
         // retrying, matching the all-or-nothing semantics of the inline path.
@@ -735,6 +767,10 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     delegate_key: &DelegateKey,
     prompter: &std::sync::Arc<P>,
     mut parking: Option<ParkingCtx<'_>>,
+    // Messages this delegate emitted BEFORE an earlier park, carried in so a
+    // round-trip that parks more than once still yields one complete response.
+    // `Vec::new()` for a fresh run; `continuation.accumulated` for a resume.
+    seed_accumulated: Vec<OutboundDelegateMsg>,
 ) -> DelegateRunOutcome
 where
     CH: ContractHandler + Send + 'static,
@@ -778,7 +814,7 @@ where
     let current_params = initial_params;
     let mut iterations = 0;
     // Accumulate non-contract-request messages across iterations
-    let mut accumulated_messages: Vec<OutboundDelegateMsg> = Vec::new();
+    let mut accumulated_messages: Vec<OutboundDelegateMsg> = seed_accumulated;
 
     loop {
         iterations += 1;
@@ -1287,6 +1323,46 @@ where
                     params: Parameters::from(Vec::new()),
                     inbound,
                 };
+                // PER-DELEGATE EXCLUSION, second door (#5544 B2).
+                //
+                // This is the SECOND call site of `execute_delegate_request`,
+                // and it invokes the TARGET delegate, not the calling one — so
+                // `dispatch_delegate_request`'s check upstream says nothing
+                // about it. Delivering here while the target is parked would
+                // run its `process()` mid-round-trip and clobber the parked
+                // continuation's `DelegateContextCache` entry: the exact
+                // corruption the exclusion exists to prevent, reached through a
+                // different door.
+                //
+                // DROPPED rather than queued, deliberately. The hop is already
+                // single-hop, fire-and-forget, and entirely suppressed on
+                // notification-driven runs, so callers cannot rely on delivery.
+                // Queueing it would mean replaying an ATTESTED caller identity
+                // (`Some(delegate_key)`, the control that replaced the deleted
+                // registration-record refusal — GHSA-824h-7x5x-wfmf) at an
+                // arbitrarily later time under a scope captured earlier, and
+                // deferring an attestation is not something to introduce as a
+                // side effect of a stall fix. Losing a fire-and-forget message
+                // beats corrupting the target's state.
+                //
+                // `info!`, not `debug!`: the crate sets `release_max_level_info`
+                // so a `debug!` compiles out of shipped binaries and a delegate
+                // author would have no way to see why their message vanished —
+                // the same reasoning as the suppression log below.
+                if parking
+                    .as_ref()
+                    .is_some_and(|ctx| ctx.park.is_parked(&target_key))
+                {
+                    tracing::info!(
+                        from_delegate = %delegate_key,
+                        target_delegate = %target_key,
+                        "Dropped an inter-delegate message: the target is parked \
+                         mid-round-trip and running it now would clobber its \
+                         parked continuation (#5544)"
+                    );
+                    continue;
+                }
+
                 match contract_handler
                     .executor()
                     // Inter-delegate hop: `user_context = None`. A
@@ -1848,7 +1924,19 @@ where
         }
 
         // Fair queue is empty. Block-wait for a new event, a resumed deferral,
-        // or a delegate notification.
+        // a delegate notification — or the park backstop deadline.
+        //
+        // That last arm is load-bearing (#5544 B6). Without it the sweep at the
+        // top of this loop only runs when some UNRELATED event happens to wake
+        // the select, so on a quiet node a wedged park would be swept late or
+        // never — and a quiet node is the normal state for a background peer,
+        // and precisely the condition under which a prompt goes unanswered
+        // because no dashboard tab is open. A backstop whose firing depends on
+        // other traffic is not a backstop.
+        //
+        // `pending()` when nothing is parked, so an idle node with no parks
+        // still blocks indefinitely rather than spinning on a timer.
+        let park_deadline = park_ctx.next_sweep_deadline();
         tokio::select! {
             result = contract_handler.channel().recv_from_sender() => {
                 let (id, event, priority) = result?;
@@ -1866,6 +1954,15 @@ where
             }
             Some(export_resume) = export_resume_rx.recv() => {
                 handle_export_resume(&mut contract_handler, export_resume).await;
+            }
+            () = async {
+                match park_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                // Wake only; the sweep itself runs at the top of the next
+                // iteration, so there is exactly one sweep implementation.
             }
             Some(delegate_resume) = delegate_resume_rx.recv() => {
                 handle_delegate_resume(
@@ -2549,7 +2646,7 @@ async fn handle_delegate_notification<CH, P>(
     contract_handler: &mut CH,
     notification: executor::DelegateNotification,
     prompter: &std::sync::Arc<P>,
-    park: Option<&mut delegate_park::DelegateParkCtx>,
+    mut park: Option<&mut delegate_park::DelegateParkCtx>,
 ) where
     CH: ContractHandler + Send + 'static,
     P: UserInputPrompter + 'static,
@@ -2609,6 +2706,57 @@ async fn handle_delegate_notification<CH, P>(
         inbound,
     };
 
+    // PER-DELEGATE EXCLUSION, first door (#5544 B1).
+    //
+    // A notification is a THIRD way into a delegate, alongside the client
+    // request and the inter-delegate hop, and it is driven by a contract's
+    // state changing rather than by anything this delegate did. So a delegate
+    // that is parked mid-round-trip — waiting up to `USER_INPUT_TIMEOUT` on a
+    // permission prompt — AND subscribed to a contract can be re-entered here
+    // the moment that contract changes, clobbering the parked continuation's
+    // `DelegateContextCache` entry.
+    //
+    // That combination is not exotic: holding a durable subscription while
+    // prompting the user is the shape the delegate epic is heading for, and a
+    // V2 delegate registers its subscription with `ctx.subscribe_contract()`.
+    //
+    // Note this hazard is about INTERLEAVING, not simultaneity: this path also
+    // runs on the serial loop, so nothing runs concurrently, and the global
+    // one-`process()`-at-a-time property does NOT save us. A serially executed
+    // notification landing INSIDE the park window corrupts the continuation
+    // just as thoroughly as a concurrent one would.
+    if let Some(park) = park.as_deref_mut()
+        && park.is_parked(&delegate_key)
+    {
+        match park.queue_pending(
+            &delegate_key,
+            delegate_park::PendingRun::Notification { req },
+        ) {
+            delegate_park::QueueOutcome::Queued => {
+                tracing::debug!(
+                    delegate = %delegate_key,
+                    contract = %contract_id,
+                    "Delegate is parked; queued this notification behind it"
+                );
+            }
+            delegate_park::QueueOutcome::Rejected(_) => {
+                // The pending queue is full. Dropping is within the
+                // notification pipeline's documented best-effort contract (see
+                // `send_delegate_contract_notifications`), and running it would
+                // corrupt the parked continuation. `info!` so it is visible in
+                // shipped binaries — a silently vanishing notification is the
+                // hardest kind of bug to chase from a user report.
+                tracing::info!(
+                    delegate = %delegate_key,
+                    contract = %contract_id,
+                    "Dropped a contract notification: the delegate is parked and \
+                     its pending queue is full (#5544)"
+                );
+            }
+        }
+        return;
+    }
+
     // A notification-driven run has no client responder to carry; the slot
     // exists only to satisfy the shared `ParkingCtx` shape.
     let mut no_responder = None;
@@ -2641,6 +2789,7 @@ async fn handle_delegate_notification<CH, P>(
             delivery: delegate_park::Delivery::Apps,
             carried_responder: &mut no_responder,
         }),
+        Vec::new(),
     )
     .await;
 
@@ -2798,6 +2947,7 @@ async fn dispatch_delegate_request<CH, P>(
             &delegate_key,
             prompter,
             None,
+            Vec::new(),
         )
         .await;
         let response = match outcome {
@@ -2824,7 +2974,7 @@ async fn dispatch_delegate_request<CH, P>(
     // the parked continuation and it would resume reading the wrong bytes.
     // Queue instead, and drain on resume.
     if park.is_parked(&delegate_key) {
-        let pending = delegate_park::PendingRequest {
+        let pending = delegate_park::PendingRun::Client {
             id,
             req,
             origin_contract,
@@ -2839,9 +2989,32 @@ async fn dispatch_delegate_request<CH, P>(
                 );
             }
             delegate_park::QueueOutcome::Rejected(pending) => {
-                // Answer rather than drop: a silently dropped request hangs
-                // that client forever.
-                contract_handler.channel().drop_waiting_response(pending.id);
+                // A REFUSAL, and it must not render as a successful empty run.
+                //
+                // `DelegateResponse(Vec::new())` is what a delegate that ran and
+                // said nothing returns, so answering with it would report
+                // success for work `process()` never performed, and log as
+                // executed. Drop the responder instead — the client's oneshot
+                // closes and it surfaces an error, the same shape the fair
+                // queue's own rejection path produces. (code-style.md: "a
+                // refusal that is not counted renders as a clean zero".)
+                let delegate_park::PendingRun::Client { id, .. } = *pending else {
+                    // A notification never reaches this arm — `queue_pending`
+                    // only returns `Rejected` for what it was handed, and the
+                    // notification path handles its own rejection.
+                    tracing::error!(
+                        delegate = %delegate_key,
+                        "non-client run rejected on the client queue path"
+                    );
+                    return;
+                };
+                tracing::warn!(
+                    delegate_key = %delegate_key,
+                    "Refused a delegate request: the delegate is parked and its \
+                     pending queue is full. Dropping the responder so the client \
+                     sees an error rather than a successful empty response (#5544)"
+                );
+                contract_handler.channel().drop_waiting_response(id);
             }
         }
         return;
@@ -2865,6 +3038,7 @@ async fn dispatch_delegate_request<CH, P>(
             delivery: delegate_park::Delivery::Client,
             carried_responder: &mut carried_responder,
         }),
+        Vec::new(),
     )
     .await;
 
@@ -2974,6 +3148,7 @@ async fn handle_delegate_resume<CH, P>(
     all_inbound.extend(inbound);
 
     let mut carried_responder = responder;
+    #[allow(clippy::if_not_else)]
     let outcome = if all_inbound.is_empty() {
         // Nothing to feed back — a dropped park that had computed no responses
         // before it. Do NOT re-enter the delegate with an empty inbound; that
@@ -2985,7 +3160,7 @@ async fn handle_delegate_resume<CH, P>(
             params,
             inbound: all_inbound,
         };
-        let outcome = handle_delegate_with_contract_requests(
+        handle_delegate_with_contract_requests(
             contract_handler,
             req,
             origin_contract.as_ref(),
@@ -2999,19 +3174,14 @@ async fn handle_delegate_resume<CH, P>(
                 delivery,
                 carried_responder: &mut carried_responder,
             }),
+            // SEED, not append-afterwards (#5544 B3). What the delegate emitted
+            // before the earlier park has to be inside the run, so that if this
+            // run parks AGAIN it lands in the new continuation. Appending to the
+            // `Completed` arm only — as this did — silently dropped every
+            // pre-park message on the second park.
+            accumulated,
         )
-        .await;
-        match outcome {
-            // Carry forward what the delegate produced BEFORE it parked, so a
-            // multi-park round-trip still yields one complete response.
-            DelegateRunOutcome::Completed(mut msgs) => {
-                let mut all = accumulated;
-                all.append(&mut msgs);
-                DelegateRunOutcome::Completed(all)
-            }
-            DelegateRunOutcome::Parked => DelegateRunOutcome::Parked,
-            DelegateRunOutcome::Failed(err) => DelegateRunOutcome::Failed(err),
-        }
+        .await
     };
 
     match outcome {
@@ -3060,17 +3230,107 @@ async fn handle_delegate_resume<CH, P>(
     // every item: the resumed run (or an earlier drained request) may have
     // parked this delegate again, and exclusion must still hold.
     for queued in pending {
-        dispatch_delegate_request(
-            contract_handler,
-            Some(&mut *park),
-            prompter,
-            queued.id,
-            queued.req,
-            queued.origin_contract,
-            queued.connection_scope,
-            queued.user_context,
-        )
-        .await;
+        match queued {
+            delegate_park::PendingRun::Client {
+                id,
+                req,
+                origin_contract,
+                connection_scope,
+                user_context,
+            } => {
+                dispatch_delegate_request(
+                    contract_handler,
+                    Some(&mut *park),
+                    prompter,
+                    id,
+                    req,
+                    origin_contract,
+                    connection_scope,
+                    user_context,
+                )
+                .await;
+            }
+            // A queued notification resumes through the SAME path it would have
+            // taken had it not been queued, so its residual messages still fan
+            // out to registered apps rather than to a client responder that does
+            // not exist. `run_queued_notification` re-checks the park, so a
+            // delegate that parked again during this drain re-queues instead of
+            // being re-entered.
+            delegate_park::PendingRun::Notification { req } => {
+                run_queued_notification(
+                    contract_handler,
+                    Some(&mut *park),
+                    prompter,
+                    &delegate_key,
+                    req,
+                )
+                .await;
+            }
+        }
+    }
+}
+
+/// Re-run a notification-driven delegate invocation that had been queued behind
+/// a park.
+///
+/// Split from `handle_delegate_notification` because that function owns
+/// building the `ContractNotification` from a `DelegateNotification`; by the
+/// time a queued run drains, the request has already been built and the
+/// notification consumed.
+async fn run_queued_notification<CH, P>(
+    contract_handler: &mut CH,
+    mut park: Option<&mut delegate_park::DelegateParkCtx>,
+    prompter: &std::sync::Arc<P>,
+    delegate_key: &DelegateKey,
+    req: DelegateRequest<'static>,
+) where
+    CH: ContractHandler + Send + 'static,
+    P: UserInputPrompter + 'static,
+{
+    // The delegate may have parked again while this drain was running.
+    if let Some(park) = park.as_deref_mut()
+        && park.is_parked(delegate_key)
+    {
+        match park.queue_pending(
+            delegate_key,
+            delegate_park::PendingRun::Notification { req },
+        ) {
+            delegate_park::QueueOutcome::Queued => {}
+            delegate_park::QueueOutcome::Rejected(_) => {
+                tracing::info!(
+                    delegate = %delegate_key,
+                    "Dropped a queued contract notification: the delegate parked \
+                     again and its pending queue is full (#5544)"
+                );
+            }
+        }
+        return;
+    }
+
+    let mut no_responder = None;
+    let outcome = handle_delegate_with_contract_requests(
+        contract_handler,
+        req,
+        None,
+        crate::client_events::ConnectionScope::Local,
+        InterDelegateDispatch::Suppressed,
+        None,
+        delegate_key,
+        prompter,
+        park.map(|park| ParkingCtx {
+            park,
+            delivery: delegate_park::Delivery::Apps,
+            carried_responder: &mut no_responder,
+        }),
+        Vec::new(),
+    )
+    .await;
+
+    match outcome {
+        DelegateRunOutcome::Parked => {}
+        DelegateRunOutcome::Completed(outbound) => {
+            route_notification_outbound(delegate_key, outbound);
+        }
     }
 }
 
@@ -6220,6 +6480,17 @@ mod hol_4391_tests {
         DelegateKey::new([7u8; 32], freenet_stdlib::prelude::CodeHash::new([7u8; 32]))
     }
 
+    /// An `ApplicationMessage` carrying `payload`, followed by the prompt that
+    /// makes the delegate park. Used to prove pre-park output survives a park —
+    /// see `a_delegate_that_parks_twice_still_answers_its_client_once`.
+    fn payload_then_prompt(payload: &[u8]) -> Vec<OutboundDelegateMsg> {
+        let mut out = vec![OutboundDelegateMsg::ApplicationMessage(
+            freenet_stdlib::prelude::ApplicationMessage::new(payload.to_vec()),
+        )];
+        out.extend(prompt_outbound());
+        out
+    }
+
     /// One scripted `RequestUserInput`, which is what makes the delegate park.
     fn prompt_outbound() -> Vec<OutboundDelegateMsg> {
         let message = freenet_stdlib::prelude::NotificationMessage::try_from(&serde_json::json!({
@@ -6361,9 +6632,19 @@ mod hol_4391_tests {
         let (mut handler, send) = build_handler(vec![]).await;
         let script = handler.runtime_mut().delegate_script.clone();
         let calls = handler.runtime_mut().delegate_calls.clone();
-        // Prompt, then prompt AGAIN on the resume, then finish.
-        script.lock().unwrap().push_back(prompt_outbound());
-        script.lock().unwrap().push_back(prompt_outbound());
+        // Emit a payload BEFORE each prompt. Without a payload this test could
+        // not see B3 — the bug where a second park silently discarded
+        // everything the delegate had emitted before the first one — because
+        // `accumulated` was empty in both parks and the only assertion was that
+        // *some* DelegateResponse came back.
+        script
+            .lock()
+            .unwrap()
+            .push_back(payload_then_prompt(b"before-park-1"));
+        script
+            .lock()
+            .unwrap()
+            .push_back(payload_then_prompt(b"before-park-2"));
 
         let send = Arc::new(send);
         let gate = Arc::new(tokio::sync::Semaphore::new(0));
@@ -6410,12 +6691,214 @@ mod hol_4391_tests {
             .expect("a twice-parked delegate must still resolve")
             .expect("join")
             .expect("the original client must be answered after the second park");
+        let ContractHandlerEvent::DelegateResponse(msgs) = resp else {
+            panic!("expected one DelegateResponse covering the whole round-trip, got {resp}");
+        };
+
+        // THE B3 ASSERTION. Both pre-park payloads must survive to the single
+        // final response. Before the fix, the resumed run's `accumulated` was
+        // dropped on the `Parked` arm, so `before-park-1` vanished.
+        let payloads: Vec<Vec<u8>> = msgs
+            .iter()
+            .filter_map(|m| match m {
+                OutboundDelegateMsg::ApplicationMessage(am) => Some(am.payload.clone()),
+                _ => None,
+            })
+            .collect();
         assert!(
-            matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
-            "expected one DelegateResponse covering the whole round-trip, got {resp}"
+            payloads.iter().any(|p| p == b"before-park-1"),
+            "output emitted before the FIRST park must survive the second park \
+             (#5544 B3); got {payloads:?}"
+        );
+        assert!(
+            payloads.iter().any(|p| p == b"before-park-2"),
+            "output emitted before the second park must survive; got {payloads:?}"
         );
 
         handle.abort();
+    }
+
+    /// B5: the request refused because the pending queue is full must surface an
+    /// ERROR, not a successful empty response.
+    ///
+    /// `DelegateResponse(Vec::new())` is exactly what a delegate that ran and
+    /// said nothing returns, so answering a refusal with it reports success for
+    /// work `process()` never performed — the repo's "a refusal that is not
+    /// counted renders as a clean zero" pattern. Dropping the responder makes
+    /// the client's channel close, which surfaces as an error.
+    ///
+    /// FALSIFY by restoring `send_delegate_response(.., Vec::new())` in
+    /// `dispatch_delegate_request`'s `Rejected` arm: the ninth request then
+    /// returns Ok and this fails.
+    #[tokio::test]
+    async fn a_request_refused_behind_a_full_pending_queue_errors_not_succeeds() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        script.lock().unwrap().push_back(prompt_outbound());
+
+        let send = Arc::new(send);
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        let key_d = test_delegate_key();
+
+        // Park it.
+        let send_0 = send.clone();
+        let k0 = key_d.clone();
+        let parked: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move { send_0.send_to_handler(delegate_event(&k0)).await });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Fill the pending queue to exactly its cap.
+        let mut queued = Vec::new();
+        for _ in 0..delegate_park::MAX_PENDING_PER_DELEGATE {
+            let s = send.clone();
+            let k = key_d.clone();
+            queued.push(GlobalExecutor::spawn(async move {
+                s.send_to_handler(delegate_event(&k)).await
+            }));
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // One more than the cap: must be REFUSED with an error.
+        let over = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(delegate_event(&key_d)),
+        )
+        .await
+        .expect("a refused request must be answered promptly, not left hanging");
+        assert!(
+            over.is_err(),
+            "over-cap request must surface an error, not a successful empty \
+             DelegateResponse that is indistinguishable from a delegate that \
+             ran and said nothing (#5544 B5); got {over:?}"
+        );
+
+        gate.add_permits(1);
+        let _ = tokio::time::timeout(Duration::from_secs(5), parked).await;
+        handle.abort();
+    }
+
+    /// B6: the park backstop must be able to fire on an otherwise idle node.
+    ///
+    /// The sweep runs at the top of a loop iteration, and iterations only happen
+    /// when something wakes the `select!`. Without a timer arm the backstop
+    /// fires whenever unrelated traffic next arrives — on a quiet node, which is
+    /// the normal state for a background peer and exactly the condition under
+    /// which a prompt goes unanswered, effectively never.
+    ///
+    /// LIMITATION, stated rather than papered over: this asserts the DEADLINE
+    /// computation and that the loop consults it, not an end-to-end sweep on an
+    /// idle node. A decisive end-to-end test is not reachable today, because
+    /// `PARK_WORK_BUDGET` (75s) is deliberately below `PARK_TTL` (90s) so the
+    /// `ParkGuard` always resumes the park first — which is what makes the TTL a
+    /// backstop rather than a timeout. Reaching the sweep would need a park with
+    /// no live guard, which no production path can currently produce. The value
+    /// of the fix is that IF that ever becomes reachable, the backstop works.
+    #[test]
+    fn park_sweep_deadline_is_armed_and_the_loop_waits_on_it() {
+        // The loop must consult the deadline, not sweep only on other traffic.
+        let src = include_str!("contract.rs");
+        let body = src
+            .split("pub(crate) async fn contract_handling")
+            .nth(1)
+            .expect("contract_handling must exist");
+        assert!(
+            body.contains("park_ctx.next_sweep_deadline()"),
+            "contract_handling must compute the park sweep deadline"
+        );
+        assert!(
+            body.contains("tokio::time::sleep_until(deadline)"),
+            "the idle select! must WAIT on the park sweep deadline, or the \
+             backstop cannot fire without unrelated traffic (#5544 B6)"
+        );
+    }
+
+    /// B1: a contract notification arriving for a delegate that is currently
+    /// parked must be QUEUED, not run.
+    ///
+    /// The notification path is a third door into a delegate, alongside the
+    /// client request and the inter-delegate hop, and it is driven by a
+    /// contract changing rather than by anything the delegate did. Running it
+    /// mid-park re-enters `process()` and clobbers the parked continuation's
+    /// context entry — the corruption the exclusion exists to prevent, reached
+    /// through a door the exclusion originally did not guard.
+    ///
+    /// NOTE: this is about INTERLEAVING, not simultaneity. The notification
+    /// path also runs on the serial loop, so the global
+    /// one-`process()`-at-a-time property is untouched and does not help. A
+    /// serially executed notification landing inside the park window corrupts
+    /// just as thoroughly as a concurrent one would.
+    ///
+    /// FALSIFY by deleting the `is_parked` gate in `handle_delegate_notification`:
+    /// `delegate_calls` then records the notification's run.
+    #[tokio::test]
+    async fn a_notification_for_a_parked_delegate_is_queued_not_run() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, _send) = build_handler(vec![]).await;
+        let calls = handler.runtime_mut().delegate_calls.clone();
+        let script = handler.runtime_mut().delegate_script.clone();
+        // Present so that, if the gate is missing, the delegate really does run
+        // rather than erroring out for an unrelated reason.
+        script.lock().unwrap().push_back(Vec::new());
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut park = delegate_park::DelegateParkCtx::new(tx);
+        let key = test_delegate_key();
+        assert!(
+            matches!(
+                park.park(key.clone(), parked_continuation()),
+                delegate_park::ParkAdmission::Admitted
+            ),
+            "the delegate must start out parked"
+        );
+
+        handle_delegate_notification(
+            &mut handler,
+            executor::DelegateNotification {
+                delegate_key: key.clone(),
+                contract_id: ContractInstanceId::new([9u8; 32]),
+                new_state: Arc::new(WrappedState::new(b"changed".to_vec())),
+            },
+            &std::sync::Arc::new(crate::contract::user_input::AutoApprovePrompter),
+            Some(&mut park),
+        )
+        .await;
+
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            0,
+            "a notification must NOT re-enter a parked delegate (#5544 B1)"
+        );
+        let (_continuation, pending) = park.take(&key).expect("still parked");
+        assert_eq!(
+            pending.len(),
+            1,
+            "the notification must be queued, not lost"
+        );
+        assert!(
+            matches!(pending[0], delegate_park::PendingRun::Notification { .. }),
+            "queued as a notification so it resumes through the app-routing path"
+        );
+    }
+
+    /// A continuation standing in for a delegate parked on a prompt.
+    fn parked_continuation() -> delegate_park::Continuation {
+        delegate_park::Continuation {
+            params: Parameters::from(Vec::new()),
+            origin_contract: None,
+            connection_scope: crate::client_events::ConnectionScope::Local,
+            user_context: None,
+            inter_delegate: InterDelegateDispatch::Allowed,
+            accumulated: Vec::new(),
+            inbound_so_far: Vec::new(),
+            responder: None,
+            delivery: delegate_park::Delivery::Client,
+        }
     }
 
     /// The second half of #5544: a delegate PUT whose contract asks for a

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1646,19 +1646,27 @@ where
                     .park(delegate_key.clone(), continuation, task_bytes)
                 {
                     delegate_park::ParkAdmission::Admitted { epoch } => {
+                        // What this park OWES. The guard synthesizes terminal
+                        // results for anything unresolved on EVERY exit —
+                        // including panic or cancellation, which reach `Drop`
+                        // and never run the task's own cleanup (#5544 P2).
+                        let owed: Vec<u32> =
+                            user_input_requests.iter().map(|r| r.request_id).collect();
+                        let owed_upserts: Vec<(ContractInstanceId, bool)> = deferred_upserts
+                            .iter()
+                            .map(|u| (*u.key.id(), u.is_put))
+                            .collect();
                         let guard = delegate_park::ParkGuard::new(
                             ctx.park.resume_tx().clone(),
                             delegate_key.clone(),
                             epoch,
+                            owed,
+                            owed_upserts,
                         );
                         let prompter = std::sync::Arc::clone(prompter);
                         let key = delegate_key.clone();
                         let op_manager = contract_handler.executor().op_manager_handle();
                         let prompts = std::mem::take(&mut user_input_requests);
-                        // Every request id this run owes an answer for. If the
-                        // budget cancels the sequence part-way, the unanswered
-                        // ones are synthesized as denials below (#5544 P1b).
-                        let owed: Vec<u32> = prompts.iter().map(|r| r.request_id).collect();
                         let upserts = std::mem::take(&mut deferred_upserts);
                         // Fire-and-forget is safe precisely because of the
                         // guard: it delivers exactly one resume even if this
@@ -1741,58 +1749,15 @@ where
                             // requests that finished and none for those that
                             // did not, which is the same shape as a denied
                             // prompt.
-                            let mut responses = std::mem::take(&mut *answers_out.lock().unwrap());
+                            let responses = std::mem::take(&mut *answers_out.lock().unwrap());
                             let resolved = std::mem::take(&mut *fetch_out.lock().unwrap());
 
-                            // Synthesize a DENIAL for every prompt the budget
-                            // cancelled (#5544 P1b). An empty `ClientResponse`
-                            // is exactly what a timed-out or dismissed prompt
-                            // yields on the normal path, so the delegate sees a
-                            // shape it already handles rather than silence — and
-                            // is not left waiting for a `UserResponse` that was
-                            // cancelled out of existence.
-                            let answered: std::collections::HashSet<u32> = responses
-                                .iter()
-                                .filter_map(|m| match m {
-                                    InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
-                                    // Only `UserResponse` carries a request id to
-                                    // reconcile against `owed`. Listed rather than
-                                    // wildcarded so a future variant that carries
-                                    // one has to be considered here, the same
-                                    // convention as `delegate_park::inbound_bytes`.
-                                    InboundDelegateMsg::ApplicationMessage(_)
-                                    | InboundDelegateMsg::GetContractResponse(_)
-                                    | InboundDelegateMsg::PutContractResponse(_)
-                                    | InboundDelegateMsg::UpdateContractResponse(_)
-                                    | InboundDelegateMsg::SubscribeContractResponse(_)
-                                    | InboundDelegateMsg::ContractNotification(_)
-                                    | InboundDelegateMsg::DelegateMessage(_)
-                                    | _ => None,
-                                })
-                                .collect();
-                            let unanswered: Vec<u32> = owed
-                                .into_iter()
-                                .filter(|id| !answered.contains(id))
-                                .collect();
-                            if !unanswered.is_empty() {
-                                tracing::warn!(
-                                    delegate = %key,
-                                    count = unanswered.len(),
-                                    "Synthesizing denials for prompts cancelled by \
-                                     PARK_WORK_BUDGET, so the delegate is told rather \
-                                     than left waiting (#5544 P1b)"
-                                );
-                                for request_id in unanswered {
-                                    responses.push(InboundDelegateMsg::UserResponse(
-                                        UserInputResponse {
-                                            request_id,
-                                            response: ClientResponse::new(Vec::new()),
-                                            context: DelegateContext::default(),
-                                        },
-                                    ));
-                                }
-                            }
-
+                            // Denial synthesis lives in `ParkGuard::deliver`
+                            // now, so it also covers the panic and
+                            // cancellation exits — those reach `Drop` and
+                            // never run this block (#5544 P2). Doing it in
+                            // both places would be duplication; doing it
+                            // only here was the bug.
                             if done.is_err() {
                                 tracing::warn!(
                                     delegate = %key,
@@ -2055,6 +2020,10 @@ where
                     cause: delegate_park::ResumeCause::TimedOut,
                     inbound: Vec::new(),
                     upserts: Vec::new(),
+                    // The sweep does not know what the task owed; that task's
+                    // own guard still fires and is rejected on epoch, so
+                    // nothing is answered twice.
+                    unresolved_upserts: Vec::new(),
                 },
             )
             .await;
@@ -3345,6 +3314,7 @@ where
         cause,
         inbound,
         upserts,
+        unresolved_upserts,
     } = resume;
 
     let Some((continuation, pending)) = park.take_matching(&delegate_key, epoch) else {
@@ -3397,6 +3367,20 @@ where
     // fetch happened off it), then feed their responses back with the rest.
     for resolved in upserts {
         all_inbound.push(apply_resolved_upsert(contract_handler, resolved).await);
+    }
+    // Upserts the off-loop task never resolved (panic, cancellation, budget).
+    // The delegate is TOLD they failed rather than left waiting for a response
+    // nothing remains to produce (#5544 P2). `DelegateContext` is defaulted
+    // because the `PendingUpsert` that carried it is gone by then.
+    for (contract_id, is_put) in unresolved_upserts {
+        all_inbound.push(upsert_response_msg(
+            is_put,
+            contract_id,
+            DelegateContext::default(),
+            Err(ExecutorError::other(anyhow::anyhow!(
+                "delegate upsert did not complete: its off-loop work ended early"
+            ))),
+        ));
     }
     all_inbound.extend(inbound);
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -4415,6 +4415,123 @@ mod tests {
         ContractKey::from_params_and_code(&params, &code)
     }
 
+    /// PIN: the NODE-WIDE "one delegate `process()` at a time" invariant, held
+    /// by the shape of the call graph and by nothing else.
+    ///
+    /// Three separate things now rest on this property:
+    ///  1. `DelegateContextCache`'s last-write-wins keying (per-delegate, and
+    ///     `DelegateParkCtx`'s exclusion supplies that half — see
+    ///     `a_parked_delegate_is_not_re_entered_until_it_resumes`);
+    ///  2. `queue_v2_delegate_broadcast`'s non-atomic marker insert/enqueue/
+    ///     rollback triple (#5490);
+    ///  3. `native_api::state_content_changed`'s non-atomic read-then-write,
+    ///     whose racing pair is two DIFFERENT delegates writing the SAME
+    ///     contract — per-CONTRACT, which per-delegate exclusion permits by
+    ///     construction, so only the node-wide property covers it.
+    ///
+    /// The third is the reason this pin exists. There is **no lock**: no
+    /// per-delegate mutex, no executor affinity, nothing in
+    /// `wasm_runtime::delegate` enforcing it. The property is supplied entirely
+    /// by every route to `process()` being awaited from the one
+    /// `contract_handling` task. That is exactly the shape a later performance
+    /// change breaks silently, and the breakage is state corruption rather than
+    /// a crash — so it gets a guard rather than a comment.
+    ///
+    /// Anchored on the PROPERTY, not on a helper's name: it asserts the
+    /// chokepoint is still a chokepoint, and that the set of functions allowed
+    /// to enter it is still the documented on-loop set. Adding a caller is not
+    /// forbidden — it fails this test, which asks you to confirm the new caller
+    /// is awaited from `contract_handling` and then to say so here.
+    ///
+    /// FALSIFY: add a call to `handle_delegate_with_contract_requests` in a new
+    /// function (for instance inside a `GlobalExecutor::spawn` body), or call
+    /// `execute_delegate_request` from anywhere but the chokepoint. Either
+    /// fails. Verified by doing both.
+    #[test]
+    fn every_delegate_run_is_reached_from_the_serial_loop() {
+        // Production text only, comments stripped. Both needles occur in this
+        // test's own prose and in the module's doc comments, and a scrape that
+        // counted those would report a true fact about the wrong text (#5450).
+        let full = include_str!("contract.rs");
+        let prod = full.split("\nmod tests {").next().unwrap_or(full);
+        let code: String = prod
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(i) => &line[..i],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // The nearest preceding `fn` declaration at statement position.
+        fn enclosing_fn(code: &str, idx: usize) -> &str {
+            code[..idx]
+                .rmatch_indices("\nfn ")
+                .next()
+                .into_iter()
+                .chain(code[..idx].rmatch_indices("\nasync fn ").next())
+                .max_by_key(|(i, _)| *i)
+                .map(|(i, m)| {
+                    let after = &code[i + m.len()..];
+                    after
+                        .split(|c: char| !c.is_alphanumeric() && c != '_')
+                        .next()
+                        .unwrap_or("")
+                })
+                .unwrap_or("")
+        }
+
+        // 1. The executor call is reached through ONE chokepoint.
+        let chokepoint = "handle_delegate_with_contract_requests";
+        for (idx, _) in code.match_indices(".execute_delegate_request(") {
+            let owner = enclosing_fn(&code, idx);
+            assert_eq!(
+                owner, chokepoint,
+                "`execute_delegate_request` must be reached only from `{chokepoint}`, \
+                 which is what makes the node-wide serialization argument checkable. \
+                 Found a call in `{owner}`. If that function is genuinely awaited \
+                 from `contract_handling`, widen this pin deliberately and say why."
+            );
+        }
+        assert_eq!(
+            code.matches(".execute_delegate_request(").count(),
+            2,
+            "expected exactly the main call and the inter-delegate hop"
+        );
+
+        // 2. Only the documented on-loop functions enter the chokepoint.
+        //    Every one of these is awaited from `contract_handling`.
+        let allowed = [
+            "handle_delegate_notification",
+            "dispatch_delegate_request",
+            "handle_delegate_resume",
+            "run_queued_notification",
+        ];
+        let mut callers: Vec<&str> = code
+            .match_indices(&format!("{chokepoint}("))
+            .map(|(idx, _)| enclosing_fn(&code, idx))
+            .filter(|owner| *owner != chokepoint)
+            .collect();
+        callers.sort_unstable();
+        callers.dedup();
+        for caller in &callers {
+            assert!(
+                allowed.contains(caller),
+                "`{caller}` calls `{chokepoint}`, and it is not one of the \
+                 functions known to be awaited from the serial `contract_handling` \
+                 loop: {allowed:?}. At most one delegate `process()` may execute \
+                 node-wide at any instant; a call from a spawned task, a pooled \
+                 executor or a second loop breaks that, and with it #5490's \
+                 broadcast marker and `state_content_changed`'s read-then-write. \
+                 If this caller IS on the loop, add it here with the reason."
+            );
+        }
+        assert!(
+            !callers.is_empty(),
+            "the scrape found no callers at all, so it is measuring nothing"
+        );
+    }
+
     /// Pin: a wrong response variant must NOT be reported to the client as a
     /// success.
     ///

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -612,12 +612,7 @@ where
             }
             contract_handler
                 .executor()
-                .upsert_contract_state(
-                    pending.key,
-                    pending.update,
-                    related_contracts,
-                    pending.code,
-                )
+                .upsert_contract_state(pending.key, pending.update, related_contracts, pending.code)
                 .await
         }
         // The fetch failed or timed out: surface it to the delegate rather than
@@ -1514,11 +1509,11 @@ where
                                     .await
                                 }
                             };
-                            let done = tokio::time::timeout(
-                                delegate_park::PARK_WORK_BUDGET,
-                                async { tokio::join!(answers, fetches) },
-                            )
-                            .await;
+                            let done =
+                                tokio::time::timeout(delegate_park::PARK_WORK_BUDGET, async {
+                                    tokio::join!(answers, fetches)
+                                })
+                                .await;
                             match done {
                                 Ok((responses, resolved)) => guard.send(responses, resolved),
                                 Err(_) => {
@@ -1550,8 +1545,7 @@ where
             // Inline fallback: no parking context (direct unit-test calls), or
             // the park cap was hit.
             for pending in std::mem::take(&mut deferred_upserts) {
-                inbound_responses
-                    .push(run_deferred_upsert_inline(contract_handler, pending).await);
+                inbound_responses.push(run_deferred_upsert_inline(contract_handler, pending).await);
             }
             if !user_input_requests.is_empty() {
                 inbound_responses.extend(
@@ -1729,13 +1723,8 @@ where
         for _ in 0..MAX_RESUME_DRAIN_BATCH {
             match delegate_resume_rx.try_recv() {
                 Ok(resume) => {
-                    handle_delegate_resume(
-                        &mut contract_handler,
-                        &mut park_ctx,
-                        &prompter,
-                        resume,
-                    )
-                    .await;
+                    handle_delegate_resume(&mut contract_handler, &mut park_ctx, &prompter, resume)
+                        .await;
                 }
                 Err(_) => break,
             }
@@ -6160,7 +6149,10 @@ mod hol_4391_tests {
     /// not clicked yet. The real `DashboardPrompter` waits up to
     /// `USER_INPUT_TIMEOUT` (60s) for exactly this.
     struct GatedPrompter {
-        gate: Arc<tokio::sync::Notify>,
+        /// One permit per prompt the test lets through. A `Notify` will not do:
+        /// it stores at most ONE permit, so a test that has to release two
+        /// prompts could silently lose a release.
+        gate: Arc<tokio::sync::Semaphore>,
     }
 
     impl user_input::UserInputPrompter for GatedPrompter {
@@ -6170,7 +6162,11 @@ mod hol_4391_tests {
             _delegate_key: &str,
             _caller: user_input::CallerIdentity,
         ) -> Option<(usize, ClientResponse<'static>)> {
-            self.gate.notified().await;
+            self.gate
+                .acquire()
+                .await
+                .expect("prompt gate closed")
+                .forget();
             Some((0, ClientResponse::new(b"approved".to_vec())))
         }
     }
@@ -6230,7 +6226,7 @@ mod hol_4391_tests {
         let key_c = contract_c.key();
 
         let send = Arc::new(send);
-        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
         let handle = GlobalExecutor::spawn(contract_handling(
             handler,
             GatedPrompter { gate: gate.clone() },
@@ -6258,9 +6254,9 @@ mod hol_4391_tests {
         let send_d = send.clone();
         let key_d = test_delegate_key();
         let delegate_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_d.send_to_handler(delegate_event(&key_d)).await
-            });
+            GlobalExecutor::spawn(
+                async move { send_d.send_to_handler(delegate_event(&key_d)).await },
+            );
 
         // Let the loop pick up the delegate request and park it.
         tokio::time::sleep(Duration::from_millis(150)).await;
@@ -6292,7 +6288,7 @@ mod hol_4391_tests {
         }
 
         // Release the human: the delegate resumes and its client is answered.
-        gate.notify_one();
+        gate.add_permits(1);
         let resp = tokio::time::timeout(Duration::from_secs(5), delegate_task)
             .await
             .expect("the parked delegate must resolve once the prompt is answered")
@@ -6301,6 +6297,77 @@ mod hol_4391_tests {
         assert!(
             matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
             "parked delegate must answer its original client exactly once, got {resp}"
+        );
+
+        handle.abort();
+    }
+
+    /// A delegate that prompts TWICE parks, resumes, and parks again. Its
+    /// client must still be answered exactly once, at the end.
+    ///
+    /// This exercises the path where the parked client responder is carried
+    /// FORWARD into the second continuation rather than being answered early
+    /// or dropped. Getting it wrong gives either a client that hangs forever
+    /// or one that receives a truncated first response — neither of which the
+    /// single-prompt tests can see.
+    #[tokio::test]
+    async fn a_delegate_that_parks_twice_still_answers_its_client_once() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        let calls = handler.runtime_mut().delegate_calls.clone();
+        // Prompt, then prompt AGAIN on the resume, then finish.
+        script.lock().unwrap().push_back(prompt_outbound());
+        script.lock().unwrap().push_back(prompt_outbound());
+
+        let send = Arc::new(send);
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        let send_d = send.clone();
+        let key_d = test_delegate_key();
+        let delegate_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(
+                async move { send_d.send_to_handler(delegate_event(&key_d)).await },
+            );
+
+        // First park.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "first entry into the delegate"
+        );
+        assert!(!delegate_task.is_finished(), "must be parked on prompt 1");
+
+        // Release prompt 1 -> resume -> the delegate prompts again -> re-park.
+        gate.add_permits(1);
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            2,
+            "the resume must have re-entered the delegate exactly once"
+        );
+        assert!(
+            !delegate_task.is_finished(),
+            "must be parked AGAIN on prompt 2; answering the client here would \
+             truncate the round-trip"
+        );
+
+        // Release prompt 2: the delegate finishes and the ORIGINAL client
+        // responder, carried across both parks, is answered.
+        gate.add_permits(1);
+        let resp = tokio::time::timeout(Duration::from_secs(5), delegate_task)
+            .await
+            .expect("a twice-parked delegate must still resolve")
+            .expect("join")
+            .expect("the original client must be answered after the second park");
+        assert!(
+            matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
+            "expected one DelegateResponse covering the whole round-trip, got {resp}"
         );
 
         handle.abort();
@@ -6348,14 +6415,15 @@ mod hol_4391_tests {
         let gate_for_stub = gate.clone();
         let off_loop_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let calls_for_stub = off_loop_calls.clone();
-        let _override = OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
-            let gate = gate_for_stub.clone();
-            calls_for_stub.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Box::pin(async move {
-                gate.notified().await;
-                Err(ExecutorError::missing_related(missing[0]))
-            })
-        }));
+        let _override =
+            OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+                let gate = gate_for_stub.clone();
+                calls_for_stub.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Box::pin(async move {
+                    gate.notified().await;
+                    Err(ExecutorError::missing_related(missing[0]))
+                })
+            }));
 
         // A locally stored contract whose GET needs no network at all.
         let contract_c = make_contract(b"park_put_c_cached");
@@ -6387,9 +6455,9 @@ mod hol_4391_tests {
         let send_d = send.clone();
         let key_d = test_delegate_key();
         let delegate_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
-            GlobalExecutor::spawn(async move {
-                send_d.send_to_handler(delegate_event(&key_d)).await
-            });
+            GlobalExecutor::spawn(
+                async move { send_d.send_to_handler(delegate_event(&key_d)).await },
+            );
 
         tokio::time::sleep(Duration::from_millis(150)).await;
 
@@ -6484,7 +6552,7 @@ mod hol_4391_tests {
         script.lock().unwrap().push_back(prompt_outbound());
 
         let send = Arc::new(send);
-        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
         let handle = GlobalExecutor::spawn(contract_handling(
             handler,
             GatedPrompter { gate: gate.clone() },
@@ -6521,7 +6589,7 @@ mod hol_4391_tests {
 
         // Release the prompt: the parked run resumes, then the queued request
         // is drained — both reach the delegate, in order.
-        gate.notify_one();
+        gate.add_permits(1);
         let r1 = tokio::time::timeout(Duration::from_secs(5), first)
             .await
             .expect("first delegate request must resolve")
@@ -6546,5 +6614,4 @@ mod hol_4391_tests {
 
         handle.abort();
     }
-
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1067,9 +1067,30 @@ where
                         });
                         continue;
                     }
+                    Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                        // Past MAX_DEFERRED_UPSERTS_PER_PARK. REFUSE — do not
+                        // fall back inline (#5544 M5).
+                        //
+                        // My own note at the park-cap fallback says refusing to
+                        // inline "is NOT defensible" when the wait is a network
+                        // op, and that reasoning applies here: nothing caps
+                        // `put_requests.len()`, so a delegate emitting 100
+                        // deferring PUTs would serialize ~100 x
+                        // RELATED_FETCH_TIMEOUT on the loop — about 16 minutes.
+                        // Surfacing MissingRelated is what the depth cap already
+                        // does one level up.
+                        let id = missing.first().copied().unwrap_or(*contract_key.id());
+                        tracing::warn!(
+                            contract = %contract_key,
+                            cap = delegate_park::MAX_DEFERRED_UPSERTS_PER_PARK,
+                            "Refusing a delegate PUT past the per-park deferral cap \
+                             rather than fetching inline on the serial loop (#5544 M5)"
+                        );
+                        Err(ExecutorError::missing_related(id))
+                    }
                     Ok(UpsertOutcome::DeferRelated(_)) => {
-                        // No parking context (direct unit-test calls): keep the
-                        // legacy inline fetch rather than failing the upsert.
+                        // No parking context at all (direct unit-test calls):
+                        // keep the legacy inline fetch rather than failing.
                         contract_handler
                             .executor()
                             .upsert_contract_state(
@@ -1246,6 +1267,18 @@ where
                                     missing,
                                 });
                                 continue;
+                            }
+                            Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                                // Past the per-park cap: REFUSE, same reasoning
+                                // as the PUT arm (#5544 M5).
+                                let id = missing.first().copied().unwrap_or(*full_key.id());
+                                tracing::warn!(
+                                    contract = %full_key,
+                                    cap = delegate_park::MAX_DEFERRED_UPSERTS_PER_PARK,
+                                    "Refusing a delegate UPDATE past the per-park \
+                                     deferral cap rather than fetching inline (#5544 M5)"
+                                );
+                                Err(ExecutorError::missing_related(id))
                             }
                             Ok(UpsertOutcome::DeferRelated(_)) => {
                                 // No parking context: keep the legacy inline
@@ -1603,16 +1636,29 @@ where
                     responder: ctx.carried_responder.take(),
                     delivery: ctx.delivery,
                 };
-                match ctx.park.park(delegate_key.clone(), continuation) {
-                    delegate_park::ParkAdmission::Admitted => {
+                // Charge what the OFF-LOOP TASK will retain, not just what the
+                // continuation points at: the prompts and the deferred upserts
+                // live for exactly as long as the park, and a single upsert can
+                // own a full state plus related contracts plus code.
+                let task_bytes = delegate_park::task_bytes(&user_input_requests, &deferred_upserts);
+                match ctx
+                    .park
+                    .park(delegate_key.clone(), continuation, task_bytes)
+                {
+                    delegate_park::ParkAdmission::Admitted { epoch } => {
                         let guard = delegate_park::ParkGuard::new(
                             ctx.park.resume_tx().clone(),
                             delegate_key.clone(),
+                            epoch,
                         );
                         let prompter = std::sync::Arc::clone(prompter);
                         let key = delegate_key.clone();
                         let op_manager = contract_handler.executor().op_manager_handle();
                         let prompts = std::mem::take(&mut user_input_requests);
+                        // Every request id this run owes an answer for. If the
+                        // budget cancels the sequence part-way, the unanswered
+                        // ones are synthesized as denials below (#5544 P1b).
+                        let owed: Vec<u32> = prompts.iter().map(|r| r.request_id).collect();
                         let upserts = std::mem::take(&mut deferred_upserts);
                         // Fire-and-forget is safe precisely because of the
                         // guard: it delivers exactly one resume even if this
@@ -1695,8 +1741,58 @@ where
                             // requests that finished and none for those that
                             // did not, which is the same shape as a denied
                             // prompt.
-                            let responses = std::mem::take(&mut *answers_out.lock().unwrap());
+                            let mut responses = std::mem::take(&mut *answers_out.lock().unwrap());
                             let resolved = std::mem::take(&mut *fetch_out.lock().unwrap());
+
+                            // Synthesize a DENIAL for every prompt the budget
+                            // cancelled (#5544 P1b). An empty `ClientResponse`
+                            // is exactly what a timed-out or dismissed prompt
+                            // yields on the normal path, so the delegate sees a
+                            // shape it already handles rather than silence — and
+                            // is not left waiting for a `UserResponse` that was
+                            // cancelled out of existence.
+                            let answered: std::collections::HashSet<u32> = responses
+                                .iter()
+                                .filter_map(|m| match m {
+                                    InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
+                                    // Only `UserResponse` carries a request id to
+                                    // reconcile against `owed`. Listed rather than
+                                    // wildcarded so a future variant that carries
+                                    // one has to be considered here, the same
+                                    // convention as `delegate_park::inbound_bytes`.
+                                    InboundDelegateMsg::ApplicationMessage(_)
+                                    | InboundDelegateMsg::GetContractResponse(_)
+                                    | InboundDelegateMsg::PutContractResponse(_)
+                                    | InboundDelegateMsg::UpdateContractResponse(_)
+                                    | InboundDelegateMsg::SubscribeContractResponse(_)
+                                    | InboundDelegateMsg::ContractNotification(_)
+                                    | InboundDelegateMsg::DelegateMessage(_)
+                                    | _ => None,
+                                })
+                                .collect();
+                            let unanswered: Vec<u32> = owed
+                                .into_iter()
+                                .filter(|id| !answered.contains(id))
+                                .collect();
+                            if !unanswered.is_empty() {
+                                tracing::warn!(
+                                    delegate = %key,
+                                    count = unanswered.len(),
+                                    "Synthesizing denials for prompts cancelled by \
+                                     PARK_WORK_BUDGET, so the delegate is told rather \
+                                     than left waiting (#5544 P1b)"
+                                );
+                                for request_id in unanswered {
+                                    responses.push(InboundDelegateMsg::UserResponse(
+                                        UserInputResponse {
+                                            request_id,
+                                            response: ClientResponse::new(Vec::new()),
+                                            context: DelegateContext::default(),
+                                        },
+                                    ));
+                                }
+                            }
+
                             if done.is_err() {
                                 tracing::warn!(
                                     delegate = %key,
@@ -1939,9 +2035,14 @@ where
         // Backstop sweep for parks that neither completed nor were dropped
         // (see `PARK_TTL`). Force-resume them so a wedged delegate cannot stay
         // wedged: the resume drains its pending queue and answers its client.
-        for delegate_key in park_ctx.expired(tokio::time::Instant::now()) {
+        for (delegate_key, epoch) in park_ctx.expired(tokio::time::Instant::now()) {
+            // Force-resume the park we OBSERVED, by epoch. The off-loop task's
+            // ParkGuard is untouched and still owes a resume; carrying the epoch
+            // is what lets that late resume be recognised as stale and dropped
+            // rather than absorbed by whatever park exists by then (#5544 H1).
             tracing::warn!(
                 delegate = %delegate_key,
+                epoch,
                 "Delegate park exceeded PARK_TTL — force-resuming"
             );
             let _ = handle_delegate_resume(
@@ -1950,6 +2051,7 @@ where
                 &prompter,
                 delegate_park::DelegateResume {
                     delegate_key,
+                    epoch,
                     cause: delegate_park::ResumeCause::TimedOut,
                     inbound: Vec::new(),
                     upserts: Vec::new(),
@@ -3216,10 +3318,17 @@ async fn send_delegate_response<CH>(
 /// Returns the number of delegate runs performed, INCLUDING the pending
 /// requests drained behind the park. The loop spends that against its
 /// `MAX_RESUME_DRAIN_BATCH` budget (#5544 S5): each drained request is a full
-/// delegate run, so an unaccounted drain could do
-/// `MAX_RESUME_DRAIN_BATCH x MAX_PENDING_PER_DELEGATE` runs before the fair
+/// delegate run, so an unaccounted drain could do many of them before the fair
 /// queue got a single turn — exactly the head-of-line blocking the batch cap
 /// exists to prevent.
+///
+/// Worst case for ONE resume is `1 + MAX_PENDING_PER_DELEGATE +
+/// MAX_PENDING_NOTIFICATION_CONTRACTS` runs: the resumed run itself, the queued
+/// client requests, and the coalesced notifications. The notification lane is
+/// deliberately NOT bounded by `MAX_PENDING_PER_DELEGATE` (see `PendingRun`), so
+/// stating "16 x 8" here would have been wrong the moment coalescing landed —
+/// which it was, until #5544 M6. Returning the real count is what keeps the
+/// loop's budget honest regardless of how those caps move.
 async fn handle_delegate_resume<CH, P>(
     contract_handler: &mut CH,
     park: &mut delegate_park::DelegateParkCtx,
@@ -3232,17 +3341,29 @@ where
 {
     let delegate_park::DelegateResume {
         delegate_key,
+        epoch,
         cause,
         inbound,
         upserts,
     } = resume;
 
-    let Some((continuation, pending)) = park.take(&delegate_key) else {
-        // Unreachable: the ParkGuard delivers exactly one resume per park, and
-        // only a resume ends a park.
-        tracing::error!(
+    let Some((continuation, pending)) = park.take_matching(&delegate_key, epoch) else {
+        // REACHABLE, and the previous comment here claiming otherwise was
+        // wrong. It said "the ParkGuard delivers exactly one resume per park,
+        // and only a resume ends a park" — but the TTL backstop ends a park
+        // WITHOUT consuming a guard, so that guard's resume still arrives.
+        // `take_matching` rejects it on epoch mismatch, which is the point:
+        // absorbing it would feed one round-trip's messages to another
+        // (#5544 H1).
+        //
+        // `debug!`, not `error!`: this is now an expected consequence of the
+        // backstop firing, and `take_matching` already logs the re-parked case
+        // at `warn!` with both epochs.
+        tracing::debug!(
             delegate = %delegate_key,
-            "Resume for a delegate that is not parked — dropping"
+            epoch,
+            "Resume for a park that no longer exists (force-resumed by the TTL \
+             backstop, or already ended) — dropping"
         );
         return 0;
     };
@@ -7043,8 +7164,8 @@ mod hol_4391_tests {
             .insert(key.clone(), b"parked-continuation".to_vec());
         assert!(
             matches!(
-                park.park(key.clone(), parked_continuation()),
-                delegate_park::ParkAdmission::Admitted
+                park.park(key.clone(), parked_continuation(), 0),
+                delegate_park::ParkAdmission::Admitted { .. }
             ),
             "the delegate must start out parked"
         );
@@ -7076,7 +7197,8 @@ mod hol_4391_tests {
              that ran would have overwritten it and the delegate would resume \
              on someone else's bytes (#5544 B1)"
         );
-        let (_continuation, pending) = park.take(&key).expect("still parked");
+        let epoch = park.epoch_of(&key).expect("still parked");
+        let (_continuation, pending) = park.take_matching(&key, epoch).expect("still parked");
         assert_eq!(
             pending.len(),
             1,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -7807,6 +7807,160 @@ mod hol_4391_tests {
         }
     }
 
+    /// A `ResolvedUpsert` for a PUT of `contract` whose off-loop fetch of
+    /// `related` came back as `fetched`.
+    fn resolved_put(
+        contract: ContractContainer,
+        related: ContractInstanceId,
+        fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
+    ) -> delegate_park::ResolvedUpsert {
+        delegate_park::ResolvedUpsert {
+            pending: delegate_park::PendingUpsert {
+                key: contract.key(),
+                update: Either::Left(WrappedState::new(b"a_state".to_vec())),
+                related_contracts: RelatedContracts::default(),
+                code: Some(contract),
+                is_put: true,
+                context: DelegateContext::default(),
+                missing: vec![related],
+            },
+            fetched,
+        }
+    }
+
+    /// The SUCCESS arm of `apply_resolved_upsert` — the happy path of one of
+    /// the two stalls #5544 removes, and it had no coverage at all.
+    ///
+    /// Found by mutation, not by reading: replacing
+    /// `Ok(UpsertOutcome::Completed(r)) => Ok(r)` with an unconditional `Err`
+    /// survived a fully green 5465-test suite. The only test that reaches this
+    /// function, `deferred_delegate_upsert_does_not_block_the_loop`, installs a
+    /// stub that ALWAYS resolves to `Err(missing_related)`, so `fetched` is
+    /// never `Ok` and the entire inject-and-rerun branch is unexecuted. That
+    /// test is decisive about the deferral HAPPENING; it says nothing about the
+    /// resume working.
+    ///
+    /// The regression that shipped undetected: a delegate PUT or UPDATE whose
+    /// related contracts ARE fetched successfully off-loop is told its write
+    /// failed — while the write lands. The delegate then sees an error for a
+    /// state change that actually happened, which is worse than either
+    /// outcome on its own.
+    ///
+    /// **Asserting that the state landed would NOT catch that**, which is why
+    /// this asserts the delegate-visible response instead: the store happens
+    /// inside `upsert_contract_state_deferrable`, BEFORE the arm that maps its
+    /// outcome, so the mutated arm still writes. What this arm decides is what
+    /// the DELEGATE is told.
+    ///
+    /// The same assertion also covers the other half of the branch: delete the
+    /// `inject_related_state` loop and the re-run's validate asks for the
+    /// related contract again, which the depth-1 cap converts to
+    /// `MissingRelated` — so the response goes to `Err` and this fails too.
+    ///
+    /// FALSIFY: map `Completed` to `Err`, or delete the injection loop.
+    #[tokio::test]
+    async fn a_resolved_delegate_upsert_reports_success_to_the_delegate() {
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_a = make_contract(b"resolved_upsert_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"resolved_upsert_b").key().id();
+
+        // A asks for B once; once B's state is injected it validates.
+        let (mut handler, _send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        // The off-loop fetch SUCCEEDED — the case no other test constructs.
+        let resolved = resolved_put(
+            contract_a,
+            id_b,
+            Ok(vec![(id_b, WrappedState::new(b"b_state".to_vec()))]),
+        );
+        let msg = apply_resolved_upsert(&mut handler, resolved).await;
+
+        let InboundDelegateMsg::PutContractResponse(response) = msg else {
+            panic!("a resolved PUT must answer with PutContractResponse, got {msg:?}");
+        };
+        assert_eq!(
+            response.contract_id,
+            *key_a.id(),
+            "the response must name the contract the delegate asked about"
+        );
+        assert_eq!(
+            response.result,
+            Ok(()),
+            "a delegate whose related contracts WERE fetched must be told its \
+             write succeeded; reporting failure for a write that landed leaves \
+             the delegate acting on a state change it believes did not happen"
+        );
+    }
+
+    /// The depth-1 cap in the same function: a resumed upsert that asks for a
+    /// DIFFERENT, still-absent related contract is refused, not deferred a
+    /// second time.
+    ///
+    /// Unexecuted for the same reason as the success arm — nothing reached
+    /// `Ok(states)` — and it is the bound that stops a contract deferring
+    /// indefinitely while holding its delegate's exclusion open (#5544 B4).
+    /// Without it the park never ends and the loop is back to waiting on the
+    /// network, which is the stall this whole change removes.
+    ///
+    /// It has to ask for a contract that is NOT present, and that is the whole
+    /// difficulty. My first attempt used `AlwaysRequestRelated` for the SAME
+    /// contract the fetch had just resolved, and it never reached this arm: the
+    /// executor found the injected state, re-validated, and returned its own
+    /// `Err` for "additional related contracts after first round" — so the
+    /// function took the plain `Err(err) => Err(err)` arm and the test asserted
+    /// a true fact about a different branch. Naming a contract that was never
+    /// fetched is what makes `upsert_contract_state_deferrable` return
+    /// `Ok(DeferRelated(..))`, which is the input this arm exists to handle.
+    ///
+    /// The contrast with the test above is what keeps both non-vacuous: same
+    /// fixture, same successful fetch, and the only difference is whether the
+    /// contract asks for something new.
+    ///
+    /// FALSIFY: map `DeferRelated` to `Ok(...)`, or defer a second time.
+    #[tokio::test]
+    async fn a_resumed_upsert_needing_a_further_contract_is_refused_not_deferred_twice() {
+        let _guard = TEST_GUARD.lock().await;
+
+        let contract_a = make_contract(b"resolved_upsert_greedy_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"resolved_upsert_greedy_b").key().id();
+        // Never fetched, never injected, never local.
+        let id_c = *make_contract(b"resolved_upsert_greedy_c").key().id();
+
+        // Whatever it is given, A asks for C — which nothing has resolved.
+        let (mut handler, _send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::AlwaysRequestRelated(vec![id_c]),
+        )])
+        .await;
+
+        let resolved = resolved_put(
+            contract_a,
+            id_b,
+            Ok(vec![(id_b, WrappedState::new(b"b_state".to_vec()))]),
+        );
+        let msg = apply_resolved_upsert(&mut handler, resolved).await;
+
+        let InboundDelegateMsg::PutContractResponse(response) = msg else {
+            panic!("a resolved PUT must answer with PutContractResponse, got {msg:?}");
+        };
+        let err = response
+            .result
+            .expect_err("a second deferral must NOT be reported to the delegate as success");
+        assert!(
+            err.contains(&id_c.to_string()),
+            "the refusal must name the contract that could not be resolved — C, \
+             the one still missing, not B which was fetched — or the delegate \
+             cannot tell which dependency failed; got {err}"
+        );
+    }
+
     /// The second half of #5544: a delegate PUT whose contract asks for a
     /// related contract this node lacks used to await a network GET INLINE, up
     /// to RELATED_FETCH_TIMEOUT (10s), on the same serial loop. Smaller than

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2750,6 +2750,41 @@ async fn dispatch_delegate_request<CH, P>(
 {
     let delegate_key = req.key().clone();
 
+    // INVARIANT this function is the chokepoint for, load-bearing for TWO
+    // separate changes and enforced by nothing but the shape of the call graph:
+    //
+    //   At most one delegate `process()` executes node-wide at any instant, and
+    //   it always executes on the `contract_handling` loop.
+    //
+    // #5544 parks a delegate mid-round-trip, which releases the loop while that
+    // delegate is SUSPENDED (its WASM call has already returned) — never while
+    // it is RUNNING. So the window parking opens is one in which a DIFFERENT
+    // delegate may START, not one in which two may RUN:
+    //
+    //   * `execute_delegate_request` is reached only via
+    //     `handle_delegate_with_contract_requests`, whose every caller — this
+    //     function, `handle_delegate_notification` and `handle_delegate_resume`
+    //     — is awaited from `contract_handling`, one task per node.
+    //   * The off-loop task #5544 spawns captures no `ContractHandler` and no
+    //     executor, so it cannot invoke a delegate. It waits on a human and
+    //     drives a sub-op GET; neither needs one.
+    //   * A resume re-enters the delegate from `handle_delegate_resume`, ON the
+    //     loop. The spawned task only ships a result back down a channel.
+    //
+    // Who depends on this, and why per-delegate exclusion is NOT enough:
+    // `native_api::state_content_changed` (V2 delegate writes, #5490) does a
+    // read-then-write that is not atomic. Its racing pair is two DIFFERENT
+    // delegates writing the SAME contract — per-CONTRACT, which the per-delegate
+    // exclusion below permits by construction. It is safe only because of the
+    // global property above. The durable fix is on #5490's side: fold the
+    // comparison into the same ReDb write transaction as the store, as
+    // `update_state_sync` already does.
+    //
+    // BREAKING IT: spawning any work that holds the `ContractHandler`, or
+    // resuming a continuation anywhere other than the loop. Do either and
+    // #5490's gate must become atomic first. (#4531's off-loop secret export is
+    // not a counter-example — it holds a pooled executor but never invokes a
+    // delegate.) See `delegate_park`'s module docs for the full argument.
     let Some(park) = park else {
         // No loop behind us (direct unit-test calls): legacy inline behaviour,
         // stalls and all.

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -4453,6 +4453,170 @@ mod tests {
         ContractKey::from_params_and_code(&params, &code)
     }
 
+    /// This file's PRODUCTION text: everything above the first test module,
+    /// with comments removed.
+    ///
+    /// Every source-scrape pin in this file must start here. Two vacuity traps
+    /// have shipped in this repo, and one shared helper is cheaper than
+    /// remembering both at each pin:
+    ///
+    ///  * `include_str!` pulls in the test modules, so a pin's own assertion
+    ///    literal can satisfy the pin (#5450). `mod tests` is the FIRST test
+    ///    module in this file, so truncating there removes `hol_4391_tests`
+    ///    too.
+    ///  * **A commented-out call is still text.** A scrape that does not strip
+    ///    comments cannot tell `foo();` from `// foo();`, so it stays green
+    ///    over a call that no longer runs — and commenting a line out is
+    ///    exactly what someone does while debugging, which is precisely when
+    ///    the pin is the only thing still watching. Three #5554-era pins in
+    ///    this file were defeatable that way, including the GHSA-824h-7x5x-wfmf
+    ///    consent gate; a pin that lets a security gate be commented out is
+    ///    worse than no pin, because it reads as coverage.
+    pub(super) fn production_code() -> String {
+        let full = include_str!("contract.rs");
+        let prod = full.split("\nmod tests {").next().unwrap_or(full);
+        strip_comments(prod)
+    }
+
+    /// Remove `//` line comments and `/* */` block comments, preserving
+    /// newlines so line-oriented reasoning still works.
+    ///
+    /// Block comments as well as line comments: `/* */` around a call is the
+    /// same defeat one syntax over, and a guard that catches only the variant
+    /// you thought of is a search with a blind spot.
+    ///
+    /// Known limits, both of which fail in the LOUD direction. It is not a Rust
+    /// lexer, so a `//` inside a string literal starts a "comment" and the rest
+    /// of that line is dropped; and Rust block comments nest, which this does
+    /// not model. Either can only REMOVE text a pin looks for, turning a pin
+    /// red rather than green — never the reverse.
+    pub(super) fn strip_comments(src: &str) -> String {
+        enum S {
+            Code,
+            Line,
+            Block,
+        }
+        let chars: Vec<char> = src.chars().collect();
+        let mut out = String::with_capacity(src.len());
+        let mut state = S::Code;
+        let mut i = 0;
+        while i < chars.len() {
+            let c = chars[i];
+            let next = chars.get(i + 1).copied();
+            match state {
+                S::Code => {
+                    if c == '/' && next == Some('/') {
+                        state = S::Line;
+                        i += 2;
+                        continue;
+                    }
+                    if c == '/' && next == Some('*') {
+                        state = S::Block;
+                        i += 2;
+                        continue;
+                    }
+                    out.push(c);
+                }
+                S::Line => {
+                    if c == '\n' {
+                        state = S::Code;
+                        out.push('\n');
+                    }
+                }
+                S::Block => {
+                    if c == '*' && next == Some('/') {
+                        state = S::Code;
+                        i += 2;
+                        continue;
+                    }
+                    if c == '\n' {
+                        out.push('\n');
+                    }
+                }
+            }
+            i += 1;
+        }
+        out
+    }
+
+    /// Byte index just past the `}` matching the `{` at `open`.
+    ///
+    /// Panics rather than returning on unbalanced braces: a scrape that cannot
+    /// bound its region must fail loudly, never silently scan the rest of the
+    /// file.
+    pub(super) fn end_of_block(code: &str, open: usize) -> usize {
+        let bytes = code.as_bytes();
+        assert_eq!(
+            bytes.get(open),
+            Some(&b'{'),
+            "end_of_block must be given the index of an opening brace"
+        );
+        let mut depth = 0usize;
+        for (i, b) in bytes.iter().enumerate().skip(open) {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("unbalanced braces from byte {open}: the scrape cannot bound this block");
+    }
+
+    /// The text of one function, bounded by BRACE MATCHING rather than by the
+    /// next `fn` keyword.
+    ///
+    /// Bounding on "the next `\nasync fn `" looks equivalent and is not: it
+    /// misses `pub async fn`, `pub(crate) async fn` and every other visibility
+    /// prefix, and a miss widens the region to the end of the file instead of
+    /// failing — which turns a `contains` assertion vacuous. Brace matching
+    /// cannot widen.
+    pub(super) fn fn_region<'a>(code: &'a str, signature: &str) -> &'a str {
+        let start = code.find(signature).unwrap_or_else(|| {
+            panic!(
+                "`{signature}` must exist in the production text of contract.rs. \
+                 If it was renamed, give this pin the new name — do not let it \
+                 quietly scan nothing."
+            )
+        });
+        let open = start
+            + code[start..]
+                .find('{')
+                .unwrap_or_else(|| panic!("`{signature}` must have a body"));
+        &code[start..end_of_block(code, open)]
+    }
+
+    /// The body of every task this file spawns off the serial loop.
+    ///
+    /// Used by the chokepoint pin to check what runs OFF the loop. Panics on a
+    /// spawn form it does not recognise, so a new one is reviewed rather than
+    /// silently skipped.
+    pub(super) fn spawned_bodies(code: &str) -> Vec<&str> {
+        let mut out = Vec::new();
+        for pattern in ["spawn(", "spawn_blocking("] {
+            for (idx, m) in code.match_indices(pattern) {
+                let arg_start = idx + m.len();
+                let rel = code[arg_start..].find('{').unwrap_or_else(|| {
+                    panic!("a `{pattern}` at byte {idx} is never followed by a block")
+                });
+                assert!(
+                    rel < 40,
+                    "unrecognised spawn form at byte {idx}: this pin bounds a \
+                     spawned task by the block it is handed, and no block \
+                     follows within 40 characters. Teach it the new form rather \
+                     than letting a spawned task go unscanned."
+                );
+                let open = arg_start + rel;
+                out.push(&code[open..end_of_block(code, open)]);
+            }
+        }
+        out
+    }
+
     /// PIN: the NODE-WIDE "one delegate `process()` at a time" invariant, held
     /// by the shape of the call graph and by nothing else.
     ///
@@ -4482,24 +4646,16 @@ mod tests {
     /// is awaited from `contract_handling` and then to say so here.
     ///
     /// FALSIFY: add a call to `handle_delegate_with_contract_requests` in a new
-    /// function (for instance inside a `GlobalExecutor::spawn` body), or call
-    /// `execute_delegate_request` from anywhere but the chokepoint. Either
-    /// fails. Verified by doing both.
+    /// function, call `execute_delegate_request` from anywhere but the
+    /// chokepoint, or — the case checks 1 and 2 could not see — put either
+    /// call inside a `GlobalExecutor::spawn` body WITHIN one of the four
+    /// allowed functions. All three fail. Verified by doing all three.
     #[test]
     fn every_delegate_run_is_reached_from_the_serial_loop() {
         // Production text only, comments stripped. Both needles occur in this
         // test's own prose and in the module's doc comments, and a scrape that
         // counted those would report a true fact about the wrong text (#5450).
-        let full = include_str!("contract.rs");
-        let prod = full.split("\nmod tests {").next().unwrap_or(full);
-        let code: String = prod
-            .lines()
-            .map(|line| match line.find("//") {
-                Some(i) => &line[..i],
-                None => line,
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let code = production_code();
 
         // The nearest preceding `fn` declaration at statement position.
         fn enclosing_fn(code: &str, idx: usize) -> &str {
@@ -4568,6 +4724,44 @@ mod tests {
             !callers.is_empty(),
             "the scrape found no callers at all, so it is measuring nothing"
         );
+
+        // 3. Neither needle may appear inside a SPAWNED task.
+        //
+        //    Checks 1 and 2 ask only which TOP-LEVEL function encloses a call,
+        //    so a `GlobalExecutor::spawn(async move { ... })` block placed
+        //    inside one of the four allowed functions passes both unchanged —
+        //    while doing exactly what the message above says breaks the
+        //    invariant ("a call from a spawned task, a pooled executor or a
+        //    second loop"). The guard returned a true answer about the wrong
+        //    thing, which is the defect this workstream keeps finding.
+        //
+        //    The "does it exist to be absent from" half is carried by the two
+        //    assertions above: `.execute_delegate_request(` is pinned at
+        //    exactly 2 occurrences and `callers` is pinned non-empty, so
+        //    neither needle can be renamed away while this check reports a
+        //    clean zero. `spawned_bodies` panics on an unrecognised spawn form
+        //    rather than skipping it, and the assertion below pins that it
+        //    found some.
+        let spawned = spawned_bodies(&code);
+        assert!(
+            !spawned.is_empty(),
+            "this file spawns tasks off the loop (the park task, the deferred \
+             fetch, the export) and the scan found none — it is measuring \
+             nothing, so a delegate run inside a spawned task would pass"
+        );
+        for body in &spawned {
+            for needle in [chokepoint, ".execute_delegate_request("] {
+                assert!(
+                    !body.contains(needle),
+                    "`{needle}` appears inside a SPAWNED task body. Whatever \
+                     top-level function encloses the spawn, the spawned block \
+                     does not run on the serial loop, so this breaks the \
+                     node-wide one-`process()`-at-a-time invariant that #5490's \
+                     broadcast marker and `state_content_changed`'s \
+                     read-then-write both rest on. Body: {body}"
+                );
+            }
+        }
     }
 
     /// Pin: a wrong response variant must NOT be reported to the client as a
@@ -4726,15 +4920,23 @@ mod tests {
     ///     hardcoded value can never reach the hop.
     #[test]
     fn inter_delegate_hop_forwards_the_originating_scope() {
-        let src = include_str!("contract.rs");
-        let body = src
-            .split("async fn handle_delegate_with_contract_requests")
-            .nth(1)
-            .expect("handle_delegate_with_contract_requests must exist");
-        let body = body
-            .split("\nasync fn ")
-            .next()
-            .expect("bounded by the next free function");
+        // Comments stripped (`production_code`): without that, commenting the
+        // hop out left every assertion below satisfied by the commented text,
+        // so the scope-laundering bug could be reinstated under a green pin.
+        let src = production_code();
+        let body = fn_region(&src, "async fn handle_delegate_with_contract_requests");
+
+        // The forbidden literal must EXIST somewhere in production, or the
+        // negative assertion below is satisfied by a rename rather than by the
+        // code being right. It legitimately appears on the notification path,
+        // which is the third assertion's whole subject.
+        assert!(
+            src.contains("ConnectionScope::Local"),
+            "the literal this pin forbids at the hop no longer appears anywhere \
+             in production. Either the variant was renamed — in which case this \
+             pin now forbids nothing — or the notification path stopped \
+             hardcoding it, in which case rewrite this pin deliberately."
+        );
 
         // Isolate the hop's own executor call.
         let hop = body
@@ -4758,14 +4960,7 @@ mod tests {
         );
 
         // And the scopeless caller must not be able to reach it at all.
-        let notification = src
-            .split("async fn handle_delegate_notification")
-            .nth(1)
-            .expect("handle_delegate_notification must exist");
-        let notification = notification
-            .split("\nasync fn ")
-            .next()
-            .expect("bounded by the next free function");
+        let notification = fn_region(&src, "async fn handle_delegate_notification");
         assert!(
             notification.contains("InterDelegateDispatch::Suppressed"),
             "the notification path hardcodes ConnectionScope::Local, so it MUST \
@@ -4788,17 +4983,17 @@ mod tests {
     /// the gate being deleted or moved below its consumer, which it does. The
     /// region is bounded to the function so the pin cannot match its own
     /// assertion strings further down the file.
+    ///
+    /// It scrapes `production_code()`, which strips comments, and that is
+    /// load-bearing rather than tidiness: the earlier version scraped raw text,
+    /// so commenting the gate out left both `find`s satisfied and the ordering
+    /// assertion true, and the pin stayed green with the gate GONE. A pin that
+    /// lets a security gate be commented out is worse than no pin, because it
+    /// reads as coverage.
     #[test]
     fn consent_prompt_identity_comes_from_the_gated_origin() {
-        let src = include_str!("contract.rs");
-        let body = src
-            .split("async fn handle_delegate_with_contract_requests")
-            .nth(1)
-            .expect("handle_delegate_with_contract_requests must exist");
-        let body = body
-            .split("\nasync fn ")
-            .next()
-            .expect("bounded by the next free function");
+        let src = production_code();
+        let body = fn_region(&src, "async fn handle_delegate_with_contract_requests");
 
         let gate = body
             .find("let origin_contract = if connection_scope.is_local()")
@@ -7288,8 +7483,8 @@ mod hol_4391_tests {
     #[test]
     fn park_sweep_deadline_is_armed_and_the_loop_waits_on_it() {
         // The loop must consult the deadline, not sweep only on other traffic.
-        let src = include_str!("contract.rs");
-        let body = contract_handling_body(src);
+        let src = contract_handling_body();
+        let body = src.as_str();
         assert!(
             body.contains("park_ctx.next_sweep_deadline()"),
             "contract_handling must compute the park sweep deadline"
@@ -7301,21 +7496,18 @@ mod hol_4391_tests {
         );
     }
 
-    /// The text of `contract_handling`, bounded to that function.
+    /// The text of `contract_handling`, comment-stripped and bounded to that
+    /// function.
     ///
-    /// `include_str!` pulls in this test module too, so an unbounded
-    /// `split(signature).nth(1)` runs to EOF and a pin over it can be satisfied
-    /// by the pin's own assertion literal. The `\n}\n` end anchor is the
-    /// top-level closing brace: everything inside the function is indented.
-    fn contract_handling_body(src: &str) -> &str {
-        let start = src
-            .find("pub(crate) async fn contract_handling")
-            .expect("contract_handling must exist");
-        let body = &src[start..];
-        let end = body
-            .find("\n}\n")
-            .expect("contract_handling must have a top-level closing brace");
-        &body[..end]
+    /// Both halves are load-bearing, and both are shared with `mod tests` so
+    /// there is one implementation rather than a second that drifts. Comment
+    /// stripping is what stops a pin over this region being satisfied by a
+    /// commented-out call — the defeat that was found in three sibling pins in
+    /// this file; the region bound is what stops it being satisfied by a pin's
+    /// own assertion literal further down (#5450).
+    fn contract_handling_body() -> String {
+        let code = super::tests::production_code();
+        super::tests::fn_region(&code, "pub(crate) async fn contract_handling").to_string()
     }
 
     /// #5554: the TTL backstop must decide from the resumes the loop has ALREADY
@@ -7334,12 +7526,13 @@ mod hol_4391_tests {
     /// responder, and waiting for unrelated traffic to wake the loop is the
     /// stall this whole change exists to remove.
     ///
-    /// FALSIFY by moving the drain below the sweep, or by deleting either the
-    /// drain or the `continue` guard.
+    /// FALSIFY by moving the drain below the sweep, by deleting either the
+    /// drain or the `continue` guard, or by commenting the drain out — the
+    /// last of which this pin missed until `contract_handling_body` started
+    /// stripping comments.
     #[test]
     fn the_ttl_sweep_decides_from_the_resumes_the_loop_already_took() {
-        let src = include_str!("contract.rs");
-        let squashed: String = contract_handling_body(src)
+        let squashed: String = contract_handling_body()
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect();

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1473,6 +1473,16 @@ where
                         // task is dropped, panics or is cancelled, so the park
                         // always ends, its pending queue always drains and the
                         // parked client is always answered.
+                        //
+                        // NOTE, load-bearing: this task deliberately captures
+                        // NO `ContractHandler` and no executor — only the
+                        // prompter, an OpManager handle and plain data. That is
+                        // what keeps delegate `process()` globally serial on the
+                        // loop even though the loop is now released mid-
+                        // round-trip, which #5490's non-atomic
+                        // `state_content_changed` gate depends on. Do not hand
+                        // this task the handler. See `delegate_park`'s module
+                        // docs, "What parking does NOT relax".
                         GlobalExecutor::spawn(async move {
                             // Prompts and fetches run CONCURRENTLY, and the whole
                             // body is capped by PARK_WORK_BUDGET. Sequentially

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -6343,10 +6343,14 @@ mod hol_4391_tests {
             )]);
 
         // B's fetch hangs until released, standing in for a slow network GET.
+        // The counter records that the OFF-LOOP path was the one taken.
         let gate = Arc::new(tokio::sync::Notify::new());
         let gate_for_stub = gate.clone();
+        let off_loop_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls_for_stub = off_loop_calls.clone();
         let _override = OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
             let gate = gate_for_stub.clone();
+            calls_for_stub.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async move {
                 gate.notified().await;
                 Err(ExecutorError::missing_related(missing[0]))
@@ -6388,6 +6392,28 @@ mod hol_4391_tests {
             });
 
         tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // The two DECISIVE assertions. Remove the deferral (drop the
+        // `DeferRelated if parking.is_some()` arm) and both fail: the upsert
+        // then fetches inline and the delegate answers straight away.
+        //
+        // Note for reviewers on why these carry the weight rather than the
+        // GET-promptness check below: this harness has no op_manager, so the
+        // INLINE related fetch fails immediately instead of hanging. The GET
+        // would therefore look prompt even with the deferral removed, which
+        // makes it corroborating rather than decisive HERE. (In the prompt
+        // test it is decisive — `prompter.prompt()` really does hang inline.)
+        assert_eq!(
+            off_loop_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the related fetch must have been routed OFF the loop, not awaited \
+             inline in the upsert (#5544)"
+        );
+        assert!(
+            !delegate_task.is_finished(),
+            "the delegate must still be PARKED while its related fetch is in \
+             flight; finishing already means the fetch was awaited inline"
+        );
 
         let get_c = tokio::time::timeout(
             Duration::from_secs(2),

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -5906,7 +5906,8 @@ mod hol_4391_tests {
                 &mut handler,
                 id,
                 received,
-                &user_input::AutoApprovePrompter,
+                &std::sync::Arc::new(user_input::AutoApprovePrompter),
+                None,
                 None,
             )
             .await
@@ -5924,4 +5925,249 @@ mod hol_4391_tests {
             other => panic!("expected DelegateResponse, got {other}"),
         }
     }
+
+    // ---- #5544: a parked delegate must not stall the loop, and must not be
+    // ---- re-entered while parked.
+
+    /// A prompter that hangs until released, standing in for a human who has
+    /// not clicked yet. The real `DashboardPrompter` waits up to
+    /// `USER_INPUT_TIMEOUT` (60s) for exactly this.
+    struct GatedPrompter {
+        gate: Arc<tokio::sync::Notify>,
+    }
+
+    impl user_input::UserInputPrompter for GatedPrompter {
+        async fn prompt(
+            &self,
+            _request: &UserInputRequest<'static>,
+            _delegate_key: &str,
+            _caller: user_input::CallerIdentity,
+        ) -> Option<(usize, ClientResponse<'static>)> {
+            self.gate.notified().await;
+            Some((0, ClientResponse::new(b"approved".to_vec())))
+        }
+    }
+
+    fn test_delegate_key() -> DelegateKey {
+        DelegateKey::new([7u8; 32], freenet_stdlib::prelude::CodeHash::new([7u8; 32]))
+    }
+
+    /// One scripted `RequestUserInput`, which is what makes the delegate park.
+    fn prompt_outbound() -> Vec<OutboundDelegateMsg> {
+        let message = freenet_stdlib::prelude::NotificationMessage::try_from(&serde_json::json!({
+            "message": "allow?"
+        }))
+        .expect("notification message");
+        vec![OutboundDelegateMsg::RequestUserInput(UserInputRequest {
+            request_id: 1,
+            message,
+            responses: vec![ClientResponse::new(b"yes".to_vec())],
+        })]
+    }
+
+    fn delegate_event(key: &DelegateKey) -> ContractHandlerEvent {
+        ContractHandlerEvent::DelegateRequest {
+            req: DelegateRequest::ApplicationMessages {
+                key: key.clone(),
+                params: Parameters::from(Vec::new()),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    freenet_stdlib::prelude::ApplicationMessage::new(b"go".to_vec()),
+                )],
+            },
+            origin_contract: None,
+            connection_scope: crate::client_events::ConnectionScope::Local,
+            user_context: None,
+        }
+    }
+
+    /// THE #5544 REGRESSION TEST: unrelated contract work must keep draining
+    /// while a delegate sits parked on a permission prompt.
+    ///
+    /// Before the fix, `prompter.prompt(...)` was awaited on the serial
+    /// `contract_handling` loop, so a delegate awaiting a human froze every
+    /// GET/PUT/UPDATE/subscribe on the node for up to `USER_INPUT_TIMEOUT`
+    /// (60s). Asserting only that the delegate still works would NOT catch a
+    /// regression to inline blocking — the delegate works either way. What
+    /// distinguishes the two is whether anything ELSE can run meanwhile, so
+    /// that is what this asserts, under a timeout far below 60s.
+    #[tokio::test]
+    async fn parked_delegate_prompt_does_not_block_the_loop() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        script.lock().unwrap().push_back(prompt_outbound());
+
+        // A locally stored contract, so the GET below needs no network and its
+        // only possible source of delay is the loop being blocked.
+        let contract_c = make_contract(b"park_c_cached");
+        let key_c = contract_c.key();
+
+        let send = Arc::new(send);
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        let put_c = put_local(
+            send.as_ref(),
+            contract_c,
+            WrappedState::new(b"c_state".to_vec()),
+        )
+        .await;
+        assert!(
+            matches!(
+                put_c,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "seed PUT for C must succeed, got {put_c}"
+        );
+
+        // Drive the delegate on a background task: it emits RequestUserInput,
+        // parks, and stays parked until the gate opens.
+        let send_d = send.clone();
+        let key_d = test_delegate_key();
+        let delegate_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_d.send_to_handler(delegate_event(&key_d)).await
+            });
+
+        // Let the loop pick up the delegate request and park it.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // The crux. Inline blocking makes this time out.
+        let get_c = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_c.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect(
+            "a local-store GET must NOT block behind a delegate parked on a \
+             user prompt (#5544)",
+        )
+        .expect("GET for C must respond");
+        match get_c {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let store = response.expect("GET for C must succeed");
+                assert_eq!(
+                    store.state.expect("C has state").as_ref(),
+                    b"c_state",
+                    "GET must return C's stored state"
+                );
+            }
+            other => panic!("expected GetResponse for C, got {other}"),
+        }
+
+        // Release the human: the delegate resumes and its client is answered.
+        gate.notify_waiters();
+        let resp = tokio::time::timeout(Duration::from_secs(5), delegate_task)
+            .await
+            .expect("the parked delegate must resolve once the prompt is answered")
+            .expect("delegate task join")
+            .expect("delegate request must be answered");
+        assert!(
+            matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
+            "parked delegate must answer its original client exactly once, got {resp}"
+        );
+
+        handle.abort();
+    }
+
+    /// THE EXCLUSION TEST. Pins the invariant that makes parking sound.
+    ///
+    /// `DelegateContextCache` is keyed by `DelegateKey` and last-write-wins, so
+    /// it is only correct while at most one `process()` per delegate is in
+    /// flight. Before #5544 the serial loop supplied that for free; parking
+    /// removes it, so `DelegateParkCtx` has to supply it instead. If it did
+    /// not, a second request would run `process()` and overwrite the parked
+    /// continuation, and the delegate would resume reading someone else's
+    /// bytes — silent state corruption, not a crash, which is why it needs a
+    /// test rather than trust.
+    ///
+    /// NOTE FOR REVIEWERS: this test CANNOT fail on pre-#5544 `main`, because
+    /// there the blocked loop prevents the interleave by construction. It is a
+    /// pin against *this* change regressing: delete the `is_parked` check in
+    /// `dispatch_delegate_request` and it fails, because the second request
+    /// reaches the executor while the first is still parked. That is the
+    /// falsification to run if you want to confirm it is not vacuous.
+    #[tokio::test]
+    async fn a_parked_delegate_is_not_re_entered_until_it_resumes() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        let calls = handler.runtime_mut().delegate_calls.clone();
+        // Only the FIRST invocation prompts; later ones return nothing, so the
+        // round-trip terminates instead of parking forever.
+        script.lock().unwrap().push_back(prompt_outbound());
+
+        let send = Arc::new(send);
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        let key_d = test_delegate_key();
+
+        // Request 1 parks the delegate.
+        let send_1 = send.clone();
+        let k1 = key_d.clone();
+        let first: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move { send_1.send_to_handler(delegate_event(&k1)).await });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "the first request must have entered the delegate exactly once"
+        );
+
+        // Request 2 for the SAME delegate arrives while it is parked.
+        let send_2 = send.clone();
+        let k2 = key_d.clone();
+        let second: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move { send_2.send_to_handler(delegate_event(&k2)).await });
+
+        // Give the loop ample opportunity to (wrongly) run it.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "a parked delegate must NOT be re-entered: the queued request would \
+             overwrite the parked continuation's context (#5544)"
+        );
+
+        // Release the prompt: the parked run resumes, then the queued request
+        // is drained — both reach the delegate, in order.
+        gate.notify_waiters();
+        let r1 = tokio::time::timeout(Duration::from_secs(5), first)
+            .await
+            .expect("first delegate request must resolve")
+            .expect("join")
+            .expect("first must be answered");
+        assert!(matches!(r1, ContractHandlerEvent::DelegateResponse(_)));
+        let r2 = tokio::time::timeout(Duration::from_secs(5), second)
+            .await
+            .expect("the queued request must be drained once the park ends")
+            .expect("join")
+            .expect("second must be answered");
+        assert!(
+            matches!(r2, ContractHandlerEvent::DelegateResponse(_)),
+            "a request queued behind a park must still be answered, never dropped"
+        );
+        assert!(
+            calls.lock().unwrap().len() >= 3,
+            "expected the resume plus the drained request to enter the delegate, \
+             got {} entries",
+            calls.lock().unwrap().len()
+        );
+
+        handle.abort();
+    }
+
 }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -8,10 +8,6 @@ use either::Either;
 use freenet_stdlib::prelude::*;
 
 pub(crate) mod delegate_app_registry;
-// Lands ahead of its call sites so the bounds, the TTL and the exactly-once
-// resume guard can be reviewed and unit-tested on their own. The `allow` goes
-// away in the commit that wires the prompt path.
-#[allow(dead_code)]
 mod delegate_park;
 mod executor;
 mod fair_queue;
@@ -526,6 +522,96 @@ enum InterDelegateDispatch {
     Suppressed,
 }
 
+/// Drive the permission prompts for one delegate iteration and build the
+/// `UserResponse` messages to feed back.
+///
+/// Extracted so the PARKED path (spawned off the loop) and the inline fallback
+/// (taken only when the park cap is hit) run byte-identical logic. Inlining it
+/// twice is how the denied/timed-out branch silently diverges.
+async fn run_user_input_prompts<P>(
+    prompter: &P,
+    requests: Vec<UserInputRequest<'static>>,
+    delegate_key: &DelegateKey,
+    delegate_key_str: &str,
+    caller: CallerIdentity,
+) -> Vec<InboundDelegateMsg<'static>>
+where
+    P: UserInputPrompter,
+{
+    let mut out = Vec::with_capacity(requests.len());
+    for req in requests {
+        let request_id = req.request_id;
+        let response = match prompter
+            .prompt(&req, delegate_key_str, caller.clone())
+            .await
+        {
+            Some((_, response)) => response,
+            None => {
+                tracing::warn!(
+                    request_id,
+                    delegate = %delegate_key,
+                    "User input request timed out or was denied"
+                );
+                // Send an empty response so the delegate knows the request
+                // was denied/timed out, rather than leaving it waiting forever.
+                ClientResponse::new(Vec::new())
+            }
+        };
+        out.push(InboundDelegateMsg::UserResponse(UserInputResponse {
+            request_id,
+            response,
+            // UserInputRequest has no context field, so we use default.
+            // The delegate's actual context is maintained separately in
+            // the process_outbound loop in delegate.rs.
+            context: DelegateContext::default(),
+        }));
+    }
+    out
+}
+
+/// Loop-side context that lets a delegate run PARK instead of blocking.
+///
+/// `None` for callers with no loop behind them (direct unit-test calls), which
+/// keep the legacy inline behaviour exactly. Mirrors the
+/// `deferral: Option<&mut DeferralCtx>` shape `handle_contract_event` already
+/// uses for #4391.
+struct ParkingCtx<'a> {
+    park: &'a mut delegate_park::DelegateParkCtx,
+    /// Where the residual messages go once the (possibly resumed) run finishes.
+    delivery: delegate_park::Delivery,
+    /// The client responder a RESUMED run is already holding (it was taken from
+    /// the channel when the run first parked, so it cannot be re-taken by event
+    /// id). Borrowed, not owned: if the run parks again the value moves into the
+    /// new continuation, and if it completes the caller reads what is left here
+    /// and answers the client. A fresh run passes `&mut None`.
+    carried_responder: &'a mut Option<StashedResponder>,
+}
+
+/// Outcome of one delegate run.
+enum DelegateRunOutcome {
+    /// The run finished; these are the residual outbound messages.
+    Completed(Vec<OutboundDelegateMsg>),
+    /// The run PARKED awaiting off-loop work and will be resumed on a later
+    /// loop iteration. The caller must NOT answer the client — it must hand the
+    /// client's responder to the park entry (`attach_responder`) and return, so
+    /// the client sees one response covering the whole round-trip.
+    Parked,
+    /// The delegate's execution FAILED, or the executor answered with a variant
+    /// that is not a delegate response at all.
+    ///
+    /// Carries #5263's propagation through parking: before that change every
+    /// such failure became an empty successful `DelegateResponse`, so a client
+    /// could not tell "the delegate said nothing" from "this node is confused".
+    /// Parking must not reintroduce that, so the failure is a variant of the
+    /// outcome rather than being folded into `Completed`.
+    ///
+    /// NOT the same thing as a delegate whose off-loop work did not finish —
+    /// that is a park that resumes with synthesized terminal results, and the
+    /// delegate is told. This is the synchronous execution failing outright,
+    /// and the CLIENT is told.
+    Failed(ExecutorError),
+}
+
 /// Handle a delegate request, including any contract request messages in the response.
 ///
 /// When a delegate emits contract request messages, this function:
@@ -547,11 +633,12 @@ async fn handle_delegate_with_contract_requests<CH, P>(
     inter_delegate: InterDelegateDispatch,
     user_context: Option<&UserSecretContext>,
     delegate_key: &DelegateKey,
-    prompter: &P,
-) -> Result<Vec<OutboundDelegateMsg>, ExecutorError>
+    prompter: &std::sync::Arc<P>,
+    mut parking: Option<ParkingCtx<'_>>,
+) -> DelegateRunOutcome
 where
     CH: ContractHandler + Send + 'static,
-    P: UserInputPrompter,
+    P: UserInputPrompter + 'static,
 {
     // Extract initial params from the request (only ApplicationMessages has params we need).
     // The registration variants (including RegisterDelegateWithPredecessors,
@@ -601,14 +688,25 @@ where
                 iterations = iterations,
                 "Exceeded maximum contract request iterations, possible infinite loop"
             );
-            // Stays `Ok` DELIBERATELY, and this is an OPEN QUESTION, not a
-            // settled decision. Exhausting the iteration budget may be a
-            // legitimate outcome for a delegate that simply has more work than
-            // the cap allows, in which case converting it to `Err` would turn
-            // working delegates into client-visible failures. Nobody has
-            // established which it is, so #5263 deliberately did not touch it.
-            // Confirm the intent before changing this -- tracked as #5454.
-            return Ok(accumulated_messages);
+            // Stays a SUCCESS deliberately (`Completed`, formerly `Ok`), and
+            // this is an OPEN QUESTION, not a settled decision. Exhausting the
+            // iteration budget may be a legitimate outcome for a delegate that
+            // simply has more work than the cap allows, in which case
+            // converting it to a failure would turn working delegates into
+            // client-visible errors. Nobody has established which it is, so
+            // #5263 deliberately did not touch it. Confirm the intent before
+            // changing this -- tracked as #5454.
+            //
+            // #5544 CHANGED WHO ARRIVES HERE, which #5454 needs to know: this
+            // branch carries `iterations` across parks (S1), so a delegate that
+            // prompts on every re-entry used to reset the count and loop
+            // forever, and now TERMINATES HERE instead. The traffic through this
+            // arm shifts toward PROMPTING delegates — the hardest case for the
+            // question above, since a human is waiting. See also the truncation
+            // gap named at `MAX_CONTRACT_REQUEST_ITERATIONS`: the delegate is
+            // not told it was cut short, which is the same question from the
+            // delegate's side rather than the client's.
+            return DelegateRunOutcome::Completed(accumulated_messages);
         }
 
         // Execute the delegate request
@@ -640,7 +738,10 @@ where
                 // below -- the client cannot tell "the delegate said nothing"
                 // from "this node is confused". Nothing legitimate reaches
                 // here, so there is no working behaviour to regress.
-                return Err(ExecutorError::other(anyhow::anyhow!(
+                //
+                // #5544 keeps this prohibition and re-expresses it in the
+                // outcome enum: `Failed`, never `Completed`.
+                return DelegateRunOutcome::Failed(ExecutorError::other(anyhow::anyhow!(
                     "unexpected response variant for a delegate request on {delegate_key}"
                 )));
             }
@@ -657,7 +758,7 @@ where
                         delegate_key = %delegate_key,
                         "Delegate not found in store (expected for migration probes)"
                     );
-                    return Ok(accumulated_messages);
+                    return DelegateRunOutcome::Completed(accumulated_messages);
                 }
                 tracing::error!(
                     delegate_key = %delegate_key,
@@ -665,7 +766,7 @@ where
                     phase = "execution_failed",
                     "Failed executing delegate request"
                 );
-                return Err(err);
+                return DelegateRunOutcome::Failed(err);
             }
         };
 
@@ -714,7 +815,7 @@ where
             && delegate_messages.is_empty()
             && user_input_requests.is_empty()
         {
-            return Ok(accumulated_messages);
+            return DelegateRunOutcome::Completed(accumulated_messages);
         }
 
         let mut inbound_responses: Vec<InboundDelegateMsg<'static>> = Vec::new();
@@ -1165,33 +1266,86 @@ where
             let caller = caller_identity_from_origin(origin_contract);
             let delegate_key_str = delegate_key.to_string();
 
-            for req in user_input_requests {
-                let request_id = req.request_id;
-                let response = match prompter
-                    .prompt(&req, &delegate_key_str, caller.clone())
-                    .await
-                {
-                    Some((_, response)) => response,
-                    None => {
-                        tracing::warn!(
-                            request_id,
-                            delegate = %delegate_key,
-                            "User input request timed out or was denied"
-                        );
-                        // Send an empty response so the delegate knows the request
-                        // was denied/timed out, rather than leaving it waiting forever.
-                        ClientResponse::new(Vec::new())
-                    }
+            // PARK rather than await (#5544).
+            //
+            // `prompter.prompt()` waits on a HUMAN for up to
+            // `USER_INPUT_TIMEOUT` (60s). Awaiting it HERE parks the single
+            // serial `contract_handling` loop for that whole time, so no GET,
+            // PUT, UPDATE, subscribe registration or delegate notification
+            // anywhere on this node is serviced until the user clicks. That is
+            // a node-wide stall triggered by any delegate that prompts, and
+            // ghostkeys prompts in four places.
+            //
+            // Nothing about the delegate needs us to stay here: it is ALREADY
+            // suspended at the runtime level. `RequestUserInput` breaks out of
+            // `process_outbound`, the WASM `process()` call has returned, and
+            // the continuation is in the `DelegateContextCache`. All that is
+            // needed is to re-enter it when the answer arrives.
+            if let Some(ctx) = parking.as_mut() {
+                let continuation = delegate_park::Continuation {
+                    params: current_params.clone(),
+                    origin_contract: origin_contract.copied(),
+                    connection_scope,
+                    user_context: user_context.cloned(),
+                    inter_delegate,
+                    accumulated: std::mem::take(&mut accumulated_messages),
+                    inbound_so_far: std::mem::take(&mut inbound_responses),
+                    // Attached by the caller right after we return `Parked`
+                    // (it owns the channel), or carried straight through if
+                    // this run is itself a resume that is parking again.
+                    responder: ctx.carried_responder.take(),
+                    delivery: ctx.delivery,
                 };
-                inbound_responses.push(InboundDelegateMsg::UserResponse(UserInputResponse {
-                    request_id,
-                    response,
-                    // UserInputRequest has no context field, so we use default.
-                    // The delegate's actual context is maintained separately in
-                    // the process_outbound loop in delegate.rs.
-                    context: DelegateContext::default(),
-                }));
+                match ctx.park.park(delegate_key.clone(), continuation) {
+                    delegate_park::ParkAdmission::Admitted => {
+                        let guard = delegate_park::ParkGuard::new(
+                            ctx.park.resume_tx().clone(),
+                            delegate_key.clone(),
+                        );
+                        let prompter = std::sync::Arc::clone(prompter);
+                        let key = delegate_key.clone();
+                        // Fire-and-forget is safe here precisely because of the
+                        // guard: it delivers exactly one resume even if this
+                        // task is dropped, panics or is cancelled, so the park
+                        // always ends, its pending queue always drains and the
+                        // parked client is always answered.
+                        GlobalExecutor::spawn(async move {
+                            let responses = run_user_input_prompts(
+                                prompter.as_ref(),
+                                user_input_requests,
+                                &key,
+                                &delegate_key_str,
+                                caller,
+                            )
+                            .await;
+                            guard.send(responses);
+                        });
+                        return DelegateRunOutcome::Parked;
+                    }
+                    delegate_park::ParkAdmission::Refused(continuation) => {
+                        // Node-wide park cap reached. Fall through to the
+                        // pre-#5544 inline wait: it stalls the loop, which is
+                        // what this change exists to stop, but silently losing
+                        // a user's permission prompt would be worse. Restore
+                        // what the refused continuation was carrying.
+                        let continuation = *continuation;
+                        accumulated_messages = continuation.accumulated;
+                        inbound_responses = continuation.inbound_so_far;
+                        *ctx.carried_responder = continuation.responder;
+                    }
+                }
             }
+
+            inbound_responses.extend(
+                run_user_input_prompts(
+                    prompter.as_ref(),
+                    user_input_requests,
+                    delegate_key,
+                    &delegate_key_str,
+                    caller,
+                )
+                .await,
+            );
         }
 
         // Create a new request to send the responses back to the delegate
@@ -1294,8 +1448,12 @@ pub(crate) async fn contract_handling<CH, P>(
 ) -> Result<(), ContractError>
 where
     CH: ContractHandler + Send + 'static,
-    P: UserInputPrompter,
+    P: UserInputPrompter + 'static,
 {
+    // `Arc` so a parked delegate's off-loop prompt task can hold the prompter
+    // while the loop keeps running (#5544). `DashboardPrompter` is not `Clone`
+    // (it owns a `Mutex`), and the task outlives this call frame.
+    let prompter = std::sync::Arc::new(prompter);
     let mut delegate_rx = contract_handler.executor().take_delegate_notification_rx();
     let mut fair_queue = fair_queue::FairEventQueue::new();
 
@@ -1318,6 +1476,14 @@ where
     let (export_resume_tx, mut export_resume_rx) =
         tokio::sync::mpsc::unbounded_channel::<ExportResume>();
     let mut deferral_ctx = DeferralCtx::new(resume_tx, export_resume_tx);
+    // Resume channel for delegates PARKED off this loop (#5544). Same
+    // channel-safety carve-out as the two above: producers are bounded by
+    // MAX_PARKED_DELEGATES, the receiver is this loop (drains every
+    // iteration), the off-loop task never reads what the loop produces, and
+    // the send is a non-blocking `unbounded_send`.
+    let (delegate_resume_tx, mut delegate_resume_rx) =
+        tokio::sync::mpsc::unbounded_channel::<delegate_park::DelegateResume>();
+    let mut park_ctx = delegate_park::DelegateParkCtx::new(delegate_resume_tx);
 
     loop {
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
@@ -1332,6 +1498,49 @@ where
                 }
                 Err(_) => break,
             }
+        }
+
+        // Resume delegates whose parked work has landed (#5544), ahead of new
+        // queued work: a parked delegate is holding a client responder and,
+        // possibly, requests queued behind it, so finishing it first keeps
+        // latency down and releases the exclusion sooner. Bounded per
+        // iteration for the same reason as the deferred-upsert drain — each
+        // resume re-enters WASM — and interleaved with the fair queue so
+        // resumes cannot head-of-line-block ordinary contract ops.
+        for _ in 0..MAX_RESUME_DRAIN_BATCH {
+            match delegate_resume_rx.try_recv() {
+                Ok(resume) => {
+                    handle_delegate_resume(
+                        &mut contract_handler,
+                        &mut park_ctx,
+                        &prompter,
+                        resume,
+                    )
+                    .await;
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Backstop sweep for parks that neither completed nor were dropped
+        // (see `PARK_TTL`). Force-resume them so a wedged delegate cannot stay
+        // wedged: the resume drains its pending queue and answers its client.
+        for delegate_key in park_ctx.expired(tokio::time::Instant::now()) {
+            tracing::warn!(
+                delegate = %delegate_key,
+                "Delegate park exceeded PARK_TTL — force-resuming"
+            );
+            handle_delegate_resume(
+                &mut contract_handler,
+                &mut park_ctx,
+                &prompter,
+                delegate_park::DelegateResume {
+                    delegate_key,
+                    cause: delegate_park::ResumeCause::TimedOut,
+                    inbound: Vec::new(),
+                },
+            )
+            .await;
         }
 
         // Drain completed off-loop EXPORTS (#4531 / #4381 P5): return/replace the
@@ -1387,8 +1596,13 @@ where
         for _ in 0..MAX_DELEGATE_DRAIN_BATCH {
             match try_recv_delegate_notification(&mut delegate_rx) {
                 Some(notification) => {
-                    handle_delegate_notification(&mut contract_handler, notification, &prompter)
-                        .await;
+                    handle_delegate_notification(
+                        &mut contract_handler,
+                        notification,
+                        &prompter,
+                        Some(&mut park_ctx),
+                    )
+                    .await;
                 }
                 None => break,
             }
@@ -1408,6 +1622,7 @@ where
                 event,
                 &prompter,
                 Some(&mut deferral_ctx),
+                Some(&mut park_ctx),
             )
             .await?;
             continue;
@@ -1433,8 +1648,23 @@ where
             Some(export_resume) = export_resume_rx.recv() => {
                 handle_export_resume(&mut contract_handler, export_resume).await;
             }
+            Some(delegate_resume) = delegate_resume_rx.recv() => {
+                handle_delegate_resume(
+                    &mut contract_handler,
+                    &mut park_ctx,
+                    &prompter,
+                    delegate_resume,
+                )
+                .await;
+            }
             notification = recv_delegate_notification(&mut delegate_rx) => {
-                handle_delegate_notification(&mut contract_handler, notification, &prompter).await;
+                handle_delegate_notification(
+                    &mut contract_handler,
+                    notification,
+                    &prompter,
+                    Some(&mut park_ctx),
+                )
+                .await;
             }
         }
     }
@@ -2099,10 +2329,11 @@ async fn send_queue_full_response(
 async fn handle_delegate_notification<CH, P>(
     contract_handler: &mut CH,
     notification: executor::DelegateNotification,
-    prompter: &P,
+    prompter: &std::sync::Arc<P>,
+    park: Option<&mut delegate_park::DelegateParkCtx>,
 ) where
     CH: ContractHandler + Send + 'static,
-    P: UserInputPrompter,
+    P: UserInputPrompter + 'static,
 {
     let executor::DelegateNotification {
         delegate_key,
@@ -2115,6 +2346,31 @@ async fn handle_delegate_notification<CH, P>(
         contract = %contract_id,
         "Delivering contract notification to delegate"
     );
+
+    // TTL SWEEP OF THE delegate->apps REGISTRY, AT THE TOP, BEFORE ANY EXIT.
+    //
+    // `sweep_expired` is the registry's only production caller and is what
+    // time-bounds the map per the AGENTS.md GC-exemption rule. #5263 placed it
+    // before its execution-failure return, reasoning that a delegate which
+    // fails on EVERY invocation must not disable the only GC. That reasoning
+    // is right and #5544 adds two more ways to leave this function that its
+    // author could not have known about: the delegate is already parked and
+    // this notification is queued, or this run itself parks. Both returned
+    // without sweeping.
+    //
+    // A parked delegate recovers — every park terminates, and the resumed run
+    // sweeps — so the effect was a DELAY of about one park lifetime rather
+    // than #5263's unbounded loss. But that bound depends on the park
+    // machinery working, and a backstop must not be conditional on the thing
+    // it backs up. Hoisting to the top makes "on every exit" true by position
+    // rather than by argument, which is also the only form a reader can check
+    // at a glance.
+    //
+    // `route_notification_outbound` sweeps too, covering the resume path where
+    // this frame is long gone. The overlap is deliberate: `sweep_expired` is a
+    // `retain` over a `DashMap` and is idempotent, so a second call is cheap
+    // and the redundancy costs less than a missed exit.
+    delegate_app_registry::sweep_expired();
 
     // Unwrap the Arc — if this is the last subscriber the state moves without cloning,
     // otherwise a clone is made (unavoidable since ContractNotification owns the state).
@@ -2134,7 +2390,10 @@ async fn handle_delegate_notification<CH, P>(
         inbound,
     };
 
-    let outbound = handle_delegate_with_contract_requests(
+    // A notification-driven run has no client responder to carry; the slot
+    // exists only to satisfy the shared `ParkingCtx` shape.
+    let mut no_responder = None;
+    let outcome = handle_delegate_with_contract_requests(
         contract_handler,
         req,
         None,
@@ -2156,29 +2415,37 @@ async fn handle_delegate_notification<CH, P>(
         None,
         &delegate_key,
         prompter,
+        park.map(|park| ParkingCtx {
+            park,
+            // No client behind a notification-driven run; residual messages fan
+            // out to registered apps instead.
+            delivery: delegate_park::Delivery::Apps,
+            carried_responder: &mut no_responder,
+        }),
     )
     .await;
 
-    // Notification-driven: there is no client waiting to answer, so an
-    // execution failure has nothing to propagate to. Already logged inside
-    // `handle_delegate_with_contract_requests`; there is nothing to route.
-    //
-    // The TTL sweep runs BEFORE this return, not after. It is the registry's
-    // only production caller, and it is what time-bounds the delegate->apps
-    // map per the AGENTS.md GC-exemption rule. Returning above it would make
-    // the sweep conditional on the delegate SUCCEEDING -- and the failure that
-    // motivated #5263 is one a delegate repeats on every single invocation
-    // (rejecting `origin: None`), so on a node whose delegates are all failing
-    // that way the backstop would never run at all. Registrations for apps
-    // that vanished without a clean disconnect would then pin their slots
-    // against MAX_APPS_PER_DELEGATE until the process restarted. Sweeping is
-    // independent of whether this particular execution produced anything.
-    delegate_app_registry::sweep_expired();
+    match outcome {
+        // Notification-driven run: no client responder to stash. The residual
+        // messages are routed by `handle_delegate_resume` when the park
+        // resolves. The TTL sweep has already run at the top of this function.
+        DelegateRunOutcome::Parked => {}
+        // Nothing to propagate: a notification has no client waiting. Already
+        // logged inside `handle_delegate_with_contract_requests` (#5263).
+        DelegateRunOutcome::Failed(_) => {}
+        DelegateRunOutcome::Completed(outbound) => {
+            route_notification_outbound(&delegate_key, outbound);
+        }
+    }
+}
 
-    let Ok(outbound) = outbound else {
-        return;
-    };
-
+/// Fan a notification-driven run's residual `ApplicationMessage`s out to the
+/// apps registered with the delegate.
+///
+/// Split out of `handle_delegate_notification` because a run that PARKS
+/// finishes on a later loop iteration inside `handle_delegate_resume`, by which
+/// point the original call frame is gone — both paths must route identically.
+fn route_notification_outbound(delegate_key: &DelegateKey, outbound: Vec<OutboundDelegateMsg>) {
     // Route outbound ApplicationMessages to the apps registered with this
     // delegate (#3275). handle_delegate_with_contract_requests already
     // processed the contract requests (GET/PUT/UPDATE/SUBSCRIBE) internally;
@@ -2221,7 +2488,7 @@ async fn handle_delegate_notification<CH, P>(
                 key: delegate_key.clone(),
                 values: vec![app_msg],
             });
-        let delivered = delegate_app_registry::route_to_apps(&delegate_key, response);
+        let delivered = delegate_app_registry::route_to_apps(delegate_key, response);
         if delivered == 0 {
             // `debug!` on purpose. This fires once per notification, so at
             // `release_max_level_info` it would ship one line per contract-state
@@ -2243,16 +2510,320 @@ async fn handle_delegate_notification<CH, P>(
     }
 }
 
+/// Run one client-driven delegate request, honouring per-delegate exclusion.
+///
+/// Shared by the `ContractHandlerEvent::DelegateRequest` arm and by the drain
+/// of requests that queued behind a park, so the exclusion check cannot be
+/// present on one path and missing on the other.
+async fn dispatch_delegate_request<CH, P>(
+    contract_handler: &mut CH,
+    park: Option<&mut delegate_park::DelegateParkCtx>,
+    prompter: &std::sync::Arc<P>,
+    id: handler::EventId,
+    req: DelegateRequest<'static>,
+    origin_contract: Option<ContractInstanceId>,
+    connection_scope: crate::client_events::ConnectionScope,
+    user_context: Option<UserSecretContext>,
+) where
+    CH: ContractHandler + Send + 'static,
+    P: UserInputPrompter + 'static,
+{
+    let delegate_key = req.key().clone();
+
+    let Some(park) = park else {
+        // No loop behind us (direct unit-test calls): legacy inline behaviour,
+        // stalls and all.
+        let outcome = handle_delegate_with_contract_requests(
+            contract_handler,
+            req,
+            origin_contract.as_ref(),
+            connection_scope,
+            InterDelegateDispatch::Allowed,
+            user_context.as_ref(),
+            &delegate_key,
+            prompter,
+            None,
+        )
+        .await;
+        let response = match outcome {
+            DelegateRunOutcome::Completed(msgs) => Ok(msgs),
+            // #5263: a genuine execution failure must reach the client as
+            // `Err`, not as an empty successful response.
+            DelegateRunOutcome::Failed(err) => Err(err),
+            DelegateRunOutcome::Parked => {
+                // Unreachable: a run given no `ParkingCtx` cannot park.
+                tracing::error!(
+                    delegate_key = %delegate_key,
+                    "delegate run parked without a parking context"
+                );
+                return;
+            }
+        };
+        send_delegate_response(contract_handler, id, &delegate_key, response).await;
+        return;
+    };
+
+    // PER-DELEGATE EXCLUSION (#5544). While this delegate has a parked
+    // continuation we must NOT run `process()` for it again: the context cache
+    // is keyed by delegate and last-write-wins, so a second run would overwrite
+    // the parked continuation and it would resume reading the wrong bytes.
+    // Queue instead, and drain on resume.
+    if park.is_parked(&delegate_key) {
+        let pending = delegate_park::PendingRequest {
+            id,
+            req,
+            origin_contract,
+            connection_scope,
+            user_context,
+        };
+        match park.queue_pending(&delegate_key, pending) {
+            delegate_park::QueueOutcome::Queued => {
+                tracing::debug!(
+                    delegate_key = %delegate_key,
+                    "Delegate is parked; queued this request behind it"
+                );
+            }
+            delegate_park::QueueOutcome::Rejected(pending) => {
+                // Answer rather than drop: a silently dropped request hangs
+                // that client forever.
+                contract_handler.channel().drop_waiting_response(pending.id);
+            }
+        }
+        return;
+    }
+
+    let mut carried_responder = None;
+    let outcome = handle_delegate_with_contract_requests(
+        contract_handler,
+        req,
+        origin_contract.as_ref(),
+        connection_scope,
+        // Client-driven: the hop forwards THIS connection's scope, so a
+        // non-local caller cannot obtain an attested caller identity
+        // through it.
+        InterDelegateDispatch::Allowed,
+        user_context.as_ref(),
+        &delegate_key,
+        prompter,
+        Some(ParkingCtx {
+            park: &mut *park,
+            delivery: delegate_park::Delivery::Client,
+            carried_responder: &mut carried_responder,
+        }),
+    )
+    .await;
+
+    match outcome {
+        DelegateRunOutcome::Parked => {
+            // Move the client's responder into the park so the resumed run can
+            // answer it. The client then sees ONE response covering the whole
+            // round-trip, exactly as it does today when the loop blocks.
+            let responder = contract_handler.channel().take_waiting_response(&id);
+            park.attach_responder(&delegate_key, responder);
+        }
+        DelegateRunOutcome::Completed(response) => {
+            send_delegate_response(contract_handler, id, &delegate_key, Ok(response)).await;
+        }
+        // #5263 propagation, carried through parking.
+        DelegateRunOutcome::Failed(err) => {
+            send_delegate_response(contract_handler, id, &delegate_key, Err(err)).await;
+        }
+    }
+}
+
+/// Answer a client-driven delegate request. A dropped channel means the client
+/// disconnected, which is not fatal — the delegate already ran.
+async fn send_delegate_response<CH>(
+    contract_handler: &mut CH,
+    id: handler::EventId,
+    delegate_key: &DelegateKey,
+    // `Result`, not `Vec`: #5263 made a delegate execution failure visible to
+    // the client instead of an empty successful response, and parking must
+    // carry that through rather than flattening it back.
+    response: Result<Vec<OutboundDelegateMsg>, ExecutorError>,
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    if let Err(error) = contract_handler
+        .channel()
+        .send_to_sender(id, ContractHandlerEvent::DelegateResponse(response))
+        .await
+    {
+        tracing::debug!(
+            error = %error,
+            delegate_key = %delegate_key,
+            "Failed to send DELEGATE response (client may have disconnected)"
+        );
+    }
+}
+
+/// Re-enter a delegate whose park has resolved, then drain whatever queued
+/// behind it.
+///
+/// Runs ON the serial loop (the delegate's WASM must stay serial); only the
+/// WAIT happened off it. This is the counterpart to #4391's
+/// `handle_deferred_resume`.
+async fn handle_delegate_resume<CH, P>(
+    contract_handler: &mut CH,
+    park: &mut delegate_park::DelegateParkCtx,
+    prompter: &std::sync::Arc<P>,
+    resume: delegate_park::DelegateResume,
+) where
+    CH: ContractHandler + Send + 'static,
+    P: UserInputPrompter + 'static,
+{
+    let delegate_park::DelegateResume {
+        delegate_key,
+        cause,
+        inbound,
+    } = resume;
+
+    let Some((continuation, pending)) = park.take(&delegate_key) else {
+        // Unreachable: the ParkGuard delivers exactly one resume per park, and
+        // only a resume ends a park.
+        tracing::error!(
+            delegate = %delegate_key,
+            "Resume for a delegate that is not parked — dropping"
+        );
+        return;
+    };
+
+    if cause == delegate_park::ResumeCause::TimedOut {
+        tracing::warn!(
+            delegate = %delegate_key,
+            "Delegate park ended without a result (task dropped, or past \
+             PARK_TTL); resuming with no inbound so the round-trip terminates \
+             and the client is answered"
+        );
+    }
+
+    let delegate_park::Continuation {
+        params,
+        origin_contract,
+        connection_scope,
+        user_context,
+        inter_delegate,
+        accumulated,
+        inbound_so_far,
+        responder,
+        delivery,
+    } = continuation;
+
+    let mut all_inbound = inbound_so_far;
+    all_inbound.extend(inbound);
+
+    let mut carried_responder = responder;
+    let outcome = if all_inbound.is_empty() {
+        // Nothing to feed back — a dropped park that had computed no responses
+        // before it. Do NOT re-enter the delegate with an empty inbound; that
+        // would run `process()` for no reason. Terminate with what we had.
+        DelegateRunOutcome::Completed(accumulated)
+    } else {
+        let req = DelegateRequest::ApplicationMessages {
+            key: delegate_key.clone(),
+            params,
+            inbound: all_inbound,
+        };
+        let outcome = handle_delegate_with_contract_requests(
+            contract_handler,
+            req,
+            origin_contract.as_ref(),
+            connection_scope,
+            inter_delegate,
+            user_context.as_ref(),
+            &delegate_key,
+            prompter,
+            Some(ParkingCtx {
+                park: &mut *park,
+                delivery,
+                carried_responder: &mut carried_responder,
+            }),
+        )
+        .await;
+        match outcome {
+            // Carry forward what the delegate produced BEFORE it parked, so a
+            // multi-park round-trip still yields one complete response.
+            DelegateRunOutcome::Completed(mut msgs) => {
+                let mut all = accumulated;
+                all.append(&mut msgs);
+                DelegateRunOutcome::Completed(all)
+            }
+            DelegateRunOutcome::Parked => DelegateRunOutcome::Parked,
+            DelegateRunOutcome::Failed(err) => DelegateRunOutcome::Failed(err),
+        }
+    };
+
+    match outcome {
+        DelegateRunOutcome::Parked => {
+            // Parked again (a delegate that prompts twice). `carried_responder`
+            // already moved into the new continuation.
+        }
+        DelegateRunOutcome::Completed(messages) => match delivery {
+            delegate_park::Delivery::Client => {
+                if let Some(responder) = carried_responder {
+                    if responder
+                        .respond(ContractHandlerEvent::DelegateResponse(Ok(messages)))
+                        .is_err()
+                    {
+                        tracing::debug!(
+                            delegate = %delegate_key,
+                            "Parked client disconnected before its delegate \
+                             round-trip finished"
+                        );
+                    }
+                }
+            }
+            delegate_park::Delivery::Apps => route_notification_outbound(&delegate_key, messages),
+        },
+        // #5263 propagation from a RESUMED run: the client behind the park
+        // still learns the execution failed, rather than getting an empty
+        // success. A notification-driven run has nobody to tell.
+        DelegateRunOutcome::Failed(err) => match delivery {
+            delegate_park::Delivery::Client => {
+                if let Some(responder) = carried_responder
+                    && responder
+                        .respond(ContractHandlerEvent::DelegateResponse(Err(err)))
+                        .is_err()
+                {
+                    tracing::debug!(
+                        delegate = %delegate_key,
+                        "Parked client disconnected before its delegate run failed"
+                    );
+                }
+            }
+            delegate_park::Delivery::Apps => {}
+        },
+    }
+
+    // Drain what queued behind the park, in arrival order. Re-check the park on
+    // every item: the resumed run (or an earlier drained request) may have
+    // parked this delegate again, and exclusion must still hold.
+    for queued in pending {
+        dispatch_delegate_request(
+            contract_handler,
+            Some(&mut *park),
+            prompter,
+            queued.id,
+            queued.req,
+            queued.origin_contract,
+            queued.connection_scope,
+            queued.user_context,
+        )
+        .await;
+    }
+}
+
 async fn handle_contract_event<CH, P>(
     contract_handler: &mut CH,
     id: handler::EventId,
     event: ContractHandlerEvent,
-    prompter: &P,
+    prompter: &std::sync::Arc<P>,
     deferral: Option<&mut DeferralCtx>,
+    park: Option<&mut delegate_park::DelegateParkCtx>,
 ) -> Result<(), ContractError>
 where
     CH: ContractHandler + Send + 'static,
-    P: UserInputPrompter,
+    P: UserInputPrompter + 'static,
 {
     tracing::debug!(
         event = %event,
@@ -2587,35 +3158,20 @@ where
                 "Processing delegate request"
             );
 
-            // Execute the delegate and handle any GetContractRequest messages
-            let response = handle_delegate_with_contract_requests(
+            // Execute the delegate and handle any contract request messages.
+            // Routed through the shared dispatcher so the #5544 per-delegate
+            // exclusion applies identically here and on the post-resume drain.
+            dispatch_delegate_request(
                 contract_handler,
-                req,
-                origin_contract.as_ref(),
-                connection_scope,
-                // Client-driven: the hop forwards THIS connection's scope, so a
-                // non-local caller cannot obtain an attested caller identity
-                // through it.
-                InterDelegateDispatch::Allowed,
-                user_context.as_ref(),
-                &delegate_key,
+                park,
                 prompter,
+                id,
+                req,
+                origin_contract,
+                connection_scope,
+                user_context,
             )
             .await;
-
-            // Send response back to caller. If the caller disconnected, the response channel
-            // may be dropped. This is not fatal - the delegate has already been processed.
-            if let Err(error) = contract_handler
-                .channel()
-                .send_to_sender(id, ContractHandlerEvent::DelegateResponse(response))
-                .await
-            {
-                tracing::debug!(
-                    error = %error,
-                    delegate_key = %delegate_key,
-                    "Failed to send DELEGATE response (client may have disconnected)"
-                );
-            }
         }
         ContractHandlerEvent::ExportUserSecrets {
             user_context,
@@ -3741,7 +4297,8 @@ mod tests {
                 handler,
                 id,
                 received,
-                &user_input::AutoApprovePrompter,
+                &std::sync::Arc::new(user_input::AutoApprovePrompter),
+                None,
                 None,
             )
             .await
@@ -3778,7 +4335,8 @@ mod tests {
                 handler,
                 id,
                 received,
-                &user_input::AutoApprovePrompter,
+                &std::sync::Arc::new(user_input::AutoApprovePrompter),
+                None,
                 None,
             )
             .await
@@ -5289,7 +5847,8 @@ mod hol_4391_tests {
                 &mut handler,
                 id,
                 received,
-                &user_input::AutoApprovePrompter,
+                &std::sync::Arc::new(user_input::AutoApprovePrompter),
+                None,
                 None,
             )
             .await

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -57,7 +57,25 @@ use self::user_input::{CallerIdentity, UserInputPrompter};
 use crate::config::GlobalExecutor;
 use crate::wasm_runtime::UserSecretContext;
 
-/// Maximum iterations when handling contract requests to prevent infinite loops
+/// Maximum iterations when handling contract requests to prevent infinite loops.
+///
+/// # What this bounds, and what it does NOT
+///
+/// It bounds one delegate ROUND-TRIP, including across parks: `#5544 S1`
+/// carries the count in `delegate_park::Continuation`, so a delegate that emits
+/// `RequestUserInput` on every re-entry can no longer loop park -> resume ->
+/// park without limit.
+///
+/// It is deliberately NOT carried across a contract NOTIFICATION. A
+/// notification is genuinely a new invocation — driven by a contract changing
+/// rather than by this delegate continuing — so resetting there is correct.
+///
+/// That leaves a real, separate gap, tracked as `#5558`: a delegate is notified
+/// of its OWN writes (`send_delegate_contract_notifications` takes no
+/// originating-delegate parameter), so a delegate that answers a notification by
+/// writing the same contract loops unbounded and broadcasts every round, with
+/// this cap reset each time. **Neither bound subsumes the other**, and nothing
+/// here closes `#5558` — do not read this cap as covering the notification path.
 const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
 
 /// Maximum delegate notifications to drain per iteration.
@@ -733,6 +751,10 @@ struct RunSeed {
     accumulated: Vec<OutboundDelegateMsg>,
     /// Iterations already consumed, so `MAX_CONTRACT_REQUEST_ITERATIONS`
     /// bounds the whole round-trip and a park cannot reset it (#5544 S1).
+    ///
+    /// Bounds the round-trip only. A contract notification is a new invocation
+    /// and legitimately starts a fresh count — see the constant's rustdoc, and
+    /// #5558 for the separate gap that leaves open.
     iterations: usize,
 }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -5177,7 +5177,7 @@ mod tests {
 mod hol_4391_tests {
     use super::*;
     use crate::config::GlobalExecutor;
-    use crate::contract::executor::mock_wasm_runtime::ValidateOverride;
+    use crate::contract::executor::mock_wasm_runtime::{ScriptedRun, ValidateOverride};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -6534,7 +6534,7 @@ mod hol_4391_tests {
         let _guard = TEST_GUARD.lock().await;
         let (mut handler, send) = build_handler(vec![]).await;
         let script = handler.runtime_mut().delegate_script.clone();
-        script.lock().unwrap().push_back(prompt_outbound());
+        script.lock().unwrap().push_back(prompt_outbound().into());
 
         // A locally stored contract, so the GET below needs no network and its
         // only possible source of delay is the loop being blocked.
@@ -6640,11 +6640,11 @@ mod hol_4391_tests {
         script
             .lock()
             .unwrap()
-            .push_back(payload_then_prompt(b"before-park-1"));
+            .push_back(payload_then_prompt(b"before-park-1").into());
         script
             .lock()
             .unwrap()
-            .push_back(payload_then_prompt(b"before-park-2"));
+            .push_back(payload_then_prompt(b"before-park-2").into());
 
         let send = Arc::new(send);
         let gate = Arc::new(tokio::sync::Semaphore::new(0));
@@ -6735,7 +6735,7 @@ mod hol_4391_tests {
         let _guard = TEST_GUARD.lock().await;
         let (mut handler, send) = build_handler(vec![]).await;
         let script = handler.runtime_mut().delegate_script.clone();
-        script.lock().unwrap().push_back(prompt_outbound());
+        script.lock().unwrap().push_back(prompt_outbound().into());
 
         let send = Arc::new(send);
         let gate = Arc::new(tokio::sync::Semaphore::new(0));
@@ -6842,13 +6842,24 @@ mod hol_4391_tests {
         let (mut handler, _send) = build_handler(vec![]).await;
         let calls = handler.runtime_mut().delegate_calls.clone();
         let script = handler.runtime_mut().delegate_script.clone();
+        let contexts = handler.runtime_mut().delegate_contexts.clone();
         // Present so that, if the gate is missing, the delegate really does run
-        // rather than erroring out for an unrelated reason.
-        script.lock().unwrap().push_back(Vec::new());
+        // rather than erroring out for an unrelated reason — and writes a
+        // DIFFERENT context, which is what makes the corruption visible.
+        script.lock().unwrap().push_back(ScriptedRun {
+            outbound: Vec::new(),
+            writes_context: Some(b"clobbered-by-notification".to_vec()),
+        });
 
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let mut park = delegate_park::DelegateParkCtx::new(tx);
         let key = test_delegate_key();
+        // What the parked round-trip left behind, as its pre-park `ctx.write()`
+        // would have.
+        contexts
+            .lock()
+            .unwrap()
+            .insert(key.clone(), b"parked-continuation".to_vec());
         assert!(
             matches!(
                 park.park(key.clone(), parked_continuation()),
@@ -6874,6 +6885,16 @@ mod hol_4391_tests {
             0,
             "a notification must NOT re-enter a parked delegate (#5544 B1)"
         );
+        // The assertion that shows the CONSEQUENCE, not just the symptom
+        // (#5544 S7): the parked continuation's context must be untouched. An
+        // extra `process()` is only a problem because it clobbers this.
+        assert_eq!(
+            contexts.lock().unwrap().get(&key).map(Vec::as_slice),
+            Some(b"parked-continuation".as_slice()),
+            "the parked continuation's context must be intact; a notification \
+             that ran would have overwritten it and the delegate would resume \
+             on someone else's bytes (#5544 B1)"
+        );
         let (_continuation, pending) = park.take(&key).expect("still parked");
         assert_eq!(
             pending.len(),
@@ -6884,6 +6905,92 @@ mod hol_4391_tests {
             matches!(pending[0], delegate_park::PendingRun::Notification { .. }),
             "queued as a notification so it resumes through the app-routing path"
         );
+    }
+
+    /// B2 via the context model: an inter-delegate message must not re-enter a
+    /// parked TARGET delegate.
+    ///
+    /// Delegate A is driven by a client and emits `SendDelegateMessage` at B.
+    /// B is parked on a prompt. Delivering the hop would run B's `process()`
+    /// mid-round-trip and overwrite the context its parked continuation
+    /// depends on.
+    ///
+    /// This is the test the mock could not express before S7. Modelling call
+    /// counts alone showed only that an extra invocation happened; modelling
+    /// the context store shows that the invocation CORRUPTED something, which
+    /// is the reason the extra invocation matters.
+    ///
+    /// FALSIFY by deleting the `is_parked(&target_key)` gate on the hop: B's
+    /// context becomes `clobbered-by-hop`.
+    #[tokio::test]
+    async fn an_inter_delegate_message_does_not_re_enter_a_parked_target() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        let contexts = handler.runtime_mut().delegate_contexts.clone();
+
+        let key_b = test_delegate_key();
+        let key_a = DelegateKey::new([8u8; 32], freenet_stdlib::prelude::CodeHash::new([8u8; 32]));
+
+        // Run 1 is B's: it parks on a prompt, having written its continuation.
+        script.lock().unwrap().push_back(ScriptedRun {
+            outbound: prompt_outbound(),
+            writes_context: Some(b"b-parked-continuation".to_vec()),
+        });
+        // Run 2 is A's: it fires a message at B.
+        script.lock().unwrap().push_back(ScriptedRun {
+            outbound: vec![OutboundDelegateMsg::SendDelegateMessage(
+                freenet_stdlib::prelude::DelegateMessage::new(
+                    key_b.clone(),
+                    key_a.clone(),
+                    b"ping".to_vec(),
+                ),
+            )],
+            writes_context: None,
+        });
+        // Run 3 would be B's, if the hop were wrongly delivered.
+        script.lock().unwrap().push_back(ScriptedRun {
+            outbound: Vec::new(),
+            writes_context: Some(b"clobbered-by-hop".to_vec()),
+        });
+
+        let send = Arc::new(send);
+        let gate = Arc::new(tokio::sync::Semaphore::new(0));
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter { gate: gate.clone() },
+        ));
+
+        // Park B.
+        let send_b = send.clone();
+        let kb = key_b.clone();
+        let parked: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move { send_b.send_to_handler(delegate_event(&kb)).await });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(
+            contexts.lock().unwrap().get(&key_b).map(Vec::as_slice),
+            Some(b"b-parked-continuation".as_slice()),
+            "B must have parked with its continuation written"
+        );
+
+        // Now drive A, which messages the parked B.
+        let _ = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(delegate_event(&key_a)),
+        )
+        .await
+        .expect("A's own request must complete; only the hop to B is dropped");
+
+        assert_eq!(
+            contexts.lock().unwrap().get(&key_b).map(Vec::as_slice),
+            Some(b"b-parked-continuation".as_slice()),
+            "an inter-delegate message must NOT re-enter a parked target; B's \
+             parked continuation was overwritten (#5544 B2)"
+        );
+
+        gate.add_permits(1);
+        let _ = tokio::time::timeout(Duration::from_secs(5), parked).await;
+        handle.abort();
     }
 
     /// A continuation standing in for a delegate parked on a prompt.
@@ -6924,10 +7031,8 @@ mod hol_4391_tests {
         .await;
 
         let script = handler.runtime_mut().delegate_script.clone();
-        script
-            .lock()
-            .unwrap()
-            .push_back(vec![OutboundDelegateMsg::PutContractRequest(
+        script.lock().unwrap().push_back(
+            vec![OutboundDelegateMsg::PutContractRequest(
                 freenet_stdlib::prelude::PutContractRequest {
                     contract: contract_a.clone(),
                     state: WrappedState::new(b"a_state".to_vec()),
@@ -6935,7 +7040,9 @@ mod hol_4391_tests {
                     context: DelegateContext::default(),
                     processed: false,
                 },
-            )]);
+            )]
+            .into(),
+        );
 
         // B's fetch hangs until released, standing in for a slow network GET.
         // The counter records that the OFF-LOOP path was the one taken.
@@ -7077,7 +7184,7 @@ mod hol_4391_tests {
         let calls = handler.runtime_mut().delegate_calls.clone();
         // Only the FIRST invocation prompts; later ones return nothing, so the
         // round-trip terminates instead of parking forever.
-        script.lock().unwrap().push_back(prompt_outbound());
+        script.lock().unwrap().push_back(prompt_outbound().into());
 
         let send = Arc::new(send);
         let gate = Arc::new(tokio::sync::Semaphore::new(0));

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2515,6 +2515,7 @@ fn route_notification_outbound(delegate_key: &DelegateKey, outbound: Vec<Outboun
 /// Shared by the `ContractHandlerEvent::DelegateRequest` arm and by the drain
 /// of requests that queued behind a park, so the exclusion check cannot be
 /// present on one path and missing on the other.
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_delegate_request<CH, P>(
     contract_handler: &mut CH,
     park: Option<&mut delegate_park::DelegateParkCtx>,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1946,6 +1946,14 @@ where
     let (delegate_resume_tx, mut delegate_resume_rx) =
         tokio::sync::mpsc::unbounded_channel::<delegate_park::DelegateResume>();
     let mut park_ctx = delegate_park::DelegateParkCtx::new(delegate_resume_tx);
+    // Resumes taken off `delegate_resume_rx` but not yet run, because the
+    // per-iteration budget ran out. Held here rather than left in the channel
+    // so the TTL backstop below can SEE them: a park whose answer is already in
+    // hand must not be force-resumed (#5554). Bounded by the same thing that
+    // bounds the channel — one resume per park, parks capped at
+    // MAX_PARKED_DELEGATES plus the guards of already-swept parks.
+    let mut delegate_resumes: std::collections::VecDeque<delegate_park::DelegateResume> =
+        std::collections::VecDeque::new();
 
     loop {
         // Drain resumed (deferred) upserts so a completed off-loop fetch is
@@ -1969,10 +1977,24 @@ where
         // iteration for the same reason as the deferred-upsert drain — each
         // resume re-enters WASM — and interleaved with the fair queue so
         // resumes cannot head-of-line-block ordinary contract ops.
+        //
+        // Read the channel ONCE, up front, into `delegate_resumes`, and make
+        // both of this iteration's decisions from that buffer: which resumes to
+        // run now (bounded, below) and which parks the TTL backstop may
+        // force-resume (further below). Deciding them from one snapshot is what
+        // stops the backstop sweeping a park whose answer is already in hand —
+        // see `DelegateParkCtx::expired`, which discards a human's response if
+        // that happens (#5554). The buffer is what makes the two decisions
+        // consistent: the budget can leave resumes unrun (one resume costs up
+        // to 25 runs against a budget of 16), and the sweep runs in the SAME
+        // iteration, immediately after.
+        while let Ok(resume) = delegate_resume_rx.try_recv() {
+            delegate_resumes.push_back(resume);
+        }
         let mut resume_budget = MAX_RESUME_DRAIN_BATCH;
         while resume_budget > 0 {
-            match delegate_resume_rx.try_recv() {
-                Ok(resume) => {
+            match delegate_resumes.pop_front() {
+                Some(resume) => {
                     // Spend the WHOLE cost, including the pending requests
                     // drained behind the park — each is a full delegate run
                     // (#5544 S5).
@@ -1985,14 +2007,19 @@ where
                     .await;
                     resume_budget = resume_budget.saturating_sub(runs.max(1));
                 }
-                Err(_) => break,
+                None => break,
             }
         }
 
         // Backstop sweep for parks that neither completed nor were dropped
         // (see `PARK_TTL`). Force-resume them so a wedged delegate cannot stay
         // wedged: the resume drains its pending queue and answers its client.
-        for (delegate_key, epoch) in park_ctx.expired(tokio::time::Instant::now()) {
+        // Parks whose resume is sitting in `delegate_resumes` are EXCLUDED by
+        // `expired` — they are queued, not wedged, and force-resuming one loses
+        // the answer it is carrying (#5554).
+        for (delegate_key, epoch) in
+            park_ctx.expired(tokio::time::Instant::now(), &delegate_resumes)
+        {
             // Force-resume the park we OBSERVED, by epoch. The off-loop task's
             // ParkGuard is untouched and still owes a resume; carrying the epoch
             // is what lets that late resume be recognised as stale and dropped
@@ -2103,6 +2130,17 @@ where
                 Some(&mut park_ctx),
             )
             .await?;
+            continue;
+        }
+
+        // Buffered delegate resumes are work already in hand: never block in
+        // the select while any remain, or they would wait on UNRELATED traffic
+        // to wake the loop — and each one is holding a client responder, and
+        // possibly a human's answer, until it runs (#5554). The top of the next
+        // iteration drains at least one (the budget starts at
+        // MAX_RESUME_DRAIN_BATCH and every run costs at least 1), so this
+        // cannot spin: the buffer strictly shrinks.
+        if !delegate_resumes.is_empty() {
             continue;
         }
 
@@ -7234,20 +7272,24 @@ mod hol_4391_tests {
     ///
     /// LIMITATION, stated rather than papered over: this asserts the DEADLINE
     /// computation and that the loop consults it, not an end-to-end sweep on an
-    /// idle node. A decisive end-to-end test is not reachable today, because
-    /// `PARK_WORK_BUDGET` (75s) is deliberately below `PARK_TTL` (90s) so the
-    /// `ParkGuard` always resumes the park first — which is what makes the TTL a
-    /// backstop rather than a timeout. Reaching the sweep would need a park with
-    /// no live guard, which no production path can currently produce. The value
-    /// of the fix is that IF that ever becomes reachable, the backstop works.
+    /// idle node.
+    ///
+    /// An earlier version of this comment went further and said the sweep was
+    /// unreachable in production, because `PARK_WORK_BUDGET` (75s) is below
+    /// `PARK_TTL` (90s) so "the `ParkGuard` always resumes the park first".
+    /// **That was wrong, and it is the reasoning that hid #5554.** The budget
+    /// bounds when the off-loop TASK finishes; it says nothing about when the
+    /// loop DRAINS the resume the task produced. The drain is capped at
+    /// `MAX_RESUME_DRAIN_BATCH` (16) while one `handle_delegate_resume` can cost
+    /// 25 runs, so a resume can wait iterations while its park ages past the
+    /// TTL — a park with a guard that has already fired, which is exactly the
+    /// case the old sentence said could not exist. See
+    /// `delegate_park::tests::the_backstop_leaves_a_park_whose_answer_is_already_in_hand`.
     #[test]
     fn park_sweep_deadline_is_armed_and_the_loop_waits_on_it() {
         // The loop must consult the deadline, not sweep only on other traffic.
         let src = include_str!("contract.rs");
-        let body = src
-            .split("pub(crate) async fn contract_handling")
-            .nth(1)
-            .expect("contract_handling must exist");
+        let body = contract_handling_body(src);
         assert!(
             body.contains("park_ctx.next_sweep_deadline()"),
             "contract_handling must compute the park sweep deadline"
@@ -7256,6 +7298,72 @@ mod hol_4391_tests {
             body.contains("tokio::time::sleep_until(deadline)"),
             "the idle select! must WAIT on the park sweep deadline, or the \
              backstop cannot fire without unrelated traffic (#5544 B6)"
+        );
+    }
+
+    /// The text of `contract_handling`, bounded to that function.
+    ///
+    /// `include_str!` pulls in this test module too, so an unbounded
+    /// `split(signature).nth(1)` runs to EOF and a pin over it can be satisfied
+    /// by the pin's own assertion literal. The `\n}\n` end anchor is the
+    /// top-level closing brace: everything inside the function is indented.
+    fn contract_handling_body(src: &str) -> &str {
+        let start = src
+            .find("pub(crate) async fn contract_handling")
+            .expect("contract_handling must exist");
+        let body = &src[start..];
+        let end = body
+            .find("\n}\n")
+            .expect("contract_handling must have a top-level closing brace");
+        &body[..end]
+    }
+
+    /// #5554: the TTL backstop must decide from the resumes the loop has ALREADY
+    /// taken off the channel, not from the registry alone.
+    ///
+    /// The registry-level guarantee is in
+    /// `delegate_park::tests::the_backstop_leaves_a_park_whose_answer_is_already_in_hand`:
+    /// `expired` excludes a park whose resume is in the buffer, because
+    /// force-resuming it discards the `UserResponse` that resume is carrying.
+    /// This pins the WIRING that makes the guarantee reachable — the loop must
+    /// actually drain into that buffer, and must do it BEFORE it sweeps.
+    /// Draining after the sweep would type-check and be exactly the bug.
+    ///
+    /// It also pins that a non-empty buffer never reaches the blocking
+    /// `select!`: those resumes are work in hand, each holding a client
+    /// responder, and waiting for unrelated traffic to wake the loop is the
+    /// stall this whole change exists to remove.
+    ///
+    /// FALSIFY by moving the drain below the sweep, or by deleting either the
+    /// drain or the `continue` guard.
+    #[test]
+    fn the_ttl_sweep_decides_from_the_resumes_the_loop_already_took() {
+        let src = include_str!("contract.rs");
+        let squashed: String = contract_handling_body(src)
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+
+        let drain =
+            "whileletOk(resume)=delegate_resume_rx.try_recv(){delegate_resumes.push_back(resume);}";
+        let sweep = "park_ctx.expired(tokio::time::Instant::now(),&delegate_resumes)";
+        let no_idle_with_work = "if!delegate_resumes.is_empty(){continue;}";
+
+        let drain_at = squashed.find(drain).unwrap_or_else(|| {
+            panic!("the loop must take every resume the channel holds into its buffer (#5554)")
+        });
+        let sweep_at = squashed.find(sweep).unwrap_or_else(|| {
+            panic!("the backstop sweep must consult that buffer, or it force-resumes parks whose answer is already in hand (#5554)")
+        });
+        assert!(
+            drain_at < sweep_at,
+            "the drain must run BEFORE the sweep: a buffer filled afterwards \
+             cannot protect the park the sweep just ended (#5554)"
+        );
+        assert!(
+            squashed.contains(no_idle_with_work),
+            "the loop must not block in the select! while buffered resumes \
+             remain — each is holding a client responder (#5554)"
         );
     }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -526,10 +526,15 @@ async fn fetch_related_off_loop(
 
 /// Whether a delegate run may deliver delegate-to-delegate messages.
 ///
-/// This exists because the two callers of
+/// This exists because the callers of
 /// [`handle_delegate_with_contract_requests`] differ in a security-relevant way:
-/// one descends from a client connection whose scope is known, the other does
-/// not descend from a connection at all (GHSA-824h-7x5x-wfmf).
+/// some descend from a client connection whose scope is known, others do not
+/// descend from a connection at all (GHSA-824h-7x5x-wfmf).
+///
+/// Stated without a count on purpose. This said "the two callers" and there are
+/// now five — the same tally rot retired from `delegate_park`'s module doc, one
+/// file over. What matters is the PROVENANCE split, which survives a new caller;
+/// the number does not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InterDelegateDispatch {
     /// Client-driven run. The hop carries the ORIGINATING connection scope, so a
@@ -1656,12 +1661,28 @@ where
                             .iter()
                             .map(|u| (*u.key.id(), u.is_put))
                             .collect();
+                        // SINKS CREATED BEFORE THE GUARD, AND SHARED WITH IT
+                        // (#5544 F2). They used to be created inside the
+                        // spawned future, so `ParkGuard::drop` could not see
+                        // them: on a panic or cancellation it delivered empty
+                        // vectors, `answered` was empty, and EVERY owed prompt
+                        // was rewritten as a denial — including ones a human
+                        // had already answered. The user clicks Allow and the
+                        // delegate is told denied.
+                        let answers_sink: std::sync::Arc<
+                            std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>,
+                        > = Default::default();
+                        let fetch_sink: std::sync::Arc<
+                            std::sync::Mutex<Vec<delegate_park::ResolvedUpsert>>,
+                        > = Default::default();
                         let guard = delegate_park::ParkGuard::new(
                             ctx.park.resume_tx().clone(),
                             delegate_key.clone(),
                             epoch,
                             owed,
                             owed_upserts,
+                            answers_sink.clone(),
+                            fetch_sink.clone(),
                         );
                         let prompter = std::sync::Arc::clone(prompter);
                         let key = delegate_key.clone();
@@ -1684,21 +1705,6 @@ where
                         // this task the handler. See `delegate_park`'s module
                         // docs, "What parking does NOT relax".
                         GlobalExecutor::spawn(async move {
-                            // Results land in these as they complete, so a
-                            // budget expiry keeps what is already done (#5544
-                            // S6). Discarding on timeout would throw away
-                            // prompt answers a HUMAN has already given, and
-                            // prompts run sequentially, so two slow ones can
-                            // exceed the budget with the first already
-                            // answered.
-                            let answers_sink: std::sync::Arc<
-                                std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>,
-                            > = Default::default();
-                            let fetch_sink: std::sync::Arc<
-                                std::sync::Mutex<Vec<delegate_park::ResolvedUpsert>>,
-                            > = Default::default();
-                            let answers_out = answers_sink.clone();
-                            let fetch_out = fetch_sink.clone();
                             // Prompts and fetches run CONCURRENTLY, and the whole
                             // body is capped by PARK_WORK_BUDGET. Sequentially
                             // they could sum past PARK_TTL, at which point the
@@ -1742,32 +1748,18 @@ where
                                     tokio::join!(answers, fetches)
                                 })
                                 .await;
-                            // Either way, resume with whatever completed. On
-                            // expiry that is a PARTIAL result rather than
-                            // nothing, so answers the user already gave are not
-                            // thrown away; the delegate sees responses for the
-                            // requests that finished and none for those that
-                            // did not, which is the same shape as a denied
-                            // prompt.
-                            let responses = std::mem::take(&mut *answers_out.lock().unwrap());
-                            let resolved = std::mem::take(&mut *fetch_out.lock().unwrap());
-
-                            // Denial synthesis lives in `ParkGuard::deliver`
-                            // now, so it also covers the panic and
-                            // cancellation exits — those reach `Drop` and
-                            // never run this block (#5544 P2). Doing it in
-                            // both places would be duplication; doing it
-                            // only here was the bug.
+                            // The guard reads the sinks itself, so this path
+                            // and the panic/cancellation path see the same
+                            // data by construction (#5544 F2). Passing results
+                            // in here is what let `Drop` see none of them.
                             if done.is_err() {
                                 tracing::warn!(
                                     delegate = %key,
-                                    kept_answers = responses.len(),
-                                    kept_fetches = resolved.len(),
                                     "Off-loop delegate work exceeded PARK_WORK_BUDGET; \
-                                     resuming with what completed"
+                                     resuming with whatever completed"
                                 );
                             }
-                            guard.send(responses, resolved);
+                            guard.send();
                         });
                         return DelegateRunOutcome::Parked;
                     }
@@ -3572,6 +3564,9 @@ async fn run_queued_notification<CH, P>(
 
     match outcome {
         DelegateRunOutcome::Parked => {}
+        // Nothing to propagate: a notification has no client waiting. Already
+        // logged inside `handle_delegate_with_contract_requests` (#5263).
+        DelegateRunOutcome::Failed(_) => {}
         DelegateRunOutcome::Completed(outbound) => {
             route_notification_outbound(delegate_key, outbound);
         }
@@ -4420,19 +4415,29 @@ mod tests {
         ContractKey::from_params_and_code(&params, &code)
     }
 
-    /// Pin: the unexpected-response arm must return `Err`, not a fake success.
+    /// Pin: a wrong response variant must NOT be reported to the client as a
+    /// success.
     ///
-    /// The executor answering a delegate request with a variant that is not a
-    /// delegate response is an internal invariant violation. Returning
-    /// `Ok(accumulated_messages)` there is the same lie #5263 removes from the
-    /// execution-failure arm: the client cannot distinguish "the delegate said
-    /// nothing" from "this node is confused".
+    /// PROHIBITION (unchanged from #5263, restated behaviourally): the executor
+    /// answering a delegate request with a variant that is not a delegate
+    /// response is an internal invariant violation, and the client must be able
+    /// to tell it from "the delegate said nothing".
+    ///
+    /// The original asserted `return Err(` and `!contains("return Ok(...)")`.
+    /// #5544 changed the return TYPE, not the prohibition: the function now
+    /// yields `DelegateRunOutcome`, where `Failed` is the only variant that
+    /// reaches the client as `Err` and `Completed` the only one that reaches it
+    /// as `Ok` (see the two `send_delegate_response` call sites). So the same
+    /// two-sided assertion is expressed one type removed — positive AND
+    /// negative, so a silent flip to success is still forbidden rather than
+    /// merely requiring an error somewhere in the arm.
+    ///
+    /// That the prohibition survives without quoting the old code is the signal
+    /// this pin was guarding behaviour rather than shape.
     ///
     /// Pinned from source rather than behaviourally because both mock
-    /// executors (`MockWasmRuntime`, `MockRuntime`) return `Err`
-    /// unconditionally, so no fixture can drive the executor to hand back a
-    /// wrong-variant `Ok`. Truncated at the test module first -- the needles
-    /// occur in this function's own text (see #5450).
+    /// executors return `Err` unconditionally, so no fixture can drive the
+    /// executor to hand back a wrong-variant `Ok`.
     #[test]
     fn unexpected_response_variant_does_not_become_a_fake_success() {
         let full = include_str!("contract.rs");
@@ -4455,40 +4460,46 @@ mod tests {
             .find("phase = \"unexpected_response\"")
             .expect("the unexpected-response arm must exist");
         let after = &body[arm..];
-        // Bound to this arm: stop at the next match arm's opening.
         let arm_end = after.find("Err(err) => {").unwrap_or(after.len());
         let arm = &after[..arm_end];
 
         assert!(
-            arm.contains("return Err("),
-            "the unexpected-response arm must return an error; returning \
-             Ok(accumulated_messages) reports an internal invariant violation \
-             to the client as an empty SUCCESS (#5263). Arm: {arm:?}"
+            arm.contains("DelegateRunOutcome::Failed"),
+            "the unexpected-response arm must yield `Failed`, which is what \
+             reaches the client as Err. Reporting an internal invariant \
+             violation as a success is the lie #5263 removed. Arm: {arm:?}"
         );
         assert!(
-            !arm.contains("return Ok(accumulated_messages)"),
-            "the unexpected-response arm must not fall back to a fake success"
+            !arm.contains("DelegateRunOutcome::Completed"),
+            "the unexpected-response arm must not fall back to a success \
+             outcome. Arm: {arm:?}"
         );
     }
 
-    /// Pin: the delegate->apps TTL sweep must run BEFORE the early return on
-    /// an execution failure.
+    /// Pin: the delegate->apps TTL sweep must not be skippable by ANY exit
+    /// from the notification path.
     ///
-    /// `sweep_expired` is the registry's ONLY production caller, and it is what
-    /// time-bounds the map per the AGENTS.md GC-exemption rule. #5263 added an
-    /// early `return` on a failed execution; putting the sweep after it makes
-    /// the backstop conditional on the delegate SUCCEEDING. The failure that
-    /// motivated #5263 is one a delegate repeats on EVERY invocation (rejecting
-    /// `origin: None`), so on a node whose delegates all fail that way the
-    /// sweep would never run and stale registrations would pin their slots
-    /// against `MAX_APPS_PER_DELEGATE` until restart.
+    /// PROHIBITION (from #5263, restated behaviourally and WIDENED): the sweep
+    /// is the registry's only production caller and is what time-bounds the map
+    /// per the AGENTS.md GC-exemption rule. It must not become conditional on
+    /// the delegate doing anything in particular.
     ///
-    /// The source is truncated at the test module BEFORE scraping: both needles
-    /// below also occur in this function's own text, which `include_str!` pulls
-    /// in, so without the cut a rename would silently widen the region instead
-    /// of panicking (see #5450).
+    /// The original asserted the sweep appears before "the execution-failure
+    /// early return" — anchoring on one named exit, because that was the only
+    /// one its author could see. #5544 added two more (the delegate is already
+    /// parked and this notification is queued; or this run itself parks), and
+    /// the anchor was precisely the part that could not survive a third exit.
+    ///
+    /// So this asserts the STRONGER property the original was reaching for: the
+    /// sweep precedes EVERY exit, by sitting before the first of them. That
+    /// forbids everything the original forbade — its failure return is one of
+    /// the exits — plus the two parking introduced.
+    ///
+    /// The source is truncated at the test module BEFORE scraping: the needles
+    /// also occur in this function's own text, which `include_str!` pulls in
+    /// (see #5450).
     #[test]
-    fn ttl_sweep_precedes_the_execution_failure_return() {
+    fn ttl_sweep_precedes_every_exit_from_the_notification_path() {
         let full = include_str!("contract.rs");
         let cutoff = full
             .find("\nmod tests {")
@@ -4505,18 +4516,42 @@ mod tests {
             .unwrap_or(body.len());
         let body = &body[..end];
 
-        let sweep = body
+        // STRIP LINE COMMENTS FIRST. The needles below occur in this
+        // function's own prose — the sweep's comment explains which exits used
+        // to skip it, and the word "return" appears there. Scanning raw text
+        // found an "exit" inside a comment ABOVE the sweep and failed a
+        // correct implementation. Same hazard as #5450, one needle over.
+        let code: String = body
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(i) => &line[..i],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let sweep = code
             .find("delegate_app_registry::sweep_expired()")
-            .expect("the TTL sweep must live in handle_delegate_notification");
-        let bail = body
-            .find("let Ok(outbound) = outbound else")
-            .expect("the execution-failure early return must exist");
+            .expect("the notification path must sweep the delegate->apps registry");
+
+        // EVERY way out of this function, not one named one. `return` covers
+        // the queued-behind-a-park exit; `match outcome` covers the park and
+        // completion exits, which leave via the tail.
+        let first_exit = code
+            .match_indices("return")
+            .map(|(i, _)| i)
+            .chain(code.match_indices("match outcome").map(|(i, _)| i))
+            .min()
+            .expect("the function must have at least one exit");
 
         assert!(
-            sweep < bail,
-            "the TTL sweep ({sweep}) must run BEFORE the execution-failure \
-             return ({bail}); after it, the registry's only production sweep \
-             becomes conditional on the delegate succeeding"
+            sweep < first_exit,
+            "the TTL sweep must precede EVERY exit from the notification path, \
+             not just the execution-failure one. It is the registry's only GC \
+             and must not be conditional on how this invocation happens to \
+             leave — #5263's case was a delegate failing every time; #5544 \
+             added a delegate PARKING every time. sweep at {sweep}, first exit \
+             at {first_exit}"
         );
     }
 
@@ -6972,9 +7007,12 @@ mod hol_4391_tests {
             .expect("a twice-parked delegate must still resolve")
             .expect("join")
             .expect("the original client must be answered after the second park");
-        let ContractHandlerEvent::DelegateResponse(msgs) = resp else {
+        let ContractHandlerEvent::DelegateResponse(result) = resp else {
             panic!("expected one DelegateResponse covering the whole round-trip, got {resp}");
         };
+        // `DelegateResponse` carries a `Result` since #5263; a successful
+        // round-trip must not arrive as an execution failure.
+        let msgs = result.expect("the round-trip completed, so it must be Ok");
 
         // THE B3 ASSERTION. Both pre-park payloads must survive to the single
         // final response. Before the fix, the resumed run's `accumulated` was

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -859,10 +859,29 @@ where
     loop {
         iterations += 1;
         if iterations > MAX_CONTRACT_REQUEST_ITERATIONS {
+            // KNOWN GAP: this truncation is visible to the NODE and invisible
+            // to the DELEGATE. We log, return whatever accumulated, and the
+            // delegate is never told it was cut short or which of its requests
+            // were dropped — so it cannot retry the remainder, degrade, or
+            // report the failure to its app.
+            //
+            // Consumer impact, concretely: a Harvest delegate bootstrapping 500
+            // per-address subscriptions needs 500 iterations and silently gets
+            // 100, with no signal distinguishing that from "all done".
+            //
+            // Surfacing it properly needs a freenet-stdlib change — there is no
+            // `InboundDelegateMsg` variant or response field that can carry
+            // "your run was truncated", and inventing one by appending a
+            // synthetic `ApplicationMessage` would be worse, since an app
+            // cannot tell it from delegate output. Deliberately NOT done here;
+            // tracked separately.
             tracing::error!(
                 delegate_key = %delegate_key,
                 iterations = iterations,
-                "Exceeded maximum contract request iterations, possible infinite loop"
+                accumulated = accumulated_messages.len(),
+                "Exceeded maximum contract request iterations, possible infinite \
+                 loop — returning a TRUNCATED response; the delegate is not \
+                 told, see the comment here and MAX_CONTRACT_REQUEST_ITERATIONS"
             );
             // Stays a SUCCESS deliberately (`Completed`, formerly `Ok`), and
             // this is an OPEN QUESTION, not a settled decision. Exhausting the
@@ -1697,6 +1716,18 @@ where
                         // what this change exists to stop, but silently losing a
                         // user's permission prompt or a delegate's write would
                         // be worse. Restore what the refused continuation held.
+                        //
+                        // NOT INHERITABLE BY #5542 — read this before reusing
+                        // the machinery. The fallback is defensible HERE
+                        // because both inline waits are self-inflicted on the
+                        // user's own node and bounded by the prompt timeout
+                        // (60s) or the related fetch (10s). It is NOT
+                        // defensible for a delegate GET/SUBSCRIBE that reaches
+                        // the network: "inline" there means a sub-op GET on the
+                        // serial loop for up to SUB_OP_FETCH_TIMEOUT (120s),
+                        // reachable by any delegate once 64 others are parked.
+                        // #5542 must REFUSE with an error on park exhaustion,
+                        // never fall back inline.
                         let continuation = *continuation;
                         accumulated_messages = continuation.accumulated;
                         inbound_responses = continuation.inbound_so_far;
@@ -2819,7 +2850,7 @@ async fn handle_delegate_notification<CH, P>(
     {
         match park.queue_pending(
             &delegate_key,
-            delegate_park::PendingRun::Notification { req },
+            delegate_park::PendingRun::Notification { contract_id, req },
         ) {
             delegate_park::QueueOutcome::Queued => {
                 tracing::debug!(
@@ -3361,12 +3392,13 @@ where
             // not exist. `run_queued_notification` re-checks the park, so a
             // delegate that parked again during this drain re-queues instead of
             // being re-entered.
-            delegate_park::PendingRun::Notification { req } => {
+            delegate_park::PendingRun::Notification { contract_id, req } => {
                 run_queued_notification(
                     contract_handler,
                     Some(&mut *park),
                     prompter,
                     &delegate_key,
+                    contract_id,
                     req,
                 )
                 .await;
@@ -3388,6 +3420,7 @@ async fn run_queued_notification<CH, P>(
     mut park: Option<&mut delegate_park::DelegateParkCtx>,
     prompter: &std::sync::Arc<P>,
     delegate_key: &DelegateKey,
+    contract_id: ContractInstanceId,
     req: DelegateRequest<'static>,
 ) where
     CH: ContractHandler + Send + 'static,
@@ -3399,7 +3432,7 @@ async fn run_queued_notification<CH, P>(
     {
         match park.queue_pending(
             delegate_key,
-            delegate_park::PendingRun::Notification { req },
+            delegate_park::PendingRun::Notification { contract_id, req },
         ) {
             delegate_park::QueueOutcome::Queued => {}
             delegate_park::QueueOutcome::Rejected(_) => {
@@ -6556,6 +6589,30 @@ mod hol_4391_tests {
     // ---- #5544: a parked delegate must not stall the loop, and must not be
     // ---- re-entered while parked.
 
+    /// Wait until `cond` holds, or fail with `label`.
+    ///
+    /// Replaces fixed sleeps before POSITIVE assertions. These tests run the
+    /// real `contract_handling` loop on a machine that may be compiling several
+    /// other worktrees at once, and a wall-clock sleep that is obviously long
+    /// enough on an idle machine is a flaky test under load — which is a broken
+    /// test, not an unlucky one. Polling for the condition is both faster in
+    /// the common case and correct in the slow one.
+    ///
+    /// Deliberately NOT used before negative assertions ("this must NOT have
+    /// happened"): a non-event cannot be waited for, so those keep an explicit
+    /// sleep, and each says so.
+    async fn wait_until(label: &str, mut cond: impl FnMut() -> bool) {
+        const LIMIT: Duration = Duration::from_secs(10);
+        let deadline = std::time::Instant::now() + LIMIT;
+        while std::time::Instant::now() < deadline {
+            if cond() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("timed out after {LIMIT:?} waiting for: {label}");
+    }
+
     /// A prompter that hangs until released, standing in for a human who has
     /// not clicked yet. The real `DashboardPrompter` waits up to
     /// `USER_INPUT_TIMEOUT` (60s) for exactly this.
@@ -6640,6 +6697,7 @@ mod hol_4391_tests {
         let _guard = TEST_GUARD.lock().await;
         let (mut handler, send) = build_handler(vec![]).await;
         let script = handler.runtime_mut().delegate_script.clone();
+        let calls_probe = handler.runtime_mut().delegate_calls.clone();
         script.lock().unwrap().push_back(prompt_outbound().into());
 
         // A locally stored contract, so the GET below needs no network and its
@@ -6681,7 +6739,11 @@ mod hol_4391_tests {
             );
 
         // Let the loop pick up the delegate request and park it.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        let parked_calls = calls_probe.clone();
+        wait_until("the delegate to be entered and park", || {
+            parked_calls.lock().unwrap().len() == 1
+        })
+        .await;
 
         // The crux. Inline blocking makes this time out.
         let get_c = tokio::time::timeout(
@@ -6767,7 +6829,11 @@ mod hol_4391_tests {
             );
 
         // First park.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        let probe = calls.clone();
+        wait_until("the first entry into the delegate", || {
+            probe.lock().unwrap().len() == 1
+        })
+        .await;
         assert_eq!(
             calls.lock().unwrap().len(),
             1,
@@ -6777,7 +6843,11 @@ mod hol_4391_tests {
 
         // Release prompt 1 -> resume -> the delegate prompts again -> re-park.
         gate.add_permits(1);
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        let probe = calls.clone();
+        wait_until("the resume to re-enter the delegate", || {
+            probe.lock().unwrap().len() == 2
+        })
+        .await;
         assert_eq!(
             calls.lock().unwrap().len(),
             2,
@@ -6841,6 +6911,7 @@ mod hol_4391_tests {
         let _guard = TEST_GUARD.lock().await;
         let (mut handler, send) = build_handler(vec![]).await;
         let script = handler.runtime_mut().delegate_script.clone();
+        let calls_probe = handler.runtime_mut().delegate_calls.clone();
         script.lock().unwrap().push_back(prompt_outbound().into());
 
         let send = Arc::new(send);
@@ -6857,7 +6928,11 @@ mod hol_4391_tests {
         let k0 = key_d.clone();
         let parked: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
             GlobalExecutor::spawn(async move { send_0.send_to_handler(delegate_event(&k0)).await });
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        let probe = calls_probe.clone();
+        wait_until("the delegate to park before its queue is filled", || {
+            probe.lock().unwrap().len() == 1
+        })
+        .await;
 
         // Fill the pending queue to exactly its cap.
         let mut queued = Vec::new();
@@ -7126,12 +7201,13 @@ mod hol_4391_tests {
         let kb = key_b.clone();
         let parked: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
             GlobalExecutor::spawn(async move { send_b.send_to_handler(delegate_event(&kb)).await });
-        tokio::time::sleep(Duration::from_millis(150)).await;
-        assert_eq!(
-            contexts.lock().unwrap().get(&key_b).map(Vec::as_slice),
-            Some(b"b-parked-continuation".as_slice()),
-            "B must have parked with its continuation written"
-        );
+        let probe = contexts.clone();
+        let kb_probe = key_b.clone();
+        wait_until("B to park with its continuation written", || {
+            probe.lock().unwrap().get(&kb_probe).map(Vec::as_slice)
+                == Some(b"b-parked-continuation".as_slice())
+        })
+        .await;
 
         // Now drive A, which messages the parked B.
         let _ = tokio::time::timeout(
@@ -7255,7 +7331,11 @@ mod hol_4391_tests {
                 async move { send_d.send_to_handler(delegate_event(&key_d)).await },
             );
 
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        let probe = off_loop_calls.clone();
+        wait_until("the off-loop related fetch to be started", || {
+            probe.load(std::sync::atomic::Ordering::SeqCst) == 1
+        })
+        .await;
 
         // The two DECISIVE assertions. Remove the deferral (drop the
         // `DeferRelated if parking.is_some()` arm) and both fail: the upsert
@@ -7361,7 +7441,11 @@ mod hol_4391_tests {
         let k1 = key_d.clone();
         let first: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
             GlobalExecutor::spawn(async move { send_1.send_to_handler(delegate_event(&k1)).await });
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        let probe = calls.clone();
+        wait_until("the first request to enter the delegate and park", || {
+            probe.lock().unwrap().len() == 1
+        })
+        .await;
         assert_eq!(
             calls.lock().unwrap().len(),
             1,
@@ -7374,7 +7458,12 @@ mod hol_4391_tests {
         let second: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
             GlobalExecutor::spawn(async move { send_2.send_to_handler(delegate_event(&k2)).await });
 
-        // Give the loop ample opportunity to (wrongly) run it.
+        // A NEGATIVE assertion follows ("this must NOT have happened"), and a
+        // non-event cannot be waited for — so this one stays a sleep by
+        // necessity, not by laziness. It is sound because the positive
+        // precondition (the first request having parked) was established with
+        // `wait_until` above, so a slow machine delays this check rather than
+        // invalidating it.
         tokio::time::sleep(Duration::from_millis(400)).await;
         assert_eq!(
             calls.lock().unwrap().len(),

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -8,6 +8,11 @@ use either::Either;
 use freenet_stdlib::prelude::*;
 
 pub(crate) mod delegate_app_registry;
+// Lands ahead of its call sites so the bounds, the TTL and the exactly-once
+// resume guard can be reviewed and unit-tested on their own. The `allow` goes
+// away in the commit that wires the prompt path.
+#[allow(dead_code)]
+mod delegate_park;
 mod executor;
 mod fair_queue;
 pub(crate) use fair_queue::Priority;

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -522,6 +522,111 @@ enum InterDelegateDispatch {
     Suppressed,
 }
 
+/// Build the delegate-facing response for a PUT/UPDATE upsert.
+///
+/// Shared by the inline path and the post-fetch resume path so a deferred
+/// upsert reports exactly what an inline one would.
+fn upsert_response_msg(
+    is_put: bool,
+    contract_id: ContractInstanceId,
+    context: DelegateContext,
+    result: Result<UpsertResult, ExecutorError>,
+) -> InboundDelegateMsg<'static> {
+    let outcome = match result {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            tracing::warn!(
+                contract = %contract_id,
+                error = %err,
+                is_put,
+                "Failed to upsert contract for a delegate contract request"
+            );
+            Err(format!("{err}"))
+        }
+    };
+    if is_put {
+        InboundDelegateMsg::PutContractResponse(PutContractResponse {
+            contract_id,
+            result: outcome,
+            context,
+        })
+    } else {
+        InboundDelegateMsg::UpdateContractResponse(UpdateContractResponse {
+            contract_id,
+            result: outcome,
+            context,
+        })
+    }
+}
+
+/// Run a deferred upsert INLINE, related fetch and all.
+///
+/// The fallback when there is no parking context, or when the node-wide park
+/// cap refused this one. It reinstates the pre-#5544 stall for that single
+/// operation, which is the deliberate trade: degrading to the old behaviour
+/// beats dropping a delegate's write.
+async fn run_deferred_upsert_inline<CH>(
+    contract_handler: &mut CH,
+    pending: delegate_park::PendingUpsert,
+) -> InboundDelegateMsg<'static>
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let contract_id = *pending.key.id();
+    let result = contract_handler
+        .executor()
+        .upsert_contract_state(
+            pending.key,
+            pending.update,
+            pending.related_contracts,
+            pending.code,
+        )
+        .await;
+    upsert_response_msg(pending.is_put, contract_id, pending.context, result)
+}
+
+/// Re-run a deferred upsert ON the loop now that its related contracts have
+/// been fetched off it.
+///
+/// The fetched states are injected so the resumed upsert resolves them locally
+/// and does NOT make a second network round trip — the same trick
+/// `handle_deferred_resume` uses for the client-driven path (#4391).
+async fn apply_resolved_upsert<CH>(
+    contract_handler: &mut CH,
+    resolved: delegate_park::ResolvedUpsert,
+) -> InboundDelegateMsg<'static>
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let delegate_park::ResolvedUpsert { pending, fetched } = resolved;
+    let contract_id = *pending.key.id();
+    let mut related_contracts = pending.related_contracts;
+    let result = match fetched {
+        Ok(states) => {
+            for (id, state) in states {
+                inject_related_state(
+                    &mut related_contracts,
+                    id,
+                    freenet_stdlib::prelude::State::from(state.as_ref().to_vec()),
+                );
+            }
+            contract_handler
+                .executor()
+                .upsert_contract_state(
+                    pending.key,
+                    pending.update,
+                    related_contracts,
+                    pending.code,
+                )
+                .await
+        }
+        // The fetch failed or timed out: surface it to the delegate rather than
+        // retrying, matching the all-or-nothing semantics of the inline path.
+        Err(err) => Err(err),
+    };
+    upsert_response_msg(pending.is_put, contract_id, pending.context, result)
+}
+
 /// Drive the permission prompts for one delegate iteration and build the
 /// `UserResponse` messages to feed back.
 ///
@@ -819,6 +924,10 @@ where
         }
 
         let mut inbound_responses: Vec<InboundDelegateMsg<'static>> = Vec::new();
+        // Delegate PUT/UPDATEs whose contract asked for related contracts this
+        // node does not hold. Their network fetch is off-loaded with the rest of
+        // this iteration's slow work rather than awaited here (#5544 stall 1).
+        let mut deferred_upserts: Vec<delegate_park::PendingUpsert> = Vec::new();
 
         // Process PUT requests (fire-and-forget: upsert state, send result back).
         // This calls upsert_contract_state which stores locally AND automatically
@@ -835,15 +944,50 @@ where
                 let contract_key = req.contract.key();
                 let context = req.context;
 
-                let result = contract_handler
+                // Deferrable: on a missing related contract this returns
+                // immediately with the ids instead of awaiting a network GET on
+                // the serial loop (#5544 stall 1). Where parking is
+                // unavailable the fetch still happens, just inline, below.
+                let update = Either::Left(req.state);
+                let outcome = contract_handler
                     .executor()
-                    .upsert_contract_state(
+                    .upsert_contract_state_deferrable(
                         contract_key,
-                        Either::Left(req.state),
-                        req.related_contracts,
-                        Some(req.contract),
+                        update.clone(),
+                        req.related_contracts.clone(),
+                        Some(req.contract.clone()),
                     )
                     .await;
+
+                let result = match outcome {
+                    Ok(UpsertOutcome::Completed(r)) => Ok(r),
+                    Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                        deferred_upserts.push(delegate_park::PendingUpsert {
+                            key: contract_key,
+                            update,
+                            related_contracts: req.related_contracts,
+                            code: Some(req.contract),
+                            is_put: true,
+                            context,
+                            missing,
+                        });
+                        continue;
+                    }
+                    Ok(UpsertOutcome::DeferRelated(_)) => {
+                        // No parking context (direct unit-test calls): keep the
+                        // legacy inline fetch rather than failing the upsert.
+                        contract_handler
+                            .executor()
+                            .upsert_contract_state(
+                                contract_key,
+                                update,
+                                req.related_contracts,
+                                Some(req.contract),
+                            )
+                            .await
+                    }
+                    Err(err) => Err(err),
+                };
 
                 let put_result = match result {
                     Ok(_) => Ok(()),
@@ -979,15 +1123,47 @@ where
                             }
                         };
 
-                        contract_handler
+                        // Deferrable, exactly as the PUT arm above (#5544
+                        // stall 1): a missing related contract off-loads its
+                        // network GET instead of pinning the serial loop.
+                        let outcome = contract_handler
                             .executor()
-                            .upsert_contract_state(
+                            .upsert_contract_state_deferrable(
                                 full_key,
-                                update_value,
+                                update_value.clone(),
                                 RelatedContracts::default(),
                                 None,
                             )
-                            .await
+                            .await;
+                        match outcome {
+                            Ok(UpsertOutcome::Completed(r)) => Ok(r),
+                            Ok(UpsertOutcome::DeferRelated(missing)) if parking.is_some() => {
+                                deferred_upserts.push(delegate_park::PendingUpsert {
+                                    key: full_key,
+                                    update: update_value,
+                                    related_contracts: RelatedContracts::default(),
+                                    code: None,
+                                    is_put: false,
+                                    context,
+                                    missing,
+                                });
+                                continue;
+                            }
+                            Ok(UpsertOutcome::DeferRelated(_)) => {
+                                // No parking context: keep the legacy inline
+                                // fetch rather than failing the update.
+                                contract_handler
+                                    .executor()
+                                    .upsert_contract_state(
+                                        full_key,
+                                        update_value,
+                                        RelatedContracts::default(),
+                                        None,
+                                    )
+                                    .await
+                            }
+                            Err(err) => Err(err),
+                        }
                     }
                     None => {
                         tracing::debug!(
@@ -1233,54 +1409,44 @@ where
             );
         }
 
-        // Process UserInput requests: prompt the user and send responses back
-        if !user_input_requests.is_empty() {
+        // Off-load this iteration's SLOW work rather than awaiting it on the
+        // serial `contract_handling` loop (#5544). Two kinds, both of which
+        // used to pin the loop:
+        //
+        //   * permission prompts — `prompter.prompt()` waits on a HUMAN for up
+        //     to USER_INPUT_TIMEOUT (60s), and production wires the real
+        //     DashboardPrompter, so any delegate that prompts froze every
+        //     GET/PUT/UPDATE/subscribe on the node for a minute. ghostkeys
+        //     prompts in four places.
+        //   * deferred related-contract fetches — a delegate PUT/UPDATE whose
+        //     contract asks for a related contract this node lacks used to
+        //     await a network GET inline, up to RELATED_FETCH_TIMEOUT (10s).
+        //
+        // Both are parked together under ONE continuation: an iteration can
+        // produce both, and two park points would mean the second kind's work
+        // was silently dropped when the first parked.
+        //
+        // Nothing about the delegate requires us to stay here. It is already
+        // suspended at the runtime level — `RequestUserInput` breaks out of
+        // `process_outbound` and the WASM `process()` call has returned — and
+        // the deferrable upsert has already rolled back its partial work. All
+        // that is needed is to re-enter the delegate when the results arrive.
+        if !user_input_requests.is_empty() || !deferred_upserts.is_empty() {
             tracing::debug!(
                 delegate_key = %delegate_key,
-                count = user_input_requests.len(),
-                "Processing UserInputRequest messages from delegate"
+                prompts = user_input_requests.len(),
+                deferred_upserts = deferred_upserts.len(),
+                "Off-loading slow delegate work from the contract-handling loop"
             );
 
             // The caller identity passed to the prompter is built from the
             // executor's runtime context, NOT from anything the delegate could
-            // influence — so a malicious DELEGATE cannot spoof another app's
-            // identity in the structured fields the prompt UI renders.
-            //
-            // That was never the whole story, and the missing half was a real
-            // hole (GHSA-824h-7x5x-wfmf): the identity came from
-            // `origin_contract`, which the CLIENT chooses by presenting a token
-            // the node mints on request for any contract id. A caller the node
-            // cannot prove is local now resolves to `None` (gated at the top of
-            // this function), so it is rendered as an unattested caller rather
-            // than as the app whose id it named. This bounds the spoof to
-            // callers that are already on this host — see the PR's limitations:
-            // "local" means this HOST, not this USER, and it is not a defence
-            // behind a colocated reverse proxy.
-            //
-            // Today the only attested non-None caller is a web app
-            // (via `MessageOrigin::WebApp`); delegate-to-delegate attestation
-            // is tracked by #3860 and will appear here as a new variant.
-            //
-            // The actual mapping lives in `caller_identity_from_origin` so it
-            // can be unit-tested independently of the executor plumbing.
+            // influence, and `origin_contract` is already gated on
+            // `connection_scope.is_local()` at the top of this function
+            // (GHSA-824h-7x5x-wfmf). See `caller_identity_from_origin`.
             let caller = caller_identity_from_origin(origin_contract);
             let delegate_key_str = delegate_key.to_string();
 
-            // PARK rather than await (#5544).
-            //
-            // `prompter.prompt()` waits on a HUMAN for up to
-            // `USER_INPUT_TIMEOUT` (60s). Awaiting it HERE parks the single
-            // serial `contract_handling` loop for that whole time, so no GET,
-            // PUT, UPDATE, subscribe registration or delegate notification
-            // anywhere on this node is serviced until the user clicks. That is
-            // a node-wide stall triggered by any delegate that prompts, and
-            // ghostkeys prompts in four places.
-            //
-            // Nothing about the delegate needs us to stay here: it is ALREADY
-            // suspended at the runtime level. `RequestUserInput` breaks out of
-            // `process_outbound`, the WASM `process()` call has returned, and
-            // the continuation is in the `DelegateContextCache`. All that is
-            // needed is to re-enter it when the answer arrives.
             if let Some(ctx) = parking.as_mut() {
                 let continuation = delegate_park::Continuation {
                     params: current_params.clone(),
@@ -1290,9 +1456,9 @@ where
                     inter_delegate,
                     accumulated: std::mem::take(&mut accumulated_messages),
                     inbound_so_far: std::mem::take(&mut inbound_responses),
-                    // Attached by the caller right after we return `Parked`
-                    // (it owns the channel), or carried straight through if
-                    // this run is itself a resume that is parking again.
+                    // Attached by the caller right after we return `Parked` (it
+                    // owns the channel), or carried straight through if this run
+                    // is itself a resume that is parking again.
                     responder: ctx.carried_responder.take(),
                     delivery: ctx.delivery,
                 };
@@ -1304,30 +1470,75 @@ where
                         );
                         let prompter = std::sync::Arc::clone(prompter);
                         let key = delegate_key.clone();
-                        // Fire-and-forget is safe here precisely because of the
+                        let op_manager = contract_handler.executor().op_manager_handle();
+                        let prompts = std::mem::take(&mut user_input_requests);
+                        let upserts = std::mem::take(&mut deferred_upserts);
+                        // Fire-and-forget is safe precisely because of the
                         // guard: it delivers exactly one resume even if this
                         // task is dropped, panics or is cancelled, so the park
                         // always ends, its pending queue always drains and the
                         // parked client is always answered.
                         GlobalExecutor::spawn(async move {
-                            let responses = run_user_input_prompts(
-                                prompter.as_ref(),
-                                user_input_requests,
-                                &key,
-                                &delegate_key_str,
-                                caller,
+                            // Prompts and fetches run CONCURRENTLY, and the whole
+                            // body is capped by PARK_WORK_BUDGET. Sequentially
+                            // they could sum past PARK_TTL, at which point the
+                            // loop's backstop sweep would force-resume while this
+                            // task was still running and its result would be
+                            // discarded. Keeping the budget below the TTL means
+                            // the guard always wins the race.
+                            let fetches = async {
+                                futures::future::join_all(upserts.into_iter().map(|pending| {
+                                    let op_manager = op_manager.clone();
+                                    async move {
+                                        let fetched = fetch_related_off_loop(
+                                            op_manager,
+                                            pending.missing.clone(),
+                                        )
+                                        .await;
+                                        delegate_park::ResolvedUpsert { pending, fetched }
+                                    }
+                                }))
+                                .await
+                            };
+                            let answers = async {
+                                if prompts.is_empty() {
+                                    Vec::new()
+                                } else {
+                                    run_user_input_prompts(
+                                        prompter.as_ref(),
+                                        prompts,
+                                        &key,
+                                        &delegate_key_str,
+                                        caller,
+                                    )
+                                    .await
+                                }
+                            };
+                            let done = tokio::time::timeout(
+                                delegate_park::PARK_WORK_BUDGET,
+                                async { tokio::join!(answers, fetches) },
                             )
                             .await;
-                            guard.send(responses);
+                            match done {
+                                Ok((responses, resolved)) => guard.send(responses, resolved),
+                                Err(_) => {
+                                    tracing::warn!(
+                                        delegate = %key,
+                                        "Off-loop delegate work exceeded PARK_WORK_BUDGET; \
+                                         resuming empty so the round-trip terminates"
+                                    );
+                                    guard.send(Vec::new(), Vec::new());
+                                }
+                            }
                         });
                         return DelegateRunOutcome::Parked;
                     }
                     delegate_park::ParkAdmission::Refused(continuation) => {
                         // Node-wide park cap reached. Fall through to the
-                        // pre-#5544 inline wait: it stalls the loop, which is
-                        // what this change exists to stop, but silently losing
-                        // a user's permission prompt would be worse. Restore
-                        // what the refused continuation was carrying.
+                        // pre-#5544 inline waits: they stall the loop, which is
+                        // what this change exists to stop, but silently losing a
+                        // user's permission prompt or a delegate's write would
+                        // be worse. Restore what the refused continuation held.
                         let continuation = *continuation;
                         accumulated_messages = continuation.accumulated;
                         inbound_responses = continuation.inbound_so_far;
@@ -1336,16 +1547,24 @@ where
                 }
             }
 
-            inbound_responses.extend(
-                run_user_input_prompts(
-                    prompter.as_ref(),
-                    user_input_requests,
-                    delegate_key,
-                    &delegate_key_str,
-                    caller,
-                )
-                .await,
-            );
+            // Inline fallback: no parking context (direct unit-test calls), or
+            // the park cap was hit.
+            for pending in std::mem::take(&mut deferred_upserts) {
+                inbound_responses
+                    .push(run_deferred_upsert_inline(contract_handler, pending).await);
+            }
+            if !user_input_requests.is_empty() {
+                inbound_responses.extend(
+                    run_user_input_prompts(
+                        prompter.as_ref(),
+                        std::mem::take(&mut user_input_requests),
+                        delegate_key,
+                        &delegate_key_str,
+                        caller,
+                    )
+                    .await,
+                );
+            }
         }
 
         // Create a new request to send the responses back to the delegate
@@ -1538,6 +1757,7 @@ where
                     delegate_key,
                     cause: delegate_park::ResumeCause::TimedOut,
                     inbound: Vec::new(),
+                    upserts: Vec::new(),
                 },
             )
             .await;
@@ -2677,6 +2897,7 @@ async fn handle_delegate_resume<CH, P>(
         delegate_key,
         cause,
         inbound,
+        upserts,
     } = resume;
 
     let Some((continuation, pending)) = park.take(&delegate_key) else {
@@ -2711,6 +2932,11 @@ async fn handle_delegate_resume<CH, P>(
     } = continuation;
 
     let mut all_inbound = inbound_so_far;
+    // Re-run any deferred upserts ON the loop (WASM stays serial; only the
+    // fetch happened off it), then feed their responses back with the rest.
+    for resolved in upserts {
+        all_inbound.push(apply_resolved_upsert(contract_handler, resolved).await);
+    }
     all_inbound.extend(inbound);
 
     let mut carried_responder = responder;
@@ -6066,7 +6292,7 @@ mod hol_4391_tests {
         }
 
         // Release the human: the delegate resumes and its client is answered.
-        gate.notify_waiters();
+        gate.notify_one();
         let resp = tokio::time::timeout(Duration::from_secs(5), delegate_task)
             .await
             .expect("the parked delegate must resolve once the prompt is answered")
@@ -6075,6 +6301,130 @@ mod hol_4391_tests {
         assert!(
             matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
             "parked delegate must answer its original client exactly once, got {resp}"
+        );
+
+        handle.abort();
+    }
+
+    /// The second half of #5544: a delegate PUT whose contract asks for a
+    /// related contract this node lacks used to await a network GET INLINE, up
+    /// to RELATED_FETCH_TIMEOUT (10s), on the same serial loop. Smaller than
+    /// the prompt stall but reachable with no user involvement at all.
+    ///
+    /// Same falsification shape as the prompt test: with the deferral removed
+    /// the local GET below times out.
+    #[tokio::test]
+    async fn deferred_delegate_upsert_does_not_block_the_loop() {
+        let _guard = TEST_GUARD.lock().await;
+
+        // Contract A requests related contract B, which is never local.
+        let contract_a = make_contract(b"park_put_a");
+        let key_a = contract_a.key();
+        let id_b = *make_contract(b"park_put_b_missing").key().id();
+
+        let (mut handler, send) = build_handler(vec![(
+            *key_a.id(),
+            ValidateOverride::RequestRelated(vec![id_b]),
+        )])
+        .await;
+
+        let script = handler.runtime_mut().delegate_script.clone();
+        script
+            .lock()
+            .unwrap()
+            .push_back(vec![OutboundDelegateMsg::PutContractRequest(
+                freenet_stdlib::prelude::PutContractRequest {
+                    contract: contract_a.clone(),
+                    state: WrappedState::new(b"a_state".to_vec()),
+                    related_contracts: RelatedContracts::default(),
+                    context: DelegateContext::default(),
+                    processed: false,
+                },
+            )]);
+
+        // B's fetch hangs until released, standing in for a slow network GET.
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let gate_for_stub = gate.clone();
+        let _override = OverrideGuard::install(Arc::new(move |missing: Vec<ContractInstanceId>| {
+            let gate = gate_for_stub.clone();
+            Box::pin(async move {
+                gate.notified().await;
+                Err(ExecutorError::missing_related(missing[0]))
+            })
+        }));
+
+        // A locally stored contract whose GET needs no network at all.
+        let contract_c = make_contract(b"park_put_c_cached");
+        let key_c = contract_c.key();
+
+        let send = Arc::new(send);
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            crate::contract::user_input::AutoApprovePrompter,
+        ));
+
+        let put_c = put_local(
+            send.as_ref(),
+            contract_c,
+            WrappedState::new(b"c_state".to_vec()),
+        )
+        .await;
+        assert!(
+            matches!(
+                put_c,
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(_),
+                    ..
+                }
+            ),
+            "seed PUT for C must succeed, got {put_c}"
+        );
+
+        let send_d = send.clone();
+        let key_d = test_delegate_key();
+        let delegate_task: tokio::task::JoinHandle<Result<ContractHandlerEvent, ContractError>> =
+            GlobalExecutor::spawn(async move {
+                send_d.send_to_handler(delegate_event(&key_d)).await
+            });
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let get_c = tokio::time::timeout(
+            Duration::from_secs(2),
+            send.send_to_handler(ContractHandlerEvent::GetQuery {
+                instance_id: *key_c.id(),
+                return_contract_code: false,
+            }),
+        )
+        .await
+        .expect(
+            "a local-store GET must NOT block behind a delegate PUT whose \
+             related-contract fetch is still in flight (#5544)",
+        )
+        .expect("GET for C must respond");
+        match get_c {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                let store = response.expect("GET for C must succeed");
+                assert_eq!(
+                    store.state.expect("C has state").as_ref(),
+                    b"c_state",
+                    "GET must return C's stored state"
+                );
+            }
+            other => panic!("expected GetResponse for C, got {other}"),
+        }
+
+        // Release the fetch: B is reported missing, so A's upsert fails and the
+        // delegate is told so — the point is that it terminates and answers.
+        gate.notify_one();
+        let resp = tokio::time::timeout(Duration::from_secs(5), delegate_task)
+            .await
+            .expect("the parked delegate must resolve once its fetch completes")
+            .expect("delegate task join")
+            .expect("delegate request must be answered");
+        assert!(
+            matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
+            "a delegate parked on a related fetch must still answer its client, got {resp}"
         );
 
         handle.abort();
@@ -6145,7 +6495,7 @@ mod hol_4391_tests {
 
         // Release the prompt: the parked run resumes, then the queued request
         // is drained — both reach the delegate, in order.
-        gate.notify_waiters();
+        gate.notify_one();
         let r1 = tokio::time::timeout(Duration::from_secs(5), first)
             .await
             .expect("first delegate request must resolve")

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2045,11 +2045,7 @@ where
             // ParkGuard is untouched and still owes a resume; carrying the epoch
             // is what lets that late resume be recognised as stale and dropped
             // rather than absorbed by whatever park exists by then (#5544 H1).
-            tracing::warn!(
-                delegate = %delegate_key,
-                epoch,
-                "Delegate park exceeded PARK_TTL — force-resuming"
-            );
+            let swept = delegate_key.clone();
             let _ = handle_delegate_resume(
                 &mut contract_handler,
                 &mut park_ctx,
@@ -2067,6 +2063,24 @@ where
                 },
             )
             .await;
+            // Logged AFTER the resume, not before, so nothing sits between
+            // `should_force_resume` and `take_matching` (the first statement of
+            // `handle_delegate_resume`) — that gap is the residual window this
+            // fix narrows, and the cheapest way to keep it narrow is to put
+            // nothing in it. On the service path this line is microseconds
+            // (`tracing_appender::non_blocking`, which drops on overflow), so
+            // this is keeping the window free of anything whose cost is not
+            // obviously bounded rather than a fix for a measured cost.
+            //
+            // The message text is UNCHANGED on purpose: it is the log signature
+            // operators grep for, paired with the later "Resume for a park that
+            // no longer exists" from the stale guard. Reword it and that pairing
+            // stops being findable.
+            tracing::warn!(
+                delegate = %swept,
+                epoch,
+                "Delegate park exceeded PARK_TTL — force-resuming"
+            );
         }
 
         // Drain completed off-loop EXPORTS (#4531 / #4381 P5): return/replace the
@@ -2157,10 +2171,32 @@ where
         // Buffered delegate resumes are work already in hand: never block in
         // the select while any remain, or they would wait on UNRELATED traffic
         // to wake the loop — and each one is holding a client responder, and
-        // possibly a human's answer, until it runs (#5554). The top of the next
-        // iteration drains at least one (the budget starts at
-        // MAX_RESUME_DRAIN_BATCH and every run costs at least 1), so this
-        // cannot spin: the buffer strictly shrinks.
+        // possibly a human's answer, until it runs (#5554).
+        //
+        // WHY THIS DOES NOT SPIN. Not because the buffer shrinks — it does not
+        // necessarily, and an earlier version of this comment claimed it did.
+        // `expired` and `should_force_resume` PUSH into it mid-iteration (they
+        // re-read the channel, which is the whole point of taking the
+        // receiver), so an iteration can end holding more than it started with.
+        // What makes it terminate is that reaching here at all means the batch
+        // above already ran at least one resume — a full delegate re-entry, not
+        // a poll — and the only thing that grows the buffer is a resume an
+        // off-loop task actually delivered, one per guard, each firing once.
+        // So every pass does bounded real work against a supply that only
+        // refills as fast as new parks are admitted. The loop is making
+        // progress, not waiting on itself, and the buffer does not need to
+        // shrink for that to hold.
+        //
+        // SECOND, LOAD-BEARING JOB (#5554): this `continue` is also what keeps
+        // a DECLINED sweep from spinning the select. The sweep can now decline
+        // a past-due park, so `next_sweep_deadline()` can stay in the past
+        // across an iteration — and `sleep_until` on a past deadline returns
+        // immediately, which would be a hot wake loop. It cannot reach the
+        // select: declining requires the park's resume to be in
+        // `delegate_resumes`, nothing between here and there pops from it, so
+        // the buffer is non-empty and this fires before the deadline is even
+        // computed. Keep the two together; moving this below `park_deadline`
+        // would reopen it.
         if !delegate_resumes.is_empty() {
             continue;
         }
@@ -7557,7 +7593,18 @@ mod hol_4391_tests {
     /// have caught this, because the property was never asserted. A guard being
     /// falsifiable is not evidence that it guards the thing you care about.
     ///
-    /// FALSIFY by deleting the `continue` guard, or by commenting it out.
+    /// The ORDERING assertion below is not a relapse into the mistake above,
+    /// and the difference is worth being explicit about. The claim that failed
+    /// was "the drain and the sweep are not separated by a suspension", which
+    /// is about duration and which source order cannot express. This one is
+    /// "the guard appears before the deadline is computed", which is a
+    /// statement about position and nothing else — no await, no timing, no
+    /// runtime behaviour in between. Position is the right tool for exactly
+    /// this shape and the wrong tool for the other; the lesson was never "never
+    /// assert order".
+    ///
+    /// FALSIFY by deleting the `continue` guard, commenting it out, or moving
+    /// it below `park_ctx.next_sweep_deadline()`.
     #[test]
     fn the_loop_never_idles_while_holding_delegate_resumes() {
         let squashed: String = contract_handling_body()
@@ -7565,11 +7612,26 @@ mod hol_4391_tests {
             .filter(|c| !c.is_whitespace())
             .collect();
 
+        let guard = "if!delegate_resumes.is_empty(){continue;}";
+        let guard_at = squashed.find(guard).unwrap_or_else(|| {
+            panic!(
+                "the loop must not block in the select! while buffered resumes \
+                 remain — each is holding a client responder, and possibly a \
+                 human's answer, until it runs (#5554)"
+            )
+        });
+        let deadline_at = squashed
+            .find("letpark_deadline=park_ctx.next_sweep_deadline();")
+            .expect("the loop must still compute the park sweep deadline");
         assert!(
-            squashed.contains("if!delegate_resumes.is_empty(){continue;}"),
-            "the loop must not block in the select! while buffered resumes \
-             remain — each is holding a client responder, and possibly a \
-             human's answer, until it runs (#5554)"
+            guard_at < deadline_at,
+            "the buffered-resume guard must run BEFORE the sweep deadline is \
+             armed. Since the sweep can now DECLINE a past-due park, \
+             `next_sweep_deadline()` can stay in the past across an iteration, \
+             and `sleep_until` on a past deadline returns immediately — a hot \
+             wake loop. Declining implies the park's resume is in \
+             `delegate_resumes`, so this guard is what keeps that unreachable \
+             (#5554)"
         );
     }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1978,16 +1978,14 @@ where
         // resume re-enters WASM — and interleaved with the fair queue so
         // resumes cannot head-of-line-block ordinary contract ops.
         //
-        // Read the channel ONCE, up front, into `delegate_resumes`, and make
-        // both of this iteration's decisions from that buffer: which resumes to
-        // run now (bounded, below) and which parks the TTL backstop may
-        // force-resume (further below). Deciding them from one snapshot is what
-        // stops the backstop sweeping a park whose answer is already in hand —
-        // see `DelegateParkCtx::expired`, which discards a human's response if
-        // that happens (#5554). The buffer is what makes the two decisions
-        // consistent: the budget can leave resumes unrun (one resume costs up
-        // to 25 runs against a budget of 16), and the sweep runs in the SAME
-        // iteration, immediately after.
+        // Take what the off-loop tasks have sent into `delegate_resumes`. This
+        // is only the FIRST read of the channel in this iteration, not a
+        // snapshot the rest of the iteration may rely on: the batch below
+        // awaits, and `DelegateParkCtx::expired` / `should_force_resume` each
+        // re-read the channel themselves for exactly that reason (#5554). A
+        // resume left unrun here is still in hand, which is what stops the TTL
+        // backstop force-resuming a park whose answer has already arrived and
+        // throwing away the human's response it carries.
         while let Ok(resume) = delegate_resume_rx.try_recv() {
             delegate_resumes.push_back(resume);
         }
@@ -2014,12 +2012,35 @@ where
         // Backstop sweep for parks that neither completed nor were dropped
         // (see `PARK_TTL`). Force-resume them so a wedged delegate cannot stay
         // wedged: the resume drains its pending queue and answers its client.
-        // Parks whose resume is sitting in `delegate_resumes` are EXCLUDED by
-        // `expired` — they are queued, not wedged, and force-resuming one loses
-        // the answer it is carrying (#5554).
-        for (delegate_key, epoch) in
-            park_ctx.expired(tokio::time::Instant::now(), &delegate_resumes)
-        {
+        //
+        // `expired` re-reads the resume channel ITSELF and excludes any park
+        // whose answer has arrived — it takes the receiver precisely so this
+        // decision cannot be made from the stale buffer the batch above
+        // snapshotted before it started awaiting (#5554).
+        for (delegate_key, epoch) in park_ctx.expired(
+            tokio::time::Instant::now(),
+            &mut delegate_resume_rx,
+            &mut delegate_resumes,
+        ) {
+            // ...and re-ask per victim, because THIS loop awaits too: a guard
+            // firing while park X is being force-resumed is invisible to the
+            // decision already made about park Y. No `.await` between this
+            // check and `take_matching` inside `handle_delegate_resume`.
+            if !park_ctx.should_force_resume(
+                &delegate_key,
+                epoch,
+                &mut delegate_resume_rx,
+                &mut delegate_resumes,
+            ) {
+                tracing::debug!(
+                    delegate = %delegate_key,
+                    epoch,
+                    "Park reached PARK_TTL but its resume arrived while an \
+                     earlier force-resume was running — running that instead, \
+                     so the answer it carries is not discarded (#5554)"
+                );
+                continue;
+            }
             // Force-resume the park we OBSERVED, by epoch. The off-loop task's
             // ParkGuard is untouched and still owes a resume; carrying the epoch
             // is what lets that late resume be recognised as stale and dropped
@@ -7510,53 +7531,45 @@ mod hol_4391_tests {
         super::tests::fn_region(&code, "pub(crate) async fn contract_handling").to_string()
     }
 
-    /// #5554: the TTL backstop must decide from the resumes the loop has ALREADY
-    /// taken off the channel, not from the registry alone.
+    /// #5554: the loop must not block in the `select!` while it is still
+    /// holding delegate resumes.
     ///
-    /// The registry-level guarantee is in
-    /// `delegate_park::tests::the_backstop_leaves_a_park_whose_answer_is_already_in_hand`:
-    /// `expired` excludes a park whose resume is in the buffer, because
-    /// force-resuming it discards the `UserResponse` that resume is carrying.
-    /// This pins the WIRING that makes the guarantee reachable — the loop must
-    /// actually drain into that buffer, and must do it BEFORE it sweeps.
-    /// Draining after the sweep would type-check and be exactly the bug.
+    /// This is what is LEFT of a pin that used to claim more. Its earlier form
+    /// also asserted that the channel drain textually preceded the sweep, and
+    /// that assertion was worthless: an independent review found the fix still
+    /// broken, because the loop AWAITS a batch of resumes between the two, and
+    /// a `ParkGuard` firing during that await lands in the channel where the
+    /// already-taken snapshot cannot see it. The drain did precede the sweep.
+    /// The buggy code satisfied the pin exactly.
     ///
-    /// It also pins that a non-empty buffer never reaches the blocking
-    /// `select!`: those resumes are work in hand, each holding a client
-    /// responder, and waiting for unrelated traffic to wake the loop is the
-    /// stall this whole change exists to remove.
+    /// **Position cannot express duration.** A source scrape can say what
+    /// comes first; it cannot say that nothing suspends in between, which was
+    /// the actual property. So the ordering is now enforced by the signature —
+    /// `DelegateParkCtx::expired` and `should_force_resume` take the RECEIVER
+    /// and re-read it themselves, so no caller can decide from a stale view —
+    /// and it is checked behaviourally by
+    /// `delegate_park::tests::a_resume_arriving_after_the_snapshot_still_stops_the_sweep`
+    /// and its sibling for the per-victim loop. Those two tests are the guard;
+    /// this one keeps only the claim a source scrape can actually make.
     ///
-    /// FALSIFY by moving the drain below the sweep, by deleting either the
-    /// drain or the `continue` guard, or by commenting the drain out — the
-    /// last of which this pin missed until `contract_handling_body` started
-    /// stripping comments.
+    /// The lesson generalises past this pin: five mutations against the earlier
+    /// version were real and all correctly went red, and not one of them could
+    /// have caught this, because the property was never asserted. A guard being
+    /// falsifiable is not evidence that it guards the thing you care about.
+    ///
+    /// FALSIFY by deleting the `continue` guard, or by commenting it out.
     #[test]
-    fn the_ttl_sweep_decides_from_the_resumes_the_loop_already_took() {
+    fn the_loop_never_idles_while_holding_delegate_resumes() {
         let squashed: String = contract_handling_body()
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect();
 
-        let drain =
-            "whileletOk(resume)=delegate_resume_rx.try_recv(){delegate_resumes.push_back(resume);}";
-        let sweep = "park_ctx.expired(tokio::time::Instant::now(),&delegate_resumes)";
-        let no_idle_with_work = "if!delegate_resumes.is_empty(){continue;}";
-
-        let drain_at = squashed.find(drain).unwrap_or_else(|| {
-            panic!("the loop must take every resume the channel holds into its buffer (#5554)")
-        });
-        let sweep_at = squashed.find(sweep).unwrap_or_else(|| {
-            panic!("the backstop sweep must consult that buffer, or it force-resumes parks whose answer is already in hand (#5554)")
-        });
         assert!(
-            drain_at < sweep_at,
-            "the drain must run BEFORE the sweep: a buffer filled afterwards \
-             cannot protect the park the sweep just ended (#5554)"
-        );
-        assert!(
-            squashed.contains(no_idle_with_work),
+            squashed.contains("if!delegate_resumes.is_empty(){continue;}"),
             "the loop must not block in the select! while buffered resumes \
-             remain — each is holding a client responder (#5554)"
+             remain — each is holding a client responder, and possibly a \
+             human's answer, until it runs (#5554)"
         );
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1208,16 +1208,44 @@ impl DelegateParkCtx {
             .min()
     }
 
-    /// Keys whose park has outlived [`PARK_TTL`].
+    /// Keys whose park has outlived [`PARK_TTL`] AND whose result is not
+    /// already in the loop's hands.
     ///
     /// Returned rather than acted on so the caller (which owns the executor and
     /// the channel) performs the force-resume; this keeps the registry a pure
     /// data structure and unit-testable without a loop.
-    pub(super) fn expired(&self, now: tokio::time::Instant) -> Vec<(DelegateKey, u64)> {
+    ///
+    /// `already_delivered` is the loop's buffer of resumes it has taken off
+    /// `delegate_resume_rx` but not yet run. **A park listed there must not be
+    /// swept**, and this is the load-bearing half of the signature (#5554).
+    /// The sweep ends a park WITHOUT consuming the off-loop task's
+    /// [`ParkGuard`], so a resume that arrives afterwards is rejected by
+    /// [`Self::take_matching`] on epoch and dropped — including everything it
+    /// carries. That payload is `deliver()`'s output, which is where a human's
+    /// answer lives: force-resuming a park whose guard has ALREADY delivered
+    /// throws away the `UserResponse` the user gave and re-enters the delegate
+    /// with `inbound: Vec::new()`, so it is told nothing about the prompt it
+    /// asked — not even a denial. The backstop exists for a park that produced
+    /// NOTHING; one that produced an answer is not wedged, it is queued, and it
+    /// runs on the next iteration.
+    ///
+    /// Matching is by `(key, epoch)`, not key alone: a buffered resume from an
+    /// EARLIER park of the same delegate (one the backstop already swept) is
+    /// stale, carries nothing the live park is owed, and must not shield it.
+    pub(super) fn expired(
+        &self,
+        now: tokio::time::Instant,
+        already_delivered: &VecDeque<DelegateResume>,
+    ) -> Vec<(DelegateKey, u64)> {
         let mut out: Vec<(DelegateKey, u64)> = self
             .parked
             .iter()
             .filter(|(_, entry)| now.duration_since(entry.parked_at) >= PARK_TTL)
+            .filter(|(key, entry)| {
+                !already_delivered
+                    .iter()
+                    .any(|resume| resume.epoch == entry.epoch && resume.delegate_key == **key)
+            })
             .map(|(key, entry)| (key.clone(), entry.epoch))
             .collect();
         // Deterministic order: `HashMap` iteration is arbitrary, and a sweep
@@ -1542,15 +1570,151 @@ mod tests {
 
         tokio::time::advance(PARK_TTL - Duration::from_secs(1)).await;
         assert!(
-            ctx.expired(tokio::time::Instant::now()).is_empty(),
+            ctx.expired(tokio::time::Instant::now(), &VecDeque::new())
+                .is_empty(),
             "must not expire early — a park cut short would report a spurious \
              failure for work that was about to succeed"
         );
 
         tokio::time::advance(Duration::from_secs(2)).await;
         assert_eq!(
-            ctx.expired(tokio::time::Instant::now()),
+            ctx.expired(tokio::time::Instant::now(), &VecDeque::new()),
             vec![(k.clone(), ctx.epoch_of(&k).expect("parked"))]
+        );
+    }
+
+    /// #5554: the backstop must NOT sweep a park whose resume is already in the
+    /// loop's hands — because sweeping it throws away a human's Allow.
+    ///
+    /// This is the one case the rest of the suite could not see. The guard tests
+    /// prove `deliver()` preserves the answer the user gave;
+    /// `a_stale_resume_from_a_force_resumed_park_is_rejected` proves a resume
+    /// arriving after a sweep is DISCARDED (correct, from the registry's point
+    /// of view). Neither asks what the discarded resume was CARRYING. Put both
+    /// facts in one room and the answer is gone: the sweep ends the park without
+    /// consuming the guard, the guard's resume is then rejected on epoch, and
+    /// the delegate is re-entered with `inbound: Vec::new()` — told nothing
+    /// about the prompt it asked, which for a delegate that branches on the
+    /// answer is worse than a denial.
+    ///
+    /// It is reachable in ordinary operation: `PARK_WORK_BUDGET < PARK_TTL`
+    /// guarantees the off-loop TASK finishes in time, NOT that the loop DRAINS
+    /// its resume in time. The drain is capped at `MAX_RESUME_DRAIN_BATCH` (16)
+    /// while one `handle_delegate_resume` can cost 25 runs, and the sweep runs
+    /// in the same iteration, immediately after.
+    ///
+    /// FALSIFY by dropping the `already_delivered` filter from `expired`: the
+    /// first assertion then reports the park as expired. The third assertion is
+    /// the counterfactual that keeps the first from passing vacuously — with an
+    /// empty buffer this very park IS swept, so the exclusion is doing the work.
+    #[tokio::test(start_paused = true)]
+    async fn the_backstop_leaves_a_park_whose_answer_is_already_in_hand() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DelegateParkCtx::new(tx.clone());
+        let k = key(1);
+        let ParkAdmission::Admitted { epoch } = ctx.park(k.clone(), continuation(), 0) else {
+            panic!("park must be admitted");
+        };
+
+        // The human clicks Allow and the off-loop task's guard delivers.
+        let (answers, fetches) = sinks();
+        answers.lock().unwrap().push(answer(1));
+        drop(ParkGuard::new(
+            tx,
+            k.clone(),
+            epoch,
+            vec![1],
+            Vec::new(),
+            answers,
+            fetches,
+        ));
+
+        // The loop takes it off the channel but runs out of budget before
+        // running it, so it sits in the buffer — and the park is still parked.
+        let mut buffered: VecDeque<DelegateResume> = VecDeque::new();
+        while let Ok(resume) = rx.try_recv() {
+            buffered.push_back(resume);
+        }
+        assert_eq!(buffered.len(), 1, "the guard must have delivered a resume");
+
+        tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
+        assert!(
+            ctx.expired(tokio::time::Instant::now(), &buffered)
+                .is_empty(),
+            "a park whose resume is already buffered is QUEUED, not wedged; \
+             force-resuming it discards the answer that resume is carrying \
+             (#5554)"
+        );
+
+        // ...and what it is carrying really is the human's answer, not a denial.
+        let InboundDelegateMsg::UserResponse(response) = buffered[0]
+            .inbound
+            .iter()
+            .find(|m| matches!(m, InboundDelegateMsg::UserResponse(r) if r.request_id == 1))
+            .expect("the buffered resume must carry the answer for request 1")
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            &response.response[..],
+            b"allow".as_slice(),
+            "this is the answer the sweep would have thrown away"
+        );
+
+        // The counterfactual: the park IS past its TTL. Without the buffer to
+        // consult, the backstop sweeps it — so the exclusion above is load-
+        // bearing rather than a park that was never expiring.
+        assert_eq!(
+            ctx.expired(tokio::time::Instant::now(), &VecDeque::new()),
+            vec![(k.clone(), epoch)],
+            "the park really is past PARK_TTL"
+        );
+    }
+
+    /// The exclusion matches on `(key, epoch)`, not key alone.
+    ///
+    /// A buffered resume from an EARLIER park of the same delegate is stale: its
+    /// park was already ended, it carries nothing the CURRENT park is owed, and
+    /// letting it shield the current one would disarm the backstop for exactly
+    /// the delegate that has already needed it once — a genuinely wedged park
+    /// would then stay wedged forever.
+    ///
+    /// FALSIFY by dropping the `resume.epoch == entry.epoch` half of the filter:
+    /// the sweep then returns empty.
+    #[tokio::test(start_paused = true)]
+    async fn a_stale_buffered_resume_does_not_shield_the_current_park() {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DelegateParkCtx::new(tx);
+        let k = key(1);
+
+        let ParkAdmission::Admitted { epoch: first } = ctx.park(k.clone(), continuation(), 0)
+        else {
+            panic!("first park must be admitted");
+        };
+        // The backstop ended park #1; the delegate re-parked.
+        assert!(ctx.take_matching(&k, first).is_some());
+        let ParkAdmission::Admitted { epoch: second } = ctx.park(k.clone(), continuation(), 0)
+        else {
+            panic!("second park must be admitted");
+        };
+
+        // Park #1's guard finally fires, and its resume lands in the buffer.
+        let mut buffered: VecDeque<DelegateResume> = VecDeque::new();
+        buffered.push_back(DelegateResume {
+            delegate_key: k.clone(),
+            epoch: first,
+            cause: ResumeCause::Completed,
+            inbound: vec![answer(1)],
+            upserts: Vec::new(),
+            unresolved_upserts: Vec::new(),
+        });
+
+        tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
+        assert_eq!(
+            ctx.expired(tokio::time::Instant::now(), &buffered),
+            vec![(k.clone(), second)],
+            "a resume for the PREVIOUS park says nothing about this one; the \
+             backstop must still fire"
         );
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -147,6 +147,89 @@ pub(super) const MAX_PARKED_DELEGATES: usize = 64;
 /// a ninth.
 pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
 
+/// Cap on deferred related-contract fetches a single park may carry (#5544 S3).
+///
+/// The client-driven path bounds its off-loop fetches with
+/// `MAX_INFLIGHT_DEFERRALS` (256) as explicit anti-amplification. The delegate
+/// path cannot consult that counter — it has no `DeferralCtx` — and nothing
+/// caps how many `PutContractRequest`s one `process()` may emit, each able to
+/// name up to `MAX_RELATED_CONTRACTS_PER_REQUEST` (10) missing contracts.
+///
+/// 4 is chosen so the node-wide worst case matches the client path rather than
+/// exceeding it: MAX_PARKED_DELEGATES (64) x 4 x 10 = 2560 ids in flight,
+/// against the client path's 256 x 10 = 2560. Over the cap the excess upserts
+/// fall back to the inline fetch, which stalls the loop for those specific
+/// operations — the same deliberate trade as the park-cap fallback: degrading
+/// to the old behaviour beats dropping a delegate's write.
+pub(super) const MAX_DEFERRED_UPSERTS_PER_PARK: usize = 4;
+
+/// Node-wide cap on the bytes a park may hold (#5544 S4).
+///
+/// `MAX_PARKED_DELEGATES` bounds the NUMBER of parks, which is not the same as
+/// bounding their footprint: `Continuation::inbound_so_far` carries
+/// `GetContractResponse`s holding full `WrappedState`s, so a count cap reads
+/// like a memory bound and is not one. This is the fourth instance of that
+/// pattern found on this change alone (see #5551), and `code-style.md` rule 4
+/// requires the cap be on the quantity actually consumed.
+///
+/// 64 MiB: generous beside the 50 MB single-state ceiling the runtime already
+/// allows, while bounding the aggregate a flood of parked delegates can pin.
+pub(super) const MAX_PARKED_BYTES: usize = 64 * 1024 * 1024;
+
+/// Approximate heap footprint of the payloads a continuation pins.
+///
+/// Counts the large, contract-controlled parts — inbound states and payloads —
+/// and ignores fixed-size bookkeeping. The point is to bound what an attacker
+/// can grow, not to be exact.
+pub(super) fn continuation_bytes(continuation: &Continuation) -> usize {
+    continuation
+        .inbound_so_far
+        .iter()
+        .map(inbound_bytes)
+        .sum::<usize>()
+        + continuation
+            .accumulated
+            .iter()
+            .map(outbound_bytes)
+            .sum::<usize>()
+}
+
+fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
+    match msg {
+        InboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
+        InboundDelegateMsg::GetContractResponse(r) => {
+            r.state.as_ref().map_or(0, |s| s.as_ref().len())
+        }
+        InboundDelegateMsg::ContractNotification(n) => n.new_state.as_ref().len(),
+        InboundDelegateMsg::UserResponse(r) => r.response.len(),
+        InboundDelegateMsg::DelegateMessage(m) => m.payload.len(),
+        // Put/Update/Subscribe responses carry only a small Result. The
+        // wildcard is required by `#[non_exhaustive]`; a future variant
+        // carrying bytes must be added above or it goes uncounted.
+        InboundDelegateMsg::PutContractResponse(_)
+        | InboundDelegateMsg::UpdateContractResponse(_)
+        | InboundDelegateMsg::SubscribeContractResponse(_)
+        | _ => 0,
+    }
+}
+
+fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
+    // The request variants never appear in `accumulated` — they are consumed by
+    // the run that produced them — and the rest carry no contract-controlled
+    // payload. Listed rather than wildcarded so a future payload-bearing
+    // variant has to be considered here.
+    match msg {
+        OutboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
+        OutboundDelegateMsg::SendDelegateMessage(m) => m.payload.len(),
+        OutboundDelegateMsg::RequestUserInput(_)
+        | OutboundDelegateMsg::ContextUpdated(_)
+        | OutboundDelegateMsg::GetContractRequest(_)
+        | OutboundDelegateMsg::PutContractRequest(_)
+        | OutboundDelegateMsg::UpdateContractRequest(_)
+        | OutboundDelegateMsg::SubscribeContractRequest(_) => 0,
+    }
+}
+
 /// Backstop lifetime for a park.
 ///
 /// The [`ParkGuard`] already guarantees exactly-one resume per park even if
@@ -173,6 +256,17 @@ pub(super) const PARK_TTL: Duration = Duration::from_secs(90);
 /// Bounding the task below the TTL means the guard always wins that race, so
 /// the TTL stays what it is meant to be — unreachable in practice.
 pub(super) const PARK_WORK_BUDGET: Duration = Duration::from_secs(75);
+
+/// The budget/TTL ordering above is load-bearing, so it is CHECKED rather than
+/// merely described. Tune one of these and the compiler makes you tune the
+/// other — prose in two rustdoc blocks is exactly the kind of coupling that
+/// rots the first time someone adjusts a timeout in isolation.
+const _: () = assert!(
+    PARK_WORK_BUDGET.as_secs() < PARK_TTL.as_secs(),
+    "PARK_WORK_BUDGET must stay below PARK_TTL: the off-loop task has to \
+     finish and deliver its resume before the loop's backstop sweep would \
+     force-resume the park, or the task's result is discarded"
+);
 
 /// A delegate invocation that arrived while its delegate was parked.
 ///
@@ -227,6 +321,16 @@ pub(super) enum Delivery {
 /// WASM env, so resuming with empty params (as the notification path does, a
 /// known v1 limitation) would run a different delegate instance.
 pub(super) struct Continuation {
+    /// Iterations this round-trip has already consumed, so
+    /// `MAX_CONTRACT_REQUEST_ITERATIONS` bounds the WHOLE round-trip rather
+    /// than each leg of it (#5544 S1).
+    ///
+    /// Without this the counter is a call-frame local that every park resets,
+    /// so a delegate emitting `RequestUserInput` on every re-entry loops
+    /// park -> resume -> park forever, holding its exclusion open the whole
+    /// time and rejecting every other request for it. Before parking existed
+    /// the same delegate stopped after 100 iterations.
+    pub iterations: usize,
     pub params: Parameters<'static>,
     pub origin_contract: Option<ContractInstanceId>,
     pub connection_scope: ConnectionScope,
@@ -414,6 +518,8 @@ pub(super) enum QueueOutcome {
 /// Loop-owned per-delegate park state.
 pub(super) struct DelegateParkCtx {
     parked: HashMap<DelegateKey, ParkEntry>,
+    /// Running total of `continuation_bytes` across live parks (#5544 S4).
+    parked_bytes: usize,
     /// Handed to each [`ParkGuard`] so an off-loop task can deliver its resume.
     /// Kept here rather than threaded separately so every call site needs only
     /// a single `&mut DelegateParkCtx`.
@@ -424,6 +530,7 @@ impl DelegateParkCtx {
     pub(super) fn new(resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>) -> Self {
         Self {
             parked: HashMap::new(),
+            parked_bytes: 0,
             resume_tx,
         }
     }
@@ -450,16 +557,24 @@ impl DelegateParkCtx {
     /// is unreachable by construction and is treated as a refusal rather than
     /// silently clobbering the live continuation.
     pub(super) fn park(&mut self, key: DelegateKey, continuation: Continuation) -> ParkAdmission {
-        if self.parked.len() >= MAX_PARKED_DELEGATES || self.parked.contains_key(&key) {
+        let bytes = continuation_bytes(&continuation);
+        let over_bytes = self.parked_bytes.saturating_add(bytes) > MAX_PARKED_BYTES;
+        if self.parked.len() >= MAX_PARKED_DELEGATES || self.parked.contains_key(&key) || over_bytes
+        {
             tracing::warn!(
                 delegate = %key,
                 parked = self.parked.len(),
                 limit = MAX_PARKED_DELEGATES,
+                parked_bytes = self.parked_bytes,
+                adding_bytes = bytes,
+                byte_limit = MAX_PARKED_BYTES,
+                over_bytes,
                 already_parked = self.parked.contains_key(&key),
                 "Refusing to park delegate; falling back to the inline path"
             );
             return ParkAdmission::Refused(Box::new(continuation));
         }
+        self.parked_bytes = self.parked_bytes.saturating_add(bytes);
         self.parked.insert(
             key,
             ParkEntry {
@@ -525,9 +640,12 @@ impl DelegateParkCtx {
         &mut self,
         key: &DelegateKey,
     ) -> Option<(Continuation, VecDeque<PendingRun>)> {
-        self.parked
-            .remove(key)
-            .map(|entry| (entry.continuation, entry.pending))
+        self.parked.remove(key).map(|entry| {
+            self.parked_bytes = self
+                .parked_bytes
+                .saturating_sub(continuation_bytes(&entry.continuation));
+            (entry.continuation, entry.pending)
+        })
     }
 
     /// The earliest instant at which some park will reach [`PARK_TTL`], or
@@ -582,6 +700,7 @@ mod tests {
             inbound_so_far: Vec::new(),
             responder: None,
             delivery: Delivery::Client,
+            iterations: 0,
         }
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1,0 +1,523 @@
+//! Parking a delegate's round-trip OFF the serial `contract_handling` loop
+//! (#5544).
+//!
+//! # The problem
+//!
+//! A delegate round-trip is already a two-invocation protocol at the runtime
+//! level: `RequestUserInput` breaks out of `process_outbound`, the WASM
+//! `process()` call returns, and the delegate's continuation lives in the
+//! [`DelegateContextCache`](crate::wasm_runtime::native_api::DelegateContextCache)
+//! until the executor re-enters with the matching `UserResponse`.
+//!
+//! What made that round-trip look atomic was that
+//! `handle_delegate_with_contract_requests` awaited the slow half INLINE, on
+//! the single serial loop — so nothing else on the node ran until it finished.
+//! For a permission prompt that is up to `USER_INPUT_TIMEOUT` (60 s) during
+//! which no GET, PUT, UPDATE, subscribe or delegate notification is serviced
+//! anywhere on this node.
+//!
+//! Parking replaces that: the loop hands the slow half to a spawned task and
+//! returns immediately, and the delegate is re-entered on a later iteration
+//! when the result arrives.
+//!
+//! # Why this needs per-delegate exclusion
+//!
+//! The context cache is keyed by `DelegateKey` alone and is last-write-wins.
+//! It is only sound while at most ONE `process()` per delegate is in flight,
+//! and — see that type's rustdoc, corrected in this same change — that
+//! property is supplied ENTIRELY by the serial loop, not by the runtime. There
+//! is no per-delegate lock in `prepare_delegate_call`, no per-delegate
+//! affinity in `RuntimePool::execute_delegate_request`, and no mutex anywhere
+//! in `wasm_runtime::delegate`.
+//!
+//! So the moment a round-trip spans two loop iterations, that protection is
+//! gone: a second request for the same delegate would run `process()`, write
+//! the shared context, and the parked continuation would resume reading
+//! someone else's bytes. Silent state corruption, not a crash.
+//!
+//! [`DelegateParkCtx`] therefore keeps its own per-delegate exclusion: while a
+//! delegate is parked, further requests for it are QUEUED rather than run, and
+//! drained when it resumes. That preserves the invariant the delegate author
+//! already relies on, and converts a node-wide stall into a per-delegate one —
+//! which is the correct semantics, not a compromise. Everything else on the
+//! node keeps running.
+//!
+//! # Ownership
+//!
+//! Loop-owned (`contract_handling` holds it and passes `&mut` down), NOT a
+//! process global. It holds this node's client responders and gates this
+//! node's loop, and an in-process multi-node simulation must not share either.
+//! Same reasoning as `client_events::user_op_rate_limit`, and deliberately
+//! unlike the older `DELEGATE_SUBSCRIPTIONS` global.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::Duration;
+
+use freenet_stdlib::client_api::DelegateRequest;
+use freenet_stdlib::prelude::{
+    ContractInstanceId, DelegateKey, InboundDelegateMsg, OutboundDelegateMsg, Parameters,
+};
+
+use super::handler::{EventId, StashedResponder};
+use crate::client_events::ConnectionScope;
+use crate::wasm_runtime::UserSecretContext;
+
+/// Node-wide cap on simultaneously parked delegates.
+///
+/// Each park holds a continuation, at most one stashed client responder and up
+/// to [`MAX_PENDING_PER_DELEGATE`] queued requests, so this bounds the whole
+/// structure's footprint. 64 is far above any realistic concurrent count — a
+/// node runs a handful of registered delegates and a prompt needs a human — and
+/// well below anything that would matter for memory.
+///
+/// At the cap a new park is REFUSED and the caller falls back to answering the
+/// delegate inline (the pre-#5544 behaviour, stall included) rather than
+/// dropping the round-trip. Degrading to the old behaviour under an
+/// implausible flood is strictly better than losing a user's prompt.
+pub(super) const MAX_PARKED_DELEGATES: usize = 64;
+
+/// Cap on requests queued behind a single parked delegate.
+///
+/// Overflow is REJECTED with a visible error, never silently dropped: the
+/// caller gets `ContractHandlerEvent::DelegateResponse` carrying nothing, which
+/// surfaces to the client as an empty response rather than a hang. A delegate
+/// with 8 requests already queued behind a prompt is not going to be helped by
+/// a ninth.
+pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
+
+/// Backstop lifetime for a park.
+///
+/// The [`ParkGuard`] already guarantees exactly-one resume per park even if
+/// the spawned task is dropped, panics or is cancelled, and both parkable
+/// waits are internally bounded (`USER_INPUT_TIMEOUT` = 60 s for a prompt,
+/// `DEFERRED_RELATED_FETCH_TIMEOUT` = `OPERATION_TTL` + 2 s for a related
+/// fetch). This TTL is the third layer: it covers a task that neither
+/// completes nor drops, which no current path can produce but which a future
+/// one could. On expiry the park is force-resumed — pending drained, responder
+/// answered — so a wedged delegate can never be wedged forever.
+///
+/// Set above BOTH inner budgets so the real timeout always wins and this never
+/// fires first on a merely-slow operation; a park cut short at its own TTL
+/// would report a spurious failure for work that was about to succeed.
+pub(super) const PARK_TTL: Duration = Duration::from_secs(90);
+
+/// A delegate request that arrived while its delegate was parked.
+///
+/// Held here rather than requeued into the fair queue: every delegate request
+/// shares the single `QueueKey::Default` lane (`fair_queue.rs`), so a
+/// pop-see-parked-repush cycle would busy-spin the loop.
+pub(super) struct PendingRequest {
+    pub id: EventId,
+    pub req: DelegateRequest<'static>,
+    pub origin_contract: Option<ContractInstanceId>,
+    pub connection_scope: ConnectionScope,
+    pub user_context: Option<UserSecretContext>,
+}
+
+/// Everything needed to re-enter a parked delegate on a later loop iteration.
+///
+/// `params` is carried explicitly and is NOT optional: `DelegateKey` identity
+/// covers `BLAKE3(code_hash ‖ params)` and the params are threaded into the
+/// WASM env, so resuming with empty params (as the notification path does, a
+/// known v1 limitation) would run a different delegate instance.
+pub(super) struct Continuation {
+    pub params: Parameters<'static>,
+    pub origin_contract: Option<ContractInstanceId>,
+    pub connection_scope: ConnectionScope,
+    pub user_context: Option<UserSecretContext>,
+    pub inter_delegate: super::InterDelegateDispatch,
+    /// Outbound messages the delegate produced before it parked. Carried so the
+    /// client sees ONE response covering the whole round-trip rather than a
+    /// partial one now and the rest out-of-band.
+    pub accumulated: Vec<OutboundDelegateMsg>,
+    /// Responses already computed for this iteration, awaiting the parked one.
+    pub inbound_so_far: Vec<InboundDelegateMsg<'static>>,
+    /// The parked client's responder, if this run descends from a client
+    /// request. `None` for a notification-driven run, which has no client.
+    pub responder: Option<StashedResponder>,
+}
+
+/// One parked delegate.
+struct ParkEntry {
+    continuation: Continuation,
+    parked_at: tokio::time::Instant,
+    pending: VecDeque<PendingRequest>,
+}
+
+/// Why a park ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResumeCause {
+    /// The awaited work delivered a result.
+    Completed,
+    /// The park outlived [`PARK_TTL`] (see its rustdoc — a backstop, not an
+    /// expected path).
+    TimedOut,
+}
+
+/// Sent from an off-loop task back to the `contract_handling` loop.
+pub(super) struct DelegateResume {
+    pub delegate_key: DelegateKey,
+    pub cause: ResumeCause,
+    /// The messages to feed back into the delegate. Empty on a dropped or
+    /// timed-out park, which still resumes so the continuation terminates.
+    pub inbound: Vec<InboundDelegateMsg<'static>>,
+}
+
+/// RAII guard guaranteeing an off-loop task delivers EXACTLY ONE
+/// [`DelegateResume`] for its park — on success, or on drop / panic /
+/// cancellation before it got there.
+///
+/// Same load-bearing invariant as #4391's `ResumeGuard`: because every park is
+/// answered exactly once, the loop needs no stale-resume guard, a parked client
+/// responder can never be stranded, and a delegate's pending queue is always
+/// drained. Never zero (Drop covers early exit), never twice (the success path
+/// takes the payload, so Drop sees `None`).
+///
+/// The resume channel is unbounded, so both sends are non-blocking. Producers
+/// are bounded by [`MAX_PARKED_DELEGATES`], the receiver is the loop (which
+/// drains every iteration), and the task never reads what the loop produces —
+/// no cycle, per `channel-safety.md`'s carve-out.
+pub(super) struct ParkGuard {
+    payload: Option<ParkGuardPayload>,
+}
+
+struct ParkGuardPayload {
+    resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
+    delegate_key: DelegateKey,
+}
+
+impl ParkGuard {
+    pub(super) fn new(
+        resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
+        delegate_key: DelegateKey,
+    ) -> Self {
+        Self {
+            payload: Some(ParkGuardPayload {
+                resume_tx,
+                delegate_key,
+            }),
+        }
+    }
+
+    /// Deliver the resolved inbound messages. Consumes the payload so a later
+    /// `Drop` is a no-op (exactly-once).
+    pub(super) fn send(mut self, inbound: Vec<InboundDelegateMsg<'static>>) {
+        if let Some(p) = self.payload.take() {
+            Self::deliver(p, ResumeCause::Completed, inbound);
+        }
+    }
+
+    fn deliver(
+        p: ParkGuardPayload,
+        cause: ResumeCause,
+        inbound: Vec<InboundDelegateMsg<'static>>,
+    ) {
+        let ParkGuardPayload {
+            resume_tx,
+            delegate_key,
+        } = p;
+        if resume_tx
+            .send(DelegateResume {
+                delegate_key: delegate_key.clone(),
+                cause,
+                inbound,
+            })
+            .is_err()
+        {
+            tracing::debug!(
+                delegate = %delegate_key,
+                "Delegate resume channel closed; contract-handling loop gone"
+            );
+        }
+    }
+}
+
+impl Drop for ParkGuard {
+    fn drop(&mut self) {
+        if let Some(p) = self.payload.take() {
+            tracing::warn!(
+                delegate = %p.delegate_key,
+                "Off-loop delegate task dropped before sending — delivering an \
+                 empty resume so the park terminates, its pending queue drains \
+                 and the parked client is answered exactly once (#5544)"
+            );
+            Self::deliver(p, ResumeCause::TimedOut, Vec::new());
+        }
+    }
+}
+
+/// Outcome of asking to park a delegate.
+pub(super) enum ParkAdmission {
+    /// Parked. The caller must spawn the off-loop work with a [`ParkGuard`].
+    Admitted,
+    /// Refused (node-wide cap). The caller keeps the old inline behaviour;
+    /// the continuation is handed back so nothing is lost.
+    Refused(Box<Continuation>),
+}
+
+/// Outcome of offering a request for an already-parked delegate.
+pub(super) enum QueueOutcome {
+    /// Queued behind the park; it will run when the delegate resumes.
+    Queued,
+    /// The delegate's queue is full. The caller must answer this request with a
+    /// visible error rather than dropping it.
+    Rejected(Box<PendingRequest>),
+}
+
+/// Loop-owned per-delegate park state.
+#[derive(Default)]
+pub(super) struct DelegateParkCtx {
+    parked: HashMap<DelegateKey, ParkEntry>,
+}
+
+impl DelegateParkCtx {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` if this delegate currently has a parked continuation, and so must
+    /// not be re-entered by a fresh request.
+    pub(super) fn is_parked(&self, key: &DelegateKey) -> bool {
+        self.parked.contains_key(key)
+    }
+
+    pub(super) fn parked_count(&self) -> usize {
+        self.parked.len()
+    }
+
+    /// Park `key`, or refuse at the node-wide cap.
+    ///
+    /// A delegate that is already parked cannot park again — the exclusion
+    /// guarantees only one round-trip per delegate is ever in flight, so this
+    /// is unreachable by construction and is treated as a refusal rather than
+    /// silently clobbering the live continuation.
+    pub(super) fn park(
+        &mut self,
+        key: DelegateKey,
+        continuation: Continuation,
+    ) -> ParkAdmission {
+        if self.parked.len() >= MAX_PARKED_DELEGATES || self.parked.contains_key(&key) {
+            tracing::warn!(
+                delegate = %key,
+                parked = self.parked.len(),
+                limit = MAX_PARKED_DELEGATES,
+                already_parked = self.parked.contains_key(&key),
+                "Refusing to park delegate; falling back to the inline path"
+            );
+            return ParkAdmission::Refused(Box::new(continuation));
+        }
+        self.parked.insert(
+            key,
+            ParkEntry {
+                continuation,
+                parked_at: tokio::time::Instant::now(),
+                pending: VecDeque::new(),
+            },
+        );
+        ParkAdmission::Admitted
+    }
+
+    /// Queue a request that arrived for a parked delegate.
+    ///
+    /// Caller must have checked [`is_parked`](Self::is_parked); queueing for an
+    /// unparked delegate is a caller bug and is reported back as a rejection so
+    /// the request is still answered.
+    pub(super) fn queue_pending(&mut self, key: &DelegateKey, req: PendingRequest) -> QueueOutcome {
+        let Some(entry) = self.parked.get_mut(key) else {
+            return QueueOutcome::Rejected(Box::new(req));
+        };
+        if entry.pending.len() >= MAX_PENDING_PER_DELEGATE {
+            tracing::warn!(
+                delegate = %key,
+                queued = entry.pending.len(),
+                limit = MAX_PENDING_PER_DELEGATE,
+                "Delegate pending queue full while parked — rejecting request"
+            );
+            return QueueOutcome::Rejected(Box::new(req));
+        }
+        entry.pending.push_back(req);
+        QueueOutcome::Queued
+    }
+
+    /// End a park, returning its continuation and everything queued behind it.
+    pub(super) fn take(
+        &mut self,
+        key: &DelegateKey,
+    ) -> Option<(Continuation, VecDeque<PendingRequest>)> {
+        self.parked
+            .remove(key)
+            .map(|entry| (entry.continuation, entry.pending))
+    }
+
+    /// Keys whose park has outlived [`PARK_TTL`].
+    ///
+    /// Returned rather than acted on so the caller (which owns the executor and
+    /// the channel) performs the force-resume; this keeps the registry a pure
+    /// data structure and unit-testable without a loop.
+    pub(super) fn expired(&self, now: tokio::time::Instant) -> Vec<DelegateKey> {
+        self.parked
+            .iter()
+            .filter(|(_, entry)| now.duration_since(entry.parked_at) >= PARK_TTL)
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> DelegateKey {
+        DelegateKey::new(
+            [byte; 32],
+            freenet_stdlib::prelude::CodeHash::new([byte; 32]),
+        )
+    }
+
+    fn continuation() -> Continuation {
+        Continuation {
+            params: Parameters::from(Vec::new()),
+            origin_contract: None,
+            connection_scope: ConnectionScope::Local,
+            user_context: None,
+            inter_delegate: super::super::InterDelegateDispatch::Allowed,
+            accumulated: Vec::new(),
+            inbound_so_far: Vec::new(),
+            responder: None,
+        }
+    }
+
+    fn pending(byte: u8) -> PendingRequest {
+        PendingRequest {
+            id: EventId { id: byte as u64 },
+            req: DelegateRequest::ApplicationMessages {
+                key: key(byte),
+                params: Parameters::from(Vec::new()),
+                inbound: Vec::new(),
+            },
+            origin_contract: None,
+            connection_scope: ConnectionScope::Local,
+            user_context: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn park_then_take_round_trips() {
+        let mut ctx = DelegateParkCtx::new();
+        let k = key(1);
+        assert!(!ctx.is_parked(&k));
+        assert!(matches!(
+            ctx.park(k.clone(), continuation()),
+            ParkAdmission::Admitted
+        ));
+        assert!(ctx.is_parked(&k));
+        let (_cont, pend) = ctx.take(&k).expect("park must be takeable");
+        assert!(pend.is_empty());
+        assert!(!ctx.is_parked(&k), "take must end the park");
+    }
+
+    #[tokio::test]
+    async fn node_wide_cap_refuses_and_hands_the_continuation_back() {
+        let mut ctx = DelegateParkCtx::new();
+        for i in 0..MAX_PARKED_DELEGATES {
+            assert!(matches!(
+                ctx.park(key(i as u8), continuation()),
+                ParkAdmission::Admitted
+            ));
+        }
+        assert_eq!(ctx.parked_count(), MAX_PARKED_DELEGATES);
+        // Over the cap: refused, and the continuation comes back so the caller
+        // can fall back inline rather than losing the round-trip.
+        assert!(matches!(
+            ctx.park(key(200), continuation()),
+            ParkAdmission::Refused(_)
+        ));
+        assert!(!ctx.is_parked(&key(200)));
+    }
+
+    #[tokio::test]
+    async fn double_park_is_refused_not_clobbered() {
+        let mut ctx = DelegateParkCtx::new();
+        let k = key(1);
+        assert!(matches!(
+            ctx.park(k.clone(), continuation()),
+            ParkAdmission::Admitted
+        ));
+        // The live continuation must survive: clobbering it would strand the
+        // first round-trip's client responder.
+        assert!(matches!(
+            ctx.park(k.clone(), continuation()),
+            ParkAdmission::Refused(_)
+        ));
+        assert!(ctx.take(&k).is_some());
+    }
+
+    #[tokio::test]
+    async fn pending_queue_is_capped_and_overflow_is_returned_not_dropped() {
+        let mut ctx = DelegateParkCtx::new();
+        let k = key(1);
+        ctx.park(k.clone(), continuation());
+        for i in 0..MAX_PENDING_PER_DELEGATE {
+            assert!(matches!(
+                ctx.queue_pending(&k, pending(i as u8)),
+                QueueOutcome::Queued
+            ));
+        }
+        // Overflow must hand the request BACK so the caller can answer it.
+        // Silently dropping it would hang that client forever.
+        assert!(matches!(
+            ctx.queue_pending(&k, pending(99)),
+            QueueOutcome::Rejected(_)
+        ));
+        let (_cont, pend) = ctx.take(&k).expect("park present");
+        assert_eq!(pend.len(), MAX_PENDING_PER_DELEGATE);
+    }
+
+    #[tokio::test]
+    async fn queueing_for_an_unparked_delegate_returns_the_request() {
+        let mut ctx = DelegateParkCtx::new();
+        assert!(matches!(
+            ctx.queue_pending(&key(1), pending(1)),
+            QueueOutcome::Rejected(_)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn park_expires_only_after_the_ttl() {
+        let mut ctx = DelegateParkCtx::new();
+        let k = key(1);
+        ctx.park(k.clone(), continuation());
+
+        tokio::time::advance(PARK_TTL - Duration::from_secs(1)).await;
+        assert!(
+            ctx.expired(tokio::time::Instant::now()).is_empty(),
+            "must not expire early — a park cut short would report a spurious \
+             failure for work that was about to succeed"
+        );
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert_eq!(ctx.expired(tokio::time::Instant::now()), vec![k]);
+    }
+
+    #[tokio::test]
+    async fn guard_delivers_exactly_one_resume_on_success() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let guard = ParkGuard::new(tx, key(1));
+        guard.send(Vec::new());
+        let resume = rx.recv().await.expect("one resume");
+        assert_eq!(resume.cause, ResumeCause::Completed);
+        assert!(rx.try_recv().is_err(), "must not deliver twice");
+    }
+
+    #[tokio::test]
+    async fn guard_delivers_a_resume_when_dropped_before_sending() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        // Simulates the spawned task being cancelled/panicking before it
+        // finished its work. Without this the park would never end: the
+        // pending queue would never drain and the client would hang.
+        drop(ParkGuard::new(tx, key(1)));
+        let resume = rx.recv().await.expect("drop must still resume the park");
+        assert_eq!(resume.cause, ResumeCause::TimedOut);
+        assert!(resume.inbound.is_empty());
+    }
+}

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -413,9 +413,39 @@ pub(super) enum PendingRun {
     /// silent loss landing on exactly the wrong population: ghostkeys parks on
     /// prompts, so the rejection window is precisely when a user is
     /// interacting, and Harvest with many address contracts subscribed would
-    /// lose payment notifications there. Coalescing is sound because the
-    /// notification contract is already "you will see the next state", so a
-    /// superseded notification carries nothing its successor does not.
+    /// lose payment notifications there. The window is reachable in practice —
+    /// Harvest's bridge backfill replays thirty blocks on restart and can emit
+    /// several claims for one script within seconds.
+    ///
+    /// # PRECONDITION: the contract's state must be ACCUMULATING
+    ///
+    /// Newest-wins is lossless only if the newest state SUBSUMES what a
+    /// superseded notification carried. That is a property of the CONTRACT, not
+    /// of this mechanism, and the node cannot tell the two apart:
+    ///
+    /// - **Holds** for a grow-only or CRDT-merge state. Harvest's `ClaimSetV1`
+    ///   is a `BTreeMap` merged by set union, deliberately grow-only because a
+    ///   Bitcoin reorg must be expressible without deletion — a retraction is a
+    ///   NEWER assertion at a higher height, not an edit. Coalescing is lossless
+    ///   there.
+    /// - **Does NOT hold** for a register-valued contract, where each update
+    ///   REPLACES the previous. Payment A sets `state = A`, payment B sets
+    ///   `state = B`; dropping A's notification means the delegate never learns
+    ///   A happened. Such a contract needs every distinct notification kept,
+    ///   not collapsed.
+    ///
+    /// The register shape is the more natural modelling, and Harvest said so
+    /// themselves — grow-only was a deliberate, slightly unusual choice. So this
+    /// is an assumption the notification API currently makes ON THE DELEGATE'S
+    /// BEHALF, and nothing here enforces it. #5467 is the place to decide
+    /// whether a delegate should be able to say "do not coalesce mine", or a
+    /// contract should declare its shape.
+    ///
+    /// One bound worth re-checking if `PARK_TTL` ever grows: grow-only is itself
+    /// capped (Harvest prunes at `MAX_CLAIMS` = 512, lowest-`as_of` first), so
+    /// "newest contains everything" holds only until that budget binds. Anything
+    /// arriving inside the current park window is by definition newest and is
+    /// not what gets pruned, so it does not affect this today.
     Notification {
         /// The contract whose change triggered this. Carried explicitly so
         /// queued notifications can be COALESCED per contract.
@@ -1245,8 +1275,9 @@ mod tests {
         assert_eq!(
             queued_state(&pending[0]),
             Some(vec![MAX_PENDING_PER_DELEGATE as u8 + 11]),
-            "the NEWEST notification must win; a superseded one carries nothing \
-             its successor does not"
+            "the NEWEST notification must win. Lossless only while the contract's \
+             state is ACCUMULATING, so the newest subsumes the superseded — see \
+             the precondition on `PendingRun::Notification`"
         );
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1814,13 +1814,18 @@ mod tests {
         })
     }
 
+    // `InboundDelegateMsg` is `#[non_exhaustive]`, so the wildcard is required
+    // rather than lazy, and this helper genuinely wants only `UserResponse`.
+    // The attribute has to sit on the EXPRESSION, not on the arm: on the arm it
+    // does not suppress the lint, which is only visible in CI because the crate
+    // warns on this locally and denies it under `-D warnings`.
+    #[allow(clippy::wildcard_enum_match_arm)]
     fn answered_ids(resume: &DelegateResume) -> Vec<u32> {
         resume
             .inbound
             .iter()
             .filter_map(|m| match m {
                 InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
-                #[allow(clippy::wildcard_enum_match_arm)]
                 _ => None,
             })
             .collect()

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -53,8 +53,8 @@
 use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
-use freenet_stdlib::client_api::DelegateRequest;
 use either::Either;
+use freenet_stdlib::client_api::DelegateRequest;
 use freenet_stdlib::prelude::{
     ContractContainer, ContractInstanceId, ContractKey, DelegateContext, DelegateKey,
     InboundDelegateMsg, OutboundDelegateMsg, Parameters, RelatedContracts, StateDelta,
@@ -373,11 +373,7 @@ impl DelegateParkCtx {
     /// guarantees only one round-trip per delegate is ever in flight, so this
     /// is unreachable by construction and is treated as a refusal rather than
     /// silently clobbering the live continuation.
-    pub(super) fn park(
-        &mut self,
-        key: DelegateKey,
-        continuation: Continuation,
-    ) -> ParkAdmission {
+    pub(super) fn park(&mut self, key: DelegateKey, continuation: Continuation) -> ParkAdmission {
         if self.parked.len() >= MAX_PARKED_DELEGATES || self.parked.contains_key(&key) {
             tracing::warn!(
                 delegate = %key,

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -157,11 +157,14 @@ pub(super) const MAX_PARKED_DELEGATES: usize = 64;
 
 /// Cap on requests queued behind a single parked delegate.
 ///
-/// Overflow is REJECTED with a visible error, never silently dropped: the
-/// caller gets `ContractHandlerEvent::DelegateResponse` carrying nothing, which
-/// surfaces to the client as an empty response rather than a hang. A delegate
-/// with 8 requests already queued behind a prompt is not going to be helped by
-/// a ninth.
+/// Overflow is REJECTED, and the caller's responder is DROPPED so the client
+/// sees an error. It must NOT be answered with an empty `DelegateResponse`:
+/// that is what a delegate which ran and said nothing returns, so it would
+/// report success for work `process()` never performed. An earlier version of
+/// this comment described exactly that rejected behaviour — the code, and
+/// `a_request_refused_behind_a_full_pending_queue_errors_not_succeeds`, do the
+/// opposite. A delegate with 8 requests already queued behind a prompt is not
+/// going to be helped by a ninth.
 pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
 
 /// Cap on DISTINCT contracts with a coalesced notification pending behind one
@@ -305,55 +308,69 @@ fn delegate_container_bytes(delegate: &freenet_stdlib::prelude::DelegateContaine
 }
 
 fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
-    // Charged OUTSIDE the match, for every variant, via the stdlib accessor.
-    // `DelegateContext` runs to nearly 400 KiB, and a client can queue
-    // small-payload messages carrying large contexts behind a park while
-    // `parked_bytes` barely moves. Doing it here rather than in each arm is
-    // deliberate: this budget has now been wrong in six distinct ways, and a
-    // per-arm charge is a seventh spot to forget. A new variant cannot omit it.
-    let context = msg.get_context().map_or(0, |c| c.as_ref().len());
-    context
-        + match msg {
-            InboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
-            InboundDelegateMsg::GetContractResponse(r) => {
-                r.state.as_ref().map_or(0, |s| s.as_ref().len())
-            }
-            InboundDelegateMsg::ContractNotification(n) => n.new_state.as_ref().len(),
-            InboundDelegateMsg::UserResponse(r) => r.response.len(),
-            InboundDelegateMsg::DelegateMessage(m) => m.payload.len(),
-            // Put/Update/Subscribe responses carry only a small Result. The
-            // wildcard is required by `#[non_exhaustive]`; a future variant
-            // carrying bytes must be added above or it goes uncounted.
-            InboundDelegateMsg::PutContractResponse(_)
-            | InboundDelegateMsg::UpdateContractResponse(_)
-            | InboundDelegateMsg::SubscribeContractResponse(_)
-            | _ => 0,
+    // EXHAUSTIVE, PER VARIANT, IN THIS CRATE'S OWN MATCH.
+    //
+    // An earlier version routed the context charge through
+    // `InboundDelegateMsg::get_context()` on the theory that a stdlib accessor
+    // covering every variant made the charge impossible to forget. IT DOES NOT:
+    // that accessor ends in `_ => None`, and it does not list `UserResponse` at
+    // all — whose `context` is CLIENT-SUPPLIED and bounded only by
+    // `DelegateContext::MAX_SIZE` (~400 KiB). So the omission moved from an arm
+    // here into an arm in another crate, where it is invisible from this file
+    // and no compiler error can point at it.
+    //
+    // The lesson is narrow and worth keeping: delegating exhaustiveness to
+    // someone else's match is not a structural guarantee, it is the same hole
+    // one indirection away. Only a match the compiler checks HERE, against the
+    // variants this code actually retains, is one.
+    match msg {
+        InboundDelegateMsg::ApplicationMessage(m) => m.payload.len() + ctx_len(&m.context),
+        InboundDelegateMsg::GetContractResponse(r) => {
+            r.state.as_ref().map_or(0, |s| s.as_ref().len()) + ctx_len(&r.context)
         }
+        InboundDelegateMsg::ContractNotification(n) => {
+            n.new_state.as_ref().len() + ctx_len(&n.context)
+        }
+        // `response` is the client's answer bytes; `context` is separate and
+        // was charged zero until #5544 H2.
+        InboundDelegateMsg::UserResponse(r) => r.response.len() + ctx_len(&r.context),
+        InboundDelegateMsg::DelegateMessage(m) => m.payload.len() + ctx_len(&m.context),
+        // Small `Result` payloads, but their contexts are not small.
+        InboundDelegateMsg::PutContractResponse(r) => ctx_len(&r.context),
+        InboundDelegateMsg::UpdateContractResponse(r) => ctx_len(&r.context),
+        InboundDelegateMsg::SubscribeContractResponse(r) => ctx_len(&r.context),
+        // Required by `#[non_exhaustive]`. A new variant that carries bytes
+        // MUST be added above; this arm is the only thing between it and going
+        // uncounted, which is why the list is written out rather than delegated.
+        _ => 0,
+    }
 }
 
 fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
-    // Same structural charge as `inbound_bytes`: context first, for every
-    // variant, so it cannot be forgotten by an arm.
-    let context = msg.get_context().map_or(0, |c| c.as_ref().len());
-    context + outbound_payload_bytes(msg)
+    // Exhaustive per variant, for the same reason as `inbound_bytes`:
+    // `OutboundDelegateMsg::get_context()` also ends in `_ => None`, and the
+    // wildcard swallows `ContextUpdated` — whose entire payload IS a context,
+    // so routing through the accessor charged it 0 + 0. It accumulates across
+    // parks via `RunSeed.accumulated` for up to MAX_CONTRACT_REQUEST_ITERATIONS
+    // (#5544 H1).
+    match msg {
+        OutboundDelegateMsg::ApplicationMessage(m) => m.payload.len() + ctx_len(&m.context),
+        OutboundDelegateMsg::SendDelegateMessage(m) => m.payload.len() + ctx_len(&m.context),
+        OutboundDelegateMsg::ContextUpdated(c) => ctx_len(c),
+        OutboundDelegateMsg::RequestUserInput(r) => {
+            r.message.bytes().len() + r.responses.iter().map(|resp| resp.len()).sum::<usize>()
+        }
+        OutboundDelegateMsg::GetContractRequest(r) => ctx_len(&r.context),
+        OutboundDelegateMsg::PutContractRequest(r) => r.state.as_ref().len() + ctx_len(&r.context),
+        OutboundDelegateMsg::UpdateContractRequest(r) => ctx_len(&r.context),
+        OutboundDelegateMsg::SubscribeContractRequest(r) => ctx_len(&r.context),
+    }
 }
 
-fn outbound_payload_bytes(msg: &OutboundDelegateMsg) -> usize {
-    // The request variants never appear in `accumulated` — they are consumed by
-    // the run that produced them — and the rest carry no contract-controlled
-    // payload. Listed rather than wildcarded so a future payload-bearing
-    // variant has to be considered here.
-    match msg {
-        OutboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
-        OutboundDelegateMsg::SendDelegateMessage(m) => m.payload.len(),
-        // `ContextUpdated`'s payload IS its context, already charged above.
-        OutboundDelegateMsg::ContextUpdated(_)
-        | OutboundDelegateMsg::RequestUserInput(_)
-        | OutboundDelegateMsg::GetContractRequest(_)
-        | OutboundDelegateMsg::PutContractRequest(_)
-        | OutboundDelegateMsg::UpdateContractRequest(_)
-        | OutboundDelegateMsg::SubscribeContractRequest(_) => 0,
-    }
+/// Bytes a `DelegateContext` pins. Bounded by `DelegateContext::MAX_SIZE`
+/// (~400 KiB), which is why omitting it was worth two High findings.
+fn ctx_len(ctx: &DelegateContext) -> usize {
+    ctx.as_ref().len()
 }
 
 /// Backstop lifetime for a park.
@@ -650,19 +667,31 @@ struct ParkGuardPayload {
     resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
     delegate_key: DelegateKey,
     epoch: u64,
-    /// Prompt request ids this park owes a `UserResponse` for.
+    /// Prompt request ids this park owes a `UserResponse` for. A MULTISET:
+    /// `request_id` is chosen by delegate WASM, so `[7, 7]` is reachable.
     owed_prompts: Vec<u32>,
-    /// Upserts this park owes a Put/Update response for: `(contract, is_put)`.
+    /// Upserts this park owes a response for, as `(contract, is_put)`. Also a
+    /// MULTISET: `deferred_upserts` is built by two independent loops (PUTs and
+    /// UPDATEs) with no de-duplication, so `[(X,true),(X,false)]` and
+    /// `[(X,true),(X,true)]` are both reachable.
     owed_upserts: Vec<(ContractInstanceId, bool)>,
+    /// Where the off-loop task deposits results AS THEY COMPLETE. Shared with
+    /// the task rather than created inside it, so `Drop` can see work that
+    /// finished before a panic or cancellation (#5544 F2).
+    answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
+    fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
 }
 
 impl ParkGuard {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
         delegate_key: DelegateKey,
         epoch: u64,
         owed_prompts: Vec<u32>,
         owed_upserts: Vec<(ContractInstanceId, bool)>,
+        answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
+        fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
     ) -> Self {
         Self {
             payload: Some(ParkGuardPayload {
@@ -671,35 +700,37 @@ impl ParkGuard {
                 epoch,
                 owed_prompts,
                 owed_upserts,
+                answers,
+                fetches,
             }),
         }
     }
 
-    /// Deliver the resolved work. Consumes the payload so a later `Drop` is a
-    /// no-op (exactly-once).
-    pub(super) fn send(
-        mut self,
-        inbound: Vec<InboundDelegateMsg<'static>>,
-        upserts: Vec<ResolvedUpsert>,
-    ) {
+    /// Deliver whatever the task completed. Consumes the payload so a later
+    /// `Drop` is a no-op (exactly-once).
+    ///
+    /// Takes NO results: they are read from the shared sinks, so this path and
+    /// `Drop` see the same data by construction. An earlier version passed them
+    /// in, which is why `Drop` saw none (#5544 F2).
+    pub(super) fn send(mut self) {
         if let Some(p) = self.payload.take() {
-            Self::deliver(p, ResumeCause::Completed, inbound, upserts);
+            Self::deliver(p, ResumeCause::Completed);
         }
     }
 
-    fn deliver(
-        p: ParkGuardPayload,
-        cause: ResumeCause,
-        mut inbound: Vec<InboundDelegateMsg<'static>>,
-        upserts: Vec<ResolvedUpsert>,
-    ) {
+    fn deliver(p: ParkGuardPayload, cause: ResumeCause) {
         let ParkGuardPayload {
             resume_tx,
             delegate_key,
             epoch,
             owed_prompts,
             owed_upserts,
+            answers,
+            fetches,
         } = p;
+
+        let mut inbound = std::mem::take(&mut *answers.lock().unwrap());
+        let upserts = std::mem::take(&mut *fetches.lock().unwrap());
 
         // TERMINAL RESULTS ARE PRODUCED HERE, not in the task body, so that
         // EVERY exit produces them — including a panic or a cancellation, which
@@ -718,57 +749,46 @@ impl ParkGuard {
         // QUESTION NEEDS RE-ASKING IS INVISIBLE FROM EITHER SIDE OF IT. Nothing
         // at this `Drop` impl announces "you are now at a different level of
         // the same question", and nothing at the task body announced it either.
-        // Both the author and the reviewer would have caught it had the boundary
-        // been visible; neither did, because it was not. Keeping the synthesis
-        // inside this guard removes the need to see the boundary at all.
         //
-        // #5544 P1b/P2. A delegate left
-        // without a response for work it requested keeps a continuation the
-        // exclusion has already released, and if nothing else is delivered it
-        // is never re-entered at all.
-        //
-        // An empty `ClientResponse` is exactly what a dismissed or timed-out
-        // prompt yields on the normal path, so the delegate sees a shape it
-        // already handles.
-        let answered: std::collections::HashSet<u32> = inbound
-            .iter()
-            .filter_map(|m| match m {
-                InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
-                // Only `UserResponse` carries a request id to reconcile
-                // against `owed_prompts`. Listed rather than wildcarded so a
-                // future variant that carries one has to be considered here.
-                InboundDelegateMsg::ApplicationMessage(_)
-                | InboundDelegateMsg::GetContractResponse(_)
-                | InboundDelegateMsg::PutContractResponse(_)
-                | InboundDelegateMsg::UpdateContractResponse(_)
-                | InboundDelegateMsg::SubscribeContractResponse(_)
-                | InboundDelegateMsg::ContractNotification(_)
-                | InboundDelegateMsg::DelegateMessage(_)
-                | _ => None,
-            })
-            .collect();
+        // RECONCILED BY COUNT, NOT BY SET (#5544 F1/F3). Both owed lists are
+        // multisets — `request_id` is delegate-chosen, and two upserts can name
+        // one contract — so filtering by membership let ONE completion cancel
+        // the obligation for BOTH, and the delegate waited forever for a
+        // response nothing remained to produce. That is reachable on the
+        // ordinary budget-expiry path too, not just on panic, because partial
+        // results are delivered by design.
+        let mut answered: HashMap<u32, usize> = HashMap::new();
+        for msg in &inbound {
+            if let InboundDelegateMsg::UserResponse(r) = msg {
+                *answered.entry(r.request_id).or_default() += 1;
+            }
+        }
         for request_id in owed_prompts {
-            if !answered.contains(&request_id) {
-                inbound.push(InboundDelegateMsg::UserResponse(
+            match answered.get_mut(&request_id) {
+                Some(n) if *n > 0 => *n -= 1,
+                _ => inbound.push(InboundDelegateMsg::UserResponse(
                     freenet_stdlib::prelude::UserInputResponse {
                         request_id,
                         response: freenet_stdlib::prelude::ClientResponse::new(Vec::new()),
                         context: DelegateContext::default(),
                     },
-                ));
+                )),
             }
         }
 
-        // Upserts cannot be synthesized here — a `ResolvedUpsert` needs the
-        // `PendingUpsert` the task owns, which is gone by the time `Drop` runs.
-        // The unresolved ids travel instead, and `handle_delegate_resume` turns
-        // them into failure responses where it has `upsert_response_msg`.
-        let resolved: std::collections::HashSet<ContractInstanceId> =
-            upserts.iter().map(|r| *r.pending.key.id()).collect();
-        let unresolved_upserts: Vec<(ContractInstanceId, bool)> = owed_upserts
-            .into_iter()
-            .filter(|(id, _)| !resolved.contains(id))
-            .collect();
+        let mut resolved: HashMap<(ContractInstanceId, bool), usize> = HashMap::new();
+        for r in &upserts {
+            *resolved
+                .entry((*r.pending.key.id(), r.pending.is_put))
+                .or_default() += 1;
+        }
+        let mut unresolved_upserts = Vec::new();
+        for (id, is_put) in owed_upserts {
+            match resolved.get_mut(&(id, is_put)) {
+                Some(n) if *n > 0 => *n -= 1,
+                _ => unresolved_upserts.push((id, is_put)),
+            }
+        }
         if !unresolved_upserts.is_empty() {
             tracing::warn!(
                 delegate = %delegate_key,
@@ -778,6 +798,7 @@ impl ParkGuard {
                  waiting (#5544)"
             );
         }
+
         if resume_tx
             .send(DelegateResume {
                 delegate_key: delegate_key.clone(),
@@ -806,7 +827,7 @@ impl Drop for ParkGuard {
                  empty resume so the park terminates, its pending queue drains \
                  and the parked client is answered exactly once (#5544)"
             );
-            Self::deliver(p, ResumeCause::TimedOut, Vec::new(), Vec::new());
+            Self::deliver(p, ResumeCause::TimedOut);
         }
     }
 }
@@ -1640,6 +1661,89 @@ mod tests {
         );
     }
 
+    /// H1/H2: EVERY variant that can carry a context is charged for it.
+    ///
+    /// One test per variant, deliberately. The previous single test used
+    /// `ApplicationMessage` — the one variant the stdlib `get_context()`
+    /// accessor DOES cover — so it asserted the property on the only case that
+    /// already worked, while `UserResponse` (client-supplied, ~400 KiB) and
+    /// `ContextUpdated` (whose payload IS a context) were charged zero through
+    /// that accessor's `_ => None`.
+    ///
+    /// FALSIFY: drop any single `ctx_len(..)` term and its row here fails.
+    #[tokio::test]
+    async fn every_context_carrying_variant_is_charged() {
+        const N: usize = 64 * 1024;
+        let ctx = DelegateContext::new(vec![0u8; N]);
+        let cid = ContractInstanceId::new([1; 32]);
+
+        let inbound: Vec<(&str, InboundDelegateMsg<'static>)> = vec![
+            (
+                "ApplicationMessage",
+                InboundDelegateMsg::ApplicationMessage(
+                    freenet_stdlib::prelude::ApplicationMessage::new(Vec::new())
+                        .with_context(ctx.clone()),
+                ),
+            ),
+            (
+                // The one the accessor does not even list.
+                "UserResponse",
+                InboundDelegateMsg::UserResponse(freenet_stdlib::prelude::UserInputResponse {
+                    request_id: 1,
+                    response: freenet_stdlib::prelude::ClientResponse::new(Vec::new()),
+                    context: ctx.clone(),
+                }),
+            ),
+            (
+                "GetContractResponse",
+                InboundDelegateMsg::GetContractResponse(
+                    freenet_stdlib::prelude::GetContractResponse {
+                        contract_id: cid,
+                        state: None,
+                        context: ctx.clone(),
+                    },
+                ),
+            ),
+            (
+                "ContractNotification",
+                InboundDelegateMsg::ContractNotification(
+                    freenet_stdlib::prelude::ContractNotification {
+                        contract_id: cid,
+                        new_state: WrappedState::new(Vec::new()),
+                        context: ctx.clone(),
+                    },
+                ),
+            ),
+        ];
+        for (name, msg) in inbound {
+            let mut cont = continuation();
+            cont.inbound_so_far = vec![msg];
+            assert!(
+                continuation_bytes(&cont) >= N,
+                "{name}: its context must be charged; payload was empty, so only \
+                 the context makes this a real cost"
+            );
+        }
+
+        // Outbound: `ContextUpdated` is the accessor's other blind spot, and it
+        // accumulates across parks via `RunSeed.accumulated`.
+        let mut cont = continuation();
+        cont.accumulated = vec![OutboundDelegateMsg::ContextUpdated(ctx.clone())];
+        assert!(
+            continuation_bytes(&cont) >= N,
+            "ContextUpdated's payload IS a context and must be charged"
+        );
+
+        let mut cont = continuation();
+        cont.accumulated = vec![OutboundDelegateMsg::ApplicationMessage(
+            freenet_stdlib::prelude::ApplicationMessage::new(Vec::new()).with_context(ctx),
+        )];
+        assert!(
+            continuation_bytes(&cont) >= N,
+            "an outbound ApplicationMessage's context must be charged"
+        );
+    }
+
     /// P1a: the byte cap must charge what is actually RETAINED, including the
     /// payloads the off-loop task holds, not just what `Continuation` points at.
     ///
@@ -1693,25 +1797,155 @@ mod tests {
         );
     }
 
+    type Sinks = (
+        std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
+        std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
+    );
+
+    fn sinks() -> Sinks {
+        (Default::default(), Default::default())
+    }
+
+    fn answer(request_id: u32) -> InboundDelegateMsg<'static> {
+        InboundDelegateMsg::UserResponse(freenet_stdlib::prelude::UserInputResponse {
+            request_id,
+            response: freenet_stdlib::prelude::ClientResponse::new(b"allow".to_vec()),
+            context: DelegateContext::default(),
+        })
+    }
+
+    fn answered_ids(resume: &DelegateResume) -> Vec<u32> {
+        resume
+            .inbound
+            .iter()
+            .filter_map(|m| match m {
+                InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
+                #[allow(clippy::wildcard_enum_match_arm)]
+                _ => None,
+            })
+            .collect()
+    }
+
     #[tokio::test]
     async fn guard_delivers_exactly_one_resume_on_success() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let guard = ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new());
-        guard.send(Vec::new(), Vec::new());
+        let (answers, fetches) = sinks();
+        let guard = ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new(), answers, fetches);
+        guard.send();
         let resume = rx.recv().await.expect("one resume");
         assert_eq!(resume.cause, ResumeCause::Completed);
         assert!(rx.try_recv().is_err(), "must not deliver twice");
     }
 
+    /// The `Drop` path must SYNTHESIZE the terminal results it owes.
+    ///
+    /// The previous version of this test built the guard with EMPTY owed lists
+    /// and then asserted `resume.inbound.is_empty()`. That is correct for the
+    /// case it constructed and the exact OPPOSITE of what the code must do when
+    /// prompts are owed — so it pinned the ABSENCE of the behaviour, and a
+    /// reader took the assertion as the contract. Mutation testing found the
+    /// whole synthesis block could be deleted with the suite still green.
     #[tokio::test]
-    async fn guard_delivers_a_resume_when_dropped_before_sending() {
+    async fn drop_synthesizes_denials_for_everything_it_owes() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        // Simulates the spawned task being cancelled/panicking before it
-        // finished its work. Without this the park would never end: the
-        // pending queue would never drain and the client would hang.
-        drop(ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new()));
+        let (answers, fetches) = sinks();
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            vec![1, 2],
+            vec![(ContractInstanceId::new([3; 32]), true)],
+            answers,
+            fetches,
+        ));
         let resume = rx.recv().await.expect("drop must still resume the park");
         assert_eq!(resume.cause, ResumeCause::TimedOut);
-        assert!(resume.inbound.is_empty());
+        assert_eq!(
+            answered_ids(&resume),
+            vec![1, 2],
+            "every owed prompt must get a synthesized response, or the delegate \
+             waits forever for one nothing remains to produce"
+        );
+        assert_eq!(
+            resume.unresolved_upserts,
+            vec![(ContractInstanceId::new([3; 32]), true)],
+            "every owed upsert must be reported unresolved"
+        );
+    }
+
+    /// F2: answers a human ALREADY GAVE must survive the `Drop` path.
+    ///
+    /// The sinks used to be created inside the spawned future, so `Drop` saw
+    /// none of them and rewrote every owed prompt as a denial. The user clicks
+    /// Allow, the task panics, and the delegate is told denied.
+    #[tokio::test]
+    async fn drop_keeps_answers_already_given_rather_than_denying_them() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (answers, fetches) = sinks();
+        answers.lock().unwrap().push(answer(1)); // the human said allow
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            vec![1, 2],
+            Vec::new(),
+            answers,
+            fetches,
+        ));
+        let resume = rx.recv().await.expect("resume");
+        let kept: Vec<&InboundDelegateMsg<'static>> = resume
+            .inbound
+            .iter()
+            .filter(|m| matches!(m, InboundDelegateMsg::UserResponse(r) if r.request_id == 1))
+            .collect();
+        assert_eq!(kept.len(), 1, "exactly one response for request 1");
+        let InboundDelegateMsg::UserResponse(r) = kept[0] else {
+            unreachable!()
+        };
+        assert_eq!(
+            &r.response[..],
+            b"allow".as_slice(),
+            "the answer the human gave must survive, not be replaced by a denial"
+        );
+        assert_eq!(
+            answered_ids(&resume),
+            vec![1, 2],
+            "the unanswered one is still synthesized"
+        );
+    }
+
+    /// F1/F3: the reconciliation is over a MULTISET, not a set.
+    ///
+    /// `request_id` is chosen by delegate WASM, and `deferred_upserts` is built
+    /// by two independent loops with no de-duplication, so duplicates on both
+    /// lists are reachable. Filtering by membership let ONE completion cancel
+    /// the obligation for BOTH, and the second waited forever.
+    #[tokio::test]
+    async fn reconciliation_counts_duplicates_rather_than_matching_by_membership() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (answers, fetches) = sinks();
+        answers.lock().unwrap().push(answer(7)); // only ONE of the two owed
+        let contract = ContractInstanceId::new([9; 32]);
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            vec![7, 7],
+            vec![(contract, true), (contract, true)],
+            answers,
+            fetches,
+        ));
+        let resume = rx.recv().await.expect("resume");
+        assert_eq!(
+            answered_ids(&resume),
+            vec![7, 7],
+            "two owed prompts with the SAME id need two responses; matching by \
+             membership would have cancelled both obligations with one answer"
+        );
+        assert_eq!(
+            resume.unresolved_upserts.len(),
+            2,
+            "two owed upserts on one contract need two outcomes"
+        );
     }
 }

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -174,17 +174,36 @@ pub(super) const PARK_TTL: Duration = Duration::from_secs(90);
 /// the TTL stays what it is meant to be — unreachable in practice.
 pub(super) const PARK_WORK_BUDGET: Duration = Duration::from_secs(75);
 
-/// A delegate request that arrived while its delegate was parked.
+/// A delegate invocation that arrived while its delegate was parked.
 ///
 /// Held here rather than requeued into the fair queue: every delegate request
 /// shares the single `QueueKey::Default` lane (`fair_queue.rs`), so a
 /// pop-see-parked-repush cycle would busy-spin the loop.
-pub(super) struct PendingRequest {
-    pub id: EventId,
-    pub req: DelegateRequest<'static>,
-    pub origin_contract: Option<ContractInstanceId>,
-    pub connection_scope: ConnectionScope,
-    pub user_context: Option<UserSecretContext>,
+///
+/// Two variants because the two entry points differ in how their result is
+/// delivered, and a queued run must resume through the SAME path it would have
+/// taken had it not been queued. Collapsing them would route a notification's
+/// residual messages to a client responder that does not exist.
+pub(super) enum PendingRun {
+    /// Client-driven (`ContractHandlerEvent::DelegateRequest`). Answers `id`.
+    Client {
+        id: EventId,
+        req: DelegateRequest<'static>,
+        origin_contract: Option<ContractInstanceId>,
+        connection_scope: ConnectionScope,
+        user_context: Option<UserSecretContext>,
+    },
+    /// Contract-notification-driven. No client; residual `ApplicationMessage`s
+    /// fan out to the apps registered with the delegate.
+    ///
+    /// Queued rather than dropped, but note the delivered state may be STALE by
+    /// the time it drains — up to `PARK_TTL`. That is within the notification
+    /// pipeline's documented contract, which is explicitly best-effort and
+    /// lossy (`send_delegate_contract_notifications`: "Delegates that require
+    /// guaranteed delivery should poll contract state periodically"). Running
+    /// it immediately is NOT an option: it would clobber the parked
+    /// continuation's context, which is the whole reason for the exclusion.
+    Notification { req: DelegateRequest<'static> },
 }
 
 /// Where a resumed run's residual `ApplicationMessage`s must go.
@@ -232,7 +251,7 @@ pub(super) struct Continuation {
 struct ParkEntry {
     continuation: Continuation,
     parked_at: tokio::time::Instant,
-    pending: VecDeque<PendingRequest>,
+    pending: VecDeque<PendingRun>,
 }
 
 /// Why a park ended.
@@ -389,7 +408,7 @@ pub(super) enum QueueOutcome {
     Queued,
     /// The delegate's queue is full. The caller must answer this request with a
     /// visible error rather than dropping it.
-    Rejected(Box<PendingRequest>),
+    Rejected(Box<PendingRun>),
 }
 
 /// Loop-owned per-delegate park state.
@@ -457,7 +476,7 @@ impl DelegateParkCtx {
     /// Caller must have checked [`is_parked`](Self::is_parked); queueing for an
     /// unparked delegate is a caller bug and is reported back as a rejection so
     /// the request is still answered.
-    pub(super) fn queue_pending(&mut self, key: &DelegateKey, req: PendingRequest) -> QueueOutcome {
+    pub(super) fn queue_pending(&mut self, key: &DelegateKey, req: PendingRun) -> QueueOutcome {
         let Some(entry) = self.parked.get_mut(key) else {
             return QueueOutcome::Rejected(Box::new(req));
         };
@@ -505,10 +524,26 @@ impl DelegateParkCtx {
     pub(super) fn take(
         &mut self,
         key: &DelegateKey,
-    ) -> Option<(Continuation, VecDeque<PendingRequest>)> {
+    ) -> Option<(Continuation, VecDeque<PendingRun>)> {
         self.parked
             .remove(key)
             .map(|entry| (entry.continuation, entry.pending))
+    }
+
+    /// The earliest instant at which some park will reach [`PARK_TTL`], or
+    /// `None` when nothing is parked.
+    ///
+    /// The loop uses this to arm a timer in its idle `select!`. Without it the
+    /// backstop sweep only runs when some UNRELATED event happens to wake the
+    /// loop, so on a quiet node — the normal state for a background peer, and
+    /// exactly the condition under which a prompt goes unanswered because no
+    /// dashboard tab is open — a wedged park would never be swept. A backstop
+    /// whose firing depends on other traffic is not a backstop.
+    pub(super) fn next_sweep_deadline(&self) -> Option<tokio::time::Instant> {
+        self.parked
+            .values()
+            .map(|entry| entry.parked_at + PARK_TTL)
+            .min()
     }
 
     /// Keys whose park has outlived [`PARK_TTL`].
@@ -550,8 +585,8 @@ mod tests {
         }
     }
 
-    fn pending(byte: u8) -> PendingRequest {
-        PendingRequest {
+    fn pending(byte: u8) -> PendingRun {
+        PendingRun::Client {
             id: EventId { id: byte as u64 },
             req: DelegateRequest::ApplicationMessages {
                 key: key(byte),

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1217,7 +1217,9 @@ impl DelegateParkCtx {
     ///
     /// `already_delivered` is the loop's buffer of resumes it has taken off
     /// `delegate_resume_rx` but not yet run. **A park listed there must not be
-    /// swept**, and this is the load-bearing half of the signature (#5554).
+    /// swept**, and this is the load-bearing half of the signature. (Every
+    /// "#5554" below is the PR that added parking, where this was found in
+    /// review, not a typo for the #5544 issue the rest of this file cites.)
     /// The sweep ends a park WITHOUT consuming the off-loop task's
     /// [`ParkGuard`], so a resume that arrives afterwards is rejected by
     /// [`Self::take_matching`] on epoch and dropped — including everything it

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -707,14 +707,20 @@ impl ParkGuard {
         //
         // IF YOU ARE ADDING AN EXIT PATH, RE-ASK THE QUESTION HERE. "Answered on
         // every exit" is not a property you establish once for a change; it has
-        // to be re-asked at EVERY level that has exits, and having answered it
-        // at one level feels like having answered it. That is not hypothetical:
-        // the same change, in the same session, put an RAII guard on the prompt
-        // REGISTRY entry — correct "on every exit" reasoning — and then put the
-        // response synthesis one level up in the task body, where a panic never
-        // reaches it. The reasoning was right and was applied at one level and
-        // not the next. Keeping the synthesis inside this guard is what makes
-        // the property structural rather than remembered.
+        // to be re-asked at EVERY level that has exits. That is not
+        // hypothetical: the same change, in the same session, put an RAII guard
+        // on the prompt REGISTRY entry — correct "on every exit" reasoning —
+        // and then put the response synthesis one level up in the task body,
+        // where a panic never reaches it.
+        //
+        // The reason to make this structural rather than to rely on noticing is
+        // NOT that people are careless. It is that THE BOUNDARY WHERE THE
+        // QUESTION NEEDS RE-ASKING IS INVISIBLE FROM EITHER SIDE OF IT. Nothing
+        // at this `Drop` impl announces "you are now at a different level of
+        // the same question", and nothing at the task body announced it either.
+        // Both the author and the reviewer would have caught it had the boundary
+        // been visible; neither did, because it was not. Keeping the synthesis
+        // inside this guard removes the need to see the boundary at all.
         //
         // #5544 P1b/P2. A delegate left
         // without a response for work it requested keeps a continuation the

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -147,6 +147,18 @@ pub(super) const MAX_PARKED_DELEGATES: usize = 64;
 /// a ninth.
 pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
 
+/// Cap on DISTINCT contracts with a coalesced notification pending behind one
+/// park.
+///
+/// Notifications coalesce per contract, so this bounds the map by the number of
+/// contracts a delegate subscribes to rather than by message rate. In principle
+/// #5493 bounds subscriptions separately; this cap does not assume that has
+/// landed, because "bounded somewhere else" is the assumption that produced
+/// three wrong-scope bounds on this change already. Over the cap the NEW
+/// notification is dropped — the delegate will see that contract's next state
+/// change, which is the pipeline's standing contract.
+pub(super) const MAX_PENDING_NOTIFICATION_CONTRACTS: usize = 64;
+
 /// Cap on deferred related-contract fetches a single park may carry (#5544 S3).
 ///
 /// The client-driven path bounds its off-loop fetches with
@@ -192,6 +204,23 @@ pub(super) fn continuation_bytes(continuation: &Continuation) -> usize {
             .iter()
             .map(outbound_bytes)
             .sum::<usize>()
+}
+
+/// Approximate bytes a queued delegate request pins.
+pub(super) fn request_bytes(req: &DelegateRequest<'static>) -> usize {
+    // Only `ApplicationMessages` carries a payload; the registration variants
+    // do not. Listed alongside the `#[non_exhaustive]` wildcard so a future
+    // payload-bearing variant has to be considered here rather than silently
+    // counting as zero.
+    match req {
+        DelegateRequest::ApplicationMessages { inbound, .. } => {
+            inbound.iter().map(inbound_bytes).sum()
+        }
+        DelegateRequest::RegisterDelegate { .. }
+        | DelegateRequest::UnregisterDelegate(_)
+        | DelegateRequest::RegisterDelegateWithPredecessors { .. }
+        | _ => 0,
+    }
 }
 
 fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
@@ -297,7 +326,21 @@ pub(super) enum PendingRun {
     /// guaranteed delivery should poll contract state periodically"). Running
     /// it immediately is NOT an option: it would clobber the parked
     /// continuation's context, which is the whole reason for the exclusion.
-    Notification { req: DelegateRequest<'static> },
+    ///
+    /// COALESCED per contract rather than capped, and not counted against
+    /// [`MAX_PENDING_PER_DELEGATE`]. Rejecting the 9th notification would be a
+    /// silent loss landing on exactly the wrong population: ghostkeys parks on
+    /// prompts, so the rejection window is precisely when a user is
+    /// interacting, and Harvest with many address contracts subscribed would
+    /// lose payment notifications there. Coalescing is sound because the
+    /// notification contract is already "you will see the next state", so a
+    /// superseded notification carries nothing its successor does not.
+    Notification {
+        /// The contract whose change triggered this. Carried explicitly so
+        /// queued notifications can be COALESCED per contract.
+        contract_id: ContractInstanceId,
+        req: DelegateRequest<'static>,
+    },
 }
 
 /// Where a resumed run's residual `ApplicationMessage`s must go.
@@ -360,7 +403,17 @@ pub(super) struct Continuation {
 struct ParkEntry {
     continuation: Continuation,
     parked_at: tokio::time::Instant,
-    pending: VecDeque<PendingRun>,
+    /// Client requests, FIFO, capped by [`MAX_PENDING_PER_DELEGATE`]. Rejection
+    /// is acceptable here precisely because the caller can be TOLD.
+    pending_clients: VecDeque<PendingRun>,
+    /// Newest pending notification per contract. Superseded ones are dropped,
+    /// which loses nothing the successor does not carry.
+    pending_notifications: HashMap<ContractInstanceId, DelegateRequest<'static>>,
+    /// Bytes held by the queued items above, so they count toward
+    /// [`MAX_PARKED_BYTES`] like the continuation does. Without this the
+    /// coalescing map would be a fresh count-bounded-but-not-byte-bounded hole
+    /// of exactly the kind #5551 tracks: 64 contracts of 50 MB state is 3.2 GB.
+    pending_bytes: usize,
 }
 
 /// Why a park ended.
@@ -585,7 +638,9 @@ impl DelegateParkCtx {
             ParkEntry {
                 continuation,
                 parked_at: tokio::time::Instant::now(),
-                pending: VecDeque::new(),
+                pending_clients: VecDeque::new(),
+                pending_notifications: HashMap::new(),
+                pending_bytes: 0,
             },
         );
         ParkAdmission::Admitted
@@ -597,20 +652,95 @@ impl DelegateParkCtx {
     /// unparked delegate is a caller bug and is reported back as a rejection so
     /// the request is still answered.
     pub(super) fn queue_pending(&mut self, key: &DelegateKey, req: PendingRun) -> QueueOutcome {
+        let parked_bytes = self.parked_bytes;
         let Some(entry) = self.parked.get_mut(key) else {
             return QueueOutcome::Rejected(Box::new(req));
         };
-        if entry.pending.len() >= MAX_PENDING_PER_DELEGATE {
-            tracing::warn!(
-                delegate = %key,
-                queued = entry.pending.len(),
-                limit = MAX_PENDING_PER_DELEGATE,
-                "Delegate pending queue full while parked — rejecting request"
-            );
-            return QueueOutcome::Rejected(Box::new(req));
+
+        match req {
+            // COALESCE, do not reject. A superseded notification carries
+            // nothing its successor does not, so replacing is lossless in a way
+            // rejecting is not — and rejecting would land on ghostkeys and
+            // Harvest exactly when they are most active.
+            PendingRun::Notification { contract_id, req } => {
+                let bytes = request_bytes(&req);
+                let superseded = entry
+                    .pending_notifications
+                    .get(&contract_id)
+                    .map_or(0, request_bytes);
+                let is_new_contract =
+                    superseded == 0 && !entry.pending_notifications.contains_key(&contract_id);
+
+                if is_new_contract
+                    && entry.pending_notifications.len() >= MAX_PENDING_NOTIFICATION_CONTRACTS
+                {
+                    tracing::info!(
+                        delegate = %key,
+                        contract = %contract_id,
+                        limit = MAX_PENDING_NOTIFICATION_CONTRACTS,
+                        "Dropped a notification: too many distinct contracts already \
+                         queued behind this park"
+                    );
+                    return QueueOutcome::Rejected(Box::new(PendingRun::Notification {
+                        contract_id,
+                        req,
+                    }));
+                }
+
+                let projected = parked_bytes
+                    .saturating_add(bytes)
+                    .saturating_sub(superseded);
+                if projected > MAX_PARKED_BYTES {
+                    tracing::info!(
+                        delegate = %key,
+                        contract = %contract_id,
+                        parked_bytes,
+                        adding_bytes = bytes,
+                        byte_limit = MAX_PARKED_BYTES,
+                        "Dropped a notification: queueing it would exceed the parked \
+                         byte budget"
+                    );
+                    return QueueOutcome::Rejected(Box::new(PendingRun::Notification {
+                        contract_id,
+                        req,
+                    }));
+                }
+
+                entry.pending_bytes = entry.pending_bytes.saturating_add(bytes);
+                if let Some(old) = entry.pending_notifications.insert(contract_id, req) {
+                    let freed = request_bytes(&old);
+                    entry.pending_bytes = entry.pending_bytes.saturating_sub(freed);
+                    self.parked_bytes = self.parked_bytes.saturating_sub(freed);
+                    tracing::debug!(
+                        delegate = %key,
+                        contract = %contract_id,
+                        "Coalesced a superseded notification behind a park"
+                    );
+                }
+                self.parked_bytes = self.parked_bytes.saturating_add(bytes);
+                QueueOutcome::Queued
+            }
+            // Client requests keep the cap: over it, the caller is TOLD.
+            client => {
+                if entry.pending_clients.len() >= MAX_PENDING_PER_DELEGATE {
+                    tracing::warn!(
+                        delegate = %key,
+                        queued = entry.pending_clients.len(),
+                        limit = MAX_PENDING_PER_DELEGATE,
+                        "Delegate pending queue full while parked — rejecting request"
+                    );
+                    return QueueOutcome::Rejected(Box::new(client));
+                }
+                let bytes = match &client {
+                    PendingRun::Client { req, .. } => request_bytes(req),
+                    PendingRun::Notification { .. } => 0,
+                };
+                entry.pending_bytes = entry.pending_bytes.saturating_add(bytes);
+                self.parked_bytes = self.parked_bytes.saturating_add(bytes);
+                entry.pending_clients.push_back(client);
+                QueueOutcome::Queued
+            }
         }
-        entry.pending.push_back(req);
-        QueueOutcome::Queued
     }
 
     /// Hand the parked client's responder to a live park.
@@ -648,8 +778,20 @@ impl DelegateParkCtx {
         self.parked.remove(key).map(|entry| {
             self.parked_bytes = self
                 .parked_bytes
-                .saturating_sub(continuation_bytes(&entry.continuation));
-            (entry.continuation, entry.pending)
+                .saturating_sub(continuation_bytes(&entry.continuation))
+                .saturating_sub(entry.pending_bytes);
+            // Client requests first, then coalesced notifications. Clients have
+            // a caller waiting on a response; notifications do not, and their
+            // ordering is already approximate because coalescing drops
+            // superseded ones.
+            let mut pending: VecDeque<PendingRun> = entry.pending_clients;
+            pending.extend(
+                entry
+                    .pending_notifications
+                    .into_iter()
+                    .map(|(contract_id, req)| PendingRun::Notification { contract_id, req }),
+            );
+            (entry.continuation, pending)
         })
     }
 
@@ -809,6 +951,144 @@ mod tests {
         assert!(matches!(
             ctx.queue_pending(&key(1), pending(1)),
             QueueOutcome::Rejected(_)
+        ));
+    }
+
+    fn notification(contract: u8, state: &[u8]) -> PendingRun {
+        let contract_id = ContractInstanceId::new([contract; 32]);
+        PendingRun::Notification {
+            contract_id,
+            req: DelegateRequest::ApplicationMessages {
+                key: key(1),
+                params: Parameters::from(Vec::new()),
+                inbound: vec![InboundDelegateMsg::ContractNotification(
+                    freenet_stdlib::prelude::ContractNotification {
+                        contract_id,
+                        new_state: WrappedState::new(state.to_vec()),
+                        context: DelegateContext::default(),
+                    },
+                )],
+            },
+        }
+    }
+
+    fn queued_state(run: &PendingRun) -> Option<Vec<u8>> {
+        let PendingRun::Notification { req, .. } = run else {
+            return None;
+        };
+        let DelegateRequest::ApplicationMessages { inbound, .. } = req else {
+            return None;
+        };
+        #[allow(clippy::wildcard_enum_match_arm)]
+        inbound.iter().find_map(|m| match m {
+            InboundDelegateMsg::ContractNotification(n) => Some(n.new_state.as_ref().to_vec()),
+            _ => None,
+        })
+    }
+
+    /// Notifications COALESCE per contract instead of being rejected at the
+    /// client queue's cap.
+    ///
+    /// Rejecting them would be a silent loss — a notification has no caller to
+    /// return an error to — and it would land on exactly the wrong population:
+    /// ghostkeys parks on prompts, so the window is precisely when a user is
+    /// interacting, and Harvest with many address contracts subscribed would
+    /// lose payment notifications there.
+    #[tokio::test]
+    async fn notifications_coalesce_per_contract_rather_than_being_rejected() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+        ctx.park(k.clone(), continuation());
+
+        // Far more than MAX_PENDING_PER_DELEGATE, all for ONE contract.
+        for i in 0..(MAX_PENDING_PER_DELEGATE as u8 + 12) {
+            assert!(
+                matches!(
+                    ctx.queue_pending(&k, notification(7, &[i])),
+                    QueueOutcome::Queued
+                ),
+                "a notification must never be rejected for queue depth; \
+                 superseded ones coalesce"
+            );
+        }
+
+        let (_cont, pending) = ctx.take(&k).expect("park present");
+        assert_eq!(
+            pending.len(),
+            1,
+            "notifications for one contract must collapse to a single pending run"
+        );
+        assert_eq!(
+            queued_state(&pending[0]),
+            Some(vec![MAX_PENDING_PER_DELEGATE as u8 + 11]),
+            "the NEWEST notification must win; a superseded one carries nothing \
+             its successor does not"
+        );
+    }
+
+    /// A full client queue must not block notifications: the two lanes are
+    /// separate, because only one of them has a caller that can be told.
+    #[tokio::test]
+    async fn a_full_client_queue_does_not_reject_notifications() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+        ctx.park(k.clone(), continuation());
+
+        for i in 0..MAX_PENDING_PER_DELEGATE {
+            assert!(matches!(
+                ctx.queue_pending(&k, pending(i as u8)),
+                QueueOutcome::Queued
+            ));
+        }
+        assert!(
+            matches!(
+                ctx.queue_pending(&k, pending(99)),
+                QueueOutcome::Rejected(_)
+            ),
+            "client requests still hit the cap — the caller can be told"
+        );
+        assert!(
+            matches!(
+                ctx.queue_pending(&k, notification(3, b"x")),
+                QueueOutcome::Queued
+            ),
+            "a notification must still be accepted with the client queue full"
+        );
+
+        let (_cont, pending_runs) = ctx.take(&k).expect("park present");
+        assert_eq!(
+            pending_runs.len(),
+            MAX_PENDING_PER_DELEGATE + 1,
+            "clients plus the coalesced notification"
+        );
+    }
+
+    /// Distinct contracts are capped, so the coalescing map cannot grow without
+    /// bound if subscriptions are not limited elsewhere.
+    #[tokio::test]
+    async fn distinct_notification_contracts_are_capped() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+        ctx.park(k.clone(), continuation());
+
+        for i in 0..MAX_PENDING_NOTIFICATION_CONTRACTS {
+            assert!(matches!(
+                ctx.queue_pending(&k, notification(i as u8, b"s")),
+                QueueOutcome::Queued
+            ));
+        }
+        assert!(
+            matches!(
+                ctx.queue_pending(&k, notification(250, b"s")),
+                QueueOutcome::Rejected(_)
+            ),
+            "a NEW contract past the cap is refused; the delegate will see that \
+             contract's next state change"
+        );
+        // An already-queued contract still coalesces at the cap.
+        assert!(matches!(
+            ctx.queue_pending(&k, notification(0, b"newer")),
+            QueueOutcome::Queued
         ));
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -114,6 +114,20 @@ pub(super) struct PendingRequest {
     pub user_context: Option<UserSecretContext>,
 }
 
+/// Where a resumed run's residual `ApplicationMessage`s must go.
+///
+/// The two entry points differ: a client-driven run answers the parked client
+/// responder (so the client sees ONE response covering the whole round-trip,
+/// exactly as it does today when the loop blocks), while a
+/// notification-driven run has no client and fans out to the apps registered
+/// with the delegate — the same route `handle_delegate_notification` already
+/// uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Delivery {
+    Client,
+    Apps,
+}
+
 /// Everything needed to re-enter a parked delegate on a later loop iteration.
 ///
 /// `params` is carried explicitly and is NOT optional: `DelegateKey` identity
@@ -133,8 +147,12 @@ pub(super) struct Continuation {
     /// Responses already computed for this iteration, awaiting the parked one.
     pub inbound_so_far: Vec<InboundDelegateMsg<'static>>,
     /// The parked client's responder, if this run descends from a client
-    /// request. `None` for a notification-driven run, which has no client.
+    /// request. Attached by the caller immediately after parking (it owns the
+    /// channel the responder is taken from), and re-attached by the resume
+    /// handler if the resumed run parks again — a delegate that prompts twice
+    /// in a row must not strand its client.
     pub responder: Option<StashedResponder>,
+    pub delivery: Delivery,
 }
 
 /// One parked delegate.
@@ -265,14 +283,24 @@ pub(super) enum QueueOutcome {
 }
 
 /// Loop-owned per-delegate park state.
-#[derive(Default)]
 pub(super) struct DelegateParkCtx {
     parked: HashMap<DelegateKey, ParkEntry>,
+    /// Handed to each [`ParkGuard`] so an off-loop task can deliver its resume.
+    /// Kept here rather than threaded separately so every call site needs only
+    /// a single `&mut DelegateParkCtx`.
+    resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
 }
 
 impl DelegateParkCtx {
-    pub(super) fn new() -> Self {
-        Self::default()
+    pub(super) fn new(resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>) -> Self {
+        Self {
+            parked: HashMap::new(),
+            resume_tx,
+        }
+    }
+
+    pub(super) fn resume_tx(&self) -> &tokio::sync::mpsc::UnboundedSender<DelegateResume> {
+        &self.resume_tx
     }
 
     /// `true` if this delegate currently has a parked continuation, and so must
@@ -281,6 +309,7 @@ impl DelegateParkCtx {
         self.parked.contains_key(key)
     }
 
+    #[cfg(test)]
     pub(super) fn parked_count(&self) -> usize {
         self.parked.len()
     }
@@ -339,6 +368,33 @@ impl DelegateParkCtx {
         QueueOutcome::Queued
     }
 
+    /// Hand the parked client's responder to a live park.
+    ///
+    /// Separate from [`park`](Self::park) because the responder is taken from
+    /// the contract-handler channel, which the caller owns and this registry
+    /// deliberately knows nothing about. A `None` responder (client already
+    /// gone) is stored as-is: the park still has to terminate.
+    pub(super) fn attach_responder(
+        &mut self,
+        key: &DelegateKey,
+        responder: Option<StashedResponder>,
+    ) {
+        match self.parked.get_mut(key) {
+            Some(entry) => entry.continuation.responder = responder,
+            None => {
+                // Unreachable: the caller attaches immediately after a
+                // successful park, on the same loop iteration, and nothing
+                // else can end a park in between. Log rather than panic — a
+                // dropped response is recoverable, a panicked loop is not.
+                tracing::error!(
+                    delegate = %key,
+                    "attach_responder for a delegate that is not parked; the \
+                     client for this run will not be answered"
+                );
+            }
+        }
+    }
+
     /// End a park, returning its continuation and everything queued behind it.
     pub(super) fn take(
         &mut self,
@@ -384,6 +440,7 @@ mod tests {
             accumulated: Vec::new(),
             inbound_so_far: Vec::new(),
             responder: None,
+            delivery: Delivery::Client,
         }
     }
 
@@ -401,9 +458,17 @@ mod tests {
         }
     }
 
+    fn ctx() -> (
+        DelegateParkCtx,
+        tokio::sync::mpsc::UnboundedReceiver<DelegateResume>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (DelegateParkCtx::new(tx), rx)
+    }
+
     #[tokio::test]
     async fn park_then_take_round_trips() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         let k = key(1);
         assert!(!ctx.is_parked(&k));
         assert!(matches!(
@@ -418,7 +483,7 @@ mod tests {
 
     #[tokio::test]
     async fn node_wide_cap_refuses_and_hands_the_continuation_back() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         for i in 0..MAX_PARKED_DELEGATES {
             assert!(matches!(
                 ctx.park(key(i as u8), continuation()),
@@ -437,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn double_park_is_refused_not_clobbered() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         let k = key(1);
         assert!(matches!(
             ctx.park(k.clone(), continuation()),
@@ -454,7 +519,7 @@ mod tests {
 
     #[tokio::test]
     async fn pending_queue_is_capped_and_overflow_is_returned_not_dropped() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         let k = key(1);
         ctx.park(k.clone(), continuation());
         for i in 0..MAX_PENDING_PER_DELEGATE {
@@ -475,7 +540,7 @@ mod tests {
 
     #[tokio::test]
     async fn queueing_for_an_unparked_delegate_returns_the_request() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         assert!(matches!(
             ctx.queue_pending(&key(1), pending(1)),
             QueueOutcome::Rejected(_)
@@ -484,7 +549,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn park_expires_only_after_the_ttl() {
-        let mut ctx = DelegateParkCtx::new();
+        let (mut ctx, _rx) = ctx();
         let k = key(1);
         ctx.park(k.clone(), continuation());
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -174,7 +174,14 @@ pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
 /// three wrong-scope bounds on this change already. Over the cap the NEW
 /// notification is dropped — the delegate will see that contract's next state
 /// change, which is the pipeline's standing contract.
-pub(super) const MAX_PENDING_NOTIFICATION_CONTRACTS: usize = 64;
+///
+/// 16 rather than something larger because this lane also sets the worst-case
+/// burst when a park is torn down: one resume runs `1 +
+/// MAX_PENDING_PER_DELEGATE + MAX_PENDING_NOTIFICATION_CONTRACTS` delegate runs
+/// before the fair queue gets a turn (#5544 M6). At 16 that is 25, against a
+/// `MAX_RESUME_DRAIN_BATCH` of 16 — one over-long batch at park tear-down,
+/// which cannot repeat until another park forms. At 64 it was 73.
+pub(super) const MAX_PENDING_NOTIFICATION_CONTRACTS: usize = 16;
 
 /// Cap on deferred related-contract fetches a single park may carry (#5544 S3).
 ///
@@ -221,23 +228,76 @@ pub(super) fn continuation_bytes(continuation: &Continuation) -> usize {
             .iter()
             .map(outbound_bytes)
             .sum::<usize>()
+        // `params` is delegate-supplied and retained for the life of the park.
+        // Omitting it was one of three ways this "byte bound" failed to bound.
+        + continuation.params.as_ref().len()
+}
+
+/// Approximate bytes an off-loop task retains for one park: the prompts it is
+/// driving and the upserts whose related contracts it is fetching.
+///
+/// Charged at admission because the task holds these for exactly as long as the
+/// park exists, and a single `PendingUpsert` can own a full state plus related
+/// contracts plus contract code. `MAX_DEFERRED_UPSERTS_PER_PARK` caps the
+/// COUNT of those, which is the same unit mismatch one level down.
+pub(super) fn task_bytes(
+    prompts: &[freenet_stdlib::prelude::UserInputRequest<'static>],
+    upserts: &[PendingUpsert],
+) -> usize {
+    let prompt_bytes: usize = prompts
+        .iter()
+        .map(|r| r.message.bytes().len() + r.responses.iter().map(|resp| resp.len()).sum::<usize>())
+        .sum();
+    let upsert_bytes: usize = upserts
+        .iter()
+        .map(|u| {
+            let update = match &u.update {
+                Either::Left(state) => state.as_ref().len(),
+                Either::Right(delta) => delta.as_ref().len(),
+            };
+            let code = u
+                .code
+                .as_ref()
+                .map_or(0, |c| c.data().len() + c.params().as_ref().len());
+            let related: usize = u
+                .related_contracts
+                .clone()
+                .into_owned()
+                .states()
+                .map(|(_, st)| st.as_ref().map_or(0, |s| s.as_ref().len()))
+                .sum();
+            update + code + related
+        })
+        .sum();
+    prompt_bytes + upsert_bytes
 }
 
 /// Approximate bytes a queued delegate request pins.
 pub(super) fn request_bytes(req: &DelegateRequest<'static>) -> usize {
-    // Only `ApplicationMessages` carries a payload; the registration variants
-    // do not. Listed alongside the `#[non_exhaustive]` wildcard so a future
-    // payload-bearing variant has to be considered here rather than silently
-    // counting as zero.
+    // The registration variants are NOT free: `RegisterDelegate` carries a whole
+    // `DelegateContainer`, i.e. the delegate's WASM, and `DelegateRequest::key()`
+    // returns that delegate's own key — so a re-registration really does queue
+    // behind that delegate's park. An earlier version of this comment asserted
+    // the opposite of the type definition and charged them zero, which is 8 per
+    // park x 64 parks = 512 delegate modules at a counted cost of nothing.
     match req {
-        DelegateRequest::ApplicationMessages { inbound, .. } => {
-            inbound.iter().map(inbound_bytes).sum()
-        }
-        DelegateRequest::RegisterDelegate { .. }
-        | DelegateRequest::UnregisterDelegate(_)
-        | DelegateRequest::RegisterDelegateWithPredecessors { .. }
-        | _ => 0,
+        DelegateRequest::ApplicationMessages {
+            inbound, params, ..
+        } => inbound.iter().map(inbound_bytes).sum::<usize>() + params.as_ref().len(),
+        DelegateRequest::RegisterDelegate { delegate, .. } => delegate_container_bytes(delegate),
+        DelegateRequest::RegisterDelegateWithPredecessors {
+            delegate,
+            predecessors,
+            ..
+        } => delegate_container_bytes(delegate) + predecessors.len() * 64,
+        DelegateRequest::UnregisterDelegate(_) | _ => 0,
     }
+}
+
+fn delegate_container_bytes(delegate: &freenet_stdlib::prelude::DelegateContainer) -> usize {
+    // `DelegateContainer` exposes the code but not the parameters directly;
+    // the code is the large part (the WASM) and is what matters for the bound.
+    delegate.code().as_ref().len()
 }
 
 fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
@@ -267,8 +327,12 @@ fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
     match msg {
         OutboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
         OutboundDelegateMsg::SendDelegateMessage(m) => m.payload.len(),
+        // NOT zero: `DelegateContext::MAX_SIZE` is 409,600 bytes, and these
+        // accumulate through park -> resume -> re-park via `RunSeed` for up to
+        // MAX_CONTRACT_REQUEST_ITERATIONS, which is ~40 MB per park if
+        // uncounted.
+        OutboundDelegateMsg::ContextUpdated(ctx) => ctx.as_ref().len(),
         OutboundDelegateMsg::RequestUserInput(_)
-        | OutboundDelegateMsg::ContextUpdated(_)
         | OutboundDelegateMsg::GetContractRequest(_)
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
@@ -419,7 +483,15 @@ pub(super) struct Continuation {
 /// One parked delegate.
 struct ParkEntry {
     continuation: Continuation,
+    /// Identity of THIS park; see [`DelegateResume::epoch`].
+    epoch: u64,
     parked_at: tokio::time::Instant,
+    /// Bytes retained by the OFF-LOOP TASK for this park — the prompts and the
+    /// deferred upserts it is holding. Not part of the continuation, but
+    /// retained for exactly as long, and each `PendingUpsert` can own a full
+    /// state plus related contracts and code. Charged so the byte cap bounds
+    /// what is actually held rather than only what this struct points at.
+    task_bytes: usize,
     /// Client requests, FIFO, capped by [`MAX_PENDING_PER_DELEGATE`]. Rejection
     /// is acceptable here precisely because the caller can be TOLD.
     pending_clients: VecDeque<PendingRun>,
@@ -473,6 +545,17 @@ pub(super) struct ResolvedUpsert {
 /// Sent from an off-loop task back to the `contract_handling` loop.
 pub(super) struct DelegateResume {
     pub delegate_key: DelegateKey,
+    /// Which PARK this resume belongs to (#5544 H1).
+    ///
+    /// A park is identified by `(key, epoch)`, not by key alone. The TTL
+    /// backstop ends a park by force-resuming it WITHOUT consuming the off-loop
+    /// task's `ParkGuard`, so that guard still owes a resume. If the delegate
+    /// has re-parked by the time it arrives, matching on key alone would hand
+    /// the OLD continuation's messages to the NEW park — the cross-round-trip
+    /// context corruption this whole mechanism exists to prevent, reached
+    /// through the backstop itself. The epoch makes the stale resume
+    /// identifiable and droppable.
+    pub epoch: u64,
     pub cause: ResumeCause,
     /// Messages that are ready to feed straight back into the delegate (the
     /// prompt path). Empty on a dropped or timed-out park, which still resumes
@@ -504,17 +587,20 @@ pub(super) struct ParkGuard {
 struct ParkGuardPayload {
     resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
     delegate_key: DelegateKey,
+    epoch: u64,
 }
 
 impl ParkGuard {
     pub(super) fn new(
         resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
         delegate_key: DelegateKey,
+        epoch: u64,
     ) -> Self {
         Self {
             payload: Some(ParkGuardPayload {
                 resume_tx,
                 delegate_key,
+                epoch,
             }),
         }
     }
@@ -540,10 +626,12 @@ impl ParkGuard {
         let ParkGuardPayload {
             resume_tx,
             delegate_key,
+            epoch,
         } = p;
         if resume_tx
             .send(DelegateResume {
                 delegate_key: delegate_key.clone(),
+                epoch,
                 cause,
                 inbound,
                 upserts,
@@ -574,8 +662,9 @@ impl Drop for ParkGuard {
 
 /// Outcome of asking to park a delegate.
 pub(super) enum ParkAdmission {
-    /// Parked. The caller must spawn the off-loop work with a [`ParkGuard`].
-    Admitted,
+    /// Parked. The caller must spawn the off-loop work with a [`ParkGuard`]
+    /// carrying this `epoch`, so a stale resume can be told from a live one.
+    Admitted { epoch: u64 },
     /// Refused (node-wide cap). The caller keeps the old inline behaviour;
     /// the continuation is handed back so nothing is lost.
     Refused(Box<Continuation>),
@@ -593,12 +682,30 @@ pub(super) enum QueueOutcome {
 /// Loop-owned per-delegate park state.
 pub(super) struct DelegateParkCtx {
     parked: HashMap<DelegateKey, ParkEntry>,
-    /// Running total of `continuation_bytes` across live parks (#5544 S4).
+    /// Running total of every retained payload across live parks (#5544 S4):
+    /// continuations, off-loop task work, and queued pending runs.
     parked_bytes: usize,
+    /// Source of park identities; see [`DelegateResume::epoch`].
+    next_epoch: u64,
+    /// Refusal counters, per cause (L9). A refusal that is only logged is a
+    /// clean zero to anything reading metrics — the same pattern this branch
+    /// fixed for the over-cap client request.
+    refused: RefusalCounts,
     /// Handed to each [`ParkGuard`] so an off-loop task can deliver its resume.
     /// Kept here rather than threaded separately so every call site needs only
     /// a single `&mut DelegateParkCtx`.
     resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
+}
+
+/// Why parked work was turned away, counted rather than only logged (L9).
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RefusalCounts {
+    /// Parks refused at the node-wide count or byte cap.
+    pub parks: u64,
+    /// Client requests refused because the pending queue was full or over budget.
+    pub client_requests: u64,
+    /// Notifications dropped at the distinct-contract cap or the byte budget.
+    pub notifications: u64,
 }
 
 impl DelegateParkCtx {
@@ -606,6 +713,8 @@ impl DelegateParkCtx {
         Self {
             parked: HashMap::new(),
             parked_bytes: 0,
+            next_epoch: 0,
+            refused: RefusalCounts::default(),
             resume_tx,
         }
     }
@@ -620,6 +729,25 @@ impl DelegateParkCtx {
         self.parked.contains_key(key)
     }
 
+    /// The live epoch for `key`, for tests that need to end a park they did not
+    /// capture the epoch from. Deliberately test-only: production code always
+    /// has the epoch from `ParkAdmission::Admitted` or the resume itself, and a
+    /// helper that looked one up by key would defeat the identity check.
+    /// Snapshot of what has been turned away, by cause.
+    ///
+    /// The running totals also ride on each refusal's own `warn!`/`info!`, so
+    /// production observability does not depend on anything calling this; this
+    /// accessor is what lets a test pin that the counting happens at all.
+    #[cfg(test)]
+    pub(super) fn refusals(&self) -> RefusalCounts {
+        self.refused
+    }
+
+    #[cfg(test)]
+    pub(super) fn epoch_of(&self, key: &DelegateKey) -> Option<u64> {
+        self.parked.get(key).map(|e| e.epoch)
+    }
+
     #[cfg(test)]
     pub(super) fn parked_count(&self) -> usize {
         self.parked.len()
@@ -631,8 +759,14 @@ impl DelegateParkCtx {
     /// guarantees only one round-trip per delegate is ever in flight, so this
     /// is unreachable by construction and is treated as a refusal rather than
     /// silently clobbering the live continuation.
-    pub(super) fn park(&mut self, key: DelegateKey, continuation: Continuation) -> ParkAdmission {
-        let bytes = continuation_bytes(&continuation);
+    pub(super) fn park(
+        &mut self,
+        key: DelegateKey,
+        continuation: Continuation,
+        // Bytes the off-loop task will retain for this park (see [`task_bytes`]).
+        task_bytes: usize,
+    ) -> ParkAdmission {
+        let bytes = continuation_bytes(&continuation).saturating_add(task_bytes);
         let over_bytes = self.parked_bytes.saturating_add(bytes) > MAX_PARKED_BYTES;
         if self.parked.len() >= MAX_PARKED_DELEGATES || self.parked.contains_key(&key) || over_bytes
         {
@@ -645,22 +779,28 @@ impl DelegateParkCtx {
                 byte_limit = MAX_PARKED_BYTES,
                 over_bytes,
                 already_parked = self.parked.contains_key(&key),
+                total_refused_parks = self.refused.parks.saturating_add(1),
                 "Refusing to park delegate; falling back to the inline path"
             );
+            self.refused.parks = self.refused.parks.saturating_add(1);
             return ParkAdmission::Refused(Box::new(continuation));
         }
         self.parked_bytes = self.parked_bytes.saturating_add(bytes);
+        let epoch = self.next_epoch;
+        self.next_epoch = self.next_epoch.wrapping_add(1);
         self.parked.insert(
             key,
             ParkEntry {
                 continuation,
+                epoch,
+                task_bytes,
                 parked_at: tokio::time::Instant::now(),
                 pending_clients: VecDeque::new(),
                 pending_notifications: HashMap::new(),
                 pending_bytes: 0,
             },
         );
-        ParkAdmission::Admitted
+        ParkAdmission::Admitted { epoch }
     }
 
     /// Queue a request that arrived for a parked delegate.
@@ -685,8 +825,10 @@ impl DelegateParkCtx {
                     .pending_notifications
                     .get(&contract_id)
                     .map_or(0, request_bytes);
-                let is_new_contract =
-                    superseded == 0 && !entry.pending_notifications.contains_key(&contract_id);
+                // `contains_key` alone is the question. An earlier
+                // `superseded == 0 &&` conjunct was dead weight that also read
+                // as if a zero-byte entry were no entry (L11).
+                let is_new_contract = !entry.pending_notifications.contains_key(&contract_id);
 
                 if is_new_contract
                     && entry.pending_notifications.len() >= MAX_PENDING_NOTIFICATION_CONTRACTS
@@ -695,9 +837,11 @@ impl DelegateParkCtx {
                         delegate = %key,
                         contract = %contract_id,
                         limit = MAX_PENDING_NOTIFICATION_CONTRACTS,
+                        total_dropped = self.refused.notifications.saturating_add(1),
                         "Dropped a notification: too many distinct contracts already \
                          queued behind this park"
                     );
+                    self.refused.notifications = self.refused.notifications.saturating_add(1);
                     return QueueOutcome::Rejected(Box::new(PendingRun::Notification {
                         contract_id,
                         req,
@@ -714,9 +858,11 @@ impl DelegateParkCtx {
                         parked_bytes,
                         adding_bytes = bytes,
                         byte_limit = MAX_PARKED_BYTES,
+                        total_dropped = self.refused.notifications.saturating_add(1),
                         "Dropped a notification: queueing it would exceed the parked \
                          byte budget"
                     );
+                    self.refused.notifications = self.refused.notifications.saturating_add(1);
                     return QueueOutcome::Rejected(Box::new(PendingRun::Notification {
                         contract_id,
                         req,
@@ -744,14 +890,36 @@ impl DelegateParkCtx {
                         delegate = %key,
                         queued = entry.pending_clients.len(),
                         limit = MAX_PENDING_PER_DELEGATE,
+                        total_refused = self.refused.client_requests.saturating_add(1),
                         "Delegate pending queue full while parked — rejecting request"
                     );
+                    self.refused.client_requests = self.refused.client_requests.saturating_add(1);
                     return QueueOutcome::Rejected(Box::new(client));
                 }
                 let bytes = match &client {
                     PendingRun::Client { req, .. } => request_bytes(req),
                     PendingRun::Notification { .. } => 0,
                 };
+                // Check the PROJECTED total BEFORE inserting. Adding first and
+                // checking never was worse than an overshoot: once
+                // `parked_bytes` passed the cap, `park()` refused EVERY delegate
+                // node-wide and everything fell back to inline stalls, so one
+                // local app pushing large ApplicationMessages behind a single
+                // park could disable parking for the whole node — reinstating
+                // the exact stall this change removes.
+                if parked_bytes.saturating_add(bytes) > MAX_PARKED_BYTES {
+                    tracing::warn!(
+                        delegate = %key,
+                        parked_bytes,
+                        adding_bytes = bytes,
+                        byte_limit = MAX_PARKED_BYTES,
+                        total_refused = self.refused.client_requests.saturating_add(1),
+                        "Refusing to queue a delegate request: it would exceed the \
+                         parked byte budget"
+                    );
+                    self.refused.client_requests = self.refused.client_requests.saturating_add(1);
+                    return QueueOutcome::Rejected(Box::new(client));
+                }
                 entry.pending_bytes = entry.pending_bytes.saturating_add(bytes);
                 self.parked_bytes = self.parked_bytes.saturating_add(bytes);
                 entry.pending_clients.push_back(client);
@@ -788,14 +956,38 @@ impl DelegateParkCtx {
     }
 
     /// End a park, returning its continuation and everything queued behind it.
-    pub(super) fn take(
+    /// End the park identified by `(key, epoch)`.
+    ///
+    /// Returns `None` when the epoch does not match — a STALE resume, from an
+    /// off-loop task whose park was already ended by the TTL backstop and whose
+    /// delegate has since re-parked. Matching on key alone would feed the old
+    /// continuation's messages into the new park (#5544 H1).
+    pub(super) fn take_matching(
         &mut self,
         key: &DelegateKey,
+        epoch: u64,
     ) -> Option<(Continuation, VecDeque<PendingRun>)> {
+        match self.parked.get(key) {
+            Some(entry) if entry.epoch == epoch => {}
+            Some(entry) => {
+                tracing::warn!(
+                    delegate = %key,
+                    stale_epoch = epoch,
+                    live_epoch = entry.epoch,
+                    "Dropping a STALE park resume: this delegate re-parked after \
+                     its previous park was force-resumed by the TTL backstop. \
+                     Absorbing it would feed the old continuation's messages to \
+                     the new park (#5544 H1)"
+                );
+                return None;
+            }
+            None => return None,
+        }
         self.parked.remove(key).map(|entry| {
             self.parked_bytes = self
                 .parked_bytes
                 .saturating_sub(continuation_bytes(&entry.continuation))
+                .saturating_sub(entry.task_bytes)
                 .saturating_sub(entry.pending_bytes);
             // Client requests first, then coalesced notifications. Clients have
             // a caller waiting on a response; notifications do not, and their
@@ -833,12 +1025,18 @@ impl DelegateParkCtx {
     /// Returned rather than acted on so the caller (which owns the executor and
     /// the channel) performs the force-resume; this keeps the registry a pure
     /// data structure and unit-testable without a loop.
-    pub(super) fn expired(&self, now: tokio::time::Instant) -> Vec<DelegateKey> {
-        self.parked
+    pub(super) fn expired(&self, now: tokio::time::Instant) -> Vec<(DelegateKey, u64)> {
+        let mut out: Vec<(DelegateKey, u64)> = self
+            .parked
             .iter()
             .filter(|(_, entry)| now.duration_since(entry.parked_at) >= PARK_TTL)
-            .map(|(key, _)| key.clone())
-            .collect()
+            .map(|(key, entry)| (key.clone(), entry.epoch))
+            .collect();
+        // Deterministic order: `HashMap` iteration is arbitrary, and a sweep
+        // that force-resumes several parks should not do so in a different
+        // order run to run (L7).
+        out.sort_by_key(|(_, epoch)| *epoch);
+        out
     }
 }
 
@@ -896,11 +1094,13 @@ mod tests {
         let k = key(1);
         assert!(!ctx.is_parked(&k));
         assert!(matches!(
-            ctx.park(k.clone(), continuation()),
-            ParkAdmission::Admitted
+            ctx.park(k.clone(), continuation(), 0),
+            ParkAdmission::Admitted { .. }
         ));
         assert!(ctx.is_parked(&k));
-        let (_cont, pend) = ctx.take(&k).expect("park must be takeable");
+        let (_cont, pend) = ctx
+            .take_matching(&k, ctx.epoch_of(&k).expect("parked"))
+            .expect("park must be takeable");
         assert!(pend.is_empty());
         assert!(!ctx.is_parked(&k), "take must end the park");
     }
@@ -910,15 +1110,15 @@ mod tests {
         let (mut ctx, _rx) = ctx();
         for i in 0..MAX_PARKED_DELEGATES {
             assert!(matches!(
-                ctx.park(key(i as u8), continuation()),
-                ParkAdmission::Admitted
+                ctx.park(key(i as u8), continuation(), 0),
+                ParkAdmission::Admitted { .. }
             ));
         }
         assert_eq!(ctx.parked_count(), MAX_PARKED_DELEGATES);
         // Over the cap: refused, and the continuation comes back so the caller
         // can fall back inline rather than losing the round-trip.
         assert!(matches!(
-            ctx.park(key(200), continuation()),
+            ctx.park(key(200), continuation(), 0),
             ParkAdmission::Refused(_)
         ));
         assert!(!ctx.is_parked(&key(200)));
@@ -929,23 +1129,26 @@ mod tests {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
         assert!(matches!(
-            ctx.park(k.clone(), continuation()),
-            ParkAdmission::Admitted
+            ctx.park(k.clone(), continuation(), 0),
+            ParkAdmission::Admitted { .. }
         ));
         // The live continuation must survive: clobbering it would strand the
         // first round-trip's client responder.
         assert!(matches!(
-            ctx.park(k.clone(), continuation()),
+            ctx.park(k.clone(), continuation(), 0),
             ParkAdmission::Refused(_)
         ));
-        assert!(ctx.take(&k).is_some());
+        assert!(
+            ctx.take_matching(&k, ctx.epoch_of(&k).expect("parked"))
+                .is_some()
+        );
     }
 
     #[tokio::test]
     async fn pending_queue_is_capped_and_overflow_is_returned_not_dropped() {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
-        ctx.park(k.clone(), continuation());
+        ctx.park(k.clone(), continuation(), 0);
         for i in 0..MAX_PENDING_PER_DELEGATE {
             assert!(matches!(
                 ctx.queue_pending(&k, pending(i as u8)),
@@ -958,7 +1161,9 @@ mod tests {
             ctx.queue_pending(&k, pending(99)),
             QueueOutcome::Rejected(_)
         ));
-        let (_cont, pend) = ctx.take(&k).expect("park present");
+        let (_cont, pend) = ctx
+            .take_matching(&k, ctx.epoch_of(&k).expect("parked"))
+            .expect("park present");
         assert_eq!(pend.len(), MAX_PENDING_PER_DELEGATE);
     }
 
@@ -1015,7 +1220,7 @@ mod tests {
     async fn notifications_coalesce_per_contract_rather_than_being_rejected() {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
-        ctx.park(k.clone(), continuation());
+        ctx.park(k.clone(), continuation(), 0);
 
         // Far more than MAX_PENDING_PER_DELEGATE, all for ONE contract.
         for i in 0..(MAX_PENDING_PER_DELEGATE as u8 + 12) {
@@ -1029,7 +1234,9 @@ mod tests {
             );
         }
 
-        let (_cont, pending) = ctx.take(&k).expect("park present");
+        let (_cont, pending) = ctx
+            .take_matching(&k, ctx.epoch_of(&k).expect("parked"))
+            .expect("park present");
         assert_eq!(
             pending.len(),
             1,
@@ -1049,7 +1256,7 @@ mod tests {
     async fn a_full_client_queue_does_not_reject_notifications() {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
-        ctx.park(k.clone(), continuation());
+        ctx.park(k.clone(), continuation(), 0);
 
         for i in 0..MAX_PENDING_PER_DELEGATE {
             assert!(matches!(
@@ -1072,7 +1279,9 @@ mod tests {
             "a notification must still be accepted with the client queue full"
         );
 
-        let (_cont, pending_runs) = ctx.take(&k).expect("park present");
+        let (_cont, pending_runs) = ctx
+            .take_matching(&k, ctx.epoch_of(&k).expect("parked"))
+            .expect("park present");
         assert_eq!(
             pending_runs.len(),
             MAX_PENDING_PER_DELEGATE + 1,
@@ -1082,11 +1291,38 @@ mod tests {
 
     /// Distinct contracts are capped, so the coalescing map cannot grow without
     /// bound if subscriptions are not limited elsewhere.
+    /// L9: refusals are COUNTED, not only logged. A refusal that increments
+    /// nothing renders as a clean zero to anything reading metrics — the same
+    /// pattern this branch fixed for the over-cap client request.
+    #[tokio::test]
+    async fn refusals_are_counted_per_cause() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+        ctx.park(k.clone(), continuation(), 0);
+
+        for i in 0..MAX_PENDING_PER_DELEGATE {
+            ctx.queue_pending(&k, pending(i as u8));
+        }
+        ctx.queue_pending(&k, pending(99));
+        for i in 0..MAX_PENDING_NOTIFICATION_CONTRACTS {
+            ctx.queue_pending(&k, notification(i as u8, b"s"));
+        }
+        ctx.queue_pending(&k, notification(250, b"s"));
+
+        let counts = ctx.refusals();
+        assert_eq!(counts.client_requests, 1, "the over-cap client request");
+        assert_eq!(
+            counts.notifications, 1,
+            "the over-cap notification contract"
+        );
+        assert_eq!(counts.parks, 0, "no park was refused here");
+    }
+
     #[tokio::test]
     async fn distinct_notification_contracts_are_capped() {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
-        ctx.park(k.clone(), continuation());
+        ctx.park(k.clone(), continuation(), 0);
 
         for i in 0..MAX_PENDING_NOTIFICATION_CONTRACTS {
             assert!(matches!(
@@ -1113,7 +1349,7 @@ mod tests {
     async fn park_expires_only_after_the_ttl() {
         let (mut ctx, _rx) = ctx();
         let k = key(1);
-        ctx.park(k.clone(), continuation());
+        ctx.park(k.clone(), continuation(), 0);
 
         tokio::time::advance(PARK_TTL - Duration::from_secs(1)).await;
         assert!(
@@ -1123,13 +1359,117 @@ mod tests {
         );
 
         tokio::time::advance(Duration::from_secs(2)).await;
-        assert_eq!(ctx.expired(tokio::time::Instant::now()), vec![k]);
+        assert_eq!(
+            ctx.expired(tokio::time::Instant::now()),
+            vec![(k.clone(), ctx.epoch_of(&k).expect("parked"))]
+        );
+    }
+
+    /// H1: a resume from a park the TTL backstop already ended must be REJECTED,
+    /// not absorbed by whatever park exists now.
+    ///
+    /// The sweep force-resumes a park without consuming the off-loop task's
+    /// `ParkGuard`, so that guard still owes a resume. If the delegate has
+    /// re-parked by the time it lands, matching on key alone hands the OLD
+    /// continuation's `UserResponse`/`PutContractResponse` messages to the NEW
+    /// park — the cross-round-trip corruption the whole exclusion exists to
+    /// prevent, arriving through the backstop I was asked to add.
+    ///
+    /// FALSIFY by making `take_matching` ignore the epoch: the stale resume is
+    /// then absorbed and this returns `Some`.
+    #[tokio::test]
+    async fn a_stale_resume_from_a_force_resumed_park_is_rejected() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+
+        let ParkAdmission::Admitted { epoch: first } = ctx.park(k.clone(), continuation(), 0)
+        else {
+            panic!("first park must be admitted");
+        };
+
+        // The TTL backstop ends park #1 WITHOUT consuming its guard.
+        assert!(
+            ctx.take_matching(&k, first).is_some(),
+            "the sweep ends the park it observed"
+        );
+
+        // The delegate re-parks: a new round-trip, a new continuation.
+        let ParkAdmission::Admitted { epoch: second } = ctx.park(k.clone(), continuation(), 0)
+        else {
+            panic!("second park must be admitted");
+        };
+        assert_ne!(first, second, "each park must have its own identity");
+
+        // Park #1's guard finally fires. It must NOT take park #2.
+        assert!(
+            ctx.take_matching(&k, first).is_none(),
+            "a stale resume must be rejected; absorbing it would feed park #1's \
+             messages into park #2 (#5544 H1)"
+        );
+        assert_eq!(
+            ctx.epoch_of(&k),
+            Some(second),
+            "the live park must survive the stale resume untouched"
+        );
+    }
+
+    /// P1a: the byte cap must charge what is actually RETAINED, including the
+    /// payloads the off-loop task holds, not just what `Continuation` points at.
+    ///
+    /// FALSIFY by reverting any of the three: dropping `task_bytes` from
+    /// `park`, omitting `params` from `continuation_bytes`, or removing the
+    /// projected-total check on the client queue lane.
+    #[tokio::test]
+    async fn the_byte_cap_charges_retained_payloads_not_just_the_continuation() {
+        let (mut ctx, _rx) = ctx();
+
+        // A continuation carrying a large inbound state, as a real parked GET
+        // response would.
+        let big = vec![0u8; 8 * 1024 * 1024];
+        let mut cont = continuation();
+        cont.inbound_so_far = vec![InboundDelegateMsg::ContractNotification(
+            freenet_stdlib::prelude::ContractNotification {
+                contract_id: ContractInstanceId::new([1; 32]),
+                new_state: WrappedState::new(big.clone()),
+                context: DelegateContext::default(),
+            },
+        )];
+        assert!(
+            continuation_bytes(&cont) >= big.len(),
+            "the continuation's inbound state must be charged"
+        );
+
+        // `params` is delegate-supplied and retained; omitting it was one of the
+        // three ways this bound failed to bound.
+        let mut with_params = continuation();
+        with_params.params = Parameters::from(vec![7u8; 4096]);
+        assert!(
+            continuation_bytes(&with_params) >= 4096,
+            "`params` must be charged: it is retained for the life of the park"
+        );
+
+        // Fill the budget with parks that each carry a large task payload, and
+        // confirm admission is refused rather than the total silently growing.
+        let per_park = MAX_PARKED_BYTES / 4;
+        let mut admitted = 0usize;
+        for i in 0..MAX_PARKED_DELEGATES {
+            match ctx.park(key(i as u8), continuation(), per_park) {
+                ParkAdmission::Admitted { .. } => admitted += 1,
+                ParkAdmission::Refused(_) => break,
+            }
+        }
+        assert!(
+            admitted <= 4,
+            "the byte cap must refuse once the RETAINED total is reached; \
+             admitted {admitted} parks of {per_park} bytes each against a \
+             {MAX_PARKED_BYTES} byte budget"
+        );
     }
 
     #[tokio::test]
     async fn guard_delivers_exactly_one_resume_on_success() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let guard = ParkGuard::new(tx, key(1));
+        let guard = ParkGuard::new(tx, key(1), 0);
         guard.send(Vec::new(), Vec::new());
         let resume = rx.recv().await.expect("one resume");
         assert_eq!(resume.cause, ResumeCause::Completed);
@@ -1142,7 +1482,7 @@ mod tests {
         // Simulates the spawned task being cancelled/panicking before it
         // finished its work. Without this the park would never end: the
         // pending queue would never drain and the client would hang.
-        drop(ParkGuard::new(tx, key(1)));
+        drop(ParkGuard::new(tx, key(1), 0));
         let resume = rx.recv().await.expect("drop must still resume the park");
         assert_eq!(resume.cause, ResumeCause::TimedOut);
         assert!(resume.inbound.is_empty());

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -330,6 +330,11 @@ pub(super) struct Continuation {
     /// park -> resume -> park forever, holding its exclusion open the whole
     /// time and rejecting every other request for it. Before parking existed
     /// the same delegate stopped after 100 iterations.
+    ///
+    /// Scope boundary: this covers PARKS, not contract NOTIFICATIONS. A
+    /// notification is a genuinely new invocation and resets the count, which
+    /// is correct — and is also why #5558 (a delegate notified of its own
+    /// writes) is a separate unbounded loop that this does not close.
     pub iterations: usize,
     pub params: Parameters<'static>,
     pub origin_contract: Option<ContractInstanceId>,

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -703,7 +703,20 @@ impl ParkGuard {
 
         // TERMINAL RESULTS ARE PRODUCED HERE, not in the task body, so that
         // EVERY exit produces them — including a panic or a cancellation, which
-        // reach `Drop` and never run the task's own cleanup. A delegate left
+        // reach `Drop` and never run the task's own cleanup.
+        //
+        // IF YOU ARE ADDING AN EXIT PATH, RE-ASK THE QUESTION HERE. "Answered on
+        // every exit" is not a property you establish once for a change; it has
+        // to be re-asked at EVERY level that has exits, and having answered it
+        // at one level feels like having answered it. That is not hypothetical:
+        // the same change, in the same session, put an RAII guard on the prompt
+        // REGISTRY entry — correct "on every exit" reasoning — and then put the
+        // response synthesis one level up in the task body, where a panic never
+        // reaches it. The reasoning was right and was applied at one level and
+        // not the next. Keeping the synthesis inside this guard is what makes
+        // the property structural rather than remembered.
+        //
+        // #5544 P1b/P2. A delegate left
         // without a response for work it requested keeps a continuation the
         // exclusion has already released, and if nothing else is delivered it
         // is never re-entered at all.

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -66,12 +66,29 @@
 //! Why the global property still holds after #5544, by construction rather than
 //! by convention:
 //!
-//! 1. `execute_delegate_request` has exactly two call sites, both inside
+//! 1. `execute_delegate_request` is reached ONLY through
 //!    `handle_delegate_with_contract_requests`.
-//! 2. That function has four call sites — `handle_delegate_notification`,
-//!    `dispatch_delegate_request` (twice) and `handle_delegate_resume` — and
-//!    every one of them is reached only by being awaited from
-//!    `contract_handling`, which is a single task per node.
+//! 2. Every route into that function is awaited, directly or one hop removed,
+//!    from `contract_handling` — a single task per node:
+//!
+//!    ```text
+//!    contract_handling
+//!      ├─ handle_contract_event ─────────► dispatch_delegate_request ─┐
+//!      ├─ handle_delegate_notification ────────────────────────────────┤
+//!      └─ handle_delegate_resume ──┬───────────────────────────────────┤
+//!                                  ├─► dispatch_delegate_request ──────┤
+//!                                  └─► run_queued_notification ────────┘
+//!                                                                      │
+//!                          handle_delegate_with_contract_requests ◄─────┘
+//!                                      └─► execute_delegate_request
+//!    ```
+//!
+//!    Stated as the PROPERTY — every route is awaited from the one loop — and
+//!    not as a count. An exact tally is a fact with an expiry date: this list
+//!    said "four call sites" until `run_queued_notification` was added for the
+//!    notification-coalescing fix, and was wrong the moment it was. The
+//!    property survives a new caller; the number does not. If you add a route,
+//!    it must be awaited from this loop or the invariant is gone.
 //! 3. The off-loop task this module spawns captures a `ParkGuard`, an
 //!    `Arc<P: UserInputPrompter>`, an `Option<Arc<OpManager>>` and plain data.
 //!    It does **not** capture the `ContractHandler` or an executor, so it

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -42,6 +42,63 @@
 //! which is the correct semantics, not a compromise. Everything else on the
 //! node keeps running.
 //!
+//! # What parking does NOT relax: `process()` stays globally serial
+//!
+//! Parking releases the loop while a delegate is **suspended**, never while it
+//! is **running**. That distinction is load-bearing for code outside this
+//! module, so state it as an invariant:
+//!
+//! > **At most one delegate `process()` executes node-wide at any instant, and
+//! > it always executes on the `contract_handling` loop.**
+//!
+//! Two separate properties depend on it:
+//!
+//! * `DelegateContextCache` needs one `process()` **per delegate** — that is
+//!   the narrower guarantee, and it is the one [`DelegateParkCtx`]'s exclusion
+//!   supplies, because parking genuinely does let a delegate's round-trip span
+//!   loop iterations.
+//! * `native_api::state_content_changed` (V2 delegate writes, #5490) needs one
+//!   write **per contract**. Its read-then-write pair is not atomic, and its
+//!   racing pair is two DIFFERENT delegates writing the SAME contract — which
+//!   per-delegate exclusion permits by construction. It is safe only because of
+//!   the global property above, not because of anything in this module.
+//!
+//! Why the global property still holds after #5544, by construction rather than
+//! by convention:
+//!
+//! 1. `execute_delegate_request` has exactly two call sites, both inside
+//!    `handle_delegate_with_contract_requests`.
+//! 2. That function has four call sites — `handle_delegate_notification`,
+//!    `dispatch_delegate_request` (twice) and `handle_delegate_resume` — and
+//!    every one of them is reached only by being awaited from
+//!    `contract_handling`, which is a single task per node.
+//! 3. The off-loop task this module spawns captures a `ParkGuard`, an
+//!    `Arc<P: UserInputPrompter>`, an `Option<Arc<OpManager>>` and plain data.
+//!    It does **not** capture the `ContractHandler` or an executor, so it
+//!    cannot invoke a delegate even by mistake. Its two jobs — waiting on a
+//!    human and driving a sub-op GET — need neither.
+//! 4. A resume re-enters the delegate from `handle_delegate_resume`, which runs
+//!    **on the loop**. The spawned task only ships a result back down a
+//!    channel; it never runs the continuation itself.
+//!
+//! So the window parking opens is a window in which a *different* delegate may
+//! **start**, not one in which two may **run**. #5490's TOCTOU stays
+//! unreachable, and its atomic compare-and-write (folding the comparison into
+//! the same ReDb write transaction as the store, the way `update_state_sync`
+//! already does) is a follow-up rather than a prerequisite for this change.
+//!
+//! **What would break it.** Spawning any work that holds the
+//! `ContractHandler`, or resuming a continuation anywhere other than the loop.
+//! If you are about to do either, #5490's gate must become atomic first. The
+//! nearest existing precedent is deliberately NOT a counter-example: #4531's
+//! hosted-secret export does run off-loop holding a pooled executor, but it
+//! enumerates and seals secrets and never invokes a delegate.
+//!
+//! **The pattern worth noticing.** This is the second documented-but-unenforced
+//! invariant found to be resting on the serial loop by accident rather than by
+//! design — the context cache was the first. Neither said so where it was
+//! relied upon. When touching this loop, assume there is a third.
+//!
 //! # Ownership
 //!
 //! Loop-owned (`contract_handling` holds it and passes `&mut` down), NOT a

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -54,9 +54,14 @@ use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
 
 use freenet_stdlib::client_api::DelegateRequest;
+use either::Either;
 use freenet_stdlib::prelude::{
-    ContractInstanceId, DelegateKey, InboundDelegateMsg, OutboundDelegateMsg, Parameters,
+    ContractContainer, ContractInstanceId, ContractKey, DelegateContext, DelegateKey,
+    InboundDelegateMsg, OutboundDelegateMsg, Parameters, RelatedContracts, StateDelta,
+    WrappedState,
 };
+
+use super::executor::ExecutorError;
 
 use super::handler::{EventId, StashedResponder};
 use crate::client_events::ConnectionScope;
@@ -100,6 +105,17 @@ pub(super) const MAX_PENDING_PER_DELEGATE: usize = 8;
 /// fires first on a merely-slow operation; a park cut short at its own TTL
 /// would report a spurious failure for work that was about to succeed.
 pub(super) const PARK_TTL: Duration = Duration::from_secs(90);
+
+/// Cap on the off-loop task's own runtime, kept BELOW [`PARK_TTL`].
+///
+/// The task runs this iteration's prompts and related-contract fetches
+/// concurrently, but several prompts (each up to `USER_INPUT_TIMEOUT`) could
+/// still sum past the TTL. If that happened the loop's backstop sweep would
+/// force-resume the park while the task was still working, and the task's own
+/// result would then arrive for a park that no longer exists and be discarded.
+/// Bounding the task below the TTL means the guard always wins that race, so
+/// the TTL stays what it is meant to be — unreachable in practice.
+pub(super) const PARK_WORK_BUDGET: Duration = Duration::from_secs(75);
 
 /// A delegate request that arrived while its delegate was parked.
 ///
@@ -172,13 +188,44 @@ pub(super) enum ResumeCause {
     TimedOut,
 }
 
+/// A delegate PUT/UPDATE that could not complete because the contract asked for
+/// related contracts this node does not hold.
+///
+/// The fetch is off-loaded (it is a network GET, and awaiting it on the loop is
+/// the second #5544 stall); the upsert itself must be RE-RUN on the loop,
+/// because it runs WASM and WASM stays serial. So the park carries everything
+/// needed to re-run it.
+pub(super) struct PendingUpsert {
+    pub key: ContractKey,
+    pub update: Either<WrappedState, StateDelta<'static>>,
+    pub related_contracts: RelatedContracts<'static>,
+    pub code: Option<ContractContainer>,
+    /// `true` builds a `PutContractResponse`, `false` an
+    /// `UpdateContractResponse`.
+    pub is_put: bool,
+    /// Echoed back to the delegate so it can match the response to its request.
+    pub context: DelegateContext,
+    /// The related contracts to fetch off-loop.
+    pub missing: Vec<ContractInstanceId>,
+}
+
+/// A [`PendingUpsert`] whose off-loop fetch has finished, one way or the other.
+pub(super) struct ResolvedUpsert {
+    pub pending: PendingUpsert,
+    pub fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
+}
+
 /// Sent from an off-loop task back to the `contract_handling` loop.
 pub(super) struct DelegateResume {
     pub delegate_key: DelegateKey,
     pub cause: ResumeCause,
-    /// The messages to feed back into the delegate. Empty on a dropped or
-    /// timed-out park, which still resumes so the continuation terminates.
+    /// Messages that are ready to feed straight back into the delegate (the
+    /// prompt path). Empty on a dropped or timed-out park, which still resumes
+    /// so the continuation terminates.
     pub inbound: Vec<InboundDelegateMsg<'static>>,
+    /// Upserts whose related contracts were fetched off-loop and which must be
+    /// RE-RUN on the loop before their responses can be built.
+    pub upserts: Vec<ResolvedUpsert>,
 }
 
 /// RAII guard guaranteeing an off-loop task delivers EXACTLY ONE
@@ -217,11 +264,15 @@ impl ParkGuard {
         }
     }
 
-    /// Deliver the resolved inbound messages. Consumes the payload so a later
-    /// `Drop` is a no-op (exactly-once).
-    pub(super) fn send(mut self, inbound: Vec<InboundDelegateMsg<'static>>) {
+    /// Deliver the resolved work. Consumes the payload so a later `Drop` is a
+    /// no-op (exactly-once).
+    pub(super) fn send(
+        mut self,
+        inbound: Vec<InboundDelegateMsg<'static>>,
+        upserts: Vec<ResolvedUpsert>,
+    ) {
         if let Some(p) = self.payload.take() {
-            Self::deliver(p, ResumeCause::Completed, inbound);
+            Self::deliver(p, ResumeCause::Completed, inbound, upserts);
         }
     }
 
@@ -229,6 +280,7 @@ impl ParkGuard {
         p: ParkGuardPayload,
         cause: ResumeCause,
         inbound: Vec<InboundDelegateMsg<'static>>,
+        upserts: Vec<ResolvedUpsert>,
     ) {
         let ParkGuardPayload {
             resume_tx,
@@ -239,6 +291,7 @@ impl ParkGuard {
                 delegate_key: delegate_key.clone(),
                 cause,
                 inbound,
+                upserts,
             })
             .is_err()
         {
@@ -259,7 +312,7 @@ impl Drop for ParkGuard {
                  empty resume so the park terminates, its pending queue drains \
                  and the parked client is answered exactly once (#5544)"
             );
-            Self::deliver(p, ResumeCause::TimedOut, Vec::new());
+            Self::deliver(p, ResumeCause::TimedOut, Vec::new(), Vec::new());
         }
     }
 }
@@ -568,7 +621,7 @@ mod tests {
     async fn guard_delivers_exactly_one_resume_on_success() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let guard = ParkGuard::new(tx, key(1));
-        guard.send(Vec::new());
+        guard.send(Vec::new(), Vec::new());
         let resume = rx.recv().await.expect("one resume");
         assert_eq!(resume.cause, ResumeCause::Completed);
         assert!(rx.try_recv().is_err(), "must not deliver twice");

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -259,10 +259,14 @@ pub(super) fn task_bytes(
                 .code
                 .as_ref()
                 .map_or(0, |c| c.data().len() + c.params().as_ref().len());
+            // BORROW, do not clone. `clone().into_owned()` here deep-copied
+            // every related state MERELY TO MEASURE IT: with up to ten 50 MiB
+            // states that is hundreds of MiB allocated synchronously on the
+            // serial loop, BEFORE the 64 MiB cap could reject the park —
+            // causing the stall and the memory blow-up the cap exists to
+            // prevent. The measurement was the harm.
             let related: usize = u
                 .related_contracts
-                .clone()
-                .into_owned()
                 .states()
                 .map(|(_, st)| st.as_ref().map_or(0, |s| s.as_ref().len()))
                 .sum();
@@ -301,25 +305,40 @@ fn delegate_container_bytes(delegate: &freenet_stdlib::prelude::DelegateContaine
 }
 
 fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
-    match msg {
-        InboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
-        InboundDelegateMsg::GetContractResponse(r) => {
-            r.state.as_ref().map_or(0, |s| s.as_ref().len())
+    // Charged OUTSIDE the match, for every variant, via the stdlib accessor.
+    // `DelegateContext` runs to nearly 400 KiB, and a client can queue
+    // small-payload messages carrying large contexts behind a park while
+    // `parked_bytes` barely moves. Doing it here rather than in each arm is
+    // deliberate: this budget has now been wrong in six distinct ways, and a
+    // per-arm charge is a seventh spot to forget. A new variant cannot omit it.
+    let context = msg.get_context().map_or(0, |c| c.as_ref().len());
+    context
+        + match msg {
+            InboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
+            InboundDelegateMsg::GetContractResponse(r) => {
+                r.state.as_ref().map_or(0, |s| s.as_ref().len())
+            }
+            InboundDelegateMsg::ContractNotification(n) => n.new_state.as_ref().len(),
+            InboundDelegateMsg::UserResponse(r) => r.response.len(),
+            InboundDelegateMsg::DelegateMessage(m) => m.payload.len(),
+            // Put/Update/Subscribe responses carry only a small Result. The
+            // wildcard is required by `#[non_exhaustive]`; a future variant
+            // carrying bytes must be added above or it goes uncounted.
+            InboundDelegateMsg::PutContractResponse(_)
+            | InboundDelegateMsg::UpdateContractResponse(_)
+            | InboundDelegateMsg::SubscribeContractResponse(_)
+            | _ => 0,
         }
-        InboundDelegateMsg::ContractNotification(n) => n.new_state.as_ref().len(),
-        InboundDelegateMsg::UserResponse(r) => r.response.len(),
-        InboundDelegateMsg::DelegateMessage(m) => m.payload.len(),
-        // Put/Update/Subscribe responses carry only a small Result. The
-        // wildcard is required by `#[non_exhaustive]`; a future variant
-        // carrying bytes must be added above or it goes uncounted.
-        InboundDelegateMsg::PutContractResponse(_)
-        | InboundDelegateMsg::UpdateContractResponse(_)
-        | InboundDelegateMsg::SubscribeContractResponse(_)
-        | _ => 0,
-    }
 }
 
 fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
+    // Same structural charge as `inbound_bytes`: context first, for every
+    // variant, so it cannot be forgotten by an arm.
+    let context = msg.get_context().map_or(0, |c| c.as_ref().len());
+    context + outbound_payload_bytes(msg)
+}
+
+fn outbound_payload_bytes(msg: &OutboundDelegateMsg) -> usize {
     // The request variants never appear in `accumulated` — they are consumed by
     // the run that produced them — and the rest carry no contract-controlled
     // payload. Listed rather than wildcarded so a future payload-bearing
@@ -327,12 +346,9 @@ fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
     match msg {
         OutboundDelegateMsg::ApplicationMessage(m) => m.payload.len(),
         OutboundDelegateMsg::SendDelegateMessage(m) => m.payload.len(),
-        // NOT zero: `DelegateContext::MAX_SIZE` is 409,600 bytes, and these
-        // accumulate through park -> resume -> re-park via `RunSeed` for up to
-        // MAX_CONTRACT_REQUEST_ITERATIONS, which is ~40 MB per park if
-        // uncounted.
-        OutboundDelegateMsg::ContextUpdated(ctx) => ctx.as_ref().len(),
-        OutboundDelegateMsg::RequestUserInput(_)
+        // `ContextUpdated`'s payload IS its context, already charged above.
+        OutboundDelegateMsg::ContextUpdated(_)
+        | OutboundDelegateMsg::RequestUserInput(_)
         | OutboundDelegateMsg::GetContractRequest(_)
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
@@ -528,6 +544,18 @@ struct ParkEntry {
     /// Newest pending notification per contract. Superseded ones are dropped,
     /// which loses nothing the successor does not carry.
     pending_notifications: HashMap<ContractInstanceId, DelegateRequest<'static>>,
+    /// ARRIVAL ORDER of the contracts in `pending_notifications`.
+    ///
+    /// The map alone would drain in hash order. Each drained notification runs
+    /// delegate WASM and can mutate secrets and contracts, so hash order makes
+    /// observable effects reorder between runs and identical simulation runs
+    /// diverge — the determinism hazard `testing.md` names. `expired()` was
+    /// sorted for the same reason (L7); this is the same defect one function
+    /// over, on the path that actually executes delegate code.
+    ///
+    /// Coalescing keeps a contract's ORIGINAL position: a newer notification
+    /// replaces the value, not the slot, so ordering stays arrival order.
+    notification_order: VecDeque<ContractInstanceId>,
     /// Bytes held by the queued items above, so they count toward
     /// [`MAX_PARKED_BYTES`] like the continuation does. Without this the
     /// coalescing map would be a fresh count-bounded-but-not-byte-bounded hole
@@ -594,6 +622,10 @@ pub(super) struct DelegateResume {
     /// Upserts whose related contracts were fetched off-loop and which must be
     /// RE-RUN on the loop before their responses can be built.
     pub upserts: Vec<ResolvedUpsert>,
+    /// Upserts the off-loop task never resolved — it panicked, was cancelled,
+    /// or ran out of budget. `(contract, is_put)`, turned into failure
+    /// responses by the resume handler so the delegate is told.
+    pub unresolved_upserts: Vec<(ContractInstanceId, bool)>,
 }
 
 /// RAII guard guaranteeing an off-loop task delivers EXACTLY ONE
@@ -618,6 +650,10 @@ struct ParkGuardPayload {
     resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
     delegate_key: DelegateKey,
     epoch: u64,
+    /// Prompt request ids this park owes a `UserResponse` for.
+    owed_prompts: Vec<u32>,
+    /// Upserts this park owes a Put/Update response for: `(contract, is_put)`.
+    owed_upserts: Vec<(ContractInstanceId, bool)>,
 }
 
 impl ParkGuard {
@@ -625,12 +661,16 @@ impl ParkGuard {
         resume_tx: tokio::sync::mpsc::UnboundedSender<DelegateResume>,
         delegate_key: DelegateKey,
         epoch: u64,
+        owed_prompts: Vec<u32>,
+        owed_upserts: Vec<(ContractInstanceId, bool)>,
     ) -> Self {
         Self {
             payload: Some(ParkGuardPayload {
                 resume_tx,
                 delegate_key,
                 epoch,
+                owed_prompts,
+                owed_upserts,
             }),
         }
     }
@@ -650,14 +690,75 @@ impl ParkGuard {
     fn deliver(
         p: ParkGuardPayload,
         cause: ResumeCause,
-        inbound: Vec<InboundDelegateMsg<'static>>,
+        mut inbound: Vec<InboundDelegateMsg<'static>>,
         upserts: Vec<ResolvedUpsert>,
     ) {
         let ParkGuardPayload {
             resume_tx,
             delegate_key,
             epoch,
+            owed_prompts,
+            owed_upserts,
         } = p;
+
+        // TERMINAL RESULTS ARE PRODUCED HERE, not in the task body, so that
+        // EVERY exit produces them — including a panic or a cancellation, which
+        // reach `Drop` and never run the task's own cleanup. A delegate left
+        // without a response for work it requested keeps a continuation the
+        // exclusion has already released, and if nothing else is delivered it
+        // is never re-entered at all.
+        //
+        // An empty `ClientResponse` is exactly what a dismissed or timed-out
+        // prompt yields on the normal path, so the delegate sees a shape it
+        // already handles.
+        let answered: std::collections::HashSet<u32> = inbound
+            .iter()
+            .filter_map(|m| match m {
+                InboundDelegateMsg::UserResponse(r) => Some(r.request_id),
+                // Only `UserResponse` carries a request id to reconcile
+                // against `owed_prompts`. Listed rather than wildcarded so a
+                // future variant that carries one has to be considered here.
+                InboundDelegateMsg::ApplicationMessage(_)
+                | InboundDelegateMsg::GetContractResponse(_)
+                | InboundDelegateMsg::PutContractResponse(_)
+                | InboundDelegateMsg::UpdateContractResponse(_)
+                | InboundDelegateMsg::SubscribeContractResponse(_)
+                | InboundDelegateMsg::ContractNotification(_)
+                | InboundDelegateMsg::DelegateMessage(_)
+                | _ => None,
+            })
+            .collect();
+        for request_id in owed_prompts {
+            if !answered.contains(&request_id) {
+                inbound.push(InboundDelegateMsg::UserResponse(
+                    freenet_stdlib::prelude::UserInputResponse {
+                        request_id,
+                        response: freenet_stdlib::prelude::ClientResponse::new(Vec::new()),
+                        context: DelegateContext::default(),
+                    },
+                ));
+            }
+        }
+
+        // Upserts cannot be synthesized here — a `ResolvedUpsert` needs the
+        // `PendingUpsert` the task owns, which is gone by the time `Drop` runs.
+        // The unresolved ids travel instead, and `handle_delegate_resume` turns
+        // them into failure responses where it has `upsert_response_msg`.
+        let resolved: std::collections::HashSet<ContractInstanceId> =
+            upserts.iter().map(|r| *r.pending.key.id()).collect();
+        let unresolved_upserts: Vec<(ContractInstanceId, bool)> = owed_upserts
+            .into_iter()
+            .filter(|(id, _)| !resolved.contains(id))
+            .collect();
+        if !unresolved_upserts.is_empty() {
+            tracing::warn!(
+                delegate = %delegate_key,
+                count = unresolved_upserts.len(),
+                "Off-loop delegate work ended without resolving every upsert; \
+                 synthesizing failures so the delegate is told rather than left \
+                 waiting (#5544)"
+            );
+        }
         if resume_tx
             .send(DelegateResume {
                 delegate_key: delegate_key.clone(),
@@ -665,6 +766,7 @@ impl ParkGuard {
                 cause,
                 inbound,
                 upserts,
+                unresolved_upserts,
             })
             .is_err()
         {
@@ -827,6 +929,7 @@ impl DelegateParkCtx {
                 parked_at: tokio::time::Instant::now(),
                 pending_clients: VecDeque::new(),
                 pending_notifications: HashMap::new(),
+                notification_order: VecDeque::new(),
                 pending_bytes: 0,
             },
         );
@@ -900,6 +1003,9 @@ impl DelegateParkCtx {
                 }
 
                 entry.pending_bytes = entry.pending_bytes.saturating_add(bytes);
+                if is_new_contract {
+                    entry.notification_order.push_back(contract_id);
+                }
                 if let Some(old) = entry.pending_notifications.insert(contract_id, req) {
                     let freed = request_bytes(&old);
                     entry.pending_bytes = entry.pending_bytes.saturating_sub(freed);
@@ -1024,11 +1130,23 @@ impl DelegateParkCtx {
             // ordering is already approximate because coalescing drops
             // superseded ones.
             let mut pending: VecDeque<PendingRun> = entry.pending_clients;
+            // Drain notifications in ARRIVAL order, not hash order. Each one
+            // runs delegate WASM, so hash order would make observable effects
+            // reorder between runs.
+            let mut notifications = entry.pending_notifications;
             pending.extend(
                 entry
-                    .pending_notifications
+                    .notification_order
                     .into_iter()
-                    .map(|(contract_id, req)| PendingRun::Notification { contract_id, req }),
+                    .filter_map(|contract_id| {
+                        notifications
+                            .remove(&contract_id)
+                            .map(|req| PendingRun::Notification { contract_id, req })
+                    }),
+            );
+            debug_assert!(
+                notifications.is_empty(),
+                "every coalesced notification must have an arrival-order slot"
             );
             (entry.continuation, pending)
         })
@@ -1444,6 +1562,65 @@ mod tests {
         );
     }
 
+    /// The context attached to a message is CHARGED. `DelegateContext` runs to
+    /// nearly 400 KiB, so a client can queue small-payload messages carrying
+    /// large contexts behind a park and move `parked_bytes` almost not at all.
+    ///
+    /// FALSIFY by dropping the `msg.get_context()` term from `inbound_bytes`.
+    #[tokio::test]
+    async fn message_contexts_are_charged_not_just_payloads() {
+        let big_ctx = DelegateContext::new(vec![0u8; 200 * 1024]);
+        let tiny_payload = InboundDelegateMsg::ApplicationMessage(
+            freenet_stdlib::prelude::ApplicationMessage::new(vec![1u8; 8])
+                .with_context(big_ctx.clone()),
+        );
+        let mut cont = continuation();
+        cont.inbound_so_far = vec![tiny_payload];
+        assert!(
+            continuation_bytes(&cont) >= 200 * 1024,
+            "a message's context must be charged; payload was 8 bytes and the \
+             context 200 KiB, and only the context makes this a real cost"
+        );
+    }
+
+    /// Coalesced notifications drain in ARRIVAL order, not hash order.
+    ///
+    /// Each drained notification executes delegate WASM and can mutate secrets
+    /// and contracts, so hash order lets observable effects reorder between
+    /// runs and identical simulation runs diverge.
+    ///
+    /// FALSIFY by draining `pending_notifications` directly instead of through
+    /// `notification_order`.
+    #[tokio::test]
+    async fn coalesced_notifications_drain_in_arrival_order() {
+        let (mut ctx, _rx) = ctx();
+        let k = key(1);
+        ctx.park(k.clone(), continuation(), 0);
+
+        // Insert in a fixed order; supersede one in the middle to confirm
+        // coalescing keeps its ORIGINAL slot rather than moving it to the back.
+        let arrival: Vec<u8> = (0..8).collect();
+        for c in &arrival {
+            ctx.queue_pending(&k, notification(*c, b"first"));
+        }
+        ctx.queue_pending(&k, notification(3, b"second"));
+
+        let epoch = ctx.epoch_of(&k).expect("parked");
+        let (_cont, pending) = ctx.take_matching(&k, epoch).expect("parked");
+        let drained: Vec<u8> = pending
+            .iter()
+            .filter_map(|run| match run {
+                PendingRun::Notification { contract_id, .. } => Some(contract_id.as_bytes()[0]),
+                PendingRun::Client { .. } => None,
+            })
+            .collect();
+        assert_eq!(
+            drained, arrival,
+            "notifications must drain in arrival order, and a superseded one \
+             must keep its original position"
+        );
+    }
+
     /// P1a: the byte cap must charge what is actually RETAINED, including the
     /// payloads the off-loop task holds, not just what `Continuation` points at.
     ///
@@ -1500,7 +1677,7 @@ mod tests {
     #[tokio::test]
     async fn guard_delivers_exactly_one_resume_on_success() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let guard = ParkGuard::new(tx, key(1), 0);
+        let guard = ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new());
         guard.send(Vec::new(), Vec::new());
         let resume = rx.recv().await.expect("one resume");
         assert_eq!(resume.cause, ResumeCause::Completed);
@@ -1513,7 +1690,7 @@ mod tests {
         // Simulates the spawned task being cancelled/panicking before it
         // finished its work. Without this the park would never end: the
         // pending queue would never drain and the client would hang.
-        drop(ParkGuard::new(tx, key(1), 0));
+        drop(ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new()));
         let resume = rx.recv().await.expect("drop must still resume the park");
         assert_eq!(resume.cause, ResumeCause::TimedOut);
         assert!(resume.inbound.is_empty());

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1298,6 +1298,14 @@ impl DelegateParkCtx {
     /// writes synchronously. What changed is the size of the hole: from a
     /// window bounded by a 60-second human wait to one bounded by two adjacent
     /// synchronous statements on the same task.
+    ///
+    /// **Absence of an await is not absence of a window.** "No `.await`
+    /// between" is exactly the sentence a later reader turns into
+    /// "impossible", and it is not: it bounds how long THIS task spends
+    /// between looking and removing, and says nothing about the other side.
+    /// `ParkGuard::deliver` runs on other worker threads and may `send()` at
+    /// any instant, including this one. The claim here is about duration, not
+    /// impossibility.
     pub(super) fn should_force_resume(
         &self,
         key: &DelegateKey,
@@ -1325,6 +1333,28 @@ fn absorb_delivered(
 }
 
 /// Whether `already_delivered` holds the resume for exactly this park.
+///
+/// **The epoch half is what does the work; the key half is redundant today.**
+/// `next_epoch` is ONE counter per registry ([`DelegateParkCtx::park`]
+/// increments it on every admission, not per delegate), so no two live parks
+/// can share an epoch and matching on epoch alone would already be exact. A
+/// mutation that drops the key comparison therefore survives every test, and
+/// that is a true fact about the code rather than a coverage gap — worth
+/// stating, because the pair reads as jointly load-bearing and a future reader
+/// would otherwise go looking for the test that pins it.
+///
+/// It is kept for two reasons. It is the assertion that makes the intent local
+/// — "this resume belongs to THIS park" — rather than something a reader has to
+/// go and confirm by finding the counter. And it is what stops the redundancy
+/// becoming a bug if `next_epoch` is ever made per-delegate, which is an
+/// entirely reasonable future change that would silently make epoch-only
+/// matching collide across delegates.
+///
+/// The direction that IS pinned, by
+/// `a_stale_buffered_resume_does_not_shield_the_current_park`, is the opposite
+/// one: matching on KEY alone is wrong, because a resume from an earlier park
+/// of the same delegate would shield the current one and disarm the backstop
+/// for exactly the delegate that has already needed it.
 fn resume_in_hand(
     already_delivered: &VecDeque<DelegateResume>,
     key: &DelegateKey,

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1234,20 +1234,39 @@ impl DelegateParkCtx {
     /// Matching is by `(key, epoch)`, not key alone: a buffered resume from an
     /// EARLIER park of the same delegate (one the backstop already swept) is
     /// stale, carries nothing the live park is owed, and must not shield it.
+    ///
+    /// # Why this takes the RECEIVER and not just the buffer
+    ///
+    /// The first version of this fix took `&VecDeque` and left the caller to
+    /// drain the channel into it. That is not enough, and the reason is the
+    /// whole bug: **the loop AWAITS between draining and sweeping.** It runs a
+    /// batch of resumes first, and a `ParkGuard` firing during that await puts
+    /// its resume in the CHANNEL, which a buffer snapshotted beforehand cannot
+    /// see. The sweep then force-resumed a park whose answer had already
+    /// arrived — bit-for-bit the bug this was supposed to close, on a window
+    /// that reaches `USER_INPUT_TIMEOUT` (60 s) whenever the park table is full
+    /// and a resume falls through to the inline prompt wait. That is precisely
+    /// the condition that makes resumes queue in the first place, so the
+    /// failure concentrated where it was most likely.
+    ///
+    /// Taking the receiver makes the snapshot and the decision ONE synchronous
+    /// step, so no caller can ask this question from a stale view — the
+    /// ordering is enforced by the signature rather than by a comment or a
+    /// source pin. (A pin cannot express it: `drain` textually preceding
+    /// `expired` is exactly what the buggy code did. Position cannot express
+    /// duration.)
     pub(super) fn expired(
         &self,
         now: tokio::time::Instant,
-        already_delivered: &VecDeque<DelegateResume>,
+        resume_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DelegateResume>,
+        already_delivered: &mut VecDeque<DelegateResume>,
     ) -> Vec<(DelegateKey, u64)> {
+        absorb_delivered(resume_rx, already_delivered);
         let mut out: Vec<(DelegateKey, u64)> = self
             .parked
             .iter()
             .filter(|(_, entry)| now.duration_since(entry.parked_at) >= PARK_TTL)
-            .filter(|(key, entry)| {
-                !already_delivered
-                    .iter()
-                    .any(|resume| resume.epoch == entry.epoch && resume.delegate_key == **key)
-            })
+            .filter(|(key, entry)| !resume_in_hand(already_delivered, key, entry.epoch))
             .map(|(key, entry)| (key.clone(), entry.epoch))
             .collect();
         // Deterministic order: `HashMap` iteration is arbitrary, and a sweep
@@ -1256,6 +1275,64 @@ impl DelegateParkCtx {
         out.sort_by_key(|(_, epoch)| *epoch);
         out
     }
+
+    /// Re-ask, for ONE park, the question [`Self::expired`] answered for the
+    /// batch: may the backstop still force-resume it?
+    ///
+    /// The sweep loop AWAITS — force-resuming park X re-enters WASM — so the
+    /// list `expired` returned is a decision made before that await, and a
+    /// guard firing while X is being resumed is invisible to the decision
+    /// already made about Y. Same defect as the outer one, one scope in, and
+    /// it needs the same remedy rather than an argument about how short the
+    /// window is.
+    ///
+    /// Call this immediately before each force-resume, with no `.await`
+    /// between: it and [`Self::take_matching`] (the first statement of
+    /// `handle_delegate_resume`) are both synchronous, so the observation and
+    /// the removal cannot be separated by a suspension point.
+    ///
+    /// RESIDUAL, stated rather than implied: a guard that fires in the
+    /// instants between this call and `take_matching` is still lost. That is
+    /// inherent to a lock-free channel plus a sweep that does not consume the
+    /// guard, and closing it would mean the registry owning a slot the guard
+    /// writes synchronously. What changed is the size of the hole: from a
+    /// window bounded by a 60-second human wait to one bounded by two adjacent
+    /// synchronous statements on the same task.
+    pub(super) fn should_force_resume(
+        &self,
+        key: &DelegateKey,
+        epoch: u64,
+        resume_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DelegateResume>,
+        already_delivered: &mut VecDeque<DelegateResume>,
+    ) -> bool {
+        absorb_delivered(resume_rx, already_delivered);
+        !resume_in_hand(already_delivered, key, epoch)
+    }
+}
+
+/// Move every resume the off-loop tasks have sent into the loop's buffer.
+///
+/// Synchronous by construction — `try_recv` never yields — which is the
+/// property the callers depend on: a drain that could suspend would reopen the
+/// window it exists to close.
+fn absorb_delivered(
+    resume_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DelegateResume>,
+    already_delivered: &mut VecDeque<DelegateResume>,
+) {
+    while let Ok(resume) = resume_rx.try_recv() {
+        already_delivered.push_back(resume);
+    }
+}
+
+/// Whether `already_delivered` holds the resume for exactly this park.
+fn resume_in_hand(
+    already_delivered: &VecDeque<DelegateResume>,
+    key: &DelegateKey,
+    epoch: u64,
+) -> bool {
+    already_delivered
+        .iter()
+        .any(|resume| resume.epoch == epoch && &resume.delegate_key == key)
 }
 
 #[cfg(test)]
@@ -1566,13 +1643,14 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn park_expires_only_after_the_ttl() {
-        let (mut ctx, _rx) = ctx();
+        let (mut ctx, mut rx) = ctx();
+        let mut buffered = VecDeque::new();
         let k = key(1);
         ctx.park(k.clone(), continuation(), 0);
 
         tokio::time::advance(PARK_TTL - Duration::from_secs(1)).await;
         assert!(
-            ctx.expired(tokio::time::Instant::now(), &VecDeque::new())
+            ctx.expired(tokio::time::Instant::now(), &mut rx, &mut buffered)
                 .is_empty(),
             "must not expire early — a park cut short would report a spurious \
              failure for work that was about to succeed"
@@ -1580,7 +1658,7 @@ mod tests {
 
         tokio::time::advance(Duration::from_secs(2)).await;
         assert_eq!(
-            ctx.expired(tokio::time::Instant::now(), &VecDeque::new()),
+            ctx.expired(tokio::time::Instant::now(), &mut rx, &mut buffered),
             vec![(k.clone(), ctx.epoch_of(&k).expect("parked"))]
         );
     }
@@ -1641,7 +1719,7 @@ mod tests {
 
         tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
         assert!(
-            ctx.expired(tokio::time::Instant::now(), &buffered)
+            ctx.expired(tokio::time::Instant::now(), &mut rx, &mut buffered)
                 .is_empty(),
             "a park whose resume is already buffered is QUEUED, not wedged; \
              force-resuming it discards the answer that resume is carrying \
@@ -1666,10 +1744,149 @@ mod tests {
         // The counterfactual: the park IS past its TTL. Without the buffer to
         // consult, the backstop sweeps it — so the exclusion above is load-
         // bearing rather than a park that was never expiring.
+        let mut nothing_in_hand = VecDeque::new();
+        let (_unused_tx, mut empty_rx) = tokio::sync::mpsc::unbounded_channel();
         assert_eq!(
-            ctx.expired(tokio::time::Instant::now(), &VecDeque::new()),
+            ctx.expired(
+                tokio::time::Instant::now(),
+                &mut empty_rx,
+                &mut nothing_in_hand
+            ),
             vec![(k.clone(), epoch)],
             "the park really is past PARK_TTL"
+        );
+    }
+
+    /// #5554 round 2: a resume that arrives AFTER the loop's batch snapshot,
+    /// while the loop is awaiting, must still stop the sweep.
+    ///
+    /// The first fix took a `&VecDeque` snapshot and left the caller to fill it,
+    /// which reads as atomic and is not: the loop drains, then AWAITS a batch of
+    /// resumes, then sweeps. A `ParkGuard` firing during that await puts its
+    /// resume in the CHANNEL, and a buffer snapshotted beforehand cannot see it
+    /// — so the sweep force-resumed a park whose answer had already arrived.
+    /// Bit-for-bit the original bug, on a window that reaches
+    /// `USER_INPUT_TIMEOUT` (60 s) when a full park table sends a resume down
+    /// the inline prompt path, which is exactly the condition that makes
+    /// resumes queue in the first place.
+    ///
+    /// This test models that sequence: the buffer is snapshotted EMPTY, the
+    /// guard fires afterwards, and only then is the sweep asked. It fails if
+    /// `expired` trusts what it was handed instead of re-reading the channel.
+    ///
+    /// It is the property test the source pin could not be. A pin asserting the
+    /// drain precedes the sweep is satisfied by the buggy code — the drain DID
+    /// precede it, with an await in between. **Position cannot express
+    /// duration**, so the ordering has to be enforced by the signature (which
+    /// takes the receiver) and checked behaviourally (here).
+    ///
+    /// FALSIFY by making `expired` skip its `absorb_delivered` call and trust
+    /// `already_delivered` as passed.
+    #[tokio::test(start_paused = true)]
+    async fn a_resume_arriving_after_the_snapshot_still_stops_the_sweep() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DelegateParkCtx::new(tx.clone());
+        let k = key(1);
+        let ParkAdmission::Admitted { epoch } = ctx.park(k.clone(), continuation(), 0) else {
+            panic!("park must be admitted");
+        };
+
+        // The loop's snapshot: nothing has been delivered yet.
+        let mut buffered: VecDeque<DelegateResume> = VecDeque::new();
+        while let Ok(resume) = rx.try_recv() {
+            buffered.push_back(resume);
+        }
+        assert!(
+            buffered.is_empty(),
+            "the snapshot must be taken BEFORE the guard fires, or this test \
+             is the buffered case again rather than the racing one"
+        );
+
+        // ...and NOW the human answers, while the loop is inside its batch.
+        let (answers, fetches) = sinks();
+        answers.lock().unwrap().push(answer(1));
+        drop(ParkGuard::new(
+            tx,
+            k.clone(),
+            epoch,
+            vec![1],
+            Vec::new(),
+            answers,
+            fetches,
+        ));
+
+        tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
+        assert!(
+            ctx.expired(tokio::time::Instant::now(), &mut rx, &mut buffered)
+                .is_empty(),
+            "the answer arrived after the snapshot but BEFORE the sweep; \
+             force-resuming now discards the human's response, which is the \
+             whole defect (#5554)"
+        );
+        assert_eq!(
+            answered_ids(&buffered[0]),
+            vec![1],
+            "and the resume it declined to sweep is the one carrying the answer"
+        );
+    }
+
+    /// The same defect one scope in: the sweep LOOP awaits too.
+    ///
+    /// `expired` returns a list, and force-resuming the first entry re-enters
+    /// WASM. A guard firing during that await is invisible to the decision
+    /// already made about the second entry, so the list is stale by the time it
+    /// is used. `should_force_resume` re-asks per victim, immediately before
+    /// each force-resume, with no `.await` in between.
+    ///
+    /// FALSIFY by making `should_force_resume` skip its `absorb_delivered`
+    /// call, or by having the loop trust `expired`'s list.
+    #[tokio::test(start_paused = true)]
+    async fn a_resume_arriving_during_an_earlier_force_resume_cancels_the_next() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut ctx = DelegateParkCtx::new(tx.clone());
+        let (first, second) = (key(1), key(2));
+        let ParkAdmission::Admitted { epoch: e1 } = ctx.park(first.clone(), continuation(), 0)
+        else {
+            panic!("park must be admitted");
+        };
+        let ParkAdmission::Admitted { epoch: e2 } = ctx.park(second.clone(), continuation(), 0)
+        else {
+            panic!("park must be admitted");
+        };
+
+        let mut buffered: VecDeque<DelegateResume> = VecDeque::new();
+        tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
+        let victims = ctx.expired(tokio::time::Instant::now(), &mut rx, &mut buffered);
+        assert_eq!(
+            victims,
+            vec![(first.clone(), e1), (second.clone(), e2)],
+            "both parks are past the TTL with nothing in hand"
+        );
+
+        // The loop force-resumes the FIRST victim. That awaits, and during it
+        // the second park's human answers.
+        let (answers, fetches) = sinks();
+        answers.lock().unwrap().push(answer(9));
+        drop(ParkGuard::new(
+            tx,
+            second.clone(),
+            e2,
+            vec![9],
+            Vec::new(),
+            answers,
+            fetches,
+        ));
+
+        assert!(
+            !ctx.should_force_resume(&second, e2, &mut rx, &mut buffered),
+            "the second victim's answer landed while the first was being \
+             force-resumed; sweeping it now throws that answer away (#5554)"
+        );
+        assert!(
+            ctx.should_force_resume(&first, e1, &mut rx, &mut buffered),
+            "the first victim produced nothing, so it is still genuinely \
+             wedged and the backstop must still fire for it — otherwise this \
+             check would disarm the backstop rather than target it"
         );
     }
 
@@ -1685,7 +1902,7 @@ mod tests {
     /// the sweep then returns empty.
     #[tokio::test(start_paused = true)]
     async fn a_stale_buffered_resume_does_not_shield_the_current_park() {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut _rx) = tokio::sync::mpsc::unbounded_channel();
         let mut ctx = DelegateParkCtx::new(tx);
         let k = key(1);
 
@@ -1713,7 +1930,7 @@ mod tests {
 
         tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
         assert_eq!(
-            ctx.expired(tokio::time::Instant::now(), &buffered),
+            ctx.expired(tokio::time::Instant::now(), &mut _rx, &mut buffered),
             vec![(k.clone(), second)],
             "a resume for the PREVIOUS park says nothing about this one; the \
              backstop must still fire"

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -429,13 +429,21 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
             // Script exhausted after a real scripted run: the delegate has
             // nothing more to say. Record the entry so exclusion assertions
             // still see it.
-            self.runtime.delegate_calls.lock().unwrap().push(key.clone());
+            self.runtime
+                .delegate_calls
+                .lock()
+                .unwrap()
+                .push(key.clone());
             return Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
                 key,
                 values: Vec::new(),
             });
         };
-        self.runtime.delegate_calls.lock().unwrap().push(key.clone());
+        self.runtime
+            .delegate_calls
+            .lock()
+            .unwrap()
+            .push(key.clone());
         Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key, values })
     }
 

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -85,7 +85,23 @@ pub(crate) struct MockWasmRuntime {
     /// Per-contract update_state overrides for testing the
     /// `requires(missing)` fetch-and-retry path.
     pub(crate) update_overrides: HashMap<ContractInstanceId, UpdateOverride>,
+    /// Scripted delegate outbound messages (#5544). Each
+    /// `execute_delegate_request` pops the next entry; an exhausted script
+    /// returns no messages, which the caller reads as "the delegate is done".
+    pub(crate) delegate_script: DelegateScript,
+    /// One entry appended per `execute_delegate_request`, so a test can assert
+    /// HOW MANY times the delegate's `process()` was entered and in what order
+    /// relative to a park. This is what makes the per-delegate exclusion
+    /// falsifiable: the invariant is "no second entry while parked".
+    pub(crate) delegate_calls: DelegateCallLog,
 }
+
+/// Shared handle to a mock delegate's scripted responses.
+pub(crate) type DelegateScript =
+    std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<Vec<OutboundDelegateMsg>>>>;
+
+/// Shared handle to the log of delegate invocations.
+pub(crate) type DelegateCallLog = std::sync::Arc<std::sync::Mutex<Vec<DelegateKey>>>;
 
 impl ContractRuntimeInterface for MockWasmRuntime {
     fn validate_state(
@@ -393,15 +409,34 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
 
     async fn execute_delegate_request(
         &mut self,
-        _req: DelegateRequest<'_>,
+        req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
         _caller_delegate: Option<&DelegateKey>,
         _connection_scope: crate::client_events::ConnectionScope,
         _user_context: Option<&UserSecretContext>,
     ) -> Response {
-        Err(ExecutorError::other(anyhow::anyhow!(
-            "delegates not supported in MockWasmRuntime"
-        )))
+        // Scripted, for the #5544 park/resume tests. Without a script this
+        // stays the "not supported" error it has always been, so no existing
+        // test changes behaviour.
+        let key = req.key().clone();
+        let script = self.runtime.delegate_script.lock().unwrap().pop_front();
+        let Some(values) = script else {
+            if self.runtime.delegate_calls.lock().unwrap().is_empty() {
+                return Err(ExecutorError::other(anyhow::anyhow!(
+                    "delegates not supported in MockWasmRuntime"
+                )));
+            }
+            // Script exhausted after a real scripted run: the delegate has
+            // nothing more to say. Record the entry so exclusion assertions
+            // still see it.
+            self.runtime.delegate_calls.lock().unwrap().push(key.clone());
+            return Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
+                key,
+                values: Vec::new(),
+            });
+        };
+        self.runtime.delegate_calls.lock().unwrap().push(key.clone());
+        Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key, values })
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
@@ -439,6 +474,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             contract_store: contract_store.unwrap_or_default(),
             validate_overrides: HashMap::new(),
             update_overrides: HashMap::new(),
+            delegate_script: DelegateScript::default(),
+            delegate_calls: DelegateCallLog::default(),
         };
 
         Executor::new(
@@ -469,6 +506,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             contract_store: InMemoryContractStore::default(),
             validate_overrides: HashMap::new(),
             update_overrides: HashMap::new(),
+            delegate_script: DelegateScript::default(),
+            delegate_calls: DelegateCallLog::default(),
         };
 
         Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
@@ -491,6 +530,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             contract_store: InMemoryContractStore::default(),
             validate_overrides: HashMap::new(),
             update_overrides: HashMap::new(),
+            delegate_script: DelegateScript::default(),
+            delegate_calls: DelegateCallLog::default(),
         };
 
         Executor::new(

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -85,23 +85,95 @@ pub(crate) struct MockWasmRuntime {
     /// Per-contract update_state overrides for testing the
     /// `requires(missing)` fetch-and-retry path.
     pub(crate) update_overrides: HashMap<ContractInstanceId, UpdateOverride>,
-    /// Scripted delegate outbound messages (#5544). Each
-    /// `execute_delegate_request` pops the next entry; an exhausted script
-    /// returns no messages, which the caller reads as "the delegate is done".
+    /// Scripted delegate runs (#5544). Each `execute_delegate_request` pops the
+    /// next entry; an exhausted script returns no messages, which the caller
+    /// reads as "the delegate is done".
     pub(crate) delegate_script: DelegateScript,
     /// One entry appended per `execute_delegate_request`, so a test can assert
     /// HOW MANY times the delegate's `process()` was entered and in what order
     /// relative to a park. This is what makes the per-delegate exclusion
     /// falsifiable: the invariant is "no second entry while parked".
     pub(crate) delegate_calls: DelegateCallLog,
+    /// Model of the runtime's real `DelegateContextCache` (#5544 S7).
+    ///
+    /// Keyed by `DelegateKey`, last-write-wins — deliberately the same shape as
+    /// the real thing, INCLUDING the property that makes it hazardous. Without
+    /// this the mock could only show that an extra `process()` happened; with
+    /// it, a test can show that the extra run CORRUPTED a parked continuation,
+    /// which is the thing that actually matters.
+    ///
+    /// Two exclusion bypasses (the notification path and the inter-delegate
+    /// hop) shipped in this PR's first round and were caught by review rather
+    /// than by a test, precisely because the mock modelled call counts and not
+    /// context continuity. Both are now caught by construction.
+    pub(crate) delegate_contexts: DelegateContexts,
+    /// What each invocation OBSERVED on entry, in order. The discriminator for
+    /// an interleaving bug: a resumed run must observe the context ITS OWN
+    /// pre-park run wrote, not one a foreign run left behind.
+    pub(crate) delegate_observations: DelegateObservations,
 }
 
-/// Shared handle to a mock delegate's scripted responses.
+/// One scripted delegate invocation.
+#[derive(Default, Clone)]
+pub(crate) struct ScriptedRun {
+    /// Messages this invocation emits.
+    pub outbound: Vec<OutboundDelegateMsg>,
+    /// Context bytes this invocation writes on exit (`None` leaves it alone),
+    /// modelling the delegate's `ctx.write()`.
+    pub writes_context: Option<Vec<u8>>,
+}
+
+impl From<Vec<OutboundDelegateMsg>> for ScriptedRun {
+    fn from(outbound: Vec<OutboundDelegateMsg>) -> Self {
+        Self {
+            outbound,
+            writes_context: None,
+        }
+    }
+}
+
+/// What one invocation saw when it entered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DelegateObservation {
+    pub delegate_key: DelegateKey,
+    /// Inbound message kinds, so a test can tell WHICH logical run this was —
+    /// a `UserResponse` is a resume, a `ContractNotification` is the
+    /// notification path, and so on. Identifying the run by script position
+    /// would not work: the whole point of an interleaving bug is that the runs
+    /// arrive in a different order than intended.
+    pub inbound_kinds: Vec<&'static str>,
+    /// The context this invocation read on entry.
+    pub observed_context: Option<Vec<u8>>,
+}
+
+/// Shared handle to a mock delegate's scripted runs.
 pub(crate) type DelegateScript =
-    std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<Vec<OutboundDelegateMsg>>>>;
+    std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<ScriptedRun>>>;
 
 /// Shared handle to the log of delegate invocations.
 pub(crate) type DelegateCallLog = std::sync::Arc<std::sync::Mutex<Vec<DelegateKey>>>;
+
+/// Shared handle to the modelled per-delegate context store.
+pub(crate) type DelegateContexts =
+    std::sync::Arc<std::sync::Mutex<std::collections::HashMap<DelegateKey, Vec<u8>>>>;
+
+/// Shared handle to the per-invocation observation log.
+pub(crate) type DelegateObservations = std::sync::Arc<std::sync::Mutex<Vec<DelegateObservation>>>;
+
+/// Name the inbound variants so an observation can identify its logical run.
+fn inbound_kind(msg: &InboundDelegateMsg<'_>) -> &'static str {
+    match msg {
+        InboundDelegateMsg::ApplicationMessage(_) => "ApplicationMessage",
+        InboundDelegateMsg::UserResponse(_) => "UserResponse",
+        InboundDelegateMsg::GetContractResponse(_) => "GetContractResponse",
+        InboundDelegateMsg::PutContractResponse(_) => "PutContractResponse",
+        InboundDelegateMsg::UpdateContractResponse(_) => "UpdateContractResponse",
+        InboundDelegateMsg::SubscribeContractResponse(_) => "SubscribeContractResponse",
+        InboundDelegateMsg::ContractNotification(_) => "ContractNotification",
+        InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+        _ => "Other",
+    }
+}
 
 impl ContractRuntimeInterface for MockWasmRuntime {
     fn validate_state(
@@ -419,8 +491,51 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
         // stays the "not supported" error it has always been, so no existing
         // test changes behaviour.
         let key = req.key().clone();
+
+        // Model the real `DelegateContextCache` read-modify-write around every
+        // invocation (#5544 S7): read on entry, record what was seen, write on
+        // exit. Same key, same last-write-wins semantics as the runtime's.
+        let observed_context = self
+            .runtime
+            .delegate_contexts
+            .lock()
+            .unwrap()
+            .get(&key)
+            .cloned();
+        // Only `ApplicationMessages` carries inbound to classify; the
+        // registration variants carry none. The wildcard is required by
+        // `#[non_exhaustive]` and is listed alongside the known variants so a
+        // future one is not silently swallowed.
+        let inbound_kinds: Vec<&'static str> = match &req {
+            DelegateRequest::ApplicationMessages { inbound, .. } => {
+                inbound.iter().map(inbound_kind).collect()
+            }
+            DelegateRequest::RegisterDelegate { .. }
+            | DelegateRequest::UnregisterDelegate(_)
+            | DelegateRequest::RegisterDelegateWithPredecessors { .. }
+            | _ => Vec::new(),
+        };
+
         let script = self.runtime.delegate_script.lock().unwrap().pop_front();
-        let Some(values) = script else {
+        let record = |rt: &MockWasmRuntime, writes: Option<Vec<u8>>| {
+            rt.delegate_calls.lock().unwrap().push(key.clone());
+            rt.delegate_observations
+                .lock()
+                .unwrap()
+                .push(DelegateObservation {
+                    delegate_key: key.clone(),
+                    inbound_kinds: inbound_kinds.clone(),
+                    observed_context: observed_context.clone(),
+                });
+            if let Some(bytes) = writes {
+                rt.delegate_contexts
+                    .lock()
+                    .unwrap()
+                    .insert(key.clone(), bytes);
+            }
+        };
+
+        let Some(run) = script else {
             if self.runtime.delegate_calls.lock().unwrap().is_empty() {
                 return Err(ExecutorError::other(anyhow::anyhow!(
                     "delegates not supported in MockWasmRuntime"
@@ -429,22 +544,17 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
             // Script exhausted after a real scripted run: the delegate has
             // nothing more to say. Record the entry so exclusion assertions
             // still see it.
-            self.runtime
-                .delegate_calls
-                .lock()
-                .unwrap()
-                .push(key.clone());
+            record(&self.runtime, None);
             return Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
                 key,
                 values: Vec::new(),
             });
         };
-        self.runtime
-            .delegate_calls
-            .lock()
-            .unwrap()
-            .push(key.clone());
-        Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key, values })
+        record(&self.runtime, run.writes_context);
+        Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {
+            key,
+            values: run.outbound,
+        })
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
@@ -484,6 +594,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             update_overrides: HashMap::new(),
             delegate_script: DelegateScript::default(),
             delegate_calls: DelegateCallLog::default(),
+            delegate_contexts: DelegateContexts::default(),
+            delegate_observations: DelegateObservations::default(),
         };
 
         Executor::new(
@@ -516,6 +628,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             update_overrides: HashMap::new(),
             delegate_script: DelegateScript::default(),
             delegate_calls: DelegateCallLog::default(),
+            delegate_contexts: DelegateContexts::default(),
+            delegate_observations: DelegateObservations::default(),
         };
 
         Executor::new(state_store, || Ok(()), OperationMode::Local, runtime, None).await
@@ -540,6 +654,8 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             update_overrides: HashMap::new(),
             delegate_script: DelegateScript::default(),
             delegate_calls: DelegateCallLog::default(),
+            delegate_contexts: DelegateContexts::default(),
+            delegate_observations: DelegateObservations::default(),
         };
 
         Executor::new(

--- a/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
@@ -53,6 +53,8 @@ fn make_mock_runtime(override_: UpdateOverride) -> MockWasmRuntime {
         contract_store: InMemoryContractStore::default(),
         validate_overrides: HashMap::new(),
         update_overrides: overrides,
+        delegate_script: Default::default(),
+        delegate_calls: Default::default(),
     }
 }
 
@@ -236,6 +238,8 @@ fn healthy_mock_is_idempotent_on_reapply() {
         contract_store: InMemoryContractStore::default(),
         validate_overrides: HashMap::new(),
         update_overrides: HashMap::new(),
+        delegate_script: Default::default(),
+        delegate_calls: Default::default(),
     };
     let key = fake_key();
     let params = Parameters::from(vec![]);

--- a/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/non_idempotent_detector_tests.rs
@@ -55,6 +55,8 @@ fn make_mock_runtime(override_: UpdateOverride) -> MockWasmRuntime {
         update_overrides: overrides,
         delegate_script: Default::default(),
         delegate_calls: Default::default(),
+        delegate_contexts: Default::default(),
+        delegate_observations: Default::default(),
     }
 }
 
@@ -240,6 +242,8 @@ fn healthy_mock_is_idempotent_on_reapply() {
         update_overrides: HashMap::new(),
         delegate_script: Default::default(),
         delegate_calls: Default::default(),
+        delegate_contexts: Default::default(),
+        delegate_observations: Default::default(),
     };
     let key = fake_key();
     let params = Parameters::from(vec![]);

--- a/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
@@ -81,6 +81,8 @@ fn setup_mock() -> MockWasmRuntime {
         update_overrides: std::collections::HashMap::new(),
         delegate_script: Default::default(),
         delegate_calls: Default::default(),
+        delegate_contexts: Default::default(),
+        delegate_observations: Default::default(),
     }
 }
 

--- a/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
@@ -79,6 +79,8 @@ fn setup_mock() -> MockWasmRuntime {
         contract_store: InMemoryContractStore::new(),
         validate_overrides: std::collections::HashMap::new(),
         update_overrides: std::collections::HashMap::new(),
+        delegate_script: Default::default(),
+        delegate_calls: Default::default(),
     }
 }
 

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -714,6 +714,71 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// #5544 P1b: a prompt future dropped mid-await must not leave its registry
+    /// entry behind.
+    ///
+    /// `PARK_WORK_BUDGET` bounds a parked delegate's whole off-loop body and its
+    /// prompts run sequentially inside it, so a slow first prompt leaves the
+    /// second cancelled while it waits for a human — after `pending.insert`,
+    /// before the explicit `pending.remove`. Nothing sweeps `pending`, so each
+    /// orphan is permanent, and `MAX_PENDING_PROMPTS` of them auto-deny every
+    /// later permission request on the node, for every delegate, forever.
+    /// `PromptEntryGuard` is the only thing standing between that and a user;
+    /// this is the only test of it.
+    ///
+    /// Cancellation is driven by dropping the future between polls rather than
+    /// by a timer: the entry is inserted on the first poll (the first await is
+    /// the wait for the human), so the drop lands in exactly the window the
+    /// budget cancels in, with no wall-clock dependence.
+    ///
+    /// FALSIFY by neutering the guard's body — `if false && self.pending.remove(
+    /// &self.nonce).is_some()`, the mutation that survived the whole 5465-test
+    /// suite before this test existed. Both assertions go red.
+    #[tokio::test]
+    async fn a_prompt_cancelled_mid_await_removes_its_pending_entry() {
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let prompter = noop_prompter(pending.clone());
+        let req = make_test_request("Allow this?", vec!["Allow", "Deny"]);
+
+        let mut prompting = Box::pin(prompter.prompt(&req, "dkey", webapp("cid")));
+        assert!(
+            futures::poll!(prompting.as_mut()).is_pending(),
+            "the prompt must be waiting for a human, not resolved"
+        );
+        let nonce = pending
+            .iter()
+            .next()
+            .expect("the prompt must have registered a pending entry")
+            .key()
+            .clone();
+
+        // Subscribe before the drop: the guard must also retire the prompt in
+        // the UI, or every tab keeps showing a dialog nothing can answer.
+        let mut events = prompt_events().subscribe();
+        drop(prompting);
+
+        assert!(
+            pending.is_empty(),
+            "a cancelled prompt must not leave its entry behind: nothing sweeps \
+             `pending`, so MAX_PENDING_PROMPTS orphans auto-deny every later \
+             permission request on this node (#5544 P1b)"
+        );
+        // The broadcast is process-global and shared with other tests, so match
+        // on OUR nonce rather than on the next event to arrive.
+        let mut removed = false;
+        while let Ok(event) = events.try_recv() {
+            if matches!(&event, PromptEvent::Removed { nonce: n } if *n == nonce) {
+                removed = true;
+                break;
+            }
+        }
+        assert!(
+            removed,
+            "the guard must emit Removed for the cancelled prompt so open tabs \
+             stop displaying a dialog that can no longer be answered"
+        );
+    }
+
     #[test]
     fn test_nonce_is_32_hex_chars() {
         let nonce = generate_nonce();

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -402,6 +402,21 @@ impl UserInputPrompter for DashboardPrompter {
                 response_tx: tx,
             },
         );
+        // CANCELLATION SAFETY (#5544 P1b). The removal below runs only if this
+        // future is polled to completion. #5544 wraps a delegate's prompts in a
+        // PARK_WORK_BUDGET timeout, so a second prompt can be DROPPED here —
+        // after the insert, before the removal — and the entry then persists
+        // forever, because nothing sweeps `pending`. Thirty-two of those fill
+        // MAX_PENDING_PROMPTS, after which every later permission request on
+        // this node is auto-denied, for every delegate, permanently.
+        //
+        // The guard removes on drop, so insert and removal are paired wherever
+        // the future ends. The explicit cleanup below still runs on the normal
+        // path; `PendingPrompts` is a DashMap and a second remove is a no-op.
+        let _cancel_guard = PromptEntryGuard {
+            pending: self.pending.clone(),
+            nonce: nonce.clone(),
+        };
 
         // Fire the broadcast Added event AFTER the DashMap insert so any
         // subscriber that wakes up on the event can immediately find the entry
@@ -465,6 +480,37 @@ impl UserInputPrompter for DashboardPrompter {
                 tracing::warn!(nonce = %nonce, "Permission prompt timed out after 60s");
                 None
             }
+        }
+    }
+}
+
+/// Removes a pending-prompt registry entry if its prompt future is dropped
+/// before it can clean up after itself (#5544 P1b).
+///
+/// Exists because a cancelled prompt is now reachable: #5544 bounds a parked
+/// delegate's off-loop work with `PARK_WORK_BUDGET`, and prompts run
+/// sequentially inside it, so a slow first prompt can leave a second one
+/// cancelled mid-await. Without this, that entry is never removed and never
+/// swept, and 32 of them disable permission prompting node-wide.
+struct PromptEntryGuard {
+    pending: PendingPrompts,
+    nonce: String,
+}
+
+impl Drop for PromptEntryGuard {
+    fn drop(&mut self) {
+        if self.pending.remove(&self.nonce).is_some() {
+            // Only reachable on the cancelled path: the normal path removes the
+            // entry before this guard drops, so a hit here means the future was
+            // dropped mid-await.
+            tracing::warn!(
+                "Permission prompt was cancelled before it completed; removed its \
+                 registry entry so it cannot accumulate toward MAX_PENDING_PROMPTS \
+                 (#5544 P1b)"
+            );
+            emit_prompt_event(PromptEvent::Removed {
+                nonce: self.nonce.clone(),
+            });
         }
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -63,13 +63,33 @@ pub(crate) static DELEGATE_SUBSCRIPTIONS: LazyLock<
 /// entry and stores the (possibly-mutated) `Vec` back on exit. Cleared on
 /// `UnregisterDelegate` so an unregistered delegate can't accumulate state.
 ///
-/// Concurrency: the runtime serializes calls into a given delegate instance
-/// (one WASM `process()` at a time), so two prompt round-trips on the same
-/// delegate cannot interleave context writes. Wrapped in `Arc` so a
-/// `RuntimePool` of `Runtime`s shares one cache: a delegate's first call
-/// might run on executor A and its `UserResponse` follow-up on executor B,
-/// so per-`Runtime` storage would have the same locality bug as the
-/// per-call `Vec`.
+/// Concurrency — READ THIS BEFORE RELYING ON IT. Because the map is keyed by
+/// `DelegateKey` alone and is last-write-wins, it is only safe while at most
+/// ONE `process()` per delegate is in flight. That property holds today, but
+/// **the runtime does not provide it**: `prepare_delegate_call` takes no
+/// per-delegate lock (its mutex guards the module cache, keyed by code hash),
+/// `RuntimePool::execute_delegate_request` pops an arbitrary pooled executor
+/// with no per-delegate affinity, and there is no per-delegate mutex anywhere
+/// in `wasm_runtime::delegate`.
+///
+/// It is supplied entirely by the SERIAL `contract::contract_handling` loop:
+/// both call sites of `execute_delegate_request` sit inside
+/// `handle_delegate_with_contract_requests`, which runs on that one loop, so a
+/// second call for the same delegate cannot begin until the first returns.
+///
+/// The consequence, spelled out because an earlier version of this comment
+/// credited the runtime and would have let someone remove the real protection
+/// believing it was redundant: anything that lets a delegate's round-trip span
+/// two loop iterations — parking it mid-prompt, deferring a contract op —
+/// breaks this invariant and must bring its own per-delegate exclusion. A
+/// second run would otherwise overwrite the parked continuation's context, and
+/// the delegate would resume reading someone else's bytes. Silent state
+/// corruption, not a crash.
+///
+/// Wrapped in `Arc` so a `RuntimePool` of `Runtime`s shares one cache: a
+/// delegate's first call might run on executor A and its `UserResponse`
+/// follow-up on executor B, so per-`Runtime` storage would have the same
+/// locality bug as the per-call `Vec`.
 ///
 /// TTL: each entry stores the `Instant` it was last written. On every
 /// `inbound_app_message` call the loader prunes entries older than


### PR DESCRIPTION
Fixes #5544.

## Problem

The delegate arms of `handle_delegate_with_contract_requests` perform blocking `.await`s while running on the **single serial `contract_handling` loop**. While one is in progress, every contract operation on the node is stalled — GET, PUT, UPDATE, subscribe registration, delegate notification delivery alike.

Two instances:

- **Up to 60 s on a user prompt.** `prompter.prompt(..).await` waits on a human clicking a button, and with no dashboard tab open it opens a browser and still waits. **This is live in production:** the ghostkeys delegate emits `RequestUserInput` in four places. Within freenet-core only test fixtures emit it, which is why it went unnoticed.
- **Up to 10 s on a related-contract fetch, unconditionally.** The delegate PUT/UPDATE arms called `upsert_contract_state` directly rather than via the deferral helper, so an unheld related contract parked the loop for `RELATED_FETCH_TIMEOUT`.

#4391 de-blocked this loop for the client paths and built the machinery to do it. The delegate path is the one corner it never reached.

## Approach

Park the delegate off the loop and resume it on a later iteration when the awaited thing arrives — reusing the shape `ContractNotification` already uses in production, and the continuation storage that already exists (`DelegateContextCache`, whose own rustdoc names the `RequestUserInput → UserResponse` round trip as its reason for existing). The delegate is already suspended at the prompt: `RequestUserInput` breaks out of `process_outbound`, so the WASM call has returned before the loop ever blocks. This makes the loop agree with what the runtime was already doing.

**One park point serves both stalls, and that is load-bearing rather than tidy.** A single iteration can produce both a prompt and a deferred upsert; with two park points, whichever parked first would silently drop the other's work, since only the parking side carries a continuation.

### Per-delegate exclusion — the part to review hardest

`DelegateContextCache` is keyed by `DelegateKey` alone, last-write-wins, and its rustdoc asserted the safety property that made this sound: *"the runtime serializes calls into a given delegate instance."*

**The runtime does not.** There is no per-delegate lock in `prepare_delegate_call`, no per-delegate affinity in `RuntimePool::execute_delegate_request`, and no mutex anywhere in `wasm_runtime/delegate/`. That serialization was supplied **entirely by the serial loop** — precisely what this change removes. Without care, a second request for a parked delegate would run `process()`, write context, and clobber the parked continuation, which then resumes reading another invocation's state: silent corruption, not a crash.

So this adds **per-delegate exclusion**: while a delegate has a parked continuation, no new `process()` runs for it; requests are held in a per-delegate pending list and drained on resume or timeout. That preserves the invariant exactly and converts a **node-wide** stall into a **per-delegate** one — which is not a compromise, it is the semantics the delegate author already assumes and the rustdoc already promises. The loop was over-delivering it at the whole node's expense.

The incorrect rustdoc is corrected in its own docs-only commit, and now names where the guarantee actually comes from.

### Bounds

- `MAX_PENDING_PER_DELEGATE = 8` — overflow is **rejected**, not dropped; the caller answers with an empty response so the client sees a response rather than hanging.
- `MAX_PARKED_DELEGATES = 64` — over the cap, park is refused and the caller falls back to the old inline wait. Degrading to pre-fix behaviour under an implausible flood beats losing a user's permission prompt.
- `PARK_TTL = 90 s` — deliberately **above** both inner budgets (`USER_INPUT_TIMEOUT` 60 s, the deferred related fetch ~62 s), so the real timeout wins; a park firing first would cut a merely-slow operation short and report a spurious failure.
- `PARK_WORK_BUDGET = 75 s` **must stay below `PARK_TTL`**, or the backstop sweep force-resumes while the task is still running and discards its result. Documented at both constants — tune one, tune both.

Exactly-once delivery holds on the **timeout** path as well as the success path: `ParkGuard::drop` delivers a resume with `cause = TimedOut`, handled identically. A dropped, panicked or cancelled task cannot strand a client or wedge a delegate.

## Concurrency: this does NOT unmask the `state_content_changed` TOCTOU in #5490

Recorded because #5490's no-change gate depends on it and nothing enforces it.

That gate does a read then a write, non-atomically, and is safe only while V2 delegate writes are globally serialized. **They still are after this change**, verified by reading the code rather than by argument:

`execute_delegate_request` is reached only through `handle_delegate_with_contract_requests`. Every route into that function is `await`ed, directly or one hop removed, from `contract_handling` — a single task per node:

```
contract_handling
  |- handle_contract_event ---------> dispatch_delegate_request --+
  |- handle_delegate_notification ---------------------------------|
  \- handle_delegate_resume --+------------------------------------|
                              |-> dispatch_delegate_request --------|
                              \-> run_queued_notification ----------+
                                                                    |
                   handle_delegate_with_contract_requests <---------+
                               \-> execute_delegate_request
```

- The off-loop task captures a `ParkGuard`, an `Arc<P: UserInputPrompter>`, an `Option<Arc<OpManager>>` and plain data — **no `ContractHandler`, no executor** — so it cannot invoke a delegate even by mistake.
- Parking returns from the loop while the delegate is **suspended, not running** — the WASM call has already returned. A resume re-enters from `handle_delegate_resume`, **on the loop**; the spawned task only ships a result down a channel.

Names, not line numbers: an earlier version of this section cited four line numbers, none of which were call sites by the time anyone read them — this file grew ~2,400 lines during review. The same reasoning retired the "four call sites" tally in `delegate_park`'s module docs, which was wrong the moment `run_queued_notification` was added (there are five).

So at most one `process()` runs at any instant node-wide, and V2 writes happen only during `process()`. Note that per-delegate exclusion alone would **not** be sufficient for that gate: its racing pair is two *different* delegates writing the same contract, which per-delegate exclusion permits. The property comes from the loop, not from the exclusion.

## Testing

Five tests, **each falsified by actually breaking the code and observing the failure**, not by inspection:

| Test | Mutation | Result |
|---|---|---|
| `parked_delegate_prompt_does_not_block_the_loop` | disable parking | GET times out |
| `a_parked_delegate_is_not_re_entered_until_it_resumes` | delete the `is_parked` check | 2 entries where 1 is allowed |
| `deferred_delegate_upsert_does_not_block_the_loop` | disable the deferral | off-loop fetch count 0, expected 1 |
| `a_delegate_that_parks_twice_still_answers_its_client_once` | drop the responder carry | client answered early |
| 8 unit tests on the park registry | bounds, TTL, exactly-once guard | — |

The exclusion test cannot fail on pre-change `main`, since the blocked loop prevents the interleave by construction. That is stated in a comment on the test with the exact falsification to re-run, so a reviewer can check it rather than take it on trust.

**One test was vacuous and was caught only by running the falsification.** The first deferred-upsert test passed with the deferral disabled: the harness has no `op_manager`, so the inline fetch fails fast instead of hanging, and "the GET stayed prompt" was true for a reason unrelated to the fix. It now asserts things that discriminate (the off-loop fetch stub was invoked; the delegate has not answered while its fetch is gated). The generalisation — *a "does not block" test is only as good as whether the counterfactual actually blocks in that harness* — applies to the pre-existing #4391 test `deferred_related_fetch_does_not_block_local_get`, which uses the same harness and makes the same claim. Flagged, not audited.

## Not in scope

#5542's network GET/SUBSCRIBE. This builds the re-entry machinery that work needs; delegate UPDATE still fails on a local miss.

## Review focus

1. **The exclusion in `dispatch_delegate_request`** — everything rests on it. A future path invoking a delegate without going through that chokepoint silently loses the guarantee.
2. **The responder lifecycle** — parked → attach → resume → answer, or re-park and carry. Exactly-once matters; a drop hangs a client.
3. **`PARK_WORK_BUDGET` vs `PARK_TTL`** — see above.
4. **A judgement call needing a second opinion:** deferred upsert responses now reach the delegate after the iteration's other responses rather than in request order. The argument that this is not a semantic change is that `inbound_app_message` already calls `process()` once per message, so it looks like a later batch, and each response carries its own `contract_id` and `context`.

https://claude.ai/code/session_01Y9qrviB48FmYHRp79e3DzV

[AI-assisted - Claude]

