### PR TITLE
fix(put): report success when a streaming PUT's watchdog outlives the reply

### DIFF
--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -148,6 +148,29 @@ async fn run_client_put(
     deliver_outcome(&op_manager, client_tx, outcome);
 }
 
+/// Decide whether an `Exhausted` retry-loop outcome should be reported to
+/// the client as success rather than a failure (#5458).
+///
+/// A streaming PUT gets exactly one attempt
+/// (`MAX_PEER_ADVANCEMENTS_STREAMING == 0`): its watchdog abandoning the
+/// wait for a downstream reply is the ONLY way it reaches `Exhausted`, and
+/// by construction (`drive_relay_put`'s Step 1) the contract is already
+/// durably stored on this node before any downstream dispatch is even
+/// attempted. So "exhausted" there means "we gave up waiting to hear back",
+/// not "the PUT failed" — PROVIDED the local store had actually finished
+/// before the watchdog fired, which `local_store_committed` is the one
+/// honest signal for (the watchdog's own clock starts before the store
+/// even begins, so a very early false stall is a real possibility this
+/// function must not paper over).
+///
+/// Non-streaming PUTs retry across multiple peers before exhausting, so a
+/// local copy existing does not mean the network-wide propagation that
+/// class of caller is more plausibly relying on has happened — they are
+/// deliberately excluded here and keep reporting the real failure.
+fn exhausted_attempt_is_local_success(is_streaming: bool, local_store_committed: bool) -> bool {
+    is_streaming && local_store_committed
+}
+
 /// PUT driver has exactly two outcomes — no `SkipAlreadyDelivered` because
 /// PUT doesn't use `NodeEvent::LocalPutComplete` (the driver owns local
 /// completion delivery directly).
@@ -555,6 +578,53 @@ async fn drive_client_put_inner(
             .into())))
         }
         RetryLoopOutcome::Exhausted(cause) => {
+            // #5458: see `exhausted_attempt_is_local_success` for why a
+            // streaming PUT's watchdog giving up is not the same as the PUT
+            // having failed.
+            let locally_stored = exhausted_attempt_is_local_success(
+                is_streaming,
+                driver
+                    .stream_progress
+                    .as_ref()
+                    .is_some_and(|p| p.handle().local_store_committed()),
+            );
+            if locally_stored {
+                tracing::info!(
+                    tx = %client_tx,
+                    contract = %key,
+                    %cause,
+                    phase = "put_exhausted_but_locally_stored",
+                    "PUT: streaming attempt gave up waiting for the downstream \
+                     reply, but the contract is already durably stored on this \
+                     node; reporting success instead of the timeout (#5458)"
+                );
+                op_manager.completed(client_tx);
+                super::finalize_put_at_originator(
+                    op_manager,
+                    client_tx,
+                    key,
+                    PutFinalizationData {
+                        sender: driver.current_target.clone(),
+                        // Unlike `LocalCompletion` (definitively zero remote
+                        // hops), the payload WAS forwarded here — we just
+                        // never learned how far. `None` avoids reporting a
+                        // knowingly wrong hop count.
+                        hop_count: None,
+                        state_hash: None,
+                        state_size: None,
+                    },
+                    false,
+                    false,
+                )
+                .await;
+
+                maybe_subscribe_child(op_manager, client_tx, key, subscribe, blocking_subscribe)
+                    .await;
+
+                return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
+                    ContractResponse::PutResponse { key },
+                ))));
+            }
             Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                 cause: cause.into(),
             }
@@ -1704,6 +1774,20 @@ where
         put_store_cause(originator_loopback),
     )
     .await?;
+
+    // #5458: the contract is now durably stored on this node, independent of
+    // whatever happens to the downstream forward below. On the
+    // originator-loopback path, `incoming_tx` is the same `attempt_tx` the
+    // client's own retry loop (Task A) registered a `StreamProgress` handle
+    // under before sending — latch the fact so Task A can tell "this PUT
+    // never applied" apart from "it applied, we just never got the
+    // downstream reply" if its watchdog gives up waiting. A genuine relay
+    // hop's lookup is a harmless no-op: this node's own registry never had
+    // `incoming_tx` inserted (that only happens in the client's own
+    // `drive_retry_loop`, on the client's own node).
+    if let Some(progress) = op_manager.stream_progress_registry().get(&incoming_tx) {
+        progress.mark_local_store_committed();
+    }
 
     // ── Step 2: Build skip list + select next hop ──────────────────────────
     let mut new_skip_list = skip_list;
@@ -5799,7 +5883,10 @@ mod tests {
     #[test]
     fn driver_outcome_exhausted_produces_client_error() {
         // Verify that RetryLoopOutcome::Exhausted maps to a client-visible
-        // OperationError, not a silent drop or infrastructure error.
+        // OperationError, not a silent drop or infrastructure error. This is
+        // the baseline (non-locally-stored) case; see
+        // `exhausted_attempt_is_local_success_*` below for the #5458 case
+        // where an exhausted streaming attempt is reported as success instead.
         let cause = "PUT to contract failed after 3 attempts".to_string();
         let outcome: DriverOutcome =
             match RetryLoopOutcome::<(ContractKey, Option<usize>)>::Exhausted(cause) {
@@ -5816,6 +5903,112 @@ mod tests {
         assert!(
             matches!(outcome, DriverOutcome::Publish(Err(_))),
             "Exhaustion must produce a client error, not be swallowed"
+        );
+    }
+
+    /// #5458: the decision table for `exhausted_attempt_is_local_success`.
+    /// Only the streaming-AND-committed cell may report success; the other
+    /// three must keep reporting the real failure.
+    #[test]
+    fn exhausted_attempt_is_local_success_decision_table() {
+        assert!(
+            exhausted_attempt_is_local_success(true, true),
+            "streaming + locally committed → success"
+        );
+        assert!(
+            !exhausted_attempt_is_local_success(true, false),
+            "streaming but NOT yet committed (watchdog fired before the local \
+             store finished) must NOT report success — that would be a false \
+             positive for a PUT that never actually applied"
+        );
+        assert!(
+            !exhausted_attempt_is_local_success(false, true),
+            "non-streaming PUTs retry across peers before exhausting; a local \
+             copy existing must not paper over exhausting every peer"
+        );
+        assert!(
+            !exhausted_attempt_is_local_success(false, false),
+            "neither streaming nor committed → definitely not a success"
+        );
+    }
+
+    /// #5458 regression: `drive_relay_put` must latch `mark_local_store_committed`
+    /// on the tx's `StreamProgress` handle (if one is registered) AFTER the
+    /// local store succeeds and BEFORE attempting the downstream forward —
+    /// mirroring `drive_relay_put_stores_locally_before_forwarding`'s ordering
+    /// check for the store itself. Without this, `drive_client_put_inner`'s
+    /// `Exhausted` arm has no way to distinguish a genuinely-applied streaming
+    /// PUT from one whose local store never even ran.
+    #[test]
+    fn drive_relay_put_marks_local_store_committed_after_storing_locally() {
+        let prod = production_source();
+        let body = extract_fn_body(prod, "async fn drive_relay_put<CB>(");
+
+        let store_pos = body
+            .find("relay_put_store_locally(")
+            .expect("relay_put_store_locally call missing in drive_relay_put");
+        let mark_pos = body.find("mark_local_store_committed()").expect(
+            "drive_relay_put MUST call mark_local_store_committed() after the \
+             local store succeeds (#5458)",
+        );
+        assert!(
+            mark_pos > store_pos,
+            "mark_local_store_committed must run AFTER relay_put_store_locally \
+             — it exists to prove the store actually happened, not to predict it"
+        );
+
+        for forward_marker in ["ctx.send_to_and_await(", "send_to_and_register_waiter("] {
+            let forward_pos = body
+                .find(forward_marker)
+                .unwrap_or_else(|| panic!("{forward_marker} call missing in drive_relay_put"));
+            assert!(
+                mark_pos < forward_pos,
+                "mark_local_store_committed must run BEFORE the downstream \
+                 forward ({forward_marker}) — the whole point is to record the \
+                 fact before anything about the forward can go wrong"
+            );
+        }
+    }
+
+    /// #5458 regression: `drive_client_put_inner`'s `Exhausted` arm must
+    /// actually consult `exhausted_attempt_is_local_success` and, when it
+    /// returns true, publish a success `PutResponse` instead of the generic
+    /// `OperationError` — not merely compute the boolean and ignore it.
+    ///
+    /// Mutation-verified: deleting the `if locally_stored { ... }` early
+    /// return (leaving only the unconditional `Err` at the bottom) makes this
+    /// FAIL, because `PutResponse` no longer appears before the `Err(...)`
+    /// this test anchors on.
+    #[test]
+    fn drive_client_put_inner_reports_success_when_locally_stored_and_exhausted() {
+        let prod = production_source();
+        let body = extract_fn_body(prod, "async fn drive_client_put_inner(");
+
+        let exhausted_pos = body
+            .find("RetryLoopOutcome::Exhausted(cause)")
+            .expect("Exhausted arm missing from drive_client_put_inner");
+        let arm = &body[exhausted_pos..];
+
+        let decision_pos = arm
+            .find("exhausted_attempt_is_local_success(")
+            .expect("Exhausted arm must consult exhausted_attempt_is_local_success");
+        let success_pos = arm
+            .find("ContractResponse::PutResponse { key }")
+            .expect("Exhausted arm must be able to publish a PutResponse success");
+        let error_pos = arm
+            .find("ErrorKind::OperationError")
+            .expect("Exhausted arm must still be able to publish the real failure");
+
+        assert!(
+            decision_pos < success_pos,
+            "the local-success decision must be computed before the success \
+             path that acts on it"
+        );
+        assert!(
+            success_pos < error_pos,
+            "the success return must be reachable BEFORE the unconditional \
+             error at the bottom of the arm, i.e. behind an early return — \
+             otherwise the success branch is dead code"
         );
     }
 

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -163,6 +163,32 @@ async fn run_client_put(
 /// even begins, so a very early false stall is a real possibility this
 /// function must not paper over).
 ///
+/// # What "success" means here — and what it does NOT confirm
+///
+/// This cannot distinguish "the downstream peer received and stored the
+/// contract, only the reply was lost" (the scenario #5458's own evidence
+/// documents — the peer's telemetry showed the store succeeded) from "the
+/// downstream peer never received anything at all" (dead target, dropped
+/// mid-transfer, one-way partition) — both dispatch without a synchronous
+/// error, so both reach this same `Exhausted` path. Reporting success here
+/// means "your data is durably stored in the network" (this node is a
+/// legitimate host per `.claude/rules/hosting-invariants.md` invariant 2),
+/// NOT "confirmed replicated to or discoverable from the target peer".
+/// That is a real, deliberate widening of the existing `ReplyClass::
+/// LocalCompletion` / #3465 precedent this mirrors: those cover a KNOWN
+/// non-delivery (no next hop, or the forward's own dispatch call returned
+/// an error), where "local success" is the only honest answer. Here the
+/// forward's outcome is genuinely UNKNOWN. The tradeoff is accepted
+/// because the alternative — reporting failure — was already just as
+/// unreliable a signal (fdev's own error text says "may have succeeded,
+/// verify out-of-band"), and #5458's evidence is that the unknown case
+/// resolves to "succeeded" far more often than not. It does mean a client
+/// that hits this path after a genuinely dead target gets no signal to
+/// retry elsewhere, and the contract may end up discoverable only from
+/// this node. See freenet/freenet-core#5458's own "suggested starting
+/// points" for the still-open work on making the real downstream reply
+/// arrive reliably, which would close this gap properly.
+///
 /// Non-streaming PUTs retry across multiple peers before exhausting, so a
 /// local copy existing does not mean the network-wide propagation that
 /// class of caller is more plausibly relying on has happened — they are
@@ -5984,10 +6010,12 @@ mod tests {
         let prod = production_source();
         let body = extract_fn_body(prod, "async fn drive_client_put_inner(");
 
-        let exhausted_pos = body
-            .find("RetryLoopOutcome::Exhausted(cause)")
-            .expect("Exhausted arm missing from drive_client_put_inner");
-        let arm = &body[exhausted_pos..];
+        // Brace-matched to the arm's OWN body (not sliced to end-of-function):
+        // `extract_fn_body` finds the first `{` after the given prefix, and
+        // the prefix here already ends in `{` — the arm's own opening brace —
+        // so this returns exactly the arm's contents, immune to a later match
+        // arm coincidentally containing either marker string.
+        let arm = extract_fn_body(body, "RetryLoopOutcome::Exhausted(cause) => {");
 
         let decision_pos = arm
             .find("exhausted_attempt_is_local_success(")

--- a/crates/core/src/operations/stream_progress.rs
+++ b/crates/core/src/operations/stream_progress.rs
@@ -56,7 +56,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -97,6 +97,16 @@ pub(crate) struct StreamProgressHandle {
     /// The single shared clock both writer and reader read from. See the
     /// single-epoch invariant in the type docs.
     now_millis: Arc<dyn Fn() -> u64 + Send + Sync>,
+    /// One-way latch: has the originator-loopback relay driver (Task B)
+    /// durably committed the contract to local storage yet? Distinct from
+    /// `last_progress_millis` — that tracks per-*fragment* liveness and goes
+    /// quiet the moment sending finishes, while this tracks a single
+    /// irreversible fact set once, before any downstream dispatch is even
+    /// attempted (see `mark_local_store_committed`). Lets the retry loop
+    /// (Task A) tell "the PUT never applied" apart from "it applied, we
+    /// just never heard the downstream reply" when its watchdog gives up
+    /// (#5458).
+    local_store_committed: Arc<AtomicBool>,
 }
 
 impl std::fmt::Debug for StreamProgressHandle {
@@ -105,6 +115,10 @@ impl std::fmt::Debug for StreamProgressHandle {
             .field(
                 "last_progress_millis",
                 &self.last_progress_millis.load(Ordering::Relaxed),
+            )
+            .field(
+                "local_store_committed",
+                &self.local_store_committed.load(Ordering::Relaxed),
             )
             .finish_non_exhaustive()
     }
@@ -123,7 +137,23 @@ impl StreamProgressHandle {
             last_progress_millis: Arc::new(AtomicU64::new(initial)),
             notify: Arc::new(Notify::new()),
             now_millis,
+            local_store_committed: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Latch that the local store has committed durably. Called exactly
+    /// once, by the originator-loopback relay driver, immediately after
+    /// `relay_put_store_locally` returns `Ok` — before it attempts (or even
+    /// decides on) the downstream dispatch. Idempotent; a relaxed store is
+    /// enough because the only thing that matters is "has this ever been
+    /// set", read later by a completely different task.
+    pub(crate) fn mark_local_store_committed(&self) {
+        self.local_store_committed.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether [`Self::mark_local_store_committed`] has been called yet.
+    pub(crate) fn local_store_committed(&self) -> bool {
+        self.local_store_committed.load(Ordering::Relaxed)
     }
 
     /// Record a fragment dispatch. Reads the handle's OWN clock (never a caller-
@@ -505,6 +535,49 @@ mod tests {
             "after the writer's record + 30 s of silence, since_last must show \
              the true elapsed time so the stall fires; a cross-epoch clock would \
              saturate this to 0 and defeat the whole fix"
+        );
+    }
+
+    /// #5458: `local_store_committed` starts false and latches true exactly
+    /// once `mark_local_store_committed` is called — it must never flip back,
+    /// and it must be independent of the fragment-progress clock (a handle
+    /// with zero fragments recorded can still be committed, since the local
+    /// store runs before the first fragment is ever sent).
+    #[test]
+    fn local_store_committed_defaults_false_and_latches_true() {
+        let handle = StreamProgressHandle::new(VirtualTime::new());
+        assert!(
+            !handle.local_store_committed(),
+            "a freshly-constructed handle must not read as committed"
+        );
+
+        handle.mark_local_store_committed();
+        assert!(
+            handle.local_store_committed(),
+            "the latch must read true once marked"
+        );
+
+        // Idempotent: marking again does not un-latch or panic.
+        handle.mark_local_store_committed();
+        assert!(handle.local_store_committed());
+    }
+
+    /// #5458: Task B (the originator-loopback relay driver) and Task A (the
+    /// client's retry loop) each hold their OWN clone of the handle — the
+    /// commit latch must be visible across clones, exactly like the existing
+    /// fragment-progress fields, or the signal can never cross the task
+    /// boundary it exists to bridge.
+    #[test]
+    fn local_store_committed_is_shared_across_clones() {
+        let reader = StreamProgressHandle::new(VirtualTime::new());
+        let writer = reader.clone();
+
+        assert!(!reader.local_store_committed());
+        writer.mark_local_store_committed();
+        assert!(
+            reader.local_store_committed(),
+            "the latch is behind an Arc — a clone's write must be visible \
+             through every other clone, including the one constructed first"
         );
     }
 

--- a/crates/core/src/operations/stream_progress.rs
+++ b/crates/core/src/operations/stream_progress.rs
@@ -388,6 +388,24 @@ impl Drop for StreamProgressGuard {
 /// handler case is rarer than the lost-reply case, so the bound goes to the
 /// common one.
 ///
+/// **#5458 update:** this watchdog firing while the local store already
+/// succeeded no longer produces a client-visible failure for the common case —
+/// `drive_client_put_inner`'s `Exhausted` arm now checks
+/// `StreamProgressHandle::local_store_committed` (set by `drive_relay_put`
+/// right after the local store succeeds) and reports success instead, via
+/// `exhausted_attempt_is_local_success`. That mitigates the "fast wrong
+/// answer" this window is sized to prefer, for the case where the local store
+/// really did finish before the watchdog fired. It does NOT make the terminal
+/// reply itself arrive, and does not help the case where the local store
+/// genuinely hadn't finished yet (a real failure still gets reported there,
+/// correctly) — so this constant's two-sided compromise still matters exactly
+/// as described above; only the consequence of getting it wrong on the "too
+/// short" side has changed from "wrong failure" to "correctly not yet a
+/// success". See `exhausted_attempt_is_local_success`'s doc comment in
+/// `operations::put::op_ctx_task` for what "success" does and does not
+/// confirm, and freenet/freenet-core#5458 for the still-open question of
+/// making the downstream reply itself reliable.
+///
 /// The real fix for both is to make the terminal reply arrive; until then this
 /// constant is a compromise between two bad outcomes rather than a derivation
 /// with a single right answer. Do not "tighten" it toward either end without

--- a/crates/core/tests/fdev_publish_e2e.rs
+++ b/crates/core/tests/fdev_publish_e2e.rs
@@ -232,11 +232,24 @@ async fn fdev_publish_observed(args: &[&str]) {
     // bounds the dead time either way and makes the test independent of
     // node-side timeout tuning.
     //
-    // Note what is being tolerated: that path is a REAL defect, filed as #5458
-    // (the store succeeds and the originator never gets its terminal reply),
-    // not a fixture quirk. Capping the wait makes this helper absorb it more
-    // quietly than a 300 s hang did, so the issue reference belongs here — when
-    // #5458 is fixed, this cap and the polling below can both go.
+    // Note what is being tolerated: that path was a REAL defect, filed as
+    // #5458 (the store succeeds and the originator never gets its terminal
+    // reply), not a fixture quirk. Capping the wait makes this helper absorb
+    // it more quietly than a 300 s hang did.
+    //
+    // #5458 status: PARTIALLY addressed, this cap and the polling below
+    // still stay. The fix makes the originator's own watchdog
+    // (STREAM_OP_INACTIVITY_TIMEOUT, 240 s) report success instead of a
+    // false failure once it gives up waiting for the downstream reply AND
+    // the local store already committed — see
+    // `operations::put::op_ctx_task::exhausted_attempt_is_local_success`.
+    // That fires well past this helper's 30 s cap, so it does not change
+    // what THIS test observes: fdev still sees nothing within 30 s either
+    // way, and the real downstream reply this helper was written to wait
+    // for is still not made reliable or prompt by that fix. The 300 s hang
+    // this cap exists to avoid is therefore still a live possibility, just
+    // with a correct (rather than a false-failure) answer waiting at the
+    // end of it.
     let output = Command::new(fdev_bin())
         .args(args)
         .env("FDEV_RESPONSE_TIMEOUT", "30")


### PR DESCRIPTION
## Problem

A streaming PUT stores locally at the originator before it ever forwards
downstream, but gets exactly one attempt
(`MAX_PEER_ADVANCEMENTS_STREAMING == 0`). When that single attempt's
watchdog (fixed deadline, stream stall, or the hard ceiling) gives up
waiting for the downstream terminal reply, `drive_retry_loop` reports
`Exhausted` and the client is told the PUT failed — even though the
contract is already durably stored on the originator's own node. If the
real downstream reply does arrive later, `try_forward_driver_reply`
finds no waiter (the slot was already released) and drops it silently.
The originator never sees a correct outcome for an operation that
actually succeeded.

This is documented and reproduced (though not fixed) in #5442, and is
what forces `STREAM_OP_INACTIVITY_TIMEOUT` to be a compromise rather
than a derivation — see the comment on that constant and on
`fdev_publish_e2e::fdev_publish_observed`, both of which reference this
issue directly.

## Approach

Give the client's retry loop (Task A) a way to know the local store
already committed, independent of whatever happens on the network round
trip:

- `StreamProgressHandle` (the existing Task A/Task B bridge, already
  used to carry per-fragment progress ticks) gets a new one-way latch:
  `mark_local_store_committed()` / `local_store_committed()`.
- `drive_relay_put`'s Step 1 (`relay_put_store_locally`) sets the latch
  immediately after the local store succeeds, before it ever attempts
  the downstream forward. On a genuine relay hop this is a harmless
  no-op (the lookup by `incoming_tx` only ever hits on the
  originator-loopback path, since only the client's own node's task
  registers an entry under that transaction).
- `drive_client_put_inner`'s `Exhausted` arm now checks a small
  extracted predicate, `exhausted_attempt_is_local_success(is_streaming,
  local_store_committed)`. When true, it reports success — mirroring
  the existing `ReplyClass::LocalCompletion` path and the #3465
  "forward dispatch failed → local success" precedent — instead of a
  spurious timeout error.

Non-streaming PUTs retry across multiple peers before exhausting, so
they're deliberately excluded: a local copy existing there doesn't mean
the network-wide propagation that class of caller more plausibly wants
also happened.

## Testing

- `stream_progress.rs`: unit tests for the new commit latch (defaults
  false, latches true, idempotent, visible across `Arc` clones).
- `op_ctx_task.rs`: a decision-table unit test for
  `exhausted_attempt_is_local_success`, plus two source-scrape pins:
  one verifying `drive_relay_put` calls the latch after the local store
  and before the downstream forward, one verifying
  `drive_client_put_inner`'s `Exhausted` arm actually consults the
  predicate and can reach the success return before the unconditional
  error at the bottom of the arm.
- Both new pins are mutation-verified: deleting the latch call, and
  separately deleting the early success return, each turns the
  corresponding pin red (confirmed locally, not just by inspection).
- `cargo test -p freenet --lib -- operations::put:: operations::stream_progress:: operations::op_ctx::`:
  155 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy -p freenet --lib --tests -- -D warnings`: clean.

I was not able to get a clean, uncontaminated timing-based reproduction
via `fdev_publish_e2e` on this (heavily shared/loaded) dev machine — the
2-node fixture's event loop sat idle for ~30s before any PUT traffic
appeared at all, which looks like host CPU contention rather than the
node's own behavior, and would have made a live-timing assertion flaky
regardless of this fix. The regression coverage above is deterministic
(no wall-clock racing) and directly pins the mechanism described in
#5442's own investigation of this exact defect.

Closes freenet/freenet-core#5458

[AI-assisted - Claude]
