### PR TITLE
fix(ci): drop docs paths-ignore from PR triggers so required checks report

### DIFF
--- a/.github/scripts/check_required_check_path_filters.py
+++ b/.github/scripts/check_required_check_path_filters.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Guard against a path filter making a PR structurally unmergeable.
+"""Guard the invariant that every required status check reports on every PR.
 
 A workflow-level ``paths:`` / ``paths-ignore:`` filter does not report a
 skipped check -- it reports NOTHING. GitHub treats a required status context
 that was never reported as **expected**, not as satisfied, so the merge queue
-refuses the pull request entry. Forever. There is no way around it short of
-adding an unrelated file to the PR.
+refuses the pull request entry. Ordinary contributors have no way around it
+short of adding an unrelated file to the PR (a ruleset bypass actor or an admin
+merge could still force it through).
 
 Shipped in ``ci.yml`` and ``claude-pr-review.yml`` as a cost optimization
 ("skip CI for docs-only changes"). Seven of the eight required contexts came
 from those two workflows, so a PR whose every file matched ``docs/**`` could
-never merge. #5322 sat blocked from 2026-08-14 until #5451 removed the filters.
+never merge. #5322 sat blocked from 2026-08-14 until #5571 removed the filters.
 
 Two things made it hard to spot:
 
@@ -25,15 +26,36 @@ The knowledge was not even new -- ``macos-dmg-swap-e2e.yml`` carries a comment
 saying precisely this above its own filter-free ``on:`` block. A comment in one
 file protected nothing in the other two. Hence this linter.
 
-Scope: a workflow is in scope only if it defines a job whose reported context
-name is in ``REQUIRED_CONTEXTS`` below. Other workflows may filter freely --
-that is a legitimate and common optimization when no required check is at stake.
+It makes two checks, because a path filter is only one of the ways a required
+context stops reporting:
 
-The ``push:`` trigger is deliberately NOT checked. A push run to main happens
-after the merge; nothing blocks on it, so filtering it is free.
+1. **No path filter on a gating trigger.** A workflow is in scope only if it
+   defines a job whose reported context is in ``REQUIRED_CONTEXTS``. Other
+   workflows may filter freely -- that is a legitimate optimization when no
+   required check is at stake. The ``push:`` trigger is deliberately NOT
+   checked: a push run to main happens after the merge and gates nothing.
+
+2. **Coverage** (on by default; ``--no-coverage-check`` for fixture scans).
+   Every context in ``REQUIRED_CONTEXTS`` must be produced by some workflow in
+   the directory. Without this, check 1 is a signal that can go vacuously
+   green: rename the ``Fmt`` job to ``Format`` and the required context ``Fmt``
+   never reports, every PR is blocked with the #5322 symptom, and a
+   filter-only linter sees nothing wrong. The same assertion also catches the
+   linter losing track of a file it is supposed to be guarding -- a
+   reindentation, a flow-style ``on:`` mapping, a job ``name:`` this parser
+   cannot read -- all of which would otherwise silently narrow its scope to
+   nothing.
+
+Parser scope, stated because check 1's message reads like total coverage and is
+not: block- and flow-style filters are both detected, at the 2-space trigger /
+4-space key indentation every workflow in this repo uses. A workflow written
+with 4-space YAML indentation, a flow-style ``on:`` mapping, or a job ``name:``
+carrying a trailing comment is not parsed. Check 2 is the backstop for exactly
+that: a required-context workflow this parser cannot read drops out of the
+coverage set and fails.
 
 Usage:
-    check_required_check_path_filters.py [WORKFLOW_DIR]
+    check_required_check_path_filters.py [WORKFLOW_DIR] [--no-coverage-check]
     check_required_check_path_filters.py --self-test
 """
 
@@ -41,6 +63,7 @@ from __future__ import annotations
 
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 # The contexts branch protection requires on the default branch.
@@ -50,10 +73,19 @@ from pathlib import Path
 #     --jq '.rules[] | select(.type=="required_status_checks")
 #           | .parameters.required_status_checks[].context'
 #
-# Drift is one-sided in its danger. If a context is REMOVED from the ruleset and
-# left here, this linter merely refuses a path filter that would now be safe --
-# noisy, not harmful. If a context is ADDED to the ruleset and not added here,
-# the new context is unguarded. Update this list whenever the ruleset changes.
+# Three ways this drifts, only the first of which is harmless:
+#
+#   * A context REMOVED from the ruleset and left here -- the linter refuses a
+#     path filter that would now be safe. Noisy, not dangerous.
+#   * A context ADDED to the ruleset and not added here -- that context is
+#     unguarded by check 1. `playwright-shell.yml` is the live candidate: it is
+#     path-filtered and its own comment contemplates being promoted to required.
+#   * A job RENAMED in a workflow without the ruleset following -- the ruleset
+#     then requires a context nothing reports (the #5322 symptom by another
+#     route) AND this file's scope silently shrinks, two failures from one
+#     cause. The coverage check exists for this one and fails closed on it.
+#
+# Update this list whenever the ruleset changes.
 REQUIRED_CONTEXTS = frozenset(
     {
         "Clippy",
@@ -71,8 +103,8 @@ REQUIRED_CONTEXTS = frozenset(
 # the module docstring).
 GATING_TRIGGERS = ("pull_request", "pull_request_target")
 
-# `jobs:` at column 0 ends the `on:` section for our purposes and begins the
-# region where job names live.
+# `jobs:` at column 0 -- everything indented under it is a job, everything
+# outside it is trigger/config territory.
 JOBS_RE = re.compile(r"^jobs:\s*(?:#.*)?$")
 
 # A job key is `  <id>:` at exactly two-space indent inside `jobs:`; its display
@@ -86,8 +118,12 @@ JOB_NAME_RE = re.compile(r"^    name:\s*(?P<name>.+?)\s*$")
 TRIGGER_RE = re.compile(r"^  (?P<trigger>[A-Za-z_][A-Za-z0-9_]*):\s*(?:#.*)?$")
 
 # `    paths:` / `    paths-ignore:` at exactly four-space indent is a filter on
-# the enclosing trigger.
-FILTER_RE = re.compile(r"^    (?P<key>paths|paths-ignore):\s*(?:#.*)?$")
+# the enclosing trigger. The value is matched loosely on purpose: the block form
+# puts it on following lines, but `paths-ignore: ['docs/**', '*.md']` is equally
+# valid YAML and equally capable of reintroducing #5451 -- and the flow style is
+# already this repo's house style for the sibling key (`branches: [main]`), so
+# it is the form someone re-adding the optimization is most likely to write.
+FILTER_RE = re.compile(r"^    (?P<key>paths|paths-ignore):(?:\s.*)?$")
 
 
 def _jobs_line(lines: list[str]) -> int | None:
@@ -98,6 +134,19 @@ def _jobs_line(lines: list[str]) -> int | None:
     return None
 
 
+def _jobs_block(lines: list[str]) -> tuple[int, int]:
+    """The [start, end) line range of the `jobs:` block's body."""
+    jobs_at = _jobs_line(lines)
+    if jobs_at is None:
+        return len(lines), len(lines)
+    end = len(lines)
+    for i in range(jobs_at + 1, len(lines)):
+        if lines[i] and not lines[i][0].isspace():
+            end = i
+            break
+    return jobs_at + 1, end
+
+
 def reported_contexts(text: str) -> set[str]:
     """The status-check contexts this workflow's jobs report.
 
@@ -105,16 +154,11 @@ def reported_contexts(text: str) -> set[str]:
     Both are collected: either could be what branch protection names.
     """
     lines = text.splitlines()
-    jobs_at = _jobs_line(lines)
-    if jobs_at is None:
-        return set()
+    start, end = _jobs_block(lines)
 
     contexts: set[str] = set()
     current_id: str | None = None
-    for line in lines[jobs_at + 1 :]:
-        if line and not line[0].isspace():
-            # A new top-level key ends the jobs block.
-            break
+    for line in lines[start:end]:
         job = JOB_ID_RE.match(line)
         if job:
             current_id = job.group("id")
@@ -133,13 +177,15 @@ def check_source(text: str, name: str) -> list[str]:
         return []
 
     lines = text.splitlines()
-    jobs_at = _jobs_line(lines)
-    on_end = jobs_at if jobs_at is not None else len(lines)
+    jobs_start, jobs_end = _jobs_block(lines)
 
     errors = []
     current_trigger: str | None = None
-    for i in range(on_end):
-        line = lines[i]
+    for i, line in enumerate(lines):
+        # YAML mappings are unordered, so `on:` may legally sit after `jobs:`.
+        # Scan everything OUTSIDE the jobs block rather than only above it.
+        if jobs_start <= i < jobs_end:
+            continue
         trigger = TRIGGER_RE.match(line)
         if trigger:
             current_trigger = trigger.group("trigger")
@@ -153,26 +199,54 @@ def check_source(text: str, name: str) -> list[str]:
                 f"    A workflow skipped by a path filter reports NOTHING, and "
                 f"GitHub treats a never-reported required context as EXPECTED "
                 f"rather than satisfied, so any PR the filter excludes can "
-                f"never enter the merge queue (#5451; #5322 was blocked for "
-                f"three weeks by exactly this).\n"
+                f"never enter the merge queue (#5451; #5322 was blocked by "
+                f"exactly this from 2026-08-14 until #5571).\n"
                 f"    A `merge_group:` trigger does not rescue it: that only "
                 f"runs for a PR already admitted to the queue.\n"
-                f"    Filter at the STEP level instead (see the `skip_check` "
-                f"steps in ci.yml), so the job still runs and still reports."
+                f"    If the cost is worth it, gate the expensive STEPS on a "
+                f"changed-files check instead, so the job still runs and still "
+                f"reports. `ci.yml`'s `skip_check` steps are the shape to "
+                f"follow, though they key on the event rather than on paths, "
+                f"so a path version needs its own diff step."
             )
     return errors
 
 
-def check_dir(workflow_dir: Path) -> list[str]:
+def check_dir(workflow_dir: Path, require_coverage: bool = True) -> list[str]:
     errors = []
+    covered: set[str] = set()
     for path in sorted(
-        p for p in workflow_dir.iterdir() if p.suffix in (".yml", ".yaml")
+        p
+        for p in workflow_dir.iterdir()
+        if p.is_file() and p.suffix in (".yml", ".yaml")
     ):
-        errors.extend(check_source(path.read_text(encoding="utf-8"), str(path)))
+        text = path.read_text(encoding="utf-8")
+        covered |= reported_contexts(text)
+        errors.extend(check_source(text, str(path)))
+
+    if require_coverage:
+        missing = sorted(REQUIRED_CONTEXTS - covered)
+        if missing:
+            errors.append(
+                f"{workflow_dir}: no workflow in this directory reports the "
+                f"required status context(s) {missing}.\n"
+                f"    A required context that nothing reports blocks EVERY pull "
+                f"request, with the same symptom as #5322: the merge queue "
+                f"says the check is 'expected' and refuses entry.\n"
+                f"    Either the job was renamed or removed without the "
+                f"ruleset following, or REQUIRED_CONTEXTS in this script is "
+                f"stale, or this script can no longer parse the workflow that "
+                f"provides it. Re-derive the list with the `gh api` command in "
+                f"the REQUIRED_CONTEXTS comment and reconcile."
+            )
     return errors
 
 
 # --- self-test ---------------------------------------------------------------
+
+# Every `_BAD_*` / `_GOOD_*` fixture below is checked with `check_source`, which
+# does not do the coverage check; the coverage check has its own cases at the
+# bottom.
 
 # The real pre-fix ci.yml shape. Must be flagged once, for `pull_request` — and
 # NOT for the `push` filter above it.
@@ -229,6 +303,53 @@ jobs:
     runs-on: ubuntu-latest
 """
 
+# The flow-sequence form. Identical effect, one line, and the style this repo
+# already uses for `branches: [main]` — so it is the likeliest way the filter
+# comes back. Must be flagged.
+_BAD_FLOW_SEQUENCE = """\
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths-ignore: ['docs/**', '*.md']
+  merge_group:
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+"""
+
+# `on:` written after `jobs:`. YAML mappings are unordered, so this is legal and
+# the filter is just as live. Must be flagged.
+_BAD_ON_AFTER_JOBS = """\
+name: CI
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+"""
+
+# A job with no `name:` reports under its job id, so the id must be matched
+# against the required list too. Must be flagged.
+_BAD_JOB_ID_CONTEXT = """\
+name: Odd
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  Simulation:
+    runs-on: ubuntu-latest
+"""
+
 # The fix. Must NOT be flagged: the `push` filter is free (nothing gates on a
 # post-merge run), and the gating trigger carries no filter.
 _GOOD_CI = """\
@@ -266,22 +387,9 @@ jobs:
     runs-on: ubuntu-latest
 """
 
-# A job with no `name:` reports under its job id, so the id must be matched
-# against the required list too. Must be flagged.
-_BAD_JOB_ID_CONTEXT = """\
-name: Odd
-on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-
-jobs:
-  Simulation:
-    runs-on: ubuntu-latest
-"""
-
-# `paths` appearing as a STEP input, not a trigger filter. Must NOT be flagged:
-# it sits past `jobs:` and at a deeper indent.
+# `paths` as a STEP input, inside the jobs block. Must NOT be flagged. The
+# jobs-block exclusion is what has to carry this, since `_BAD_ON_AFTER_JOBS`
+# forces the scan to cover lines below `jobs:`.
 _GOOD_PATHS_AS_STEP_INPUT = """\
 name: CI
 on:
@@ -298,6 +406,20 @@ jobs:
             target/debug
 """
 
+# A key that merely starts with `paths` is not a path filter. Must NOT be
+# flagged, or the loosened value-matching above becomes a false-positive source.
+_GOOD_PATHSLIKE_KEY = """\
+name: CI
+on:
+  pull_request:
+    paths_are_not_this: true
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+"""
+
 # The `on: [pull_request]` inline-list form carries no filter and cannot.
 # Must NOT be flagged.
 _GOOD_INLINE_TRIGGER_LIST = """\
@@ -310,34 +432,88 @@ jobs:
     runs-on: ubuntu-latest
 """
 
+# (description, source, expected error count, expected 1-based line of the first
+# error or None). The line is asserted so that a mutation reporting the right
+# NUMBER of errors in the wrong place still fails.
 _CASES = [
-    ("pre-fix ci.yml pull_request filter", _BAD_CI, 1),
-    ("pre-fix claude-pr-review.yml filter", _BAD_TARGET, 1),
-    ("allowlist `paths:` on a required workflow", _BAD_PATHS_ALLOWLIST, 1),
-    ("fixed ci.yml (push filter kept)", _GOOD_CI, 0),
-    ("workflow with no required context", _GOOD_NOT_REQUIRED, 0),
-    ("required context from a bare job id", _BAD_JOB_ID_CONTEXT, 1),
-    ("`paths:` as a step input", _GOOD_PATHS_AS_STEP_INPUT, 0),
-    ("inline `on: [pull_request]` list", _GOOD_INLINE_TRIGGER_LIST, 0),
+    ("pre-fix ci.yml pull_request filter", _BAD_CI, 1, 8),
+    ("pre-fix claude-pr-review.yml filter", _BAD_TARGET, 1, 5),
+    ("allowlist `paths:` on a required workflow", _BAD_PATHS_ALLOWLIST, 1, 4),
+    ("flow-sequence `paths-ignore: [...]`", _BAD_FLOW_SEQUENCE, 1, 6),
+    ("`on:` written after `jobs:`", _BAD_ON_AFTER_JOBS, 1, 9),
+    ("required context from a bare job id", _BAD_JOB_ID_CONTEXT, 1, 4),
+    ("fixed ci.yml (push filter kept)", _GOOD_CI, 0, None),
+    ("workflow with no required context", _GOOD_NOT_REQUIRED, 0, None),
+    ("`paths:` as a step input", _GOOD_PATHS_AS_STEP_INPUT, 0, None),
+    ("a key merely starting with `paths`", _GOOD_PATHSLIKE_KEY, 0, None),
+    ("inline `on: [pull_request]` list", _GOOD_INLINE_TRIGGER_LIST, 0, None),
 ]
+
+
+def _coverage_fixture(rename: str | None = None) -> dict[str, str]:
+    """One filter-free workflow per required context, optionally renaming one."""
+    files = {}
+    for i, context in enumerate(sorted(REQUIRED_CONTEXTS)):
+        reported = rename if (rename and context == "Fmt") else context
+        files[f"w{i}.yml"] = (
+            f"name: W{i}\non:\n  pull_request:\n\njobs:\n"
+            f"  job_{i}:\n    name: {reported}\n    runs-on: ubuntu-latest\n"
+        )
+    return files
+
+
+_COVERAGE_CASES = [
+    ("every required context is reported", _coverage_fixture(), 0),
+    (
+        "a required job renamed out from under the ruleset",
+        _coverage_fixture(rename="Format"),
+        1,
+    ),
+]
+
+
+def _first_error_line(errors: list[str]) -> int | None:
+    if not errors:
+        return None
+    return int(errors[0].split(":")[1])
 
 
 def self_test() -> int:
     failures = 0
-    for desc, source, expected in _CASES:
-        found = len(check_source(source, "<fixture>"))
-        if found == expected:
+    for desc, source, expected, expected_line in _CASES:
+        errors = check_source(source, "<fixture>")
+        found = len(errors)
+        line = _first_error_line(errors)
+        if found == expected and line == expected_line:
             print(f"ok   - {desc}")
         else:
             print(
-                f"FAIL - {desc}: expected {expected} error(s), got {found}",
+                f"FAIL - {desc}: expected {expected} error(s) at line "
+                f"{expected_line}, got {found} at line {line}",
                 file=sys.stderr,
             )
             failures += 1
+
+    for desc, files, expected in _COVERAGE_CASES:
+        with tempfile.TemporaryDirectory() as tmp:
+            for filename, source in files.items():
+                (Path(tmp) / filename).write_text(source, encoding="utf-8")
+            found = len(check_dir(Path(tmp)))
+        if found == expected:
+            print(f"ok   - coverage: {desc}")
+        else:
+            print(
+                f"FAIL - coverage: {desc}: expected {expected} error(s), "
+                f"got {found}",
+                file=sys.stderr,
+            )
+            failures += 1
+
+    total = len(_CASES) + len(_COVERAGE_CASES)
     if failures:
         print(f"\n{failures} self-test failure(s)", file=sys.stderr)
         return 1
-    print(f"\nAll {len(_CASES)} self-tests passed")
+    print(f"\nAll {total} self-tests passed")
     return 0
 
 
@@ -345,12 +521,16 @@ def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         return self_test()
 
-    workflow_dir = Path(argv[1]) if len(argv) > 1 else Path(".github/workflows")
+    require_coverage = "--no-coverage-check" not in argv
+    positional = [a for a in argv[1:] if not a.startswith("--")]
+    workflow_dir = (
+        Path(positional[0]) if positional else Path(".github/workflows")
+    )
     if not workflow_dir.is_dir():
         print(f"ERROR: {workflow_dir} is not a directory", file=sys.stderr)
         return 2
 
-    errors = check_dir(workflow_dir)
+    errors = check_dir(workflow_dir, require_coverage=require_coverage)
     if errors:
         print(
             "ERROR: required-check path-filter check failed "

--- a/.github/scripts/check_required_check_path_filters.py
+++ b/.github/scripts/check_required_check_path_filters.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Guard against a path filter making a PR structurally unmergeable.
+
+A workflow-level ``paths:`` / ``paths-ignore:`` filter does not report a
+skipped check -- it reports NOTHING. GitHub treats a required status context
+that was never reported as **expected**, not as satisfied, so the merge queue
+refuses the pull request entry. Forever. There is no way around it short of
+adding an unrelated file to the PR.
+
+Shipped in ``ci.yml`` and ``claude-pr-review.yml`` as a cost optimization
+("skip CI for docs-only changes"). Seven of the eight required contexts came
+from those two workflows, so a PR whose every file matched ``docs/**`` could
+never merge. #5322 sat blocked from 2026-08-14 until #5451 removed the filters.
+
+Two things made it hard to spot:
+
+* ``*.md`` does NOT match at depth in GitHub path filters, so a PR touching
+  ``.claude/rules/foo.md`` still ran the full suite and merged normally
+  (#5375). "Docs PRs merge here all the time" was true and did not cover it.
+* ``ci.yml`` also triggers on ``merge_group``, which reads like a rescue. It is
+  not: a merge_group run only happens for a PR that has already been ADMITTED
+  to the queue, and admission is exactly what was refused.
+
+The knowledge was not even new -- ``macos-dmg-swap-e2e.yml`` carries a comment
+saying precisely this above its own filter-free ``on:`` block. A comment in one
+file protected nothing in the other two. Hence this linter.
+
+Scope: a workflow is in scope only if it defines a job whose reported context
+name is in ``REQUIRED_CONTEXTS`` below. Other workflows may filter freely --
+that is a legitimate and common optimization when no required check is at stake.
+
+The ``push:`` trigger is deliberately NOT checked. A push run to main happens
+after the merge; nothing blocks on it, so filtering it is free.
+
+Usage:
+    check_required_check_path_filters.py [WORKFLOW_DIR]
+    check_required_check_path_filters.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The contexts branch protection requires on the default branch.
+#
+# Re-derive with:
+#   gh api repos/freenet/freenet-core/rulesets/4028534 \
+#     --jq '.rules[] | select(.type=="required_status_checks")
+#           | .parameters.required_status_checks[].context'
+#
+# Drift is one-sided in its danger. If a context is REMOVED from the ruleset and
+# left here, this linter merely refuses a path filter that would now be safe --
+# noisy, not harmful. If a context is ADDED to the ruleset and not added here,
+# the new context is unguarded. Update this list whenever the ruleset changes.
+REQUIRED_CONTEXTS = frozenset(
+    {
+        "Clippy",
+        "Fmt",
+        "Unit & Integration",
+        "Simulation",
+        "NAT Validation",
+        "Rule Lint",
+        "Claude Rule Review",
+        "macOS bundle-swap E2E",
+    }
+)
+
+# Triggers whose runs gate a pull request. `push` is excluded on purpose (see
+# the module docstring).
+GATING_TRIGGERS = ("pull_request", "pull_request_target")
+
+# `jobs:` at column 0 ends the `on:` section for our purposes and begins the
+# region where job names live.
+JOBS_RE = re.compile(r"^jobs:\s*(?:#.*)?$")
+
+# A job key is `  <id>:` at exactly two-space indent inside `jobs:`; its display
+# name, when set, is `    name: ...` at exactly four. The context GitHub reports
+# is the `name:` if present, otherwise the job id.
+JOB_ID_RE = re.compile(r"^  (?P<id>[A-Za-z_][A-Za-z0-9_-]*):\s*(?:#.*)?$")
+JOB_NAME_RE = re.compile(r"^    name:\s*(?P<name>.+?)\s*$")
+
+# `  pull_request:` / `  pull_request_target:` at exactly two-space indent is a
+# trigger under `on:`. Deeper indents are something else.
+TRIGGER_RE = re.compile(r"^  (?P<trigger>[A-Za-z_][A-Za-z0-9_]*):\s*(?:#.*)?$")
+
+# `    paths:` / `    paths-ignore:` at exactly four-space indent is a filter on
+# the enclosing trigger.
+FILTER_RE = re.compile(r"^    (?P<key>paths|paths-ignore):\s*(?:#.*)?$")
+
+
+def _jobs_line(lines: list[str]) -> int | None:
+    """Index of the top-level `jobs:` line, or None if absent."""
+    for i, line in enumerate(lines):
+        if JOBS_RE.match(line):
+            return i
+    return None
+
+
+def reported_contexts(text: str) -> set[str]:
+    """The status-check contexts this workflow's jobs report.
+
+    A job reports under its `name:` when it has one, otherwise under its job id.
+    Both are collected: either could be what branch protection names.
+    """
+    lines = text.splitlines()
+    jobs_at = _jobs_line(lines)
+    if jobs_at is None:
+        return set()
+
+    contexts: set[str] = set()
+    current_id: str | None = None
+    for line in lines[jobs_at + 1 :]:
+        if line and not line[0].isspace():
+            # A new top-level key ends the jobs block.
+            break
+        job = JOB_ID_RE.match(line)
+        if job:
+            current_id = job.group("id")
+            contexts.add(current_id)
+            continue
+        named = JOB_NAME_RE.match(line)
+        if named and current_id is not None:
+            contexts.add(named.group("name").strip("'\""))
+    return contexts
+
+
+def check_source(text: str, name: str) -> list[str]:
+    """Return human-readable errors for one workflow's source."""
+    guarded = reported_contexts(text) & REQUIRED_CONTEXTS
+    if not guarded:
+        return []
+
+    lines = text.splitlines()
+    jobs_at = _jobs_line(lines)
+    on_end = jobs_at if jobs_at is not None else len(lines)
+
+    errors = []
+    current_trigger: str | None = None
+    for i in range(on_end):
+        line = lines[i]
+        trigger = TRIGGER_RE.match(line)
+        if trigger:
+            current_trigger = trigger.group("trigger")
+            continue
+        filt = FILTER_RE.match(line)
+        if filt and current_trigger in GATING_TRIGGERS:
+            errors.append(
+                f"{name}:{i + 1}: `{filt.group('key')}:` on the "
+                f"`{current_trigger}:` trigger of a workflow that provides "
+                f"required status check(s) {sorted(guarded)}.\n"
+                f"    A workflow skipped by a path filter reports NOTHING, and "
+                f"GitHub treats a never-reported required context as EXPECTED "
+                f"rather than satisfied, so any PR the filter excludes can "
+                f"never enter the merge queue (#5451; #5322 was blocked for "
+                f"three weeks by exactly this).\n"
+                f"    A `merge_group:` trigger does not rescue it: that only "
+                f"runs for a PR already admitted to the queue.\n"
+                f"    Filter at the STEP level instead (see the `skip_check` "
+                f"steps in ci.yml), so the job still runs and still reports."
+            )
+    return errors
+
+
+def check_dir(workflow_dir: Path) -> list[str]:
+    errors = []
+    for path in sorted(
+        p for p in workflow_dir.iterdir() if p.suffix in (".yml", ".yaml")
+    ):
+        errors.extend(check_source(path.read_text(encoding="utf-8"), str(path)))
+    return errors
+
+
+# --- self-test ---------------------------------------------------------------
+
+# The real pre-fix ci.yml shape. Must be flagged once, for `pull_request` — and
+# NOT for the `push` filter above it.
+_BAD_CI = """\
+name: CI
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  merge_group:
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+"""
+
+# The real pre-fix claude-pr-review.yml shape: pull_request_target, with a
+# `types:` key sitting between the trigger and the filter. Must be flagged.
+_BAD_TARGET = """\
+name: Claude PR Rule Review
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    paths-ignore:
+      - 'docs/**'
+  merge_group:
+
+jobs:
+  rule-review:
+    name: Claude Rule Review
+    runs-on: ubuntu-latest
+"""
+
+# An allowlist filter is exactly as dangerous as a denylist one: every PR
+# OUTSIDE the list is then the one that can never merge. Must be flagged.
+_BAD_PATHS_ALLOWLIST = """\
+name: CI
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+
+jobs:
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+"""
+
+# The fix. Must NOT be flagged: the `push` filter is free (nothing gates on a
+# post-merge run), and the gating trigger carries no filter.
+_GOOD_CI = """\
+name: CI
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+  merge_group:
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+  rule_lint:
+    name: Rule Lint
+    runs-on: ubuntu-latest
+"""
+
+# A workflow that provides no required context may filter freely — flagging it
+# would make this linter noise rather than signal.
+_GOOD_NOT_REQUIRED = """\
+name: Benchmarks
+on:
+  pull_request:
+    paths:
+      - 'crates/core/benches/**'
+
+jobs:
+  bench:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+"""
+
+# A job with no `name:` reports under its job id, so the id must be matched
+# against the required list too. Must be flagged.
+_BAD_JOB_ID_CONTEXT = """\
+name: Odd
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  Simulation:
+    runs-on: ubuntu-latest
+"""
+
+# `paths` appearing as a STEP input, not a trigger filter. Must NOT be flagged:
+# it sits past `jobs:` and at a deeper indent.
+_GOOD_PATHS_AS_STEP_INPUT = """\
+name: CI
+on:
+  pull_request:
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v4
+        with:
+          paths: |
+            target/debug
+"""
+
+# The `on: [pull_request]` inline-list form carries no filter and cannot.
+# Must NOT be flagged.
+_GOOD_INLINE_TRIGGER_LIST = """\
+name: CI
+on: [pull_request, merge_group]
+
+jobs:
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+"""
+
+_CASES = [
+    ("pre-fix ci.yml pull_request filter", _BAD_CI, 1),
+    ("pre-fix claude-pr-review.yml filter", _BAD_TARGET, 1),
+    ("allowlist `paths:` on a required workflow", _BAD_PATHS_ALLOWLIST, 1),
+    ("fixed ci.yml (push filter kept)", _GOOD_CI, 0),
+    ("workflow with no required context", _GOOD_NOT_REQUIRED, 0),
+    ("required context from a bare job id", _BAD_JOB_ID_CONTEXT, 1),
+    ("`paths:` as a step input", _GOOD_PATHS_AS_STEP_INPUT, 0),
+    ("inline `on: [pull_request]` list", _GOOD_INLINE_TRIGGER_LIST, 0),
+]
+
+
+def self_test() -> int:
+    failures = 0
+    for desc, source, expected in _CASES:
+        found = len(check_source(source, "<fixture>"))
+        if found == expected:
+            print(f"ok   - {desc}")
+        else:
+            print(
+                f"FAIL - {desc}: expected {expected} error(s), got {found}",
+                file=sys.stderr,
+            )
+            failures += 1
+    if failures:
+        print(f"\n{failures} self-test failure(s)", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(_CASES)} self-tests passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+
+    workflow_dir = Path(argv[1]) if len(argv) > 1 else Path(".github/workflows")
+    if not workflow_dir.is_dir():
+        print(f"ERROR: {workflow_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    errors = check_dir(workflow_dir)
+    if errors:
+        print(
+            "ERROR: required-check path-filter check failed "
+            "(see #5451 for what this prevents)"
+        )
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print("required-check path-filter check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ name: CI
 #    workflow-level path filter is the one optimization that can make a PR
 #    permanently unmergeable, so it is confined to the trigger where no
 #    required check is at stake.
+#    This is a REAL cost increase, not a relocation: since #5571 a docs-only PR
+#    pays the full PR suite (Clippy on ubicloud-standard-8; Unit & Integration,
+#    Simulation and NAT Validation on ubicloud-standard-16; the macOS/Windows
+#    unit jobs) PLUS a paid Claude rule review, on top of the merge_group run it
+#    already paid. That was accepted because docs-only merges are rare (15 in
+#    the year to 2026-09-05) and the alternative — gating each expensive STEP on
+#    a changed-files check — is a large, subtle diff on required checks, where a
+#    mistake makes them pass unconditionally. If docs-only PRs ever become
+#    frequent, that step-level version is the right answer, with data behind it.
 # 2. Skip expensive jobs on main push — PR already validated
 # 3. Skip NAT validation for dependabot PRs — Test is sufficient for version bumps
 # 4. Run fast checks (Fmt, Clippy) in parallel for quick fail-fast
@@ -35,13 +44,15 @@ on:
   # filter reports NOTHING, and GitHub treats a never-reported required context
   # as "expected", not as satisfied — so the merge queue refuses entry forever.
   # A docs-only PR was therefore structurally unmergeable; #5322 sat blocked
-  # from 2026-08-14 until this was removed. The `merge_group:` trigger below
+  # from 2026-08-14 until #5571 removed this. The `merge_group:` trigger below
   # does not rescue it: that only runs for a PR already ADMITTED to the queue.
   #
   # This was easy to miss because `*.md` does not match at depth in GitHub path
   # filters, so a PR touching `.claude/rules/foo.md` always ran full CI and
-  # merged normally (#5375). Only a PR whose every file matched `docs/**` or a
-  # ROOT-level `*.md` hit it.
+  # merged normally (#5375). It bit only a PR whose EVERY file matched one of
+  # the removed patterns — `docs/**`, a ROOT-level `*.md`, `LICENSE`,
+  # `.github/ISSUE_TEMPLATE/**` or `.github/FUNDING.yml`. A PR touching just
+  # `LICENSE`, or just an issue template, was equally stuck.
   #
   # Enforced by .github/scripts/check_required_check_path_filters.py, run from
   # the Rule Lint job below.
@@ -198,6 +209,19 @@ jobs:
       # still wired into rule_lint.
       - name: Self-test merge-queue concurrency guard
         run: bash scripts/merge_group_concurrency_test.sh
+
+      # Regression gate for #5451: a `paths-ignore` on the pull-request trigger
+      # of a workflow that provides a required status context makes every PR the
+      # filter excludes permanently unmergeable — the context is never reported,
+      # and GitHub reads never-reported as "expected" rather than satisfied.
+      # #5322 sat blocked by exactly this from 2026-08-14 until #5571. Pins that
+      # the linter still fires on the real pre-fix `on:` blocks (which #5571
+      # deletes from the repo, so nothing else records them), that it fires on
+      # the one-line flow form, that this repo satisfies both halves of the
+      # invariant, and that the linter is still wired into rule_lint with its
+      # coverage half enabled.
+      - name: Self-test required-check path-filter guard
+        run: bash scripts/required_check_path_filters_test.sh
 
       # Regression gate for the release driver's cross-compile wait: under
       # `set -euo pipefail` a bare `var=$(gh ...)` aborts the whole driver on a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 
 # Cost optimization strategy (Ubicloud runners ~$0.13/run):
-# 1. Skip CI entirely for docs-only changes (paths-ignore)
+# 1. Skip CI entirely for docs-only changes on PUSH TO MAIN only (paths-ignore).
+#    NOT on `pull_request` — see the `on:` block below and #5451. A
+#    workflow-level path filter is the one optimization that can make a PR
+#    permanently unmergeable, so it is confined to the trigger where no
+#    required check is at stake.
 # 2. Skip expensive jobs on main push — PR already validated
 # 3. Skip NAT validation for dependabot PRs — Test is sufficient for version bumps
 # 4. Run fast checks (Fmt, Clippy) in parallel for quick fail-fast
@@ -25,13 +29,23 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/FUNDING.yml'
+  # DO NOT add `paths-ignore:` (or `paths:`) here. Six of the eight required
+  # status contexts come from this workflow (Fmt, Clippy, Rule Lint, Unit &
+  # Integration, Simulation, NAT Validation). A workflow skipped by a path
+  # filter reports NOTHING, and GitHub treats a never-reported required context
+  # as "expected", not as satisfied — so the merge queue refuses entry forever.
+  # A docs-only PR was therefore structurally unmergeable; #5322 sat blocked
+  # from 2026-08-14 until this was removed. The `merge_group:` trigger below
+  # does not rescue it: that only runs for a PR already ADMITTED to the queue.
+  #
+  # This was easy to miss because `*.md` does not match at depth in GitHub path
+  # filters, so a PR touching `.claude/rules/foo.md` always ran full CI and
+  # merged normally (#5375). Only a PR whose every file matched `docs/**` or a
+  # ROOT-level `*.md` hit it.
+  #
+  # Enforced by .github/scripts/check_required_check_path_filters.py, run from
+  # the Rule Lint job below.
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/FUNDING.yml'
   merge_group:
 
 # Cancel in-progress runs when a new commit is pushed to the same branch.
@@ -370,6 +384,17 @@ jobs:
 
       - name: Check merge_group workflows vary their concurrency group
         run: python3 .github/scripts/check_merge_group_concurrency.py .github/workflows
+
+      # Self-test the required-check path-filter linter, then run it. Like the
+      # concurrency linter above it is NOT diff-scoped — the invariant is a
+      # property of each workflow file as it stands. Guards #5451: a workflow
+      # skipped by a path filter reports NOTHING, and a required context that
+      # never reports is "expected" forever, so the merge queue refuses entry.
+      - name: Required-check path-filter linter self-test
+        run: python3 .github/scripts/check_required_check_path_filters.py --self-test
+
+      - name: Check required-check workflows carry no PR path filter
+        run: python3 .github/scripts/check_required_check_path_filters.py .github/workflows
 
       - name: Check for banned patterns in new code
         env:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -86,8 +86,11 @@ on:
   # required status context "Claude Rule Review". A workflow skipped by a path
   # filter reports NOTHING, and GitHub treats a never-reported required context
   # as "expected" rather than satisfied, so the merge queue refuses the PR entry
-  # permanently. Removed for #5451 alongside the same filter on ci.yml; enforced
-  # by .github/scripts/check_required_check_path_filters.py.
+  # permanently. Removed in #5571 (issue #5451) alongside the same filter on
+  # ci.yml; enforced by .github/scripts/check_required_check_path_filters.py.
+  # Consequence worth knowing: docs-only PRs now get a full rule review, which
+  # costs an LLM call and may raise WARNING findings (e.g. "Missing PR
+  # description sections") on a one-line docs change.
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened, labeled]
   # Required by branch protection — merge queue expects this check to report.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -82,14 +82,14 @@ name: Claude PR Rule Review
 # - claude-ci-analysis (in ci.yml): failure debugging
 
 on:
+  # DO NOT add `paths-ignore:` (or `paths:`) here. This workflow provides the
+  # required status context "Claude Rule Review". A workflow skipped by a path
+  # filter reports NOTHING, and GitHub treats a never-reported required context
+  # as "expected" rather than satisfied, so the merge queue refuses the PR entry
+  # permanently. Removed for #5451 alongside the same filter on ci.yml; enforced
+  # by .github/scripts/check_required_check_path_filters.py.
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened, labeled]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/FUNDING.yml'
   # Required by branch protection — merge queue expects this check to report.
   # The job skips the actual review in merge_group context (PR was already reviewed).
   merge_group:

--- a/.github/workflows/playwright-shell.yml
+++ b/.github/workflows/playwright-shell.yml
@@ -18,7 +18,11 @@ name: Shell Playwright E2E
 # required without first restructuring it into an always-green gate + a
 # conditional real job (see the note in macos-dmg-swap-e2e.yml). Until then it
 # runs as an informational gate on PRs that touch the relevant surface and on
-# main.
+# main. If it IS ever promoted, add its context to REQUIRED_CONTEXTS in
+# .github/scripts/check_required_check_path_filters.py in the same change —
+# that linter is what would otherwise catch this filter, and it only looks at
+# workflows providing a context it knows to be required. #5451 is what happens
+# when a required context comes from a path-filtered workflow.
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,10 +308,10 @@ on every run that's missing the secret, so the gap is visible
 early.
 
 `.github/workflows/check-token-coalesce.yml` runs on every PR that
-touches a workflow file (it is path-filtered to
-`.github/workflows/**.yml` and `**.yaml`, which is safe because it is
-not a required check) and fails if any
-new event-emitting step regresses to bare
+touches a workflow file — it is path-filtered to
+`.github/workflows/**.yml` and `**.yaml`, which is safe here because it
+is not a required check (a path-filtered *required* check is #5451) —
+and fails if any new event-emitting step regresses to bare
 `GITHUB_TOKEN` / `github.token` — see issue #4118 for the regression
 class this guard prevents.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,8 +307,11 @@ human has to intervene. `release.yml` emits a GitHub `::warning::`
 on every run that's missing the secret, so the gap is visible
 early.
 
-`.github/workflows/check-token-coalesce.yml` runs on every PR and
-fails if any new event-emitting step regresses to bare
+`.github/workflows/check-token-coalesce.yml` runs on every PR that
+touches a workflow file (it is path-filtered to
+`.github/workflows/**.yml` and `**.yaml`, which is safe because it is
+not a required check) and fails if any
+new event-emitting step regresses to bare
 `GITHUB_TOKEN` / `github.token` — see issue #4118 for the regression
 class this guard prevents.
 

--- a/scripts/required_check_path_filters_test.sh
+++ b/scripts/required_check_path_filters_test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Regression tests for the required-check path-filter guard (#5451).
+#
+# The bug: `ci.yml` and `claude-pr-review.yml` carried a `paths-ignore` covering
+# `docs/**` on their pull-request triggers. Seven of the eight required status
+# contexts came from those two workflows, and a workflow skipped by a path
+# filter reports NOTHING. GitHub treats a required context that never reported
+# as "expected" rather than satisfied, so the merge queue refused entry — #5322
+# was structurally unmergeable from 2026-08-14 until #5571. The `merge_group:`
+# trigger was no rescue: it only runs for a PR already admitted to the queue.
+#
+# `.github/scripts/check_required_check_path_filters.py` has its own
+# `--self-test` over synthetic fixtures. This file tests what that self-test
+# cannot: that the linter fires on the REAL pre-fix files as they stood on
+# `main`, that the repo satisfies the invariant today, and that the linter is
+# actually wired into CI — a guard nobody runs is not a guard. The real pre-fix
+# text is the part that matters most, because #5571 deletes it from the repo:
+# after that, the hand-written fixtures are the only other record.
+#
+# Run manually with: bash scripts/required_check_path_filters_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/.github/scripts/check_required_check_path_filters.py"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+FAILURES=0
+check() {
+    # check <description> <actual> <expected>
+    local desc="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "ok   - $desc"
+    else
+        echo "FAIL - $desc (got '$actual', expected '$expected')" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# The linter's own fixture suite must pass.
+SELF_TEST_RC=0
+python3 "$LINTER" --self-test >/dev/null 2>&1 || SELF_TEST_RC=$?
+check "linter self-test passes" "$SELF_TEST_RC" "0"
+
+# The exact `on:` blocks that shipped and caused the incident, reproduced
+# verbatim from the pre-#5571 files. If the linter does not flag these, it would
+# not have caught the bug it exists to catch.
+mkdir -p "$TEST_TMP/prefix"
+cat > "$TEST_TMP/prefix/ci.yml" <<'YAML'
+name: CI
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+  merge_group:
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+  clippy_check:
+    name: Clippy
+    runs-on: ubicloud-standard-8
+  rule_lint:
+    name: Rule Lint
+    runs-on: ubuntu-latest
+YAML
+cat > "$TEST_TMP/prefix/claude-pr-review.yml" <<'YAML'
+name: Claude PR Rule Review
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+  merge_group:
+
+jobs:
+  rule-review:
+    name: Claude Rule Review
+    runs-on: ubuntu-latest
+YAML
+PREFIX_RC=0
+PREFIX_OUT=$(python3 "$LINTER" --no-coverage-check "$TEST_TMP/prefix" 2>&1) || PREFIX_RC=$?
+check "flags the pre-fix ci.yml and claude-pr-review.yml" "$PREFIX_RC" "1"
+check "flags the pull_request filter, not the push one" \
+    "$(echo "$PREFIX_OUT" | grep -c "on the .pull_request:. trigger")" "1"
+check "flags the pull_request_target filter" \
+    "$(echo "$PREFIX_OUT" | grep -c "on the .pull_request_target:. trigger")" "1"
+check "names the required contexts at risk" \
+    "$(echo "$PREFIX_OUT" | grep -c "'Clippy', 'Fmt', 'Rule Lint'")" "1"
+
+# The one-line flow form is equally valid YAML, equally destructive, and is the
+# style this repo already uses for `branches: [main]` — so it is the likeliest
+# way the optimization comes back. It must not slip past.
+mkdir -p "$TEST_TMP/flow"
+cat > "$TEST_TMP/flow/ci.yml" <<'YAML'
+name: CI
+on:
+  pull_request:
+    paths-ignore: ['docs/**', '*.md']
+
+jobs:
+  fmt_check:
+    name: Fmt
+    runs-on: ubuntu-latest
+YAML
+FLOW_RC=0
+python3 "$LINTER" --no-coverage-check "$TEST_TMP/flow" >/dev/null 2>&1 || FLOW_RC=$?
+check "flags the one-line flow-sequence filter" "$FLOW_RC" "1"
+
+# A workflow that provides no required context may filter freely. Over-reach
+# would turn this linter into noise and get it disabled.
+mkdir -p "$TEST_TMP/unrelated"
+cat > "$TEST_TMP/unrelated/benchmarks.yml" <<'YAML'
+name: Benchmarks
+on:
+  pull_request:
+    paths:
+      - 'crates/core/benches/**'
+
+jobs:
+  bench:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+YAML
+UNRELATED_RC=0
+python3 "$LINTER" --no-coverage-check "$TEST_TMP/unrelated" >/dev/null 2>&1 || UNRELATED_RC=$?
+check "ignores workflows that provide no required context" "$UNRELATED_RC" "0"
+
+# The repo must satisfy both halves of the invariant as it stands: no filter on
+# a gating trigger, and every required context actually reported by something.
+REPO_RC=0
+python3 "$LINTER" "$REPO_ROOT/.github/workflows" >/dev/null 2>&1 || REPO_RC=$?
+check "this repo's required-check workflows carry no PR path filter" "$REPO_RC" "0"
+
+# Pin the CI wiring. Without this, deleting the steps from ci.yml silently
+# retires the guard while every test above still passes.
+check "ci.yml runs the linter over the workflows dir" \
+    "$(grep -c 'check_required_check_path_filters\.py .github/workflows' "$CI_YML")" "1"
+check "ci.yml runs the linter's self-test" \
+    "$(grep -c 'check_required_check_path_filters\.py --self-test' "$CI_YML")" "1"
+check "ci.yml runs this pin test" \
+    "$(grep -c 'scripts/required_check_path_filters_test\.sh' "$CI_YML")" "1"
+# The coverage half is only on when the repo scan passes no opt-out. If someone
+# adds --no-coverage-check to the ci.yml invocation, the job-rename guard is
+# gone and nothing else would notice.
+check "ci.yml does not disable the coverage half" \
+    "$(grep -c 'check_required_check_path_filters\.py .*--no-coverage-check' "$CI_YML")" "0"
+
+if (( FAILURES > 0 )); then
+    echo ""
+    echo "$FAILURES test(s) failed" >&2
+    exit 1
+fi
+echo ""
+echo "All tests passed"


### PR DESCRIPTION
## Problem

**A pull request touching only `docs/**` can never be merged.** It cannot enter the merge queue, and there is no ordinary path around it short of adding an unrelated file to the PR.

The obvious objection is "docs PRs merge here all the time". They do — and the ones that merged were the ones that **skipped the gate**. See "How has anything merged, then?" below; that is the answer to why an eight-month-old structural block has been invisible.

Both `.github/workflows/ci.yml` and `.github/workflows/claude-pr-review.yml` carried the same `paths-ignore` on their pull-request trigger:

```yaml
paths-ignore:
  - 'docs/**'
  - '*.md'
  - 'LICENSE'
  - '.github/ISSUE_TEMPLATE/**'
  - '.github/FUNDING.yml'
```

Seven of the eight required status contexts come from those two workflows — `Fmt`, `Clippy`, `Rule Lint`, `Unit & Integration`, `Simulation`, `NAT Validation` from `ci.yml`, and `Claude Rule Review` from `claude-pr-review.yml`. Only `macOS bundle-swap E2E` comes from elsewhere.

**A workflow skipped by a path filter does not report a skipped check — it reports nothing at all.** GitHub treats a required context that never reported as *expected*, not as satisfied, so the merge queue refuses entry. Permanently. Reproduced on #5322 (one file, `docs/design/demand-driven-hosting.md`, open since 2026-08-14):

```
$ gh api graphql -f query="mutation{enqueuePullRequest(input:{pullRequestId:\"PR_kwDOFwu4Lc7-6hn5\"}){mergeQueueEntry{position state}}}"
{"type":"UNPROCESSABLE","message":"Pull request 7 of 8 required status checks are expected."}
```

The `merge_group:` trigger reads like a rescue and is not one: a merge-queue run only happens for a PR that has already been **admitted** to the queue, and admission is exactly what was refused.

### How has anything merged, then?

Because maintainer bypasses have been silently absorbing this. #5322 is not the only case. #5093 (`docs: drop stale git submodule step from build instructions`, one file, `README.md` — a root-level `*.md`) shows the same signature: its `statusCheckRollup` carries exactly three real contexts, `macOS bundle-swap E2E`, `license/cla` and `security/snyk`. The other seven never reported.

It merged anyway, on 2026-08-07, because a maintainer merged it directly: ruleset 4028534 grants `bypass_mode: always` to the `freenet-developers` team, and #5093's `merged_by` is a maintainer of that team. So the ruleset was bypassed rather than satisfied.

So a docs-only PR that a maintainer touched merged by hand and nobody learned anything; one from someone without bypass rights — or one relying on auto-merge, as #5322 was from 2026-08-24 — simply stopped. The population of docs-only PRs that "merged fine" and the population that exercised the gate were disjoint, which is exactly why the block never surfaced as a bug report. It is also why the honest phrasing above is "no *ordinary* path around it" rather than "no path".

Worth flagging beyond this PR: a bypass that quietly substitutes for a gate makes that gate's failures invisible to precisely the people who could fix them.

### Why this went unnoticed for three weeks

`*.md` does **not** match at depth in GitHub path filters. A PR touching `.claude/rules/foo.md` or `crates/**/README.md` therefore ran the full suite and merged normally — #5375 did exactly that on 2026-08-20. "Docs PRs merge here all the time" was true, and did not cover this case. It bit only a PR whose *every* file matched one of the five removed patterns, and those are rare enough that the failure looked like "that docs PR is just sitting there".

## Approach

Remove the filter from the two PR triggers:

- `ci.yml`: `pull_request` — filter removed.
- `claude-pr-review.yml`: `pull_request_target` — filter removed.
- `ci.yml`: `push` (main) — **filter kept.** A post-merge run on `main` gates nothing, so filtering it costs nothing and risks nothing. The optimization is confined to the trigger where no required check is at stake. Verified nothing consumes main's CI signal: there is no `workflow_run` trigger anywhere in the repo, `release.yml` is `workflow_dispatch`, and the deploy/announce workflows key on `release.published`.

Both `on:` blocks now carry a comment saying why the filter must not come back.

### The cost, stated plainly

This is a real cost increase, not a relocation. A docs-only PR now pays the **full PR suite** — Clippy on `ubicloud-standard-8`; Unit & Integration, Simulation and NAT Validation on `ubicloud-standard-16`; the macOS and Windows unit jobs — **plus a paid Claude rule review**, on top of the `merge_group` run it already paid (`merge_group` was never path-filtered). That is considerably more than the `~$0.13/run` figure the file header quotes.

### Why not the job-level `changes` filter

The standard remedy is to drop `paths-ignore`, add a `changes` job (`dorny/paths-filter` or a `git diff` step), and gate the expensive *steps* on its output so the jobs still run and still report. `ci.yml` already has that idiom — the `skip_check` steps in `test_simulation` and `nat_validation` for the non-release `merge_group` path.

I rejected it here, and the reason is the numbers:

- **Docs-only merges are rare.** Counting commits on `main` in the twelve months to 2026-09-05 whose entire file set matched the removed patterns: **15**, the most recent 2026-08-13. That is the population paying the cost above.
- **Half the saving was already gone.** `merge_group:` has no path filter, so a docs-only PR burned a merge-queue run regardless. The `pull_request` filter was only ever saving the PR-level run.
- **The risk is asymmetric.** Gating steps means adding an `if:` to essentially every step of six jobs across two workflows, plus a changed-files detector. A mistake there does not cost a few CI runs a year — it silently turns required checks into unconditional passes for *every* PR, which is far worse than the bug being fixed. Removing a trigger filter cannot do that.
- **The complexity is what caused this.** This bug is a cost optimization that made a PR unmergeable for three weeks to save a handful of CI runs. Replacing it with a larger, subtler cost optimization on the same surface invites the next instance.

If docs-only PRs ever become frequent enough that this matters, the job-level version is the right answer, added then with real data behind it.

## Prevention

The knowledge was not new. `macos-dmg-swap-e2e.yml` already carries this comment above its own filter-free `on:` block:

```
# No path filter — this is a required status check, and skipped-by-
# path-filter workflows do not reliably produce a "check context" that
# branch protection sees as passing.
```

A correct comment in one file protected nothing in the other two.

**And this is a regression of a fix, not a first occurrence.** `git log -S"docs/**" -- .github/workflows/ci.yml` shows the same filter has been removed from this file before:

| | |
|---|---|
| 2025-03-06 | `d7f9f41b9` — *"remove path exclusions as it was screwing up CI"* (#1448), deleting `paths-ignore: ["docs/**", "README.md"]` from both `push` and `pull_request` |
| 2026-01-07 | `8c38e9217` — *"ci: reduce costs by skipping redundant CI runs"*, putting it back |

#1448 has an empty body so I cannot claim its symptom was identical to this one; what is verifiable is that the same filter on the same trigger of the same file was removed for breaking CI, and reintroduced ten months later by a cost-optimization commit that had no way to know. That is precisely the gap a comment cannot close and a lint can.

The 2025 form is also worth noting: `paths-ignore: ["docs/**", "README.md"]`, written **flow style**. The first version of this linter matched only the block form and would have missed it. Review caught that; the released version flags the historical file correctly:

```
$ python3 .github/scripts/check_required_check_path_filters.py --no-coverage-check <ci.yml @ d7f9f41b9^>
ci.yml:9: `paths-ignore:` on the `pull_request:` trigger of a workflow that provides
required status check(s) ['Clippy', 'Fmt'].
```

So this PR also adds `.github/scripts/check_required_check_path_filters.py`, wired into the existing `Rule Lint` job next to `check_merge_group_concurrency.py` and following the same shape.

It makes **two** checks, because a path filter is only one of the ways a required context stops reporting:

1. **No path filter on a gating trigger** for any workflow providing one of the eight required contexts. Block and flow forms both — `paths-ignore: ['docs/**']` is one line, is valid, reintroduces the bug exactly, and is the style this repo already uses for the sibling `branches: [main]` key. `push` is deliberately not checked. Workflows providing no required context (`benchmarks.yml`, `lint-assets.yml`, `playwright-shell.yml`, `check-token-coalesce.yml`, `docker-publish.yml`) may filter freely and are untouched.

2. **Coverage**: every context in `REQUIRED_CONTEXTS` must actually be reported by some workflow. Without this, check 1 is a signal that can go vacuously green — rename the `Fmt` job to `Format` and the required context `Fmt` never reports, every PR is blocked with the identical #5322 symptom, and a filter-only linter sees nothing wrong. It is also the backstop for the linter losing track of a file it is supposed to be guarding.

`scripts/required_check_path_filters_test.sh` (the shape `check_merge_group_concurrency.py` already has) pins what the synthetic self-test cannot: that the linter fires on the **real pre-fix `on:` blocks** — which this PR deletes from the repo, so nothing else would record them — that it fires on the flow form, that the repo satisfies both halves today, and that the linter is **still wired into CI with its coverage half enabled**. Deleting the steps from `ci.yml` now turns `Fmt` red instead of silently retiring the guard.

The required-context list is hardcoded, with the `gh api` command to re-derive it in a comment. Three drift directions are documented; the third (a job renamed out from under the ruleset) is the one the coverage check exists for.

## Testing

**Verified**

- `--self-test`: 13 fixtures, including both real pre-fix shapes, the flow-sequence form, an allowlist `paths:`, `on:` written after `jobs:`, a bare-job-id context, `paths:` as a step input, a key merely starting with `paths`, and both coverage cases. Error **line numbers** are asserted, not just counts.
- Run against the **actual pre-fix files from `main`**, it flags both, naming all six `ci.yml` contexts and `Claude Rule Review`, and correctly leaves `macos-dmg-swap-e2e.yml` alone. Run against this branch, both checks pass. It would have caught the bug it documents.
- `scripts/required_check_path_filters_test.sh`: 12 assertions, all passing; `shellcheck -x` clean.
- **A genuinely docs-only PR now produces reported contexts.** #5573 changes exactly one file, `docs/ci-verification-5451.md`, and is based on this branch rather than `main` so the fixed workflows are on both sides of the merge. `Fmt`, `Clippy`, `Rule Lint`, `Unit & Integration`, `Simulation`, `NAT Validation` and `macOS bundle-swap E2E` all run and report on it, where on `main`'s configuration a docs-only PR reports only three contexts (see #5093's rollup above). It is a throwaway and will be closed and its branch deleted; full check list in the comment below.

  **The one context it could not demonstrate is `Claude Rule Review`.** No run was created for the verification PR at all — not even a skipped one — even though its base branch carries the fix. That is consistent with `pull_request_target` resolving its workflow from `main`, which still has the filter; I did not chase the mechanism further because the conclusion is the same either way, and it is the limit already described below.
- No job `if:`, step gating, or skip condition was touched, so nothing here can make a required check pass unconditionally. The only added steps are linters that can fail and cannot pass anything. This PR's own green CI is that check.
- Both workflows still parse; `on:` resolves to `push`/`pull_request`/`merge_group` and `pull_request_target`/`merge_group`, with `pull_request` now a bare key carrying GitHub's default event types — the same set as before, since the old form specified no `types:`.

**What could NOT be verified before merge, and why**

Required-context behaviour is a property of the branch-protection ruleset on `main`, so the end-to-end claim — that a docs-only PR *targeting `main`* can now enter the merge queue — cannot be tested from a branch. Two specific limits, which are also why #5573 targets this branch:

- For `pull_request_target`, GitHub uses the workflow file from the **base** ref. Until this is on `main`, a docs PR targeting `main` still gets `main`'s filtered `claude-pr-review.yml`.
- Any PR that *carries* this fix is by construction not docs-only, so it cannot exercise the filter it removes.

**The honest claim** is therefore: this should let #5322 enter the queue; confirm after merge. #5322 will also need a fresh pull-request event (a push, or "Update branch") once this lands — nothing re-evaluates a PR's workflows on its own.

## Review

Full tier, per `.claude/rules/pr-quality.md` (CI configuration is a high-risk surface here). Two independent blind lenses — `freenet:skeptical-reviewer` and `freenet:code-first-reviewer` — both read-only. No external (Codex) pass was run; two Claude lenses with distinct briefs were used instead.

Neither found a way for this change to make a required check falsely pass. Everything else they raised is fixed in the second commit: the flow-form false negative, the missing coverage check, the missing CI wiring pin, `on:` after `jobs:`, line assertions in the self-test, the understated cost, the `on:` comment listing 2 of the 5 removed patterns, `#5451`-vs-`#5571` attribution, the overclaimed "no way around it", `p.is_file()`, and the file mode. Two adjacent inaccuracies they surfaced are also fixed: `playwright-shell.yml` now points at `REQUIRED_CONTEXTS` (its own comment contemplates being promoted to required *while path-filtered*, which is exactly this bug), and `AGENTS.md` no longer claims `check-token-coalesce.yml` "runs on every PR" — it is path-filtered, safely, because it is not required.

One behavioural consequence worth knowing rather than fixing: docs-only PRs now draw a full Claude rule review, which can raise WARNING findings such as "Missing PR description sections" on a one-line docs change. That posts to the non-required `rule-review/warnings` status and blocks nothing.

## After merge — three things close the loop

Recorded here so they are not lost:

1. **Confirm `Claude Rule Review` runs on a docs-only PR.** This is the 8th required context, and it is verifiable only once `main` carries the fix (see the `pull_request_target` limit above).
2. **Push #5322, or use "Update branch", and confirm it can enter the merge queue.** Nothing re-evaluates an open PR's workflows on its own, so it needs a fresh pull-request event. This is the real end-to-end proof.
3. **Close #5573 and delete its branch.** (#5576 is already closed and its branch deleted.)

Closes #5451

[AI-assisted - Claude]
