### PR TITLE
feat(telemetry): add bootstrap-acceptance-churn instrumentation (#4787)

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -1326,6 +1326,12 @@ fn log_umask_override() {
 fn log_umask_override() {}
 
 fn main() {
+    // Anchor the bootstrap-latency clock at process start, before anything
+    // else, so `freenet.bootstrap.time_to_min_connections_seconds` measures
+    // what its name says — including config load, storage open and the
+    // cached-peer fast-reconnect path (issue #4787).
+    freenet::mark_process_start();
+
     // Defense-in-depth: tighten umask BEFORE the tokio runtime spawns
     // any worker threads. See `set_secure_umask` and issue #4196.
     set_secure_umask();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -67,6 +67,19 @@ mod wasm_runtime;
 /// Deterministic simulation testing framework.
 pub mod simulation;
 
+/// Pin the process-start anchor used by the bootstrap-latency metric
+/// (`freenet.bootstrap.time_to_min_connections_seconds`, issue #4787).
+///
+/// `Instant` cannot be constructed for "when this process started", so the
+/// earliest instant available is whenever something first asks. Call this on
+/// the first line of `main` and the metric genuinely measures from process
+/// start — including config load, storage open, and every other startup step
+/// that can delay CONNECT. Without it the anchor falls back to
+/// `network_status::init()`, i.e. node start.
+pub fn mark_process_start() {
+    node::network_status::mark_process_start();
+}
+
 /// Exports to build a running local node.
 pub mod local_node {
     use super::*;

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -346,17 +346,32 @@ impl P2pConnManager {
                         .ok();
                     return Ok(());
                 }
-                let just_became_ready = self
+                // #4787 instrumentation: count the promotion only if the ring
+                // actually took the connection. `add_connection`'s own `bool`
+                // reports the readiness-threshold crossing, NOT acceptance, so
+                // the outcome struct is what this has to branch on — otherwise
+                // a cap-rejected promotion inflates `promoted_to_ring` in
+                // exactly the saturation direction the counter is meant to
+                // expose.
+                let outcome = self
                     .bridge
                     .op_manager
                     .ring
-                    .add_connection(loc, PeerId::new(peer.pub_key().clone(), peer_addr), true)
+                    .add_connection_reporting(
+                        loc,
+                        PeerId::new(peer.pub_key().clone(), peer_addr),
+                        true,
+                    )
                     .await;
-                crate::node::network_status::record_bootstrap_promoted_to_ring();
+                if outcome.added {
+                    crate::node::network_status::record_bootstrap_promoted_to_ring();
+                }
+                let just_became_ready = outcome.just_became_ready;
                 tracing::info!(
                     tx = %tx,
                     remote = %peer,
                     transient_expired,
+                    added = outcome.added,
                     "connect_peer: promoted to ring"
                 );
 
@@ -1214,12 +1229,28 @@ impl P2pConnManager {
                     return Ok(());
                 }
                 tracing::info!(%peer_addr, %loc, "handle_successful_connection: promoting connection into ring");
-                let just_became_ready = self
+                // #4787 instrumentation: this is the OTHER promotion path, and
+                // on a gateway it is the one inbound connections with a known
+                // peer_id actually take (`promote_to_ring` above is true for
+                // any transient when `is_gateway()`). Leaving it uncounted made
+                // the `transient_expired : promoted_to_ring` ratio the PR's own
+                // doc tells operators to build read far worse than reality.
+                // Gated on `added` for the same reason as the `handle_connect_peer`
+                // site.
+                let outcome = self
                     .bridge
                     .op_manager
                     .ring
-                    .add_connection(loc, PeerId::new(peer.pub_key().clone(), peer_addr), true)
+                    .add_connection_reporting(
+                        loc,
+                        PeerId::new(peer.pub_key().clone(), peer_addr),
+                        true,
+                    )
                     .await;
+                if outcome.added {
+                    crate::node::network_status::record_bootstrap_promoted_to_ring();
+                }
+                let just_became_ready = outcome.just_became_ready;
                 let pkl = crate::ring::PeerKeyLocation::new(peer.pub_key().clone(), peer_addr);
                 crate::node::network_status::record_peer_connected(
                     peer_addr,
@@ -1293,8 +1324,17 @@ impl P2pConnManager {
                     // These connections don't go through should_accept() so there's no pending
                     // reservation. Compute location from address directly.
                     let loc = Location::from_address(&peer_addr);
-                    connection_manager.try_register_transient(peer_addr, Some(loc));
-                    crate::node::network_status::record_bootstrap_transient_registered();
+                    // #4787 instrumentation: `try_register_transient` returns
+                    // `true` both for a fresh insertion and for refreshing an
+                    // address it already tracks, and `false` when the transient
+                    // budget refused it (nothing inserted at all). Only a fresh
+                    // insertion is a "transient registered".
+                    let already_transient = connection_manager.is_transient(peer_addr);
+                    let registered =
+                        connection_manager.try_register_transient(peer_addr, Some(loc));
+                    if registered && !already_transient {
+                        crate::node::network_status::record_bootstrap_transient_registered();
+                    }
                     tracing::info!(
                         peer_id = ?peer_id,
                         %peer_addr,

--- a/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc/connection_lifecycle.rs
@@ -352,6 +352,7 @@ impl P2pConnManager {
                     .ring
                     .add_connection(loc, PeerId::new(peer.pub_key().clone(), peer_addr), true)
                     .await;
+                crate::node::network_status::record_bootstrap_promoted_to_ring();
                 tracing::info!(
                     tx = %tx,
                     remote = %peer,
@@ -1293,6 +1294,7 @@ impl P2pConnManager {
                     // reservation. Compute location from address directly.
                     let loc = Location::from_address(&peer_addr);
                     connection_manager.try_register_transient(peer_addr, Some(loc));
+                    crate::node::network_status::record_bootstrap_transient_registered();
                     tracing::info!(
                         peer_id = ?peer_id,
                         %peer_addr,
@@ -1312,6 +1314,7 @@ impl P2pConnManager {
                             // the peer to ring topology (see #3113 fix). If it
                             // never succeeds, the transport idle timeout handles
                             // cleanup.
+                            crate::node::network_status::record_bootstrap_transient_expired();
                             tracing::info!(
                                 %peer_addr,
                                 "Transient connection expired; removed tracking entry \

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -370,26 +370,47 @@ pub struct NetworkStatus {
 }
 
 /// Bootstrap-acceptance-churn counters (issue #4787): a restarted node's
-/// connection to a gateway lingers as transient, expires, and the transport
-/// is later reaped as a zombie before the onward CONNECT promotes it to the
-/// ring — cycling the joiner through repeated reconnects before it acquires
-/// real peers. These counters are the "instrumentation before a fix" step
-/// the issue calls for: they don't change acceptance behavior, only make the
-/// churn rate and the time-to-bootstrap legible in production telemetry.
+/// connection to a gateway lingers as transient, its tracking entry expires,
+/// and (if the onward CONNECT never promotes it) the underlying transport is
+/// later reaped as a zombie by a separate, uninstrumented sweep — cycling the
+/// joiner through repeated reconnects before it acquires real peers. These
+/// counters are the "instrumentation before a fix" step the issue calls for:
+/// they don't change acceptance behavior, only make the churn rate and the
+/// time-to-bootstrap legible in production telemetry.
 ///
 /// `transient_registered` / `transient_expired` / `promoted_to_ring` are
 /// GATEWAY-side, monotonic lifetime totals, recorded at the three log sites
 /// in `p2p_protoc/connection_lifecycle.rs` that this issue's live-log
 /// evidence was read from. A sustained high `transient_expired` :
-/// `promoted_to_ring` ratio is the churn signature reported in the issue.
+/// `promoted_to_ring` ratio is the churn signature reported in the issue —
+/// but the two are NOT a clean partition of `transient_registered`: the
+/// #3113 recovery path (a slow CONNECT that completes after the tracking
+/// entry's TTL already expired, `connection_lifecycle.rs`'s
+/// `handle_connect_peer`) increments BOTH `transient_expired` (the tracking
+/// entry lapsed) AND `promoted_to_ring` (it promoted anyway) for the SAME
+/// connection. So `transient_expired + promoted_to_ring` can exceed
+/// `transient_registered`, and a connection that recovers this way is
+/// indistinguishable in these counters from one that is genuinely lost and
+/// later reaped as a zombie (the zombie-reap sweep itself, `p2p_protoc.rs`'s
+/// `drop_zombie_connection`, is not instrumented here) — both increment
+/// `transient_expired` exactly once. Read the ratio as a churn signal, not a
+/// strict recovered-vs-lost accounting.
 ///
 /// `time_to_min_connections` / `startup_connect_retries` are JOINER-side,
 /// recorded by `initial_join_procedure` in `operations/connect.rs`.
 /// `time_to_min_connections` is set at most once per process (the first time
 /// `open_connections()` reaches `min_connections`); `startup_connect_retries`
-/// counts each below-threshold retry round issued before that point.
+/// counts each below-threshold retry round issued before that point only —
+/// a later transient dip back below `min_connections` (ordinary post-startup
+/// churn) does not resume incrementing it.
 #[derive(Default)]
 pub struct BootstrapChurnStats {
+    /// Counts calls to the "Registered transient connection" log site, not
+    /// confirmed new-entry insertions: `try_register_transient` also returns
+    /// `true` (and the site still logs/increments) for an already-tracked
+    /// entry, so this can be a slight overcount relative to the transient
+    /// table's real size. Faithfully mirrors the pre-existing log statement's
+    /// own semantics at that site.
     pub transient_registered: u64,
     pub transient_expired: u64,
     pub promoted_to_ring: u64,

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, LazyLock, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 use crate::ring::reconcile::ReconcileActionDivergence;
@@ -150,7 +150,9 @@ pub(crate) struct OtelStatusScalars {
     pub bootstrap_transient_expired: u64,
     pub bootstrap_promoted_to_ring: u64,
     pub bootstrap_time_to_min_connections: Option<Duration>,
-    pub bootstrap_startup_connect_retries: u64,
+    pub bootstrap_startup_rounds_connect_issued: u64,
+    pub bootstrap_startup_rounds_backoff_blocked: u64,
+    pub bootstrap_startup_rounds_no_target: u64,
 }
 
 /// Read this module's own scalars, or `None` before [`init`] has run.
@@ -185,7 +187,9 @@ pub(crate) fn otel_status_scalars() -> Option<OtelStatusScalars> {
         bootstrap_transient_expired: b.transient_expired,
         bootstrap_promoted_to_ring: b.promoted_to_ring,
         bootstrap_time_to_min_connections: b.time_to_min_connections,
-        bootstrap_startup_connect_retries: b.startup_connect_retries,
+        bootstrap_startup_rounds_connect_issued: b.startup_rounds_connect_issued,
+        bootstrap_startup_rounds_backoff_blocked: b.startup_rounds_backoff_blocked,
+        bootstrap_startup_rounds_no_target: b.startup_rounds_no_target,
     })
 }
 
@@ -379,44 +383,78 @@ pub struct NetworkStatus {
 /// time-to-bootstrap legible in production telemetry.
 ///
 /// `transient_registered` / `transient_expired` / `promoted_to_ring` are
-/// GATEWAY-side, monotonic lifetime totals, recorded at the three log sites
-/// in `p2p_protoc/connection_lifecycle.rs` that this issue's live-log
-/// evidence was read from. A sustained high `transient_expired` :
-/// `promoted_to_ring` ratio is the churn signature reported in the issue —
-/// but the two are NOT a clean partition of `transient_registered`: the
-/// #3113 recovery path (a slow CONNECT that completes after the tracking
-/// entry's TTL already expired, `connection_lifecycle.rs`'s
-/// `handle_connect_peer`) increments BOTH `transient_expired` (the tracking
-/// entry lapsed) AND `promoted_to_ring` (it promoted anyway) for the SAME
-/// connection. So `transient_expired + promoted_to_ring` can exceed
-/// `transient_registered`, and a connection that recovers this way is
-/// indistinguishable in these counters from one that is genuinely lost and
-/// later reaped as a zombie (the zombie-reap sweep itself, `p2p_protoc.rs`'s
-/// `drop_zombie_connection`, is not instrumented here) — both increment
-/// `transient_expired` exactly once. Read the ratio as a churn signal, not a
-/// strict recovered-vs-lost accounting.
+/// ACCEPTOR-side, monotonic lifetime totals, recorded at the four sites in
+/// `p2p_protoc/connection_lifecycle.rs` that own the transient lifecycle. A
+/// sustained high `transient_expired` : `promoted_to_ring` ratio is the churn
+/// signature reported in the issue.
 ///
-/// `time_to_min_connections` / `startup_connect_retries` are JOINER-side,
-/// recorded by `initial_join_procedure` in `operations/connect.rs`.
-/// `time_to_min_connections` is set at most once per process (the first time
-/// `open_connections()` reaches `min_connections`); `startup_connect_retries`
-/// counts each below-threshold retry round issued before that point only —
-/// a later transient dip back below `min_connections` (ordinary post-startup
-/// churn) does not resume incrementing it.
-#[derive(Default)]
+/// They are still not a clean partition of `transient_registered`: the #3113
+/// recovery path (a slow CONNECT that completes after the tracking entry's
+/// TTL already expired, `handle_connect_peer`) increments BOTH
+/// `transient_expired` (the tracking entry lapsed) AND `promoted_to_ring` (it
+/// promoted anyway) for the SAME connection. So `transient_expired +
+/// promoted_to_ring` can exceed `transient_registered`, and a connection that
+/// recovers this way is indistinguishable in these counters from one that is
+/// genuinely lost and later reaped as a zombie (the zombie-reap sweep itself,
+/// `p2p_protoc.rs`'s `drop_zombie_connection`, is not instrumented here) —
+/// both increment `transient_expired` exactly once. Read the ratio as a churn
+/// signal, not a strict recovered-vs-lost accounting.
+///
+/// The remaining fields are JOINER-side, recorded by `initial_join_procedure`
+/// in `operations/connect.rs`. `time_to_min_connections` is set at most once
+/// per process (the first time `open_connections()` reaches
+/// `min_connections`), measured from [`mark_process_start`]; `None` means this
+/// node has NOT bootstrapped yet, which is a distinct state from "no data" —
+/// the exporter publishes `freenet.bootstrap.completed` as a 0/1 gauge so a
+/// permanently-stuck joiner is visible rather than absent.
+///
+/// The three `startup_rounds_*` counters partition every below-threshold
+/// iteration of the join loop by what that iteration actually DID, and stop
+/// at the process's first real bootstrap (a later transient dip below
+/// `min_connections` is ordinary post-startup churn, not startup). Splitting
+/// them is what keeps them from degrading into a process-uptime proxy: a node
+/// stuck below `min_connections` forever increments SOMETHING every ~4s no
+/// matter how the counter is shaped, so the informative quantity is which one
+/// — `connect_issued` means it is actively retrying and being refused,
+/// `backoff_blocked` means every gateway is in exponential backoff, and
+/// `no_target` means the gateway transports look connected/pending while no
+/// real peers are being acquired, which is the #4787 stall signature.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BootstrapChurnStats {
-    /// Counts calls to the "Registered transient connection" log site, not
-    /// confirmed new-entry insertions: the call site increments unconditionally,
-    /// without branching on `try_register_transient`'s return value, so it also
-    /// counts an already-tracked entry (returns `true`) and a budget-exhausted
-    /// refusal where nothing was actually inserted (returns `false`). Faithfully
-    /// mirrors the pre-existing log statement's own (also-unconditional)
-    /// semantics at that site.
+    /// Counts transient tracking entries actually inserted, not call-site
+    /// visits: the recording site branches on whether `try_register_transient`
+    /// inserted a NEW entry, so a budget-exhausted refusal (nothing inserted)
+    /// and a re-registration of an already-tracked address (nothing new
+    /// inserted) do not inflate it.
     pub transient_registered: u64,
     pub transient_expired: u64,
+    /// Counts promotions the ring actually accepted — both promotion call
+    /// sites gate on `Ring::add_connection`'s reported `added`, so a
+    /// cap-rejected promotion attempt is not counted as a promotion.
     pub promoted_to_ring: u64,
     pub time_to_min_connections: Option<Duration>,
-    pub startup_connect_retries: u64,
+    /// Below-threshold join-loop rounds that issued a CONNECT round (to
+    /// unconnected gateways, or routed through already-connected gateways).
+    pub startup_rounds_connect_issued: u64,
+    /// Below-threshold join-loop rounds that issued nothing because every
+    /// candidate gateway was in exponential backoff.
+    pub startup_rounds_backoff_blocked: u64,
+    /// Below-threshold join-loop rounds that issued nothing for any other
+    /// reason — principally "all gateways appear connected/pending" while the
+    /// node still has no real peers. The #4787 stall signature.
+    pub startup_rounds_no_target: u64,
+}
+
+/// Why one below-bootstrap-threshold round of `initial_join_procedure` did or
+/// did not issue CONNECTs (#4787). See [`BootstrapChurnStats`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupRoundOutcome {
+    /// A CONNECT round was actually issued this iteration.
+    ConnectIssued,
+    /// Nothing issued: every candidate gateway was in exponential backoff.
+    BackoffBlocked,
+    /// Nothing issued for any other reason.
+    NoTarget,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -823,6 +861,10 @@ pub enum FailureReason {
 /// `RING_STATS_PROVIDER`, `ROUTER`) live in their own statics with their own
 /// replace-on-set semantics and are intentionally left untouched here.
 pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: String) {
+    // Pin the process-start anchor if `main` didn't (library embeddings), so
+    // the #4787 bootstrap-latency metric is measured from node start at worst
+    // rather than from the moment the threshold happened to be crossed.
+    mark_process_start();
     let status = NetworkStatus {
         gateway_failures: Vec::new(),
         connection_attempts: 0,
@@ -1385,11 +1427,42 @@ pub fn record_bootstrap_promoted_to_ring() {
     }
 }
 
-/// Record the time from process start to first reaching `min_connections`
-/// (issue #4787 instrumentation, joiner-side). Idempotent: only the first
-/// call per process has any effect, so a wobble around the threshold does
-/// not overwrite the real bootstrap latency with a later value.
-pub fn record_bootstrap_min_connections_reached(elapsed: Duration) {
+/// Process-start anchor for the bootstrap-latency metric (#4787).
+///
+/// `Instant` has no "process start" constructor, so this is the earliest
+/// instant the process is able to take. The `freenet` binary forces it on the
+/// first line of `main` (via [`crate::mark_process_start`]), which makes
+/// `freenet.bootstrap.time_to_min_connections_seconds` literally
+/// time-from-process-start for real nodes — including config load, storage
+/// open and every other startup step that can delay CONNECT. Anything
+/// embedding the node as a library and never calling it gets the anchor
+/// lazily at first touch, which [`init`] forces, i.e. node start rather than
+/// process start.
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Pin the process-start anchor to *now*. Call as early as possible in
+/// `main`; see [`PROCESS_START`].
+pub fn mark_process_start() {
+    LazyLock::force(&PROCESS_START);
+}
+
+/// Elapsed time since the process-start anchor (see [`PROCESS_START`]).
+pub fn since_process_start() -> Duration {
+    PROCESS_START.elapsed()
+}
+
+/// Record that this process has first reached `min_connections`, measured from
+/// the [`PROCESS_START`] anchor (issue #4787 instrumentation, joiner-side).
+///
+/// Taking the elapsed time here rather than from a caller-supplied clock is
+/// the point: the caller's own clock necessarily starts after the cached-peer
+/// fast-reconnect path and after all node startup, so a successful cached
+/// reconnect would report ~0s for a bootstrap that really took seconds.
+///
+/// Idempotent: only the first call per process has any effect, so a wobble
+/// around the threshold does not overwrite the real bootstrap latency.
+pub fn record_bootstrap_min_connections_reached() {
+    let elapsed = since_process_start();
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             if s.bootstrap_churn_stats.time_to_min_connections.is_none() {
@@ -1399,35 +1472,31 @@ pub fn record_bootstrap_min_connections_reached(elapsed: Duration) {
     }
 }
 
-/// Record one below-threshold CONNECT retry round issued by
-/// `initial_join_procedure` at startup (issue #4787 instrumentation,
-/// joiner-side).
-pub fn record_bootstrap_startup_connect_retry() {
+/// Record one below-threshold round of `initial_join_procedure`, classified by
+/// what that round actually did (issue #4787 instrumentation, joiner-side).
+/// See [`BootstrapChurnStats`] for why the classification is the measurement.
+pub fn record_bootstrap_startup_round(outcome: StartupRoundOutcome) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
-            s.bootstrap_churn_stats.startup_connect_retries = s
-                .bootstrap_churn_stats
-                .startup_connect_retries
-                .saturating_add(1);
+            let b = &mut s.bootstrap_churn_stats;
+            let slot = match outcome {
+                StartupRoundOutcome::ConnectIssued => &mut b.startup_rounds_connect_issued,
+                StartupRoundOutcome::BackoffBlocked => &mut b.startup_rounds_backoff_blocked,
+                StartupRoundOutcome::NoTarget => &mut b.startup_rounds_no_target,
+            };
+            *slot = slot.saturating_add(1);
         }
     }
 }
 
 /// Read the current bootstrap-churn counters for export to `router_snapshot`
-/// (issue #4787). Returns `(transient_registered, transient_expired,
-/// promoted_to_ring, time_to_min_connections, startup_connect_retries)` or
-/// `None` before the singleton is initialized.
-pub fn bootstrap_churn_counts() -> Option<(u64, u64, u64, Option<Duration>, u64)> {
+/// (issue #4787). `None` before the singleton is initialized — which is what
+/// distinguishes "no data" from a node that has simply never bootstrapped
+/// (present, with `time_to_min_connections: None`).
+pub fn bootstrap_churn_counts() -> Option<BootstrapChurnStats> {
     let status = NETWORK_STATUS.get()?;
     let s = status.read().ok()?;
-    let b = &s.bootstrap_churn_stats;
-    Some((
-        b.transient_registered,
-        b.transient_expired,
-        b.promoted_to_ring,
-        b.time_to_min_connections,
-        b.startup_connect_retries,
-    ))
+    Some(s.bootstrap_churn_stats)
 }
 
 /// Count of this node's active connections that are to gateways (the
@@ -2461,7 +2530,7 @@ mod tests {
 
         assert_eq!(
             bootstrap_churn_counts(),
-            Some((0, 0, 0, None, 0)),
+            Some(BootstrapChurnStats::default()),
             "counters start at zero/None after init"
         );
 
@@ -2471,22 +2540,69 @@ mod tests {
         record_bootstrap_transient_expired();
         record_bootstrap_transient_expired();
         record_bootstrap_promoted_to_ring();
-        record_bootstrap_startup_connect_retry();
-        record_bootstrap_startup_connect_retry();
-        record_bootstrap_startup_connect_retry();
-        record_bootstrap_startup_connect_retry();
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
+        record_bootstrap_startup_round(StartupRoundOutcome::BackoffBlocked);
+        record_bootstrap_startup_round(StartupRoundOutcome::BackoffBlocked);
+        record_bootstrap_startup_round(StartupRoundOutcome::NoTarget);
 
-        record_bootstrap_min_connections_reached(Duration::from_secs(5));
+        // Not yet bootstrapped: the getter must distinguish this from
+        // "no data" — it returns `Some(..)` with a `None` latency.
+        let before = bootstrap_churn_counts().expect("singleton is initialized");
+        assert_eq!(
+            before.time_to_min_connections, None,
+            "time_to_min_connections is None until min_connections is reached"
+        );
+
+        record_bootstrap_min_connections_reached();
+        let first = bootstrap_churn_counts()
+            .expect("singleton is initialized")
+            .time_to_min_connections
+            .expect("recorded on the first call");
         // A second call must NOT overwrite the first — the real bootstrap
         // latency, not the latest wobble around the threshold.
-        record_bootstrap_min_connections_reached(Duration::from_secs(99));
+        record_bootstrap_min_connections_reached();
 
         assert_eq!(
             bootstrap_churn_counts(),
-            Some((3, 2, 1, Some(Duration::from_secs(5)), 4)),
-            "getter returns (transient_registered, transient_expired, promoted_to_ring, \
-             time_to_min_connections, startup_connect_retries); time-to-min-connections \
-             is set on the FIRST call only"
+            Some(BootstrapChurnStats {
+                transient_registered: 3,
+                transient_expired: 2,
+                promoted_to_ring: 1,
+                time_to_min_connections: Some(first),
+                startup_rounds_connect_issued: 4,
+                startup_rounds_backoff_blocked: 2,
+                startup_rounds_no_target: 1,
+            }),
+            "each record function must feed its own field, and \
+             time-to-min-connections is set on the FIRST call only"
+        );
+    }
+
+    /// The bootstrap-latency clock must run from the process-start anchor, not
+    /// from the moment the threshold is crossed — otherwise a fast cached-peer
+    /// reconnect reports ~0s for a bootstrap that really took the whole
+    /// startup. Pins that `record_bootstrap_min_connections_reached` reads
+    /// [`since_process_start`] rather than starting a fresh clock.
+    #[test]
+    fn bootstrap_latency_measures_from_process_start_anchor() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        init(31338, HashSet::new(), "test".to_string());
+        // The anchor is process-global and was forced no later than the first
+        // `init()` in this test binary, so real elapsed time has accrued.
+        let before = since_process_start();
+        record_bootstrap_min_connections_reached();
+        let recorded = bootstrap_churn_counts()
+            .expect("singleton is initialized")
+            .time_to_min_connections
+            .expect("recorded");
+        assert!(
+            recorded >= before,
+            "recorded latency {recorded:?} must be measured from the \
+             process-start anchor (>= {before:?} observed just before the call), \
+             not from a clock started at the call site"
         );
     }
 

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::ring::reconcile::ReconcileActionDivergence;
 use crate::ring::{PeerKeyLocation, SubscribedContractSnapshot};
@@ -143,6 +143,14 @@ pub struct RingStatsSnapshot {
 pub(crate) struct OtelStatusScalars {
     pub connection_attempts: u32,
     pub op_stats: OperationStats,
+    /// Bootstrap-acceptance-churn counters (#4787). Sourced from the same
+    /// `NETWORK_STATUS` lock as the fields above, so it rides this existing
+    /// scalar source rather than a new provider.
+    pub bootstrap_transient_registered: u64,
+    pub bootstrap_transient_expired: u64,
+    pub bootstrap_promoted_to_ring: u64,
+    pub bootstrap_time_to_min_connections: Option<Duration>,
+    pub bootstrap_startup_connect_retries: u64,
 }
 
 /// Read this module's own scalars, or `None` before [`init`] has run.
@@ -169,9 +177,15 @@ pub(crate) fn otel_status_scalars() -> Option<OtelStatusScalars> {
         });
         poisoned.into_inner()
     });
+    let b = &status.bootstrap_churn_stats;
     Some(OtelStatusScalars {
         connection_attempts: status.connection_attempts,
         op_stats: status.op_stats.clone(),
+        bootstrap_transient_registered: b.transient_registered,
+        bootstrap_transient_expired: b.transient_expired,
+        bootstrap_promoted_to_ring: b.promoted_to_ring,
+        bootstrap_time_to_min_connections: b.time_to_min_connections,
+        bootstrap_startup_connect_retries: b.startup_connect_retries,
     })
 }
 
@@ -351,6 +365,36 @@ pub struct NetworkStatus {
     pub reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats,
     pub reconcile_shadow_connection_drop: ReconcileShadowStats,
     pub reconcile_shadow_host_formation: ReconcileShadowStats,
+    /// Bootstrap-acceptance-churn counters (#4787). See [`BootstrapChurnStats`].
+    pub bootstrap_churn_stats: BootstrapChurnStats,
+}
+
+/// Bootstrap-acceptance-churn counters (issue #4787): a restarted node's
+/// connection to a gateway lingers as transient, expires, and the transport
+/// is later reaped as a zombie before the onward CONNECT promotes it to the
+/// ring — cycling the joiner through repeated reconnects before it acquires
+/// real peers. These counters are the "instrumentation before a fix" step
+/// the issue calls for: they don't change acceptance behavior, only make the
+/// churn rate and the time-to-bootstrap legible in production telemetry.
+///
+/// `transient_registered` / `transient_expired` / `promoted_to_ring` are
+/// GATEWAY-side, monotonic lifetime totals, recorded at the three log sites
+/// in `p2p_protoc/connection_lifecycle.rs` that this issue's live-log
+/// evidence was read from. A sustained high `transient_expired` :
+/// `promoted_to_ring` ratio is the churn signature reported in the issue.
+///
+/// `time_to_min_connections` / `startup_connect_retries` are JOINER-side,
+/// recorded by `initial_join_procedure` in `operations/connect.rs`.
+/// `time_to_min_connections` is set at most once per process (the first time
+/// `open_connections()` reaches `min_connections`); `startup_connect_retries`
+/// counts each below-threshold retry round issued before that point.
+#[derive(Default)]
+pub struct BootstrapChurnStats {
+    pub transient_registered: u64,
+    pub transient_expired: u64,
+    pub promoted_to_ring: u64,
+    pub time_to_min_connections: Option<Duration>,
+    pub startup_connect_retries: u64,
 }
 
 /// Per-node counters measuring how often the demand-driven-hosting **computed
@@ -780,6 +824,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         reconcile_shadow_inbound_unsubscribe: ReconcileShadowStats::default(),
         reconcile_shadow_connection_drop: ReconcileShadowStats::default(),
         reconcile_shadow_host_formation: ReconcileShadowStats::default(),
+        bootstrap_churn_stats: BootstrapChurnStats::default(),
     };
     match NETWORK_STATUS.get() {
         // Already initialized: overwrite the existing tracker in place so
@@ -1276,6 +1321,91 @@ pub fn connect_emit_counts() -> Option<(u64, u64)> {
     let s = status.read().ok()?;
     let c = &s.connect_emit_stats;
     Some((c.accepts_emitted, c.rejects_emitted))
+}
+
+/// Record that a gateway-side connection was registered as transient (not
+/// yet added to ring topology) — issue #4787 instrumentation. Called from
+/// the "Registered transient connection" site in
+/// `p2p_protoc/connection_lifecycle.rs`.
+pub fn record_bootstrap_transient_registered() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.bootstrap_churn_stats.transient_registered = s
+                .bootstrap_churn_stats
+                .transient_registered
+                .saturating_add(1);
+        }
+    }
+}
+
+/// Record that a transient tracking entry expired (TTL elapsed) before the
+/// onward CONNECT promoted it — issue #4787 instrumentation. Called from the
+/// "Transient connection expired" site in
+/// `p2p_protoc/connection_lifecycle.rs`.
+pub fn record_bootstrap_transient_expired() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.bootstrap_churn_stats.transient_expired =
+                s.bootstrap_churn_stats.transient_expired.saturating_add(1);
+        }
+    }
+}
+
+/// Record that a connection was promoted from transient to ring topology —
+/// issue #4787 instrumentation. Called from the "connect_peer: promoted to
+/// ring" site in `p2p_protoc/connection_lifecycle.rs`.
+pub fn record_bootstrap_promoted_to_ring() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.bootstrap_churn_stats.promoted_to_ring =
+                s.bootstrap_churn_stats.promoted_to_ring.saturating_add(1);
+        }
+    }
+}
+
+/// Record the time from process start to first reaching `min_connections`
+/// (issue #4787 instrumentation, joiner-side). Idempotent: only the first
+/// call per process has any effect, so a wobble around the threshold does
+/// not overwrite the real bootstrap latency with a later value.
+pub fn record_bootstrap_min_connections_reached(elapsed: Duration) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            if s.bootstrap_churn_stats.time_to_min_connections.is_none() {
+                s.bootstrap_churn_stats.time_to_min_connections = Some(elapsed);
+            }
+        }
+    }
+}
+
+/// Record one below-threshold CONNECT retry round issued by
+/// `initial_join_procedure` at startup (issue #4787 instrumentation,
+/// joiner-side).
+pub fn record_bootstrap_startup_connect_retry() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.bootstrap_churn_stats.startup_connect_retries = s
+                .bootstrap_churn_stats
+                .startup_connect_retries
+                .saturating_add(1);
+        }
+    }
+}
+
+/// Read the current bootstrap-churn counters for export to `router_snapshot`
+/// (issue #4787). Returns `(transient_registered, transient_expired,
+/// promoted_to_ring, time_to_min_connections, startup_connect_retries)` or
+/// `None` before the singleton is initialized.
+pub fn bootstrap_churn_counts() -> Option<(u64, u64, u64, Option<Duration>, u64)> {
+    let status = NETWORK_STATUS.get()?;
+    let s = status.read().ok()?;
+    let b = &s.bootstrap_churn_stats;
+    Some((
+        b.transient_registered,
+        b.transient_expired,
+        b.promoted_to_ring,
+        b.time_to_min_connections,
+        b.startup_connect_retries,
+    ))
 }
 
 /// Count of this node's active connections that are to gateways (the
@@ -2292,6 +2422,49 @@ mod tests {
             Some((5, 2)),
             "getter returns (comparisons, divergences); every call bumps comparisons, \
              only diverged calls bump divergences"
+        );
+    }
+
+    /// End-to-end for the bootstrap-acceptance-churn counters (#4787): each
+    /// record function must feed the `bootstrap_churn_counts()` getter that
+    /// `Ring` polls for the `router_snapshot` export. Distinct counts per
+    /// field so a transposition can't pass; `time_to_min_connections` is
+    /// asserted idempotent (only the FIRST call has effect).
+    #[test]
+    fn bootstrap_churn_counts_reflect_recorded_events() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        // Fresh singleton state for a deterministic baseline (init overwrites
+        // the process-global tracker in place, zeroing the counters).
+        init(31337, HashSet::new(), "test".to_string());
+
+        assert_eq!(
+            bootstrap_churn_counts(),
+            Some((0, 0, 0, None, 0)),
+            "counters start at zero/None after init"
+        );
+
+        record_bootstrap_transient_registered();
+        record_bootstrap_transient_registered();
+        record_bootstrap_transient_registered();
+        record_bootstrap_transient_expired();
+        record_bootstrap_transient_expired();
+        record_bootstrap_promoted_to_ring();
+        record_bootstrap_startup_connect_retry();
+        record_bootstrap_startup_connect_retry();
+        record_bootstrap_startup_connect_retry();
+        record_bootstrap_startup_connect_retry();
+
+        record_bootstrap_min_connections_reached(Duration::from_secs(5));
+        // A second call must NOT overwrite the first — the real bootstrap
+        // latency, not the latest wobble around the threshold.
+        record_bootstrap_min_connections_reached(Duration::from_secs(99));
+
+        assert_eq!(
+            bootstrap_churn_counts(),
+            Some((3, 2, 1, Some(Duration::from_secs(5)), 4)),
+            "getter returns (transient_registered, transient_expired, promoted_to_ring, \
+             time_to_min_connections, startup_connect_retries); time-to-min-connections \
+             is set on the FIRST call only"
         );
     }
 

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -406,11 +406,12 @@ pub struct NetworkStatus {
 #[derive(Default)]
 pub struct BootstrapChurnStats {
     /// Counts calls to the "Registered transient connection" log site, not
-    /// confirmed new-entry insertions: `try_register_transient` also returns
-    /// `true` (and the site still logs/increments) for an already-tracked
-    /// entry, so this can be a slight overcount relative to the transient
-    /// table's real size. Faithfully mirrors the pre-existing log statement's
-    /// own semantics at that site.
+    /// confirmed new-entry insertions: the call site increments unconditionally,
+    /// without branching on `try_register_transient`'s return value, so it also
+    /// counts an already-tracked entry (returns `true`) and a budget-exhausted
+    /// refusal where nothing was actually inserted (returns `false`). Faithfully
+    /// mirrors the pre-existing log statement's own (also-unconditional)
+    /// semantics at that site.
     pub transient_registered: u64,
     pub transient_expired: u64,
     pub promoted_to_ring: u64,

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -150,7 +150,8 @@ pub(crate) struct OtelStatusScalars {
     pub bootstrap_transient_expired: u64,
     pub bootstrap_promoted_to_ring: u64,
     pub bootstrap_time_to_min_connections: Option<Duration>,
-    pub bootstrap_startup_rounds_connect_issued: u64,
+    pub bootstrap_startup_rounds_connect_issued_gateway: u64,
+    pub bootstrap_startup_rounds_connect_issued_routed: u64,
     pub bootstrap_startup_rounds_backoff_blocked: u64,
     pub bootstrap_startup_rounds_no_target: u64,
 }
@@ -187,7 +188,8 @@ pub(crate) fn otel_status_scalars() -> Option<OtelStatusScalars> {
         bootstrap_transient_expired: b.transient_expired,
         bootstrap_promoted_to_ring: b.promoted_to_ring,
         bootstrap_time_to_min_connections: b.time_to_min_connections,
-        bootstrap_startup_rounds_connect_issued: b.startup_rounds_connect_issued,
+        bootstrap_startup_rounds_connect_issued_gateway: b.startup_rounds_connect_issued_gateway,
+        bootstrap_startup_rounds_connect_issued_routed: b.startup_rounds_connect_issued_routed,
         bootstrap_startup_rounds_backoff_blocked: b.startup_rounds_backoff_blocked,
         bootstrap_startup_rounds_no_target: b.startup_rounds_no_target,
     })
@@ -408,17 +410,40 @@ pub struct NetworkStatus {
 /// the exporter publishes `freenet.bootstrap.completed` as a 0/1 gauge so a
 /// permanently-stuck joiner is visible rather than absent.
 ///
-/// The three `startup_rounds_*` counters partition every below-threshold
+/// The four `startup_rounds_*` counters partition every below-threshold
 /// iteration of the join loop by what that iteration actually DID, and stop
 /// at the process's first real bootstrap (a later transient dip below
 /// `min_connections` is ordinary post-startup churn, not startup). Splitting
 /// them is what keeps them from degrading into a process-uptime proxy: a node
 /// stuck below `min_connections` forever increments SOMETHING every ~4s no
-/// matter how the counter is shaped, so the informative quantity is which one
-/// — `connect_issued` means it is actively retrying and being refused,
-/// `backoff_blocked` means every gateway is in exponential backoff, and
-/// `no_target` means the gateway transports look connected/pending while no
-/// real peers are being acquired, which is the #4787 stall signature.
+/// matter how the counter is shaped, so the informative quantity is which one:
+///
+/// - `connect_issued_gateway` — dialled gateways this node was not yet
+///   connected to. Ordinary bootstrap; a healthy joiner's first rounds.
+/// - `connect_issued_routed` — every gateway transport was already up and the
+///   node was still more than `gateways.len()` connections short, so CONNECTs
+///   were routed THROUGH the connected gateways toward gap locations.
+///   **This is the series that moves during the #4787 stall.** With
+///   `min_connections = 25` and the 1–3 gateways a real deployment has, a
+///   joiner whose gateway transports are up but which acquires no real peers
+///   takes this branch on every round, for the whole multi-minute stall.
+/// - `backoff_blocked` — issued nothing because every candidate gateway was
+///   in exponential backoff.
+/// - `no_target` — issued nothing for any other reason. Principally: all
+///   gateways connected AND the node is within `gateways.len()` of the
+///   threshold, so the routed-CONNECT branch above does not apply and the
+///   round deliberately waits. This is a comparatively quiet outcome, NOT the
+///   stall signature — an earlier revision of this instrumentation documented
+///   it as such, which would have had an operator watching a series that
+///   reads flat zero for the entire stall.
+///
+/// The stall signature is therefore sustained `connect_issued_routed` growth
+/// while `time_to_min_connections` stays `None` (exported as
+/// `freenet.bootstrap.completed = 0`). The `completed` gauge is load-bearing
+/// here: a HEALTHY joiner with few gateways also emits some
+/// `connect_issued_routed` while it fills out its ring, and what distinguishes
+/// the stall is that the counter keeps climbing without the gauge ever
+/// flipping to 1.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BootstrapChurnStats {
     /// Counts transient tracking entries actually inserted, not call-site
@@ -433,15 +458,23 @@ pub struct BootstrapChurnStats {
     /// cap-rejected promotion attempt is not counted as a promotion.
     pub promoted_to_ring: u64,
     pub time_to_min_connections: Option<Duration>,
-    /// Below-threshold join-loop rounds that issued a CONNECT round (to
-    /// unconnected gateways, or routed through already-connected gateways).
-    pub startup_rounds_connect_issued: u64,
+    /// Below-threshold join-loop rounds that dialled gateways this node was
+    /// not yet connected to.
+    pub startup_rounds_connect_issued_gateway: u64,
+    /// Below-threshold join-loop rounds that routed CONNECTs through
+    /// already-connected gateways because every gateway transport was already
+    /// up. Sustained growth here with `time_to_min_connections == None` is the
+    /// #4787 stall signature.
+    pub startup_rounds_connect_issued_routed: u64,
     /// Below-threshold join-loop rounds that issued nothing because every
     /// candidate gateway was in exponential backoff.
     pub startup_rounds_backoff_blocked: u64,
     /// Below-threshold join-loop rounds that issued nothing for any other
-    /// reason — principally "all gateways appear connected/pending" while the
-    /// node still has no real peers. The #4787 stall signature.
+    /// reason — principally: every gateway is connected AND the node is within
+    /// `gateways.len()` of the threshold, so the routed-CONNECT branch does
+    /// not apply and the round deliberately waits for handshakes or pending
+    /// reservations. NOT the #4787 stall signature; see
+    /// `startup_rounds_connect_issued_routed`.
     pub startup_rounds_no_target: u64,
 }
 
@@ -449,8 +482,12 @@ pub struct BootstrapChurnStats {
 /// did not issue CONNECTs (#4787). See [`BootstrapChurnStats`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StartupRoundOutcome {
-    /// A CONNECT round was actually issued this iteration.
-    ConnectIssued,
+    /// CONNECTs were issued to gateways this node is not yet connected to.
+    ConnectIssuedGateway,
+    /// CONNECTs were routed through already-connected gateways toward gap
+    /// locations, because every gateway transport is already up. The #4787
+    /// stall signature — see [`BootstrapChurnStats`].
+    ConnectIssuedRouted,
     /// Nothing issued: every candidate gateway was in exponential backoff.
     BackoffBlocked,
     /// Nothing issued for any other reason.
@@ -1480,7 +1517,12 @@ pub fn record_bootstrap_startup_round(outcome: StartupRoundOutcome) {
         if let Ok(mut s) = status.write() {
             let b = &mut s.bootstrap_churn_stats;
             let slot = match outcome {
-                StartupRoundOutcome::ConnectIssued => &mut b.startup_rounds_connect_issued,
+                StartupRoundOutcome::ConnectIssuedGateway => {
+                    &mut b.startup_rounds_connect_issued_gateway
+                }
+                StartupRoundOutcome::ConnectIssuedRouted => {
+                    &mut b.startup_rounds_connect_issued_routed
+                }
                 StartupRoundOutcome::BackoffBlocked => &mut b.startup_rounds_backoff_blocked,
                 StartupRoundOutcome::NoTarget => &mut b.startup_rounds_no_target,
             };
@@ -2540,10 +2582,15 @@ mod tests {
         record_bootstrap_transient_expired();
         record_bootstrap_transient_expired();
         record_bootstrap_promoted_to_ring();
-        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
-        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
-        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
-        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssued);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedGateway);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedGateway);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedGateway);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedGateway);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedRouted);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedRouted);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedRouted);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedRouted);
+        record_bootstrap_startup_round(StartupRoundOutcome::ConnectIssuedRouted);
         record_bootstrap_startup_round(StartupRoundOutcome::BackoffBlocked);
         record_bootstrap_startup_round(StartupRoundOutcome::BackoffBlocked);
         record_bootstrap_startup_round(StartupRoundOutcome::NoTarget);
@@ -2572,7 +2619,8 @@ mod tests {
                 transient_expired: 2,
                 promoted_to_ring: 1,
                 time_to_min_connections: Some(first),
-                startup_rounds_connect_issued: 4,
+                startup_rounds_connect_issued_gateway: 4,
+                startup_rounds_connect_issued_routed: 5,
                 startup_rounds_backoff_blocked: 2,
                 startup_rounds_no_target: 1,
             }),

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -432,18 +432,43 @@ pub struct NetworkStatus {
 /// - `no_target` — issued nothing for any other reason. Principally: all
 ///   gateways connected AND the node is within `gateways.len()` of the
 ///   threshold, so the routed-CONNECT branch above does not apply and the
-///   round deliberately waits. This is a comparatively quiet outcome, NOT the
-///   stall signature — an earlier revision of this instrumentation documented
-///   it as such, which would have had an operator watching a series that
-///   reads flat zero for the entire stall.
+///   round deliberately waits. This is NOT the #4787 acceptance-churn
+///   signature — an earlier revision of this instrumentation documented it as
+///   such, which would have had an operator watching a series that reads flat
+///   zero for the entire stall. But do not read it as merely quiet either: a
+///   node parked at, say, 24 of 25 connections matches this condition on
+///   every round forever, so sustained growth here is its own kind of stall —
+///   a joiner that has stopped issuing anything a few connections short of
+///   the threshold.
 ///
-/// The stall signature is therefore sustained `connect_issued_routed` growth
-/// while `time_to_min_connections` stays `None` (exported as
-/// `freenet.bootstrap.completed = 0`). The `completed` gauge is load-bearing
-/// here: a HEALTHY joiner with few gateways also emits some
-/// `connect_issued_routed` while it fills out its ring, and what distinguishes
-/// the stall is that the counter keeps climbing without the gauge ever
-/// flipping to 1.
+/// ## Reading the routed counter
+///
+/// Sustained `connect_issued_routed` growth while `time_to_min_connections`
+/// stays `None` (exported as `freenet.bootstrap.completed = 0`) identifies **a
+/// joiner that never bootstrapped**. That is NECESSARY for the #4787 stall but
+/// not SUFFICIENT, and the difference matters operationally: a network with
+/// fewer than `min_connections` reachable peers, a node behind restrictive
+/// NAT, and a node whose peers keep refusing for capacity all match the pair
+/// permanently and identically. An alert built on it alone fires forever on
+/// every node of a small network, gets muted, and then the real stall is
+/// invisible — the same defect this instrumentation exists to fix, one level
+/// up.
+///
+/// **The discriminator is `transient_registered` / `transient_expired` /
+/// `promoted_to_ring`**, documented above. A high `transient_expired` :
+/// `promoted_to_ring` ratio alongside climbing `connect_issued_routed` is
+/// acceptance churn — connections are being made and lost, which is #4787.
+/// Churn near zero with `connect_issued_routed` climbing means the CONNECTs
+/// are simply not finding acceptable peers: too few peers, or unreachable
+/// ones. Same routed counter, different fix.
+///
+/// Quantifying "sustained", so the guidance is implementable without
+/// re-deriving it from this loop: a round takes `BASE_WAIT_SECS * 3` plus 0–2s
+/// of jitter once the node holds any connection, so a joiner stuck in this
+/// branch emits on the order of 900 routed rounds per hour, without bound. A
+/// healthy joiner emits a few tens of them over the first minute or two and
+/// then stops, because reaching `min_connections` ends the counting. More than
+/// a few minutes of continued growth is the threshold worth alerting on.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BootstrapChurnStats {
     /// Counts transient tracking entries actually inserted, not call-site
@@ -463,8 +488,10 @@ pub struct BootstrapChurnStats {
     pub startup_rounds_connect_issued_gateway: u64,
     /// Below-threshold join-loop rounds that routed CONNECTs through
     /// already-connected gateways because every gateway transport was already
-    /// up. Sustained growth here with `time_to_min_connections == None` is the
-    /// #4787 stall signature.
+    /// up. Sustained growth with `time_to_min_connections == None` means this
+    /// joiner never bootstrapped; the `transient_*` / `promoted_to_ring` ratio
+    /// is what separates #4787 acceptance churn from simply having too few
+    /// acceptable peers. See [`BootstrapChurnStats`].
     pub startup_rounds_connect_issued_routed: u64,
     /// Below-threshold join-loop rounds that issued nothing because every
     /// candidate gateway was in exponential backoff.
@@ -473,8 +500,10 @@ pub struct BootstrapChurnStats {
     /// reason — principally: every gateway is connected AND the node is within
     /// `gateways.len()` of the threshold, so the routed-CONNECT branch does
     /// not apply and the round deliberately waits for handshakes or pending
-    /// reservations. NOT the #4787 stall signature; see
-    /// `startup_rounds_connect_issued_routed`.
+    /// reservations. Not the #4787 acceptance-churn signature (see
+    /// `startup_rounds_connect_issued_routed`), but not benign either:
+    /// sustained growth means a joiner parked a few connections short of the
+    /// threshold and no longer issuing anything.
     pub startup_rounds_no_target: u64,
 }
 

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2146,6 +2146,67 @@ mod tests {
     use crate::transport::TransportKeypair;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+    /// Source-scrape pin (issue #4787 review finding): `startup_connect_retries`
+    /// must only increment BEFORE the process's first real bootstrap. A prior
+    /// version had no such gate, so a later transient dip below
+    /// `bootstrap_threshold` (ordinary post-startup churn, e.g. losing peers)
+    /// kept incrementing a counter documented and exported as startup-only.
+    /// `initial_join_procedure` runs inside a `GlobalExecutor::spawn`'d loop for
+    /// the node's lifetime, so this invariant isn't practically unit-testable by
+    /// driving the loop directly — this pins the gate's presence at the source
+    /// level instead. Mutation-verified: removing the `if !min_connections_reached`
+    /// wrapper (leaving the bare `record_bootstrap_startup_connect_retry();` call)
+    /// makes this test FAIL.
+    #[test]
+    fn initial_join_procedure_gates_startup_retry_counter_on_min_connections_reached() {
+        let src = include_str!("connect.rs");
+        let sig = "pub(crate) async fn initial_join_procedure(";
+        let start = src
+            .find(sig)
+            .expect("initial_join_procedure signature not found");
+        let body_start = src[start..]
+            .find('{')
+            .map(|i| start + i)
+            .expect("no opening brace after signature");
+        // Walk forward counting brace depth to find the MATCHING closing
+        // brace, so the region is exact regardless of nested blocks — unlike
+        // a naive "first \n}\n after this point" search, which would stop at
+        // the end of the first inner block instead of the function itself.
+        let mut depth: i32 = 0;
+        let mut end = None;
+        for (i, ch) in src[body_start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(body_start + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let end = end.expect("unbalanced braces scanning initial_join_procedure body");
+        let body = &src[body_start..=end];
+
+        let gate = "if !min_connections_reached {";
+        let gate_at = body.find(gate).expect(
+            "initial_join_procedure must gate the startup retry counter on \
+             !min_connections_reached — see the doc comment on \
+             BootstrapChurnStats::startup_connect_retries",
+        );
+        let after_gate = &body[gate_at..];
+        assert!(
+            after_gate
+                .lines()
+                .take(3)
+                .any(|l| l.contains("record_bootstrap_startup_connect_retry()")),
+            "the `if !min_connections_reached` gate must directly wrap the \
+             record_bootstrap_startup_connect_retry() call, not some other statement"
+        );
+    }
+
     #[test]
     fn resolve_probe_gateway_addr_returns_known_socket() {
         let pub_key = TransportKeypair::new().public().clone();

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2228,6 +2228,28 @@ mod tests {
         op_manager
     }
 
+    /// Run `body` with the process-global `NETWORK_STATUS` guard held.
+    ///
+    /// The guard is acquired and released in this SYNC frame and the async body
+    /// runs inside `block_on`, so the lock is never live across an `.await` in
+    /// an async fn — the shape `clippy::await_holding_lock` forbids — while
+    /// still serializing these tests against every other test that touches the
+    /// singleton.
+    fn with_network_status_lock<F>(body: F)
+    where
+        F: std::future::Future<Output = ()>,
+    {
+        let _lock = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        crate::node::network_status::init(0, HashSet::new(), "test".to_string());
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime")
+            .block_on(body);
+    }
+
     fn bootstrap_gateway(port: u16) -> PeerKeyLocation {
         let pub_key = TransportKeypair::new().public().clone();
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
@@ -2263,101 +2285,98 @@ mod tests {
     /// only increment inside `open_conns < threshold && unconnected_count > 0`,
     /// so it recorded ZERO for the entire multi-minute stall it was added to
     /// measure. The loop must classify this round.
-    #[tokio::test]
-    async fn startup_rounds_counted_while_all_gateways_appear_connected() {
-        let _lock = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        crate::node::network_status::init(0, HashSet::new(), "test".to_string());
+    #[test]
+    fn startup_rounds_counted_while_all_gateways_appear_connected() {
+        with_network_status_lock(async {
+            let op_manager =
+                bootstrap_test_op_manager("bootstrap-4787-stall", "127.0.0.1:14787").await;
+            let cm = &op_manager.ring.connection_manager;
+            let gateways = vec![bootstrap_gateway(24787), bootstrap_gateway(24788)];
 
-        let op_manager = bootstrap_test_op_manager("bootstrap-4787-stall", "127.0.0.1:14787").await;
-        let cm = &op_manager.ring.connection_manager;
-        let gateways = vec![bootstrap_gateway(24787), bootstrap_gateway(24788)];
-
-        // Make every gateway look connected — the stall's defining symptom.
-        for gw in &gateways {
-            let addr = gw.socket_addr().expect("gateway has an address");
+            // Make every gateway look connected — the stall's defining symptom.
+            for gw in &gateways {
+                let addr = gw.socket_addr().expect("gateway has an address");
+                assert!(
+                    cm.add_connection(
+                        Location::from_address(&addr),
+                        addr,
+                        gw.pub_key().clone(),
+                        false
+                    ),
+                    "test setup: gateway must be accepted into the ring"
+                );
+            }
+            assert_eq!(op_manager.ring.open_connections(), gateways.len());
             assert!(
-                cm.add_connection(
-                    Location::from_address(&addr),
-                    addr,
-                    gw.pub_key().clone(),
-                    false
-                ),
-                "test setup: gateway must be accepted into the ring"
+                op_manager.ring.open_connections() < cm.min_connections,
+                "test setup: node must be below the bootstrap threshold"
             );
-        }
-        assert_eq!(op_manager.ring.open_connections(), gateways.len());
-        assert!(
-            op_manager.ring.open_connections() < cm.min_connections,
-            "test setup: node must be below the bootstrap threshold"
-        );
-        assert_eq!(
-            op_manager.ring.is_not_connected(gateways.iter()).count(),
-            0,
-            "test setup: no gateway may look unconnected — that is the stall"
-        );
+            assert_eq!(
+                op_manager.ring.is_not_connected(gateways.iter()).count(),
+                0,
+                "test setup: no gateway may look unconnected — that is the stall"
+            );
 
-        let handle = initial_join_procedure(op_manager.clone(), &gateways)
-            .await
-            .expect("spawn join procedure");
-        let (issued, backoff, no_target) = wait_for_startup_round(Duration::from_secs(10)).await;
-        handle.abort();
+            let handle = initial_join_procedure(op_manager.clone(), &gateways)
+                .await
+                .expect("spawn join procedure");
+            let (issued, backoff, no_target) =
+                wait_for_startup_round(Duration::from_secs(10)).await;
+            handle.abort();
 
-        assert!(
-            issued + backoff + no_target > 0,
-            "the join loop must count a below-threshold round during the stall; \
+            assert!(
+                issued + backoff + no_target > 0,
+                "the join loop must count a below-threshold round during the stall; \
              got connect_issued={issued} backoff_blocked={backoff} no_target={no_target}"
-        );
-        // With 25 - 2 > 2 the loop routes CONNECTs through the connected
-        // gateways (`use_connected_as_routers`), a path the first version of
-        // this instrumentation also left uncounted.
-        assert!(
-            issued > 0,
-            "rounds routed through connected gateways must count as \
+            );
+            // With 25 - 2 > 2 the loop routes CONNECTs through the connected
+            // gateways (`use_connected_as_routers`), a path the first version of
+            // this instrumentation also left uncounted.
+            assert!(
+                issued > 0,
+                "rounds routed through connected gateways must count as \
              connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
              no_target={no_target}"
-        );
+            );
 
-        // And the joiner must be visibly un-bootstrapped rather than absent.
-        let b = crate::node::network_status::bootstrap_churn_counts().expect("initialized");
-        assert_eq!(
-            b.time_to_min_connections, None,
-            "a node that never reached min_connections must report no latency, \
+            // And the joiner must be visibly un-bootstrapped rather than absent.
+            let b = crate::node::network_status::bootstrap_churn_counts().expect("initialized");
+            assert_eq!(
+                b.time_to_min_connections, None,
+                "a node that never reached min_connections must report no latency, \
              while still being present in the snapshot"
-        );
+            );
+        });
     }
 
     /// The ordinary case still counts: gateways unconnected and not in backoff
     /// means a real CONNECT round is issued to them.
-    #[tokio::test]
-    async fn startup_rounds_counted_when_gateways_are_unconnected() {
-        let _lock = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        crate::node::network_status::init(0, HashSet::new(), "test".to_string());
+    #[test]
+    fn startup_rounds_counted_when_gateways_are_unconnected() {
+        with_network_status_lock(async {
+            let op_manager =
+                bootstrap_test_op_manager("bootstrap-4787-unconnected", "127.0.0.1:14789").await;
+            let gateways = vec![bootstrap_gateway(24790), bootstrap_gateway(24791)];
+            assert_eq!(
+                op_manager.ring.is_not_connected(gateways.iter()).count(),
+                gateways.len(),
+                "test setup: both gateways must look unconnected"
+            );
 
-        let op_manager =
-            bootstrap_test_op_manager("bootstrap-4787-unconnected", "127.0.0.1:14789").await;
-        let gateways = vec![bootstrap_gateway(24790), bootstrap_gateway(24791)];
-        assert_eq!(
-            op_manager.ring.is_not_connected(gateways.iter()).count(),
-            gateways.len(),
-            "test setup: both gateways must look unconnected"
-        );
+            let handle = initial_join_procedure(op_manager.clone(), &gateways)
+                .await
+                .expect("spawn join procedure");
+            let (issued, backoff, no_target) =
+                wait_for_startup_round(Duration::from_secs(10)).await;
+            handle.abort();
 
-        let handle = initial_join_procedure(op_manager.clone(), &gateways)
-            .await
-            .expect("spawn join procedure");
-        let (issued, backoff, no_target) = wait_for_startup_round(Duration::from_secs(10)).await;
-        handle.abort();
-
-        assert!(
-            issued > 0,
-            "a round that issues CONNECTs to unconnected gateways must count as \
+            assert!(
+                issued > 0,
+                "a round that issues CONNECTs to unconnected gateways must count as \
              connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
              no_target={no_target}"
-        );
+            );
+        });
     }
 
     #[test]

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -106,6 +106,7 @@ use crate::config::{GlobalExecutor, GlobalRng};
 use crate::dev_tool::Location;
 use crate::message::{InnerMessage, NodeEvent, Transaction};
 use crate::node::OpManager;
+use crate::node::network_status::StartupRoundOutcome;
 use crate::operations::OpError;
 use crate::ring::{KnownPeerKeyLocation, PeerAddr, PeerKeyLocation};
 use crate::router::{EstimatorType, IsotonicEstimator, IsotonicEvent};
@@ -1863,9 +1864,13 @@ pub(crate) async fn initial_join_procedure(
 
         // Issue #4787 instrumentation (joiner-side): record how long it takes
         // this process to first reach `bootstrap_threshold` connections, and
-        // how many below-threshold retry rounds it takes to get there. Set at
-        // most once per process — see `record_bootstrap_min_connections_reached`.
-        let procedure_started_at = Instant::now();
+        // classify every below-threshold round by what it actually did. The
+        // latency is measured from the process-start anchor inside
+        // `record_bootstrap_min_connections_reached`, NOT from here: a clock
+        // started at this point excludes the cached-peer fast-reconnect block
+        // above (up to CACHED_PEER_TIMEOUT) and all node startup before the
+        // spawn, so on a restart — the issue's own scenario — a successful
+        // cached reconnect would report ~0s for a bootstrap that took seconds.
         let mut min_connections_reached = false;
 
         loop {
@@ -1873,10 +1878,23 @@ pub(crate) async fn initial_join_procedure(
 
             if !min_connections_reached && open_conns >= bootstrap_threshold {
                 min_connections_reached = true;
-                crate::node::network_status::record_bootstrap_min_connections_reached(
-                    procedure_started_at.elapsed(),
-                );
+                crate::node::network_status::record_bootstrap_min_connections_reached();
             }
+
+            // Has this round already been classified (#4787)? Each branch that
+            // decides what the round does records its own outcome BEFORE
+            // awaiting anything, so a CONNECT fan-out that hangs still leaves a
+            // counted round; whatever reaches the bottom unrecorded is a round
+            // that issued nothing, which is the "all gateways appear
+            // connected/pending" stall the issue was filed about and which the
+            // first version of this instrumentation could not see at all.
+            let mut round_recorded = false;
+            let mut record_round = |outcome: StartupRoundOutcome| {
+                if !round_recorded && !min_connections_reached {
+                    crate::node::network_status::record_bootstrap_startup_round(outcome);
+                }
+                round_recorded = true;
+            };
 
             let unconnected_gateways: Vec<_> =
                 op_manager.ring.is_not_connected(gateways.iter()).collect();
@@ -1986,6 +2004,7 @@ pub(crate) async fn initial_join_procedure(
                             open_connections = open_conns,
                             "All gateways in backoff, waiting before retry"
                         );
+                        record_round(StartupRoundOutcome::BackoffBlocked);
                         tokio::select! {
                             _ = tokio::time::sleep(effective_wait) => {},
                             _ = op_manager.gateway_backoff_cleared.notified() => {
@@ -1996,16 +2015,16 @@ pub(crate) async fn initial_join_procedure(
                     }
                 }
 
-                // Only counts retry rounds BEFORE the process's first real
-                // bootstrap (issue #4787 instrumentation semantics — see the
-                // doc comment on `BootstrapChurnStats::startup_connect_retries`).
-                // Without this gate a later transient dip back below
-                // `bootstrap_threshold` (ordinary post-bootstrap churn, e.g.
-                // losing peers) would keep incrementing a counter that is
-                // documented and exported as a startup-only metric.
-                if !min_connections_reached {
-                    crate::node::network_status::record_bootstrap_startup_connect_retry();
-                }
+                // #4787: `eligible_count == 0` can still reach here when every
+                // gateway was filtered for backoff but none reported a
+                // remaining duration, in which case the CONNECT fan-out below
+                // is empty and no CONNECT is issued. Classify by what actually
+                // happens, not by which branch we are in.
+                record_round(if eligible_count > 0 {
+                    StartupRoundOutcome::ConnectIssued
+                } else {
+                    StartupRoundOutcome::BackoffBlocked
+                });
                 tracing::info!(
                     "Below bootstrap threshold ({} < {}), attempting to connect to {} gateways (skipped {} in backoff)",
                     open_conns,
@@ -2059,6 +2078,12 @@ pub(crate) async fn initial_join_procedure(
                 };
 
                 if !eligible.is_empty() {
+                    // #4787: these are CONNECT rounds too. They were uncounted
+                    // in the first version of this instrumentation, and they
+                    // are the rounds a stalled joiner actually issues — its
+                    // gateway transports are up, so the branch above (which
+                    // needs an UNCONNECTED gateway) never runs.
+                    record_round(StartupRoundOutcome::ConnectIssued);
                     tracing::info!(
                         eligible = eligible.len(),
                         total_gateways = gateways.len(),
@@ -2106,6 +2131,14 @@ pub(crate) async fn initial_join_procedure(
                 );
             }
 
+            // Nothing was issued this round (#4787). `record_round` is gated on
+            // `!min_connections_reached` so these stay startup-only counters: a
+            // later transient dip below `bootstrap_threshold` is ordinary
+            // post-bootstrap churn, not bootstrap. `min_connections_reached` is
+            // set at the top of this iteration, so reaching here with it false
+            // means `open_conns < bootstrap_threshold`.
+            record_round(StartupRoundOutcome::NoTarget);
+
             // Add random jitter to prevent thundering herd after gateway restart.
             // Without jitter, all peers that lose their gateway connection retry
             // at the same interval, causing synchronized reconnection storms.
@@ -2146,64 +2179,184 @@ mod tests {
     use crate::transport::TransportKeypair;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    /// Source-scrape pin (issue #4787 review finding): `startup_connect_retries`
-    /// must only increment BEFORE the process's first real bootstrap. A prior
-    /// version had no such gate, so a later transient dip below
-    /// `bootstrap_threshold` (ordinary post-startup churn, e.g. losing peers)
-    /// kept incrementing a counter documented and exported as startup-only.
-    /// `initial_join_procedure` runs inside a `GlobalExecutor::spawn`'d loop for
-    /// the node's lifetime, so this invariant isn't practically unit-testable by
-    /// driving the loop directly — this pins the gate's presence at the source
-    /// level instead. Mutation-verified: removing the `if !min_connections_reached`
-    /// wrapper (leaving the bare `record_bootstrap_startup_connect_retry();` call)
-    /// makes this test FAIL.
-    #[test]
-    fn initial_join_procedure_gates_startup_retry_counter_on_min_connections_reached() {
-        let src = include_str!("connect.rs");
-        let sig = "pub(crate) async fn initial_join_procedure(";
-        let start = src
-            .find(sig)
-            .expect("initial_join_procedure signature not found");
-        let body_start = src[start..]
-            .find('{')
-            .map(|i| start + i)
-            .expect("no opening brace after signature");
-        // Walk forward counting brace depth to find the MATCHING closing
-        // brace, so the region is exact regardless of nested blocks — unlike
-        // a naive "first \n}\n after this point" search, which would stop at
-        // the end of the first inner block instead of the function itself.
-        let mut depth: i32 = 0;
-        let mut end = None;
-        for (i, ch) in src[body_start..].char_indices() {
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = Some(body_start + i);
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        let end = end.expect("unbalanced braces scanning initial_join_procedure body");
-        let body = &src[body_start..=end];
+    // --- #4787 joiner-side bootstrap instrumentation ---------------------
+    //
+    // These drive the REAL `initial_join_procedure` loop against a real
+    // `OpManager`, which is what the previous source-scrape pin could not do:
+    // a text assertion that a gate exists says nothing about whether the loop
+    // ever reaches it, and the two shapes below are exactly the cases where it
+    // did not.
 
-        let gate = "if !min_connections_reached {";
-        let gate_at = body.find(gate).expect(
-            "initial_join_procedure must gate the startup retry counter on \
-             !min_connections_reached — see the doc comment on \
-             BootstrapChurnStats::startup_connect_retries",
+    /// Build a minimal but real `OpManager` for driving the join loop.
+    async fn bootstrap_test_op_manager(id: &str, own_addr: &str) -> Arc<OpManager> {
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = Arc::new(
+            OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
         );
-        let after_gate = &body[gate_at..];
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test(own_addr.parse().unwrap());
+        // The receivers above must outlive the loop under test, otherwise the
+        // CONNECT fan-out fails for the wrong reason. Leak them for the
+        // duration of the test process rather than threading them back out.
+        std::mem::forget((_notification_rx, _ch_channel, _result_router_rx));
+        op_manager
+    }
+
+    fn bootstrap_gateway(port: u16) -> PeerKeyLocation {
+        let pub_key = TransportKeypair::new().public().clone();
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
+        PeerKeyLocation::new(pub_key, addr)
+    }
+
+    /// Total below-threshold rounds recorded so far, by category.
+    fn startup_round_totals() -> (u64, u64, u64) {
+        let b = crate::node::network_status::bootstrap_churn_counts()
+            .expect("network_status singleton initialized by the test");
+        (
+            b.startup_rounds_connect_issued,
+            b.startup_rounds_backoff_blocked,
+            b.startup_rounds_no_target,
+        )
+    }
+
+    /// Poll until the join loop has classified at least one round, or give up.
+    async fn wait_for_startup_round(deadline: Duration) -> (u64, u64, u64) {
+        let start = std::time::Instant::now();
+        loop {
+            let totals = startup_round_totals();
+            if totals.0 + totals.1 + totals.2 > 0 || start.elapsed() >= deadline {
+                return totals;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    /// The #4787 stall, reproduced: the joiner's gateway transports are UP (so
+    /// `is_not_connected` yields nothing) while the node sits far below
+    /// `min_connections`. The first version of this instrumentation put its
+    /// only increment inside `open_conns < threshold && unconnected_count > 0`,
+    /// so it recorded ZERO for the entire multi-minute stall it was added to
+    /// measure. The loop must classify this round.
+    #[tokio::test]
+    async fn startup_rounds_counted_while_all_gateways_appear_connected() {
+        let _lock = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        crate::node::network_status::init(0, HashSet::new(), "test".to_string());
+
+        let op_manager = bootstrap_test_op_manager("bootstrap-4787-stall", "127.0.0.1:14787").await;
+        let cm = &op_manager.ring.connection_manager;
+        let gateways = vec![bootstrap_gateway(24787), bootstrap_gateway(24788)];
+
+        // Make every gateway look connected — the stall's defining symptom.
+        for gw in &gateways {
+            let addr = gw.socket_addr().expect("gateway has an address");
+            assert!(
+                cm.add_connection(
+                    Location::from_address(&addr),
+                    addr,
+                    gw.pub_key().clone(),
+                    false
+                ),
+                "test setup: gateway must be accepted into the ring"
+            );
+        }
+        assert_eq!(op_manager.ring.open_connections(), gateways.len());
         assert!(
-            after_gate
-                .lines()
-                .take(3)
-                .any(|l| l.contains("record_bootstrap_startup_connect_retry()")),
-            "the `if !min_connections_reached` gate must directly wrap the \
-             record_bootstrap_startup_connect_retry() call, not some other statement"
+            op_manager.ring.open_connections() < cm.min_connections,
+            "test setup: node must be below the bootstrap threshold"
+        );
+        assert_eq!(
+            op_manager.ring.is_not_connected(gateways.iter()).count(),
+            0,
+            "test setup: no gateway may look unconnected — that is the stall"
+        );
+
+        let handle = initial_join_procedure(op_manager.clone(), &gateways)
+            .await
+            .expect("spawn join procedure");
+        let (issued, backoff, no_target) = wait_for_startup_round(Duration::from_secs(10)).await;
+        handle.abort();
+
+        assert!(
+            issued + backoff + no_target > 0,
+            "the join loop must count a below-threshold round during the stall; \
+             got connect_issued={issued} backoff_blocked={backoff} no_target={no_target}"
+        );
+        // With 25 - 2 > 2 the loop routes CONNECTs through the connected
+        // gateways (`use_connected_as_routers`), a path the first version of
+        // this instrumentation also left uncounted.
+        assert!(
+            issued > 0,
+            "rounds routed through connected gateways must count as \
+             connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
+             no_target={no_target}"
+        );
+
+        // And the joiner must be visibly un-bootstrapped rather than absent.
+        let b = crate::node::network_status::bootstrap_churn_counts().expect("initialized");
+        assert_eq!(
+            b.time_to_min_connections, None,
+            "a node that never reached min_connections must report no latency, \
+             while still being present in the snapshot"
+        );
+    }
+
+    /// The ordinary case still counts: gateways unconnected and not in backoff
+    /// means a real CONNECT round is issued to them.
+    #[tokio::test]
+    async fn startup_rounds_counted_when_gateways_are_unconnected() {
+        let _lock = crate::node::network_status::TEST_GLOBAL_STATE_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        crate::node::network_status::init(0, HashSet::new(), "test".to_string());
+
+        let op_manager =
+            bootstrap_test_op_manager("bootstrap-4787-unconnected", "127.0.0.1:14789").await;
+        let gateways = vec![bootstrap_gateway(24790), bootstrap_gateway(24791)];
+        assert_eq!(
+            op_manager.ring.is_not_connected(gateways.iter()).count(),
+            gateways.len(),
+            "test setup: both gateways must look unconnected"
+        );
+
+        let handle = initial_join_procedure(op_manager.clone(), &gateways)
+            .await
+            .expect("spawn join procedure");
+        let (issued, backoff, no_target) = wait_for_startup_round(Duration::from_secs(10)).await;
+        handle.abort();
+
+        assert!(
+            issued > 0,
+            "a round that issues CONNECTs to unconnected gateways must count as \
+             connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
+             no_target={no_target}"
         );
     }
 

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1861,8 +1861,22 @@ pub(crate) async fn initial_join_procedure(
             }
         }
 
+        // Issue #4787 instrumentation (joiner-side): record how long it takes
+        // this process to first reach `bootstrap_threshold` connections, and
+        // how many below-threshold retry rounds it takes to get there. Set at
+        // most once per process — see `record_bootstrap_min_connections_reached`.
+        let procedure_started_at = Instant::now();
+        let mut min_connections_reached = false;
+
         loop {
             let open_conns = op_manager.ring.open_connections();
+
+            if !min_connections_reached && open_conns >= bootstrap_threshold {
+                min_connections_reached = true;
+                crate::node::network_status::record_bootstrap_min_connections_reached(
+                    procedure_started_at.elapsed(),
+                );
+            }
 
             let unconnected_gateways: Vec<_> =
                 op_manager.ring.is_not_connected(gateways.iter()).collect();
@@ -1982,6 +1996,7 @@ pub(crate) async fn initial_join_procedure(
                     }
                 }
 
+                crate::node::network_status::record_bootstrap_startup_connect_retry();
                 tracing::info!(
                     "Below bootstrap threshold ({} < {}), attempting to connect to {} gateways (skipped {} in backoff)",
                     open_conns,

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1996,7 +1996,16 @@ pub(crate) async fn initial_join_procedure(
                     }
                 }
 
-                crate::node::network_status::record_bootstrap_startup_connect_retry();
+                // Only counts retry rounds BEFORE the process's first real
+                // bootstrap (issue #4787 instrumentation semantics — see the
+                // doc comment on `BootstrapChurnStats::startup_connect_retries`).
+                // Without this gate a later transient dip back below
+                // `bootstrap_threshold` (ordinary post-bootstrap churn, e.g.
+                // losing peers) would keep incrementing a counter that is
+                // documented and exported as a startup-only metric.
+                if !min_connections_reached {
+                    crate::node::network_status::record_bootstrap_startup_connect_retry();
+                }
                 tracing::info!(
                     "Below bootstrap threshold ({} < {}), attempting to connect to {} gateways (skipped {} in backoff)",
                     open_conns,

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2069,8 +2069,20 @@ pub(crate) async fn initial_join_procedure(
                 // Route CONNECTs through connected gateways toward gap locations.
                 // #4787: count the gateways excluded specifically FOR backoff,
                 // separately from those excluded for having no resolved socket
-                // address. An empty `eligible` means very different things in
-                // those two cases and the round must be classified by which.
+                // address, so the empty-`eligible` case below is classified by
+                // the actual reason.
+                //
+                // In THIS branch the no-address case is currently unreachable,
+                // and a reader should not waste time trying to construct it:
+                // `gateways` is non-empty (the join task returns early
+                // otherwise), and `is_not_connected` counts an address-less
+                // peer as UNCONNECTED (`ring.rs`), so any such gateway would
+                // have made `unconnected_count > 0` and taken the branch above
+                // instead. The count is kept anyway rather than assuming
+                // `eligible.is_empty()` means backoff: that identity holds only
+                // via an invariant enforced two modules away, and a counter
+                // that silently mislabels a round if it ever changes is the
+                // failure mode this whole PR is about.
                 let (eligible, blocked_by_backoff) = {
                     let backoff = op_manager.gateway_backoff.lock();
                     let mut blocked = 0usize;
@@ -2531,6 +2543,88 @@ mod tests {
             assert_eq!(
                 t.routed, 0,
                 "nothing was routed — no gateway was eligible; got {t:?}"
+            );
+        });
+    }
+
+    /// The one arm with no positive pin, and the one whose documented meaning
+    /// this change altered most: `NoTarget` is now specifically "all gateways
+    /// connected AND the node is within `gateways.len()` of the threshold", so
+    /// `use_connected_as_routers` is false and the round deliberately issues
+    /// nothing. Every other shape must land in one of the three siblings.
+    ///
+    /// Without this, `NoTarget` was only ever asserted to be ZERO (by the two
+    /// tests above), which a counter that can never fire would also satisfy.
+    #[test]
+    fn startup_rounds_report_no_target_when_close_to_threshold() {
+        with_network_status_lock(async {
+            let op_manager =
+                bootstrap_test_op_manager("bootstrap-4787-no-target", "127.0.0.1:14795").await;
+            let cm = &op_manager.ring.connection_manager;
+            let gateways = vec![bootstrap_gateway(24796), bootstrap_gateway(24797)];
+            let min_conns = cm.min_connections;
+            assert!(
+                min_conns > gateways.len() + 1,
+                "test setup: this shape needs room for non-gateway peers below \
+             the threshold; min_connections={min_conns}"
+            );
+
+            // Fill the ring to exactly `min_connections - 1`, gateways included,
+            // so the remaining gap is 1 — which is <= gateways.len(), the
+            // condition that makes `use_connected_as_routers` false.
+            let mut addrs: Vec<SocketAddr> = gateways
+                .iter()
+                .map(|gw| gw.socket_addr().expect("gateway has an address"))
+                .collect();
+            for port in 30000..(30000 + (min_conns - 1 - gateways.len()) as u16) {
+                addrs.push(SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    port,
+                ));
+            }
+            for addr in &addrs {
+                let pub_key = TransportKeypair::new().public().clone();
+                assert!(
+                    cm.add_connection(Location::from_address(addr), *addr, pub_key, false),
+                    "test setup: ring must accept {addr}"
+                );
+            }
+
+            let open = op_manager.ring.open_connections();
+            assert_eq!(
+                open,
+                min_conns - 1,
+                "test setup: node must sit exactly one connection below the threshold"
+            );
+            assert!(
+                min_conns - open <= gateways.len(),
+                "test setup: the gap must be within gateways.len(), or the loop \
+             routes CONNECTs instead of idling"
+            );
+            assert_eq!(
+                op_manager.ring.is_not_connected(gateways.iter()).count(),
+                0,
+                "test setup: no gateway may look unconnected"
+            );
+
+            let handle = initial_join_procedure(op_manager.clone(), &gateways)
+                .await
+                .expect("spawn join procedure");
+            let t = wait_for_startup_round(Duration::from_secs(10)).await;
+            handle.abort();
+
+            assert!(
+                t.no_target > 0,
+                "a below-threshold round that deliberately issues nothing must \
+             count as no_target; got {t:?}"
+            );
+            assert_eq!(
+                t.routed, 0,
+                "the gap is within gateways.len(), so nothing may be routed; got {t:?}"
+            );
+            assert_eq!(
+                t.gateway, 0,
+                "every gateway is connected, so nothing may be dialled; got {t:?}"
             );
         });
     }

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1885,9 +1885,11 @@ pub(crate) async fn initial_join_procedure(
             // decides what the round does records its own outcome BEFORE
             // awaiting anything, so a CONNECT fan-out that hangs still leaves a
             // counted round; whatever reaches the bottom unrecorded is a round
-            // that issued nothing, which is the "all gateways appear
-            // connected/pending" stall the issue was filed about and which the
-            // first version of this instrumentation could not see at all.
+            // that issued nothing AND had no more specific reason, which is a
+            // quiet "nothing to do" and NOT the stall the issue was filed
+            // about. The stall — gateway transports up, no real peers acquired
+            // — routes CONNECTs through the connected gateways and is counted
+            // as `ConnectIssuedRouted`.
             let mut round_recorded = false;
             let mut record_round = |outcome: StartupRoundOutcome| {
                 if !round_recorded && !min_connections_reached {
@@ -2021,7 +2023,7 @@ pub(crate) async fn initial_join_procedure(
                 // is empty and no CONNECT is issued. Classify by what actually
                 // happens, not by which branch we are in.
                 record_round(if eligible_count > 0 {
-                    StartupRoundOutcome::ConnectIssued
+                    StartupRoundOutcome::ConnectIssuedGateway
                 } else {
                     StartupRoundOutcome::BackoffBlocked
                 });
@@ -2065,25 +2067,37 @@ pub(crate) async fn initial_join_procedure(
             } else if use_connected_as_routers {
                 // All gateways connected but still need many more peers.
                 // Route CONNECTs through connected gateways toward gap locations.
-                let eligible: Vec<_> = {
+                // #4787: count the gateways excluded specifically FOR backoff,
+                // separately from those excluded for having no resolved socket
+                // address. An empty `eligible` means very different things in
+                // those two cases and the round must be classified by which.
+                let (eligible, blocked_by_backoff) = {
                     let backoff = op_manager.gateway_backoff.lock();
-                    gateways
+                    let mut blocked = 0usize;
+                    let eligible: Vec<_> = gateways
                         .iter()
-                        .filter(|gw| {
-                            gw.socket_addr()
-                                .map(|addr| !backoff.is_in_backoff(addr))
-                                .unwrap_or(false)
+                        .filter(|gw| match gw.socket_addr() {
+                            Some(addr) if backoff.is_in_backoff(addr) => {
+                                blocked += 1;
+                                false
+                            }
+                            Some(_) => true,
+                            None => false,
                         })
-                        .collect()
+                        .collect();
+                    (eligible, blocked)
                 };
 
                 if !eligible.is_empty() {
-                    // #4787: these are CONNECT rounds too. They were uncounted
-                    // in the first version of this instrumentation, and they
-                    // are the rounds a stalled joiner actually issues — its
-                    // gateway transports are up, so the branch above (which
-                    // needs an UNCONNECTED gateway) never runs.
-                    record_round(StartupRoundOutcome::ConnectIssued);
+                    // #4787: these are CONNECT rounds too, and they are THE
+                    // rounds a stalled joiner issues — its gateway transports
+                    // are up, so the branch above (which needs an UNCONNECTED
+                    // gateway) never runs. They are counted separately from the
+                    // dial-a-gateway case above precisely because this is the
+                    // series that moves during the stall the issue describes;
+                    // an operator told to watch `no_target` instead would watch
+                    // a flat zero for the whole outage.
+                    record_round(StartupRoundOutcome::ConnectIssuedRouted);
                     tracing::info!(
                         eligible = eligible.len(),
                         total_gateways = gateways.len(),
@@ -2122,6 +2136,22 @@ pub(crate) async fn initial_join_procedure(
                             }
                         })
                         .await;
+                } else if blocked_by_backoff > 0 {
+                    // #4787: nothing was issued because every gateway this
+                    // round could route through is in exponential backoff —
+                    // which is `BackoffBlocked`, not `NoTarget`. Without this
+                    // the round fell through to the default at the bottom of
+                    // the loop and was misreported. Reachable from the
+                    // fully-isolated path (`open_conns == 0` with every gateway
+                    // transport apparently up and every gateway backed off),
+                    // i.e. exactly when the classification matters most.
+                    record_round(StartupRoundOutcome::BackoffBlocked);
+                    tracing::info!(
+                        blocked_by_backoff,
+                        total_gateways = gateways.len(),
+                        open_connections = open_conns,
+                        "All connected gateways in backoff, cannot route CONNECTs this round"
+                    );
                 }
             } else if open_conns >= bootstrap_threshold {
                 tracing::trace!(
@@ -2131,12 +2161,19 @@ pub(crate) async fn initial_join_procedure(
                 );
             }
 
-            // Nothing was issued this round (#4787). `record_round` is gated on
-            // `!min_connections_reached` so these stay startup-only counters: a
-            // later transient dip below `bootstrap_threshold` is ordinary
-            // post-bootstrap churn, not bootstrap. `min_connections_reached` is
-            // set at the top of this iteration, so reaching here with it false
-            // means `open_conns < bootstrap_threshold`.
+            // Nothing was issued this round and no branch above claimed a more
+            // specific reason (#4787). Principally: every gateway is connected
+            // AND the node is within `gateways.len()` of the threshold, so
+            // `use_connected_as_routers` is false and the round deliberately
+            // waits for handshakes or pending reservations to resolve. This is
+            // NOT the stall signature — see `startup_rounds_connect_issued_routed`.
+            //
+            // `record_round` is gated on `!min_connections_reached` so these
+            // stay startup-only counters: a later transient dip below
+            // `bootstrap_threshold` is ordinary post-bootstrap churn, not
+            // bootstrap. `min_connections_reached` is set at the top of this
+            // iteration, so reaching here with it false means
+            // `open_conns < bootstrap_threshold`.
             record_round(StartupRoundOutcome::NoTarget);
 
             // Add random jitter to prevent thundering herd after gateway restart.
@@ -2257,22 +2294,40 @@ mod tests {
     }
 
     /// Total below-threshold rounds recorded so far, by category.
-    fn startup_round_totals() -> (u64, u64, u64) {
-        let b = crate::node::network_status::bootstrap_churn_counts()
-            .expect("network_status singleton initialized by the test");
-        (
-            b.startup_rounds_connect_issued,
-            b.startup_rounds_backoff_blocked,
-            b.startup_rounds_no_target,
-        )
+    #[derive(Debug, Clone, Copy)]
+    struct RoundTotals {
+        /// Dialled gateways this node was not yet connected to.
+        gateway: u64,
+        /// Routed CONNECTs through already-connected gateways — the #4787
+        /// stall signature.
+        routed: u64,
+        backoff: u64,
+        no_target: u64,
+    }
+
+    impl RoundTotals {
+        fn read() -> Self {
+            let b = crate::node::network_status::bootstrap_churn_counts()
+                .expect("network_status singleton initialized by the test");
+            Self {
+                gateway: b.startup_rounds_connect_issued_gateway,
+                routed: b.startup_rounds_connect_issued_routed,
+                backoff: b.startup_rounds_backoff_blocked,
+                no_target: b.startup_rounds_no_target,
+            }
+        }
+
+        fn total(&self) -> u64 {
+            self.gateway + self.routed + self.backoff + self.no_target
+        }
     }
 
     /// Poll until the join loop has classified at least one round, or give up.
-    async fn wait_for_startup_round(deadline: Duration) -> (u64, u64, u64) {
+    async fn wait_for_startup_round(deadline: Duration) -> RoundTotals {
         let start = std::time::Instant::now();
         loop {
-            let totals = startup_round_totals();
-            if totals.0 + totals.1 + totals.2 > 0 || start.elapsed() >= deadline {
+            let totals = RoundTotals::read();
+            if totals.total() > 0 || start.elapsed() >= deadline {
                 return totals;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
@@ -2284,7 +2339,16 @@ mod tests {
     /// `min_connections`. The first version of this instrumentation put its
     /// only increment inside `open_conns < threshold && unconnected_count > 0`,
     /// so it recorded ZERO for the entire multi-minute stall it was added to
-    /// measure. The loop must classify this round.
+    /// measure.
+    ///
+    /// This pins WHICH series moves, not merely that something does. With
+    /// `min_connections = 25` and 1-3 gateways the stall takes the
+    /// `use_connected_as_routers` branch, so the moving series is
+    /// `connect_issued_routed` — and NOT `no_target`, which four doc sites
+    /// previously named as "the #4787 stall signature". An operator following
+    /// that guidance would have watched a series that reads flat zero for the
+    /// whole outage, which is the same defect (a counter that reads healthy
+    /// during the failure it observes) this PR exists to fix.
     #[test]
     fn startup_rounds_counted_while_all_gateways_appear_connected() {
         with_network_status_lock(async {
@@ -2320,23 +2384,33 @@ mod tests {
             let handle = initial_join_procedure(op_manager.clone(), &gateways)
                 .await
                 .expect("spawn join procedure");
-            let (issued, backoff, no_target) =
-                wait_for_startup_round(Duration::from_secs(10)).await;
+            let t = wait_for_startup_round(Duration::from_secs(10)).await;
             handle.abort();
 
             assert!(
-                issued + backoff + no_target > 0,
-                "the join loop must count a below-threshold round during the stall; \
-             got connect_issued={issued} backoff_blocked={backoff} no_target={no_target}"
+                t.total() > 0,
+                "the join loop must count a below-threshold round during the stall; got {t:?}"
             );
             // With 25 - 2 > 2 the loop routes CONNECTs through the connected
             // gateways (`use_connected_as_routers`), a path the first version of
-            // this instrumentation also left uncounted.
+            // this instrumentation left uncounted entirely.
             assert!(
-                issued > 0,
-                "rounds routed through connected gateways must count as \
-             connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
-             no_target={no_target}"
+                t.routed > 0,
+                "the stall must move `connect_issued_routed` — the series the \
+             docs now name as its signature; got {t:?}"
+            );
+            // The discrimination that makes the split worth having: the stall
+            // must NOT show up in the ordinary dial-a-gateway series, and must
+            // NOT show up as `no_target`, which the docs used to name.
+            assert_eq!(
+                t.gateway, 0,
+                "no gateway is unconnected here, so the dial-a-gateway series \
+             must stay at zero; got {t:?}"
+            );
+            assert_eq!(
+                t.no_target, 0,
+                "`no_target` must stay flat through the stall — documenting it \
+             as the stall signature is precisely the bug this pins; got {t:?}"
             );
 
             // And the joiner must be visibly un-bootstrapped rather than absent.
@@ -2366,15 +2440,97 @@ mod tests {
             let handle = initial_join_procedure(op_manager.clone(), &gateways)
                 .await
                 .expect("spawn join procedure");
-            let (issued, backoff, no_target) =
-                wait_for_startup_round(Duration::from_secs(10)).await;
+            let t = wait_for_startup_round(Duration::from_secs(10)).await;
             handle.abort();
 
             assert!(
-                issued > 0,
-                "a round that issues CONNECTs to unconnected gateways must count as \
-             connect_issued; got connect_issued={issued} backoff_blocked={backoff} \
-             no_target={no_target}"
+                t.gateway > 0,
+                "a round that dials unconnected gateways must count as \
+             connect_issued_gateway; got {t:?}"
+            );
+            // The other half of the split: ordinary bootstrap must not be
+            // mistaken for the stall signature.
+            assert_eq!(
+                t.routed, 0,
+                "dialling unconnected gateways is not a routed CONNECT round; got {t:?}"
+            );
+        });
+    }
+
+    /// Finding 2: `use_connected_as_routers` with every gateway in backoff
+    /// issues nothing, and that is `BackoffBlocked` — not `NoTarget`. Before
+    /// the fix this branch had no `else`, so the round fell through to the
+    /// `NoTarget` default at the bottom of the loop and was misreported as
+    /// "gateways all connected, nothing to do" while the real reason was
+    /// exponential backoff.
+    ///
+    /// The same branch is reached from the fully-isolated path
+    /// (`open_conns == 0` with every gateway transport apparently up); the
+    /// setup here uses real ring connections because that is deterministic to
+    /// construct, and the classification under test is identical.
+    #[test]
+    fn startup_rounds_report_backoff_when_routing_through_connected_gateways() {
+        with_network_status_lock(async {
+            let op_manager =
+                bootstrap_test_op_manager("bootstrap-4787-routed-backoff", "127.0.0.1:14792").await;
+            let cm = &op_manager.ring.connection_manager;
+            let gateways = vec![bootstrap_gateway(24793), bootstrap_gateway(24794)];
+
+            for gw in &gateways {
+                let addr = gw.socket_addr().expect("gateway has an address");
+                assert!(
+                    cm.add_connection(
+                        Location::from_address(&addr),
+                        addr,
+                        gw.pub_key().clone(),
+                        false
+                    ),
+                    "test setup: gateway must be accepted into the ring"
+                );
+            }
+            assert_eq!(
+                op_manager.ring.is_not_connected(gateways.iter()).count(),
+                0,
+                "test setup: no gateway may look unconnected"
+            );
+            assert!(
+                op_manager.ring.open_connections() < cm.min_connections,
+                "test setup: node must be below the bootstrap threshold"
+            );
+
+            // Every gateway in backoff, so the routed-CONNECT branch has no
+            // eligible gateway to route through.
+            {
+                let mut backoff = op_manager.gateway_backoff.lock();
+                for gw in &gateways {
+                    let addr = gw.socket_addr().expect("gateway has an address");
+                    backoff.record_failure(addr);
+                    assert!(
+                        backoff.is_in_backoff(addr),
+                        "test setup: gateway must actually be in backoff"
+                    );
+                }
+            }
+
+            let handle = initial_join_procedure(op_manager.clone(), &gateways)
+                .await
+                .expect("spawn join procedure");
+            let t = wait_for_startup_round(Duration::from_secs(10)).await;
+            handle.abort();
+
+            assert!(
+                t.backoff > 0,
+                "a routed-CONNECT round blocked entirely by gateway backoff must \
+             count as backoff_blocked; got {t:?}"
+            );
+            assert_eq!(
+                t.no_target, 0,
+                "misclassifying a backoff-blocked round as `no_target` is the bug \
+             this pins; got {t:?}"
+            );
+            assert_eq!(
+                t.routed, 0,
+                "nothing was routed — no gateway was eligible; got {t:?}"
             );
         });
     }

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1993,6 +1993,22 @@ impl Ring {
                 snapshot.connect_rejects_emitted = Some(rejects);
             }
 
+            // Bootstrap-acceptance-churn counters (#4787): gateway-side
+            // transient registration/expiry/promotion totals plus
+            // joiner-side time-to-min-connections and startup retry count.
+            // Instrumentation only, no behavior change — see
+            // `network_status::BootstrapChurnStats`.
+            if let Some((registered, expired, promoted, time_to_min_conns, retries)) =
+                crate::node::network_status::bootstrap_churn_counts()
+            {
+                snapshot.bootstrap_transient_registered = Some(registered);
+                snapshot.bootstrap_transient_expired = Some(expired);
+                snapshot.bootstrap_promoted_to_ring = Some(promoted);
+                snapshot.bootstrap_time_to_min_connections_secs =
+                    time_to_min_conns.map(|d| d.as_secs_f64());
+                snapshot.bootstrap_startup_connect_retries = Some(retries);
+            }
+
             // Computed-upstream vs. stored-`is_upstream`-flag divergence counters
             // (#4642 piece D / #4671). Recorded at `send_unsubscribe_upstream`
             // where the stored flag is still consulted; exported here so the

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -230,6 +230,22 @@ struct ContractConnectState {
     last_attempt: Instant,
 }
 
+/// Outcome of [`Ring::add_connection_reporting`].
+///
+/// Exists because `add_connection`'s `bool` answers a different question than
+/// callers usually want: it reports the readiness-threshold crossing, and is
+/// `false` both for a rejected connection and for the ordinary successful add
+/// on an already-ready node. Instrumentation that counts promotions needs
+/// `added` (issue #4787).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AddConnectionOutcome {
+    /// The ring accepted the connection into the topology. `false` means it
+    /// was rejected — e.g. the `max_connections` cap.
+    pub added: bool,
+    /// Adding this connection crossed the readiness threshold.
+    pub just_became_ready: bool,
+}
+
 pub(crate) struct Ring {
     pub max_hops_to_live: usize,
     pub connection_manager: ConnectionManager,
@@ -1998,15 +2014,21 @@ impl Ring {
             // joiner-side time-to-min-connections and startup retry count.
             // Instrumentation only, no behavior change — see
             // `network_status::BootstrapChurnStats`.
-            if let Some((registered, expired, promoted, time_to_min_conns, retries)) =
-                crate::node::network_status::bootstrap_churn_counts()
-            {
-                snapshot.bootstrap_transient_registered = Some(registered);
-                snapshot.bootstrap_transient_expired = Some(expired);
-                snapshot.bootstrap_promoted_to_ring = Some(promoted);
+            if let Some(b) = crate::node::network_status::bootstrap_churn_counts() {
+                snapshot.bootstrap_transient_registered = Some(b.transient_registered);
+                snapshot.bootstrap_transient_expired = Some(b.transient_expired);
+                snapshot.bootstrap_promoted_to_ring = Some(b.promoted_to_ring);
                 snapshot.bootstrap_time_to_min_connections_secs =
-                    time_to_min_conns.map(|d| d.as_secs_f64());
-                snapshot.bootstrap_startup_connect_retries = Some(retries);
+                    b.time_to_min_connections.map(|d| d.as_secs_f64());
+                // `Some(false)` (never bootstrapped) is a different fact from
+                // `None` (this build/collector doesn't report it) — see #4787
+                // finding 3.
+                snapshot.bootstrap_completed = Some(b.time_to_min_connections.is_some());
+                snapshot.bootstrap_startup_rounds_connect_issued =
+                    Some(b.startup_rounds_connect_issued);
+                snapshot.bootstrap_startup_rounds_backoff_blocked =
+                    Some(b.startup_rounds_backoff_blocked);
+                snapshot.bootstrap_startup_rounds_no_target = Some(b.startup_rounds_no_target);
             }
 
             // Computed-upstream vs. stored-`is_upstream`-flag divergence counters
@@ -3732,7 +3754,28 @@ impl Ring {
     /// (i.e., we just became ready to accept non-CONNECT operations).
     /// Returns `false` if the connection was rejected (e.g., capacity cap) or we
     /// were already ready.
+    ///
+    /// NOTE the two meanings of `false` collapsed here: callers that need to
+    /// know whether the connection was actually *added* — as opposed to
+    /// whether readiness was just crossed — must use
+    /// [`Ring::add_connection_reporting`]. Reading this `bool` as "added" is
+    /// wrong in both directions: it is `false` for the overwhelmingly common
+    /// successful add (we were already ready), and it is only ever `true` for
+    /// the single add that crosses the threshold.
     pub async fn add_connection(&self, loc: Location, peer: PeerId, was_reserved: bool) -> bool {
+        self.add_connection_reporting(loc, peer, was_reserved)
+            .await
+            .just_became_ready
+    }
+
+    /// [`Ring::add_connection`], reporting whether the ring actually accepted
+    /// the connection as well as whether readiness was crossed.
+    pub async fn add_connection_reporting(
+        &self,
+        loc: Location,
+        peer: PeerId,
+        was_reserved: bool,
+    ) -> AddConnectionOutcome {
         tracing::info!(
             peer = %peer,
             peer_location = %loc,
@@ -3754,7 +3797,10 @@ impl Ring {
                 peer_location = %loc,
                 "Ring rejected connection - not updating caches or logging connection event"
             );
-            return false;
+            return AddConnectionOutcome {
+                added: false,
+                just_became_ready: false,
+            };
         }
         if let Some(own_loc) = self.connection_manager.own_location().location() {
             crate::node::network_status::set_own_location(own_loc.as_f64());
@@ -3764,8 +3810,11 @@ impl Ring {
         self.refresh_density_request_cache();
 
         let is_ready = self.connection_manager.is_self_ready();
-        // Return true only if we just crossed the threshold
-        !was_ready && is_ready
+        AddConnectionOutcome {
+            added: true,
+            // Only report readiness if we just crossed the threshold.
+            just_became_ready: !was_ready && is_ready,
+        }
     }
 
     pub fn update_connection_identity(&self, old_peer: &PeerId, new_peer: PeerId) {
@@ -9112,6 +9161,104 @@ mod cost_pressure_seam_tests {
             freenet_stdlib::prelude::ContractInstanceId::new([seed; 32]),
             freenet_stdlib::prelude::CodeHash::new([seed.wrapping_add(1); 32]),
         )
+    }
+
+    /// `Ring::add_connection`'s `bool` reports the READINESS-threshold
+    /// crossing, not acceptance — it is `false` both when the ring rejects the
+    /// connection and (far more often) when the connection is added while the
+    /// node is already ready. #4787's promotion counter has to know which
+    /// happened, so `add_connection_reporting` splits the two. This pins that
+    /// split, because gating the counter on the plain `bool` — the obvious
+    /// reading of a function returning `false` on rejection — would silently
+    /// count almost no promotions at all.
+    #[tokio::test]
+    async fn add_connection_reporting_separates_added_from_readiness() {
+        let config_args = crate::config::ConfigArgs {
+            id: Some("add-conn-outcome-4787".to_string()),
+            mode: Some(crate::contract::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (_notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, _ch_channel, _wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = std::sync::Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        op_manager
+            .ring
+            .connection_manager
+            .set_own_addr_local_for_test("127.0.0.1:14101".parse().unwrap());
+        let ring = &op_manager.ring;
+
+        let max = ring.connection_manager.max_connections;
+        // Beyond max + LATTICE_OVERMAX_SLACK the ceiling is hard, so a margin
+        // past that guarantees we observe a rejection.
+        let attempts = max + super::connection_manager::LATTICE_OVERMAX_SLACK + 16;
+
+        let mut added = 0usize;
+        let mut ready_crossings = 0usize;
+        let mut added_without_readiness = 0usize;
+        let mut first_rejection: Option<usize> = None;
+        for i in 0..attempts {
+            let kp = crate::transport::TransportKeypair::new();
+            let addr: std::net::SocketAddr = format!("127.0.0.2:{}", 20000 + i as u16)
+                .parse()
+                .expect("addr");
+            let loc = super::Location::new((i as f64 + 0.5) / attempts as f64);
+            let outcome = ring
+                .add_connection_reporting(loc, super::PeerId::new(kp.public().clone(), addr), false)
+                .await;
+            if outcome.added {
+                added += 1;
+                if outcome.just_became_ready {
+                    ready_crossings += 1;
+                } else {
+                    added_without_readiness += 1;
+                }
+            } else {
+                first_rejection = Some(i);
+                break;
+            }
+        }
+
+        let rejected_at = first_rejection.expect(
+            "the ring must eventually reject an add at the connection ceiling — \
+             without a rejection this test cannot show `added` is meaningful",
+        );
+        assert!(
+            rejected_at >= max,
+            "rejection came at {rejected_at}, before max_connections={max}"
+        );
+        assert!(
+            added_without_readiness > 0,
+            "the overwhelming majority of accepted adds report \
+             just_became_ready=false; if this is 0 the test proves nothing"
+        );
+        assert!(
+            ready_crossings <= 1,
+            "readiness can be crossed at most once, got {ready_crossings}"
+        );
+        assert!(
+            added >= max,
+            "expected at least {max} accepted adds, got {added}"
+        );
     }
 
     /// Runs under `start_paused` so `tokio::time::Instant` — the clock behind

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2024,8 +2024,10 @@ impl Ring {
                 // `None` (this build/collector doesn't report it) — see #4787
                 // finding 3.
                 snapshot.bootstrap_completed = Some(b.time_to_min_connections.is_some());
-                snapshot.bootstrap_startup_rounds_connect_issued =
-                    Some(b.startup_rounds_connect_issued);
+                snapshot.bootstrap_startup_rounds_connect_issued_gateway =
+                    Some(b.startup_rounds_connect_issued_gateway);
+                snapshot.bootstrap_startup_rounds_connect_issued_routed =
+                    Some(b.startup_rounds_connect_issued_routed);
                 snapshot.bootstrap_startup_rounds_backoff_blocked =
                     Some(b.startup_rounds_backoff_blocked);
                 snapshot.bootstrap_startup_rounds_no_target = Some(b.startup_rounds_no_target);

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -892,6 +892,26 @@ pub(crate) struct RouterSnapshotInfo {
     /// Monotonic lifetime totals. `None` until the ring's snapshot task populates.
     pub connect_accepts_emitted: Option<u64>,
     pub connect_rejects_emitted: Option<u64>,
+    /// Bootstrap-acceptance-churn counters (#4787): a restarted node's
+    /// gateway connection lingers as transient, expires, and is later reaped
+    /// as a zombie before the onward CONNECT promotes it to the ring — the
+    /// joiner cycles through repeated reconnects before it acquires real
+    /// peers. These are the "instrumentation before a fix" step the issue
+    /// calls for, not a behavior change. `bootstrap_transient_registered` /
+    /// `_expired` / `_promoted_to_ring` are monotonic lifetime totals on the
+    /// GATEWAY side; a sustained high `_expired`:`_promoted_to_ring` ratio is
+    /// the churn signature. `bootstrap_time_to_min_connections_secs` and
+    /// `bootstrap_startup_connect_retries` are JOINER-side: time from process
+    /// start to first reaching `min_connections` (recorded once per process,
+    /// `None` until reached) and the number of below-threshold retry rounds
+    /// `initial_join_procedure` has issued at startup. Populated by `Ring`
+    /// from the network_status singleton on the snapshot cadence; `None`
+    /// until the ring's snapshot task populates them.
+    pub bootstrap_transient_registered: Option<u64>,
+    pub bootstrap_transient_expired: Option<u64>,
+    pub bootstrap_promoted_to_ring: Option<u64>,
+    pub bootstrap_time_to_min_connections_secs: Option<f64>,
+    pub bootstrap_startup_connect_retries: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1850,6 +1870,13 @@ impl Router {
             // cadence (firehose-retirement precursor).
             connect_accepts_emitted: None,
             connect_rejects_emitted: None,
+            // Bootstrap-acceptance-churn counters, populated by Ring on the
+            // snapshot cadence (#4787).
+            bootstrap_transient_registered: None,
+            bootstrap_transient_expired: None,
+            bootstrap_promoted_to_ring: None,
+            bootstrap_time_to_min_connections_secs: None,
+            bootstrap_startup_connect_retries: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -897,21 +897,34 @@ pub(crate) struct RouterSnapshotInfo {
     /// as a zombie before the onward CONNECT promotes it to the ring — the
     /// joiner cycles through repeated reconnects before it acquires real
     /// peers. These are the "instrumentation before a fix" step the issue
-    /// calls for, not a behavior change. `bootstrap_transient_registered` /
-    /// `_expired` / `_promoted_to_ring` are monotonic lifetime totals on the
-    /// GATEWAY side; a sustained high `_expired`:`_promoted_to_ring` ratio is
-    /// the churn signature. `bootstrap_time_to_min_connections_secs` and
-    /// `bootstrap_startup_connect_retries` are JOINER-side: time from process
-    /// start to first reaching `min_connections` (recorded once per process,
-    /// `None` until reached) and the number of below-threshold retry rounds
-    /// `initial_join_procedure` has issued at startup. Populated by `Ring`
-    /// from the network_status singleton on the snapshot cadence; `None`
-    /// until the ring's snapshot task populates them.
+    /// calls for, not a behavior change.
+    ///
+    /// `bootstrap_transient_registered` / `_expired` / `_promoted_to_ring` are
+    /// monotonic lifetime totals on the ACCEPTOR side; a sustained high
+    /// `_expired`:`_promoted_to_ring` ratio is the churn signature. Both
+    /// promotion paths are counted, and only when the ring actually accepted
+    /// the connection.
+    ///
+    /// The rest are JOINER-side. `bootstrap_time_to_min_connections_secs` is
+    /// time from process start to first reaching `min_connections`, recorded
+    /// once per process; `bootstrap_completed` disambiguates the `None` there —
+    /// `Some(false)` means this node has never bootstrapped, `None` means the
+    /// field wasn't reported at all. The three `bootstrap_startup_rounds_*`
+    /// fields partition below-threshold join-loop rounds by what each round
+    /// actually did (issued CONNECTs / blocked by gateway backoff / had no
+    /// target), which is what keeps a permanently-stuck joiner's count from
+    /// being an undifferentiated process-uptime proxy.
+    ///
+    /// Populated by `Ring` from the network_status singleton on the snapshot
+    /// cadence; `None` until the ring's snapshot task populates them.
     pub bootstrap_transient_registered: Option<u64>,
     pub bootstrap_transient_expired: Option<u64>,
     pub bootstrap_promoted_to_ring: Option<u64>,
     pub bootstrap_time_to_min_connections_secs: Option<f64>,
-    pub bootstrap_startup_connect_retries: Option<u64>,
+    pub bootstrap_completed: Option<bool>,
+    pub bootstrap_startup_rounds_connect_issued: Option<u64>,
+    pub bootstrap_startup_rounds_backoff_blocked: Option<u64>,
+    pub bootstrap_startup_rounds_no_target: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
     pub per_op_curves: HashMap<String, PerOpCurves>,
     /// Renegade predictor diagnostics. These (and `renegade_accuracy_pairs`) are
@@ -1876,7 +1889,10 @@ impl Router {
             bootstrap_transient_expired: None,
             bootstrap_promoted_to_ring: None,
             bootstrap_time_to_min_connections_secs: None,
-            bootstrap_startup_connect_retries: None,
+            bootstrap_completed: None,
+            bootstrap_startup_rounds_connect_issued: None,
+            bootstrap_startup_rounds_backoff_blocked: None,
+            bootstrap_startup_rounds_no_target: None,
             // Renegade predictor diagnostics
             renegade_failure_events: self.renegade_predictor.len(),
             renegade_response_time_events: self.renegade_predictor.stage_sizes().1,

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -922,7 +922,10 @@ pub(crate) struct RouterSnapshotInfo {
     pub bootstrap_promoted_to_ring: Option<u64>,
     pub bootstrap_time_to_min_connections_secs: Option<f64>,
     pub bootstrap_completed: Option<bool>,
-    pub bootstrap_startup_rounds_connect_issued: Option<u64>,
+    pub bootstrap_startup_rounds_connect_issued_gateway: Option<u64>,
+    /// Sustained growth here with `bootstrap_completed == Some(false)` is
+    /// the #4787 stall signature.
+    pub bootstrap_startup_rounds_connect_issued_routed: Option<u64>,
     pub bootstrap_startup_rounds_backoff_blocked: Option<u64>,
     pub bootstrap_startup_rounds_no_target: Option<u64>,
     /// Per-operation-type estimator curves, keyed by op type name (e.g., "GET").
@@ -1890,7 +1893,8 @@ impl Router {
             bootstrap_promoted_to_ring: None,
             bootstrap_time_to_min_connections_secs: None,
             bootstrap_completed: None,
-            bootstrap_startup_rounds_connect_issued: None,
+            bootstrap_startup_rounds_connect_issued_gateway: None,
+            bootstrap_startup_rounds_connect_issued_routed: None,
             bootstrap_startup_rounds_backoff_blocked: None,
             bootstrap_startup_rounds_no_target: None,
             // Renegade predictor diagnostics

--- a/crates/core/src/router.rs
+++ b/crates/core/src/router.rs
@@ -909,11 +909,12 @@ pub(crate) struct RouterSnapshotInfo {
     /// time from process start to first reaching `min_connections`, recorded
     /// once per process; `bootstrap_completed` disambiguates the `None` there —
     /// `Some(false)` means this node has never bootstrapped, `None` means the
-    /// field wasn't reported at all. The three `bootstrap_startup_rounds_*`
+    /// field wasn't reported at all. The four `bootstrap_startup_rounds_*`
     /// fields partition below-threshold join-loop rounds by what each round
-    /// actually did (issued CONNECTs / blocked by gateway backoff / had no
-    /// target), which is what keeps a permanently-stuck joiner's count from
-    /// being an undifferentiated process-uptime proxy.
+    /// actually did (dialled unconnected gateways / routed CONNECTs through
+    /// already-connected ones / blocked by gateway backoff / had no target),
+    /// which is what keeps a permanently-stuck joiner's count from being an
+    /// undifferentiated process-uptime proxy.
     ///
     /// Populated by `Ring` from the network_status singleton on the snapshot
     /// cadence; `None` until the ring's snapshot task populates them.
@@ -923,8 +924,10 @@ pub(crate) struct RouterSnapshotInfo {
     pub bootstrap_time_to_min_connections_secs: Option<f64>,
     pub bootstrap_completed: Option<bool>,
     pub bootstrap_startup_rounds_connect_issued_gateway: Option<u64>,
-    /// Sustained growth here with `bootstrap_completed == Some(false)` is
-    /// the #4787 stall signature.
+    /// Sustained growth with `bootstrap_completed == Some(false)` means this
+    /// joiner never bootstrapped; the `bootstrap_transient_expired` :
+    /// `bootstrap_promoted_to_ring` ratio separates #4787 acceptance churn
+    /// from simply having too few acceptable peers.
     pub bootstrap_startup_rounds_connect_issued_routed: Option<u64>,
     pub bootstrap_startup_rounds_backoff_blocked: Option<u64>,
     pub bootstrap_startup_rounds_no_target: Option<u64>,

--- a/crates/core/src/tracing/otel.rs
+++ b/crates/core/src/tracing/otel.rs
@@ -1449,14 +1449,15 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
     // gateway connection lingers as transient, expires, and is reaped as a
     // zombie before the onward CONNECT promotes it to the ring, cycling the
     // joiner through repeated reconnects. Instrumentation only (the issue's
-    // "before a fix" step) — no acceptance behavior changes here. GATEWAY
-    // side: `event` distinguishes the three log sites this is read from; a
-    // sustained high `transient_expired`:`promoted_to_ring` ratio is the
-    // churn signature.
+    // "before a fix" step) — no acceptance behavior changes here. ACCEPTOR
+    // side: `event` distinguishes the transient lifecycle sites; a sustained
+    // high `transient_expired`:`promoted_to_ring` ratio is the churn
+    // signature. `promoted_to_ring` covers BOTH promotion paths and counts
+    // only promotions the ring actually accepted.
     let _bootstrap_churn = meter
         .u64_observable_counter("freenet.bootstrap.churn")
         .with_description(
-            "Gateway-side transient connection registration/expiry/promotion \
+            "Acceptor-side transient connection registration/expiry/promotion \
              totals since startup (bootstrap-acceptance-churn instrumentation, #4787)",
         )
         .with_callback(move |observer| {
@@ -1478,9 +1479,16 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
         .build();
 
     // JOINER side (#4787): time from process start to first reaching
-    // `min_connections`, and how many below-threshold retry rounds it took.
-    // `time_to_min_connections` is `None` until reached (e.g. a node that
-    // never bootstraps), so this gauge simply has no datapoint until then.
+    // `min_connections`. The clock is anchored at
+    // `network_status::mark_process_start()`, called on the first line of the
+    // `freenet` binary's `main`, so this genuinely includes config load,
+    // storage open and the cached-peer fast-reconnect path — the startup work
+    // that can itself delay CONNECT. (A library embedding that never calls it
+    // gets the anchor at `network_status::init()`, i.e. node start.)
+    //
+    // `None` until reached, so this gauge has no datapoint for a node that has
+    // not bootstrapped. `freenet.bootstrap.completed` below is what makes that
+    // state visible rather than merely absent.
     let _bootstrap_time_to_min_connections = meter
         .f64_observable_gauge("freenet.bootstrap.time_to_min_connections_seconds")
         .with_description(
@@ -1496,15 +1504,52 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
         })
         .build();
 
-    let _bootstrap_startup_connect_retries = meter
-        .u64_observable_counter("freenet.bootstrap.startup_connect_retries")
+    // 1 once this process has reached `min_connections`, 0 before that (#4787
+    // finding 3). Without it a permanently-stuck joiner is indistinguishable
+    // from an old build or a dropped collector: both simply have no
+    // time_to_min_connections datapoint.
+    let _bootstrap_completed = meter
+        .u64_observable_gauge("freenet.bootstrap.completed")
         .with_description(
-            "Below-threshold CONNECT retry rounds issued at startup \
+            "1 if this process has reached min_connections at least once, 0 if it \
+             never has (bootstrap-acceptance-churn instrumentation, #4787)",
+        )
+        .with_callback(move |observer| {
+            if let Some(status) = (sources.status_scalars)() {
+                let completed = u64::from(status.bootstrap_time_to_min_connections.is_some());
+                observer.observe(completed, &[]);
+            }
+        })
+        .build();
+
+    // Below-threshold join-loop rounds, split by what each round actually did
+    // (#4787). A node stuck below `min_connections` increments one of these
+    // every ~4s forever, so an unsplit total degrades into a process-uptime
+    // proxy; the split is the measurement. `connect_issued` = actively
+    // retrying and being refused, `backoff_blocked` = every gateway in
+    // exponential backoff, `no_target` = gateway transports look
+    // connected/pending while no real peers are acquired (the #4787 stall
+    // signature). Read alongside `freenet.bootstrap.completed`.
+    let _bootstrap_startup_rounds = meter
+        .u64_observable_counter("freenet.bootstrap.startup_rounds")
+        .with_description(
+            "Below-min_connections join-loop rounds since startup, by outcome \
              (bootstrap-acceptance-churn instrumentation, #4787)",
         )
         .with_callback(move |observer| {
             if let Some(status) = (sources.status_scalars)() {
-                observer.observe(status.bootstrap_startup_connect_retries, &[]);
+                observer.observe(
+                    status.bootstrap_startup_rounds_connect_issued,
+                    &[KeyValue::new("outcome", "connect_issued")],
+                );
+                observer.observe(
+                    status.bootstrap_startup_rounds_backoff_blocked,
+                    &[KeyValue::new("outcome", "backoff_blocked")],
+                );
+                observer.observe(
+                    status.bootstrap_startup_rounds_no_target,
+                    &[KeyValue::new("outcome", "no_target")],
+                );
             }
         })
         .build();
@@ -1899,7 +1944,9 @@ mod tests {
                 bootstrap_transient_registered: 10,
                 bootstrap_transient_expired: 9,
                 bootstrap_promoted_to_ring: 1,
-                bootstrap_startup_connect_retries: 4,
+                bootstrap_startup_rounds_connect_issued: 4,
+                bootstrap_startup_rounds_backoff_blocked: 3,
+                bootstrap_startup_rounds_no_target: 2,
                 ..Default::default()
             })
         }
@@ -2914,7 +2961,8 @@ mod tests {
             // Bootstrap-acceptance-churn instrumentation (#4787).
             "freenet.bootstrap.churn",
             "freenet.bootstrap.time_to_min_connections_seconds",
-            "freenet.bootstrap.startup_connect_retries",
+            "freenet.bootstrap.completed",
+            "freenet.bootstrap.startup_rounds",
         ] {
             assert!(
                 names.contains(&expected),
@@ -2983,6 +3031,12 @@ mod tests {
             ("freenet.bootstrap.churn", "event=transient_registered"),
             ("freenet.bootstrap.churn", "event=transient_expired"),
             ("freenet.bootstrap.churn", "event=promoted_to_ring"),
+            ("freenet.bootstrap.startup_rounds", "outcome=connect_issued"),
+            (
+                "freenet.bootstrap.startup_rounds",
+                "outcome=backoff_blocked",
+            ),
+            ("freenet.bootstrap.startup_rounds", "outcome=no_target"),
             ("freenet.contract.updates", "result=accepted"),
             ("freenet.contract.updates", "result=rate_limited"),
             ("freenet.contract.updates", "result=capacity_dropped"),

--- a/crates/core/src/tracing/otel.rs
+++ b/crates/core/src/tracing/otel.rs
@@ -1445,6 +1445,70 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
         })
         .build();
 
+    // Bootstrap-acceptance-churn counters (#4787): a restarted node's
+    // gateway connection lingers as transient, expires, and is reaped as a
+    // zombie before the onward CONNECT promotes it to the ring, cycling the
+    // joiner through repeated reconnects. Instrumentation only (the issue's
+    // "before a fix" step) — no acceptance behavior changes here. GATEWAY
+    // side: `event` distinguishes the three log sites this is read from; a
+    // sustained high `transient_expired`:`promoted_to_ring` ratio is the
+    // churn signature.
+    let _bootstrap_churn = meter
+        .u64_observable_counter("freenet.bootstrap.churn")
+        .with_description(
+            "Gateway-side transient connection registration/expiry/promotion \
+             totals since startup (bootstrap-acceptance-churn instrumentation, #4787)",
+        )
+        .with_callback(move |observer| {
+            if let Some(status) = (sources.status_scalars)() {
+                observer.observe(
+                    status.bootstrap_transient_registered,
+                    &[KeyValue::new("event", "transient_registered")],
+                );
+                observer.observe(
+                    status.bootstrap_transient_expired,
+                    &[KeyValue::new("event", "transient_expired")],
+                );
+                observer.observe(
+                    status.bootstrap_promoted_to_ring,
+                    &[KeyValue::new("event", "promoted_to_ring")],
+                );
+            }
+        })
+        .build();
+
+    // JOINER side (#4787): time from process start to first reaching
+    // `min_connections`, and how many below-threshold retry rounds it took.
+    // `time_to_min_connections` is `None` until reached (e.g. a node that
+    // never bootstraps), so this gauge simply has no datapoint until then.
+    let _bootstrap_time_to_min_connections = meter
+        .f64_observable_gauge("freenet.bootstrap.time_to_min_connections_seconds")
+        .with_description(
+            "Seconds from process start to first reaching min_connections \
+             (bootstrap-acceptance-churn instrumentation, #4787)",
+        )
+        .with_callback(move |observer| {
+            if let Some(status) = (sources.status_scalars)() {
+                if let Some(elapsed) = status.bootstrap_time_to_min_connections {
+                    observer.observe(elapsed.as_secs_f64(), &[]);
+                }
+            }
+        })
+        .build();
+
+    let _bootstrap_startup_connect_retries = meter
+        .u64_observable_counter("freenet.bootstrap.startup_connect_retries")
+        .with_description(
+            "Below-threshold CONNECT retry rounds issued at startup \
+             (bootstrap-acceptance-churn instrumentation, #4787)",
+        )
+        .with_callback(move |observer| {
+            if let Some(status) = (sources.status_scalars)() {
+                observer.observe(status.bootstrap_startup_connect_retries, &[]);
+            }
+        })
+        .build();
+
     // Read from the dashboard's own cumulative op counters rather than
     // incremented at `record_op_result`: same instrument, one fewer thing that
     // can be forgotten at a new call site. `record_op_result` is itself a
@@ -1827,7 +1891,17 @@ mod tests {
             Some(crate::ring::HostingReasonStats::default())
         }
         fn scalars() -> Option<OtelStatusScalars> {
-            Some(OtelStatusScalars::default())
+            Some(OtelStatusScalars {
+                // `Some`, or the time-to-min-connections gauge emits no
+                // datapoint at all and its name goes unasserted — same
+                // reasoning as `lattice_successor_distance` above.
+                bootstrap_time_to_min_connections: Some(std::time::Duration::from_secs(7)),
+                bootstrap_transient_registered: 10,
+                bootstrap_transient_expired: 9,
+                bootstrap_promoted_to_ring: 1,
+                bootstrap_startup_connect_retries: 4,
+                ..Default::default()
+            })
         }
         RingSources {
             ring_stats: ring,
@@ -2837,6 +2911,10 @@ mod tests {
             "freenet.ring.lattice.neighbor.distance",
             "freenet.ring.lattice.probes",
             "freenet.contract.updates",
+            // Bootstrap-acceptance-churn instrumentation (#4787).
+            "freenet.bootstrap.churn",
+            "freenet.bootstrap.time_to_min_connections_seconds",
+            "freenet.bootstrap.startup_connect_retries",
         ] {
             assert!(
                 names.contains(&expected),
@@ -2902,6 +2980,9 @@ mod tests {
             ),
             ("freenet.ring.lattice.probes", "result=issued"),
             ("freenet.ring.lattice.probes", "result=improvement"),
+            ("freenet.bootstrap.churn", "event=transient_registered"),
+            ("freenet.bootstrap.churn", "event=transient_expired"),
+            ("freenet.bootstrap.churn", "event=promoted_to_ring"),
             ("freenet.contract.updates", "result=accepted"),
             ("freenet.contract.updates", "result=rate_limited"),
             ("freenet.contract.updates", "result=capacity_dropped"),

--- a/crates/core/src/tracing/otel.rs
+++ b/crates/core/src/tracing/otel.rs
@@ -1525,11 +1525,25 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
     // Below-threshold join-loop rounds, split by what each round actually did
     // (#4787). A node stuck below `min_connections` increments one of these
     // every ~4s forever, so an unsplit total degrades into a process-uptime
-    // proxy; the split is the measurement. `connect_issued` = actively
-    // retrying and being refused, `backoff_blocked` = every gateway in
-    // exponential backoff, `no_target` = gateway transports look
-    // connected/pending while no real peers are acquired (the #4787 stall
-    // signature). Read alongside `freenet.bootstrap.completed`.
+    // proxy; the split is the measurement.
+    //
+    //   connect_issued_gateway — dialled gateways not yet connected to
+    //                            (ordinary bootstrap).
+    //   connect_issued_routed  — every gateway transport already up and the
+    //                            node still far below the threshold, so
+    //                            CONNECTs were routed THROUGH the connected
+    //                            gateways. THIS is the series that moves
+    //                            during the #4787 stall.
+    //   backoff_blocked        — every candidate gateway in exponential
+    //                            backoff.
+    //   no_target              — nothing to do: gateways all connected and the
+    //                            node within `gateways.len()` of the
+    //                            threshold. Quiet, NOT the stall signature.
+    //
+    // Alert on sustained `connect_issued_routed` growth while
+    // `freenet.bootstrap.completed` stays 0 — a healthy joiner with few
+    // gateways emits some of these too, and the gauge is what separates the
+    // two.
     let _bootstrap_startup_rounds = meter
         .u64_observable_counter("freenet.bootstrap.startup_rounds")
         .with_description(
@@ -1539,8 +1553,12 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
         .with_callback(move |observer| {
             if let Some(status) = (sources.status_scalars)() {
                 observer.observe(
-                    status.bootstrap_startup_rounds_connect_issued,
-                    &[KeyValue::new("outcome", "connect_issued")],
+                    status.bootstrap_startup_rounds_connect_issued_gateway,
+                    &[KeyValue::new("outcome", "connect_issued_gateway")],
+                );
+                observer.observe(
+                    status.bootstrap_startup_rounds_connect_issued_routed,
+                    &[KeyValue::new("outcome", "connect_issued_routed")],
                 );
                 observer.observe(
                     status.bootstrap_startup_rounds_backoff_blocked,
@@ -1944,7 +1962,8 @@ mod tests {
                 bootstrap_transient_registered: 10,
                 bootstrap_transient_expired: 9,
                 bootstrap_promoted_to_ring: 1,
-                bootstrap_startup_rounds_connect_issued: 4,
+                bootstrap_startup_rounds_connect_issued_gateway: 4,
+                bootstrap_startup_rounds_connect_issued_routed: 5,
                 bootstrap_startup_rounds_backoff_blocked: 3,
                 bootstrap_startup_rounds_no_target: 2,
                 ..Default::default()
@@ -3031,7 +3050,14 @@ mod tests {
             ("freenet.bootstrap.churn", "event=transient_registered"),
             ("freenet.bootstrap.churn", "event=transient_expired"),
             ("freenet.bootstrap.churn", "event=promoted_to_ring"),
-            ("freenet.bootstrap.startup_rounds", "outcome=connect_issued"),
+            (
+                "freenet.bootstrap.startup_rounds",
+                "outcome=connect_issued_gateway",
+            ),
+            (
+                "freenet.bootstrap.startup_rounds",
+                "outcome=connect_issued_routed",
+            ),
             (
                 "freenet.bootstrap.startup_rounds",
                 "outcome=backoff_blocked",

--- a/crates/core/src/tracing/otel.rs
+++ b/crates/core/src/tracing/otel.rs
@@ -1540,10 +1540,20 @@ fn register_ring_metrics(meter: &opentelemetry::metrics::Meter, sources: RingSou
     //                            node within `gateways.len()` of the
     //                            threshold. Quiet, NOT the stall signature.
     //
-    // Alert on sustained `connect_issued_routed` growth while
-    // `freenet.bootstrap.completed` stays 0 — a healthy joiner with few
-    // gateways emits some of these too, and the gauge is what separates the
-    // two.
+    // `connect_issued_routed` climbing while `freenet.bootstrap.completed`
+    // stays 0 identifies a joiner that NEVER BOOTSTRAPPED. That is necessary
+    // for the #4787 stall but not sufficient — a network with fewer than
+    // `min_connections` reachable peers, or a node behind restrictive NAT,
+    // matches it permanently and identically, so an alert on the pair alone
+    // fires forever on a small network and gets muted.
+    //
+    // `freenet.bootstrap.churn` is the discriminator: a high
+    // `event=transient_expired` : `event=promoted_to_ring` ratio alongside it
+    // is acceptance churn (#4787); churn near zero means the CONNECTs are
+    // simply not finding acceptable peers. Rounds come ~every 3-5s, so a stuck
+    // joiner emits on the order of 900/hour without bound while a healthy one
+    // emits a few tens over the first minute or two and stops. Alert on more
+    // than a few minutes of continued growth.
     let _bootstrap_startup_rounds = meter
         .u64_observable_counter("freenet.bootstrap.startup_rounds")
         .with_description(

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3187,8 +3187,16 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         snapshot.bootstrap_promoted_to_ring,
                     ),
                     (
-                        "bootstrap_startup_connect_retries",
-                        snapshot.bootstrap_startup_connect_retries,
+                        "bootstrap_startup_rounds_connect_issued",
+                        snapshot.bootstrap_startup_rounds_connect_issued,
+                    ),
+                    (
+                        "bootstrap_startup_rounds_backoff_blocked",
+                        snapshot.bootstrap_startup_rounds_backoff_blocked,
+                    ),
+                    (
+                        "bootstrap_startup_rounds_no_target",
+                        snapshot.bootstrap_startup_rounds_no_target,
                     ),
                 ] {
                     obj.insert(key.to_string(), serde_json::json!(value));
@@ -3200,6 +3208,12 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                 obj.insert(
                     "bootstrap_time_to_min_connections_secs".to_string(),
                     serde_json::json!(snapshot.bootstrap_time_to_min_connections_secs),
+                );
+                // Disambiguates the `null` above: `false` = this node has never
+                // reached min_connections, absent = the field wasn't reported.
+                obj.insert(
+                    "bootstrap_completed".to_string(),
+                    serde_json::json!(snapshot.bootstrap_completed),
                 );
                 // Computed-upstream vs. stored-flag divergence counters (piece D,
                 // #4642 / #4671) — same hand-mirror footgun: a new
@@ -4134,13 +4148,41 @@ mod tests {
         info.bootstrap_transient_expired = Some(9);
         info.bootstrap_promoted_to_ring = Some(1);
         info.bootstrap_time_to_min_connections_secs = Some(12.5);
-        info.bootstrap_startup_connect_retries = Some(4);
+        info.bootstrap_completed = Some(true);
+        info.bootstrap_startup_rounds_connect_issued = Some(4);
+        info.bootstrap_startup_rounds_backoff_blocked = Some(3);
+        info.bootstrap_startup_rounds_no_target = Some(2);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         assert_eq!(json["bootstrap_transient_registered"], 10);
         assert_eq!(json["bootstrap_transient_expired"], 9);
         assert_eq!(json["bootstrap_promoted_to_ring"], 1);
         assert_eq!(json["bootstrap_time_to_min_connections_secs"], 12.5);
-        assert_eq!(json["bootstrap_startup_connect_retries"], 4);
+        assert_eq!(json["bootstrap_completed"], true);
+        assert_eq!(json["bootstrap_startup_rounds_connect_issued"], 4);
+        assert_eq!(json["bootstrap_startup_rounds_backoff_blocked"], 3);
+        assert_eq!(json["bootstrap_startup_rounds_no_target"], 2);
+    }
+
+    /// Pin the "never bootstrapped" vs "no data" distinction (#4787 finding 3):
+    /// a node that has not reached `min_connections` must emit
+    /// `bootstrap_completed: false` alongside the null latency, so a
+    /// permanently-stuck joiner is visible instead of indistinguishable from a
+    /// build that doesn't report the field.
+    #[test]
+    fn router_snapshot_json_distinguishes_never_bootstrapped_from_no_data() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.bootstrap_time_to_min_connections_secs = None;
+        info.bootstrap_completed = Some(false);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert!(json["bootstrap_time_to_min_connections_secs"].is_null());
+        assert_eq!(
+            json["bootstrap_completed"], false,
+            "a stuck joiner must report bootstrap_completed=false, not merely a \
+             null latency that also means 'field not reported'"
+        );
     }
 
     /// Pin: the computed-upstream vs. stored-flag divergence counters (piece D,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3174,9 +3174,33 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     ("relayed_updates_total", snapshot.relayed_updates_total),
                     ("connect_accepts_emitted", snapshot.connect_accepts_emitted),
                     ("connect_rejects_emitted", snapshot.connect_rejects_emitted),
+                    (
+                        "bootstrap_transient_registered",
+                        snapshot.bootstrap_transient_registered,
+                    ),
+                    (
+                        "bootstrap_transient_expired",
+                        snapshot.bootstrap_transient_expired,
+                    ),
+                    (
+                        "bootstrap_promoted_to_ring",
+                        snapshot.bootstrap_promoted_to_ring,
+                    ),
+                    (
+                        "bootstrap_startup_connect_retries",
+                        snapshot.bootstrap_startup_connect_retries,
+                    ),
                 ] {
                     obj.insert(key.to_string(), serde_json::json!(value));
                 }
+                // Bootstrap-acceptance-churn time-to-bootstrap gauge (#4787):
+                // an `Option<f64>`, so it can't join the `Option<u64>` loop
+                // above. Pinned by
+                // `router_snapshot_json_includes_bootstrap_churn_counters`.
+                obj.insert(
+                    "bootstrap_time_to_min_connections_secs".to_string(),
+                    serde_json::json!(snapshot.bootstrap_time_to_min_connections_secs),
+                );
                 // Computed-upstream vs. stored-flag divergence counters (piece D,
                 // #4642 / #4671) — same hand-mirror footgun: a new
                 // `RouterSnapshotInfo` field is invisible to the collector unless
@@ -4095,6 +4119,28 @@ mod tests {
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
         assert_eq!(json["connect_accepts_emitted"], 41);
         assert_eq!(json["connect_rejects_emitted"], 42);
+    }
+
+    /// Pin: the bootstrap-acceptance-churn counters (#4787 instrumentation)
+    /// must reach the hand-mirrored OTLP body — same hand-mirror footgun as
+    /// the connect-emit counters above.
+    #[test]
+    fn router_snapshot_json_includes_bootstrap_churn_counters() {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut u = Unstructured::new(&[0u8; 4096]);
+        let mut info = crate::router::RouterSnapshotInfo::arbitrary(&mut u)
+            .expect("construct RouterSnapshotInfo for test");
+        info.bootstrap_transient_registered = Some(10);
+        info.bootstrap_transient_expired = Some(9);
+        info.bootstrap_promoted_to_ring = Some(1);
+        info.bootstrap_time_to_min_connections_secs = Some(12.5);
+        info.bootstrap_startup_connect_retries = Some(4);
+        let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
+        assert_eq!(json["bootstrap_transient_registered"], 10);
+        assert_eq!(json["bootstrap_transient_expired"], 9);
+        assert_eq!(json["bootstrap_promoted_to_ring"], 1);
+        assert_eq!(json["bootstrap_time_to_min_connections_secs"], 12.5);
+        assert_eq!(json["bootstrap_startup_connect_retries"], 4);
     }
 
     /// Pin: the computed-upstream vs. stored-flag divergence counters (piece D,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -3187,8 +3187,12 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         snapshot.bootstrap_promoted_to_ring,
                     ),
                     (
-                        "bootstrap_startup_rounds_connect_issued",
-                        snapshot.bootstrap_startup_rounds_connect_issued,
+                        "bootstrap_startup_rounds_connect_issued_gateway",
+                        snapshot.bootstrap_startup_rounds_connect_issued_gateway,
+                    ),
+                    (
+                        "bootstrap_startup_rounds_connect_issued_routed",
+                        snapshot.bootstrap_startup_rounds_connect_issued_routed,
                     ),
                     (
                         "bootstrap_startup_rounds_backoff_blocked",
@@ -4149,7 +4153,8 @@ mod tests {
         info.bootstrap_promoted_to_ring = Some(1);
         info.bootstrap_time_to_min_connections_secs = Some(12.5);
         info.bootstrap_completed = Some(true);
-        info.bootstrap_startup_rounds_connect_issued = Some(4);
+        info.bootstrap_startup_rounds_connect_issued_gateway = Some(4);
+        info.bootstrap_startup_rounds_connect_issued_routed = Some(5);
         info.bootstrap_startup_rounds_backoff_blocked = Some(3);
         info.bootstrap_startup_rounds_no_target = Some(2);
         let json = event_kind_to_json(&EventKind::RouterSnapshot(Box::new(info)));
@@ -4158,7 +4163,8 @@ mod tests {
         assert_eq!(json["bootstrap_promoted_to_ring"], 1);
         assert_eq!(json["bootstrap_time_to_min_connections_secs"], 12.5);
         assert_eq!(json["bootstrap_completed"], true);
-        assert_eq!(json["bootstrap_startup_rounds_connect_issued"], 4);
+        assert_eq!(json["bootstrap_startup_rounds_connect_issued_gateway"], 4);
+        assert_eq!(json["bootstrap_startup_rounds_connect_issued_routed"], 5);
         assert_eq!(json["bootstrap_startup_rounds_backoff_blocked"], 3);
         assert_eq!(json["bootstrap_startup_rounds_no_target"], 2);
     }

--- a/docs/design/otel-metrics-exporter.md
+++ b/docs/design/otel-metrics-exporter.md
@@ -65,7 +65,8 @@ Registered in `tracing/otel.rs::register_metrics`.
 | `freenet.contract.queue.background_shed` | counter | — | `FairQueueStats` |
 | `freenet.bootstrap.churn` | counter | `event` | `NetworkStatus::bootstrap_churn_stats` (#4787) |
 | `freenet.bootstrap.time_to_min_connections_seconds` | gauge | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
-| `freenet.bootstrap.startup_connect_retries` | counter | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
+| `freenet.bootstrap.completed` | gauge | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
+| `freenet.bootstrap.startup_rounds` | counter | `outcome` | `NetworkStatus::bootstrap_churn_stats` (#4787) |
 
 Everything but the two histograms is an observable callback over state that
 already existed for the local dashboard.

--- a/docs/design/otel-metrics-exporter.md
+++ b/docs/design/otel-metrics-exporter.md
@@ -63,6 +63,9 @@ Registered in `tracing/otel.rs::register_metrics`.
 | `freenet.contract.queue.depth.high_water` | gauge | — | `FairQueueStats` |
 | `freenet.contract.queue.rejected` | counter | `reason` | `FairQueueStats` |
 | `freenet.contract.queue.background_shed` | counter | — | `FairQueueStats` |
+| `freenet.bootstrap.churn` | counter | `event` | `NetworkStatus::bootstrap_churn_stats` (#4787) |
+| `freenet.bootstrap.time_to_min_connections_seconds` | gauge | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
+| `freenet.bootstrap.startup_connect_retries` | counter | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
 
 Everything but the two histograms is an observable callback over state that
 already existed for the local dashboard.

--- a/docs/design/otel-metrics-exporter.md
+++ b/docs/design/otel-metrics-exporter.md
@@ -70,11 +70,31 @@ Registered in `tracing/otel.rs::register_metrics`.
 
 `freenet.bootstrap.startup_rounds`'s `outcome` label takes
 `connect_issued_gateway`, `connect_issued_routed`, `backoff_blocked` and
-`no_target`. The #4787 bootstrap stall shows up as sustained
+`no_target`. A joiner that never bootstraps shows up as sustained
 `connect_issued_routed` growth while `freenet.bootstrap.completed` stays 0 —
-that branch is the one a joiner takes when its gateway transports are all up
-but it is still far below `min_connections`. `no_target` is the quiet
-"nothing to do this round" case and stays near flat during that stall.
+that branch is the one it takes when its gateway transports are all up but it
+is still far below `min_connections`.
+
+That pair is **necessary but not sufficient** for the #4787 acceptance-churn
+stall. A network with fewer than `min_connections` reachable peers, a node
+behind restrictive NAT, and a node whose peers keep refusing for capacity all
+match it permanently and identically, so an alert built on it alone fires
+forever on every node of a small network, gets muted, and hides the stall it
+was meant to catch. **`freenet.bootstrap.churn` is the discriminator:** a high
+`event=transient_expired` : `event=promoted_to_ring` ratio alongside climbing
+`connect_issued_routed` is acceptance churn (#4787); churn near zero means the
+CONNECTs are simply not finding acceptable peers. Same counter, different fix.
+
+Rounds arrive every ~3-5s once the node holds any connection, so a stuck joiner
+emits on the order of 900 routed rounds per hour without bound, while a healthy
+one emits a few tens over its first minute or two and then stops — reaching
+`min_connections` ends the counting. Alert on more than a few minutes of
+continued growth.
+
+`no_target` is the "nothing to do this round" case (all gateways connected and
+the node within `gateways.len()` of the threshold) and stays flat during that
+stall — but it is not benign: sustained growth there means a joiner parked a
+few connections short of the threshold and no longer issuing anything.
 
 Everything but the two histograms is an observable callback over state that
 already existed for the local dashboard.

--- a/docs/design/otel-metrics-exporter.md
+++ b/docs/design/otel-metrics-exporter.md
@@ -68,6 +68,14 @@ Registered in `tracing/otel.rs::register_metrics`.
 | `freenet.bootstrap.completed` | gauge | — | `NetworkStatus::bootstrap_churn_stats` (#4787) |
 | `freenet.bootstrap.startup_rounds` | counter | `outcome` | `NetworkStatus::bootstrap_churn_stats` (#4787) |
 
+`freenet.bootstrap.startup_rounds`'s `outcome` label takes
+`connect_issued_gateway`, `connect_issued_routed`, `backoff_blocked` and
+`no_target`. The #4787 bootstrap stall shows up as sustained
+`connect_issued_routed` growth while `freenet.bootstrap.completed` stays 0 —
+that branch is the one a joiner takes when its gateway transports are all up
+but it is still far below `min_connections`. `no_target` is the quiet
+"nothing to do this round" case and stays near flat during that stall.
+
 Everything but the two histograms is an observable callback over state that
 already existed for the local dashboard.
 


### PR DESCRIPTION
## Problem

Nodes restarted onto a new binary (e.g. auto-update) can linger as
transient-at-gateway, expire, get reaped as a zombie transport, and cycle
through repeated reconnects before entering the ring topology proper.
freenet/freenet-core#4787 documents this from live gateway telemetry
(nova/vega: ~10:1 `Transient connection expired` vs `promoted to ring`,
worst-case peers cycling 23-25x with zero promotions) and names #4760's
lattice-tightening as a candidate (unconfirmed) contributing factor.

## Approach

The issue's own priority/cost assessment flags a direct behavioral fix as
premature: the mechanism (30s transient TTL, 90s/180s zombie-reap, the
`LATTICE_OVERMAX_SLACK` displacement path) is confirmed still present and
unmodified, but the root cause between "saturated-neighborhood CONNECT
rejection" and "lattice over-max displacement of a fresh joiner's edge" is
not yet disambiguated. The issue's own suggested next step is exactly that:
add production telemetry, then reproduce at scale, **before** touching
CONNECT/lattice acceptance logic — a high-risk surface per this repo's
bug-prevention rules (connection admission, retry/backoff).

This PR implements that first step only — **instrumentation, no behavior
change**:

- **Gateway-side** counters at the three log sites the issue's live-log
  evidence was read from (`connection_lifecycle.rs`): `transient_registered`,
  `transient_expired`, `promoted_to_ring`. A sustained high
  `transient_expired`:`promoted_to_ring` ratio is the churn signature
  reported in the issue.
- **Joiner-side**: time-to-min-connections (recorded once per process, the
  first time `open_connections()` reaches `min_connections`) and a
  below-threshold CONNECT retry-round counter, both from
  `initial_join_procedure` in `operations/connect.rs`.
- Exported via **both** telemetry pipelines, following each one's existing
  template (connect-emit-counters for the dashboard, gateway-failures for
  OTel):
  - Dashboard: new fields in `RouterSnapshotInfo` / `router_snapshot` JSON.
  - OTel: three new instruments — `freenet.bootstrap.churn` (counter,
    `event=` attribute), `freenet.bootstrap.time_to_min_connections_seconds`
    (gauge), `freenet.bootstrap.startup_connect_retries` (counter).

**This does not close #4787.** A fix to the CONNECT/lattice acceptance path
still needs the production-scale simulation reproduction the issue describes
as its next phase, informed by this telemetry — that phase is deliberately
out of scope here given its size and risk (large-scale sim test
infrastructure + changes to core CONNECT/lattice logic, which the issue's own
cost assessment estimates as multi-PR, Full-review-tier work).

## Testing

- `bootstrap_churn_counts_reflect_recorded_events` (network_status.rs):
  end-to-end for every record fn + the getter, with distinct counts per
  field and an explicit check that `time_to_min_connections` is set on the
  first call only (not overwritten by a later wobble around the threshold).
- `router_snapshot_json_includes_bootstrap_churn_counters` (telemetry.rs):
  pins the new fields reaching the hand-mirrored OTLP JSON body.
- `instrument_callbacks_export_named_datapoints` (otel.rs): extended to
  assert the three new OTel instrument names and the `event=` attribute
  values on `freenet.bootstrap.churn`.
- `cargo fmt`, `cargo clippy -p freenet --lib --tests -- -D warnings`, and
  the full affected unit-test surface (`network_status`, `router`,
  `operations::connect`, `tracing::otel`, `tracing::telemetry`) all pass.

Part of freenet/freenet-core#4787

[AI-assisted - Claude]