### PR TITLE
test: add per-test slow-timeout override for three tight-margin sim tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -70,6 +70,16 @@ filter = "test(graceful_shutdown_on_sigterm_exits_zero)"
 retries = 0
 slow-timeout = { period = "300s", terminate-after = 2 }
 
+# #5176: three simulation tests run 138-147s on CI against the default 240s
+# cap (~1.6x headroom, measured over nine runs). Their spread is 1-16%, so they
+# are stable rather than erratic — the risk is a systematically slower runner
+# breaching the cap for all of them at once, not intermittent flakiness. The
+# `Simulation` job runs on `merge_group` as well as `pull_request`, so a
+# breach stalls the whole merge queue, not just one PR.
+[[profile.ci.overrides]]
+filter = "test(test_placement_migration_at_scale_renewal_load_stays_bounded) | test(test_connection_growth_plateau_diagnostic) | test(test_connection_growth_stall_regression)"
+slow-timeout = { period = "150s", terminate-after = 2 }
+
 [profile.nightly]
 # Nightly tests run longer by design; no retries since failures need investigation.
 retries = 0


### PR DESCRIPTION
## Problem

Three `simulation_integration` tests sit at ~1.6x headroom against the default 240s `[profile.ci]` nextest cap, and none has a per-test override:

| Test | mean headroom | worst-case headroom | spread |
|---|---|---|---|
| `test_placement_migration_at_scale_renewal_load_stays_bounded` | 1.74x | 1.58x | 16% |
| `test_connection_growth_plateau_diagnostic` | 1.64x | 1.61x | 3% |
| `test_connection_growth_stall_regression` | 1.63x | 1.62x | 1% |

The tight spread (1-16% across nine sampled `pull_request` CI runs) means these are stable, not flaky — the risk is a systematically slower runner pool breaching the cap for all three simultaneously, not intermittent flakiness on one PR. Because the `Simulation` job runs on `merge_group` as well as `pull_request`, a breach doesn't just fail one PR's CI — it stalls the entire merge queue, and per #5170 that failure can be invisible on the PR page.

## Approach

Add a single `[[profile.ci.overrides]]` block to `.config/nextest.toml` covering all three tests, following the same pattern as the four overrides already in that file (`test_interest_renewal`, `freenet-ping-app`, `test_fanout_liveness`, `test_ping_blocked_peers`). `slow-timeout = { period = "150s", terminate-after = 2 }` gives a 300s cap, ~2.0x the worst observed run — enough headroom that a genuine hang is still caught, without raising the global 240s cap for every other test.

## Testing

Config-only change (no source/test logic changed); verified via `tomllib`/`toml` that the file still parses, and confirmed all three test functions still exist at their current locations in `crates/core/tests/simulation_integration.rs`. Correctness of the applied timeout will show up as green CI on this PR itself (`Simulation` job).

Closes freenet/freenet-core#5176

[AI-assisted - Claude]