### PR TITLE
feat(contracts): route the contract-visible clock through TimeSource

### DIFF
--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -512,7 +512,7 @@ async fn a_contract_sees_the_overridden_clock_through_real_wasm()
 
     use super::oracle::ConformanceOracle;
     use crate::util::time_source::{DynTimeSource, SharedMockTimeSource};
-    use crate::wasm_runtime::native_api::time::override_contract_clock;
+    use crate::wasm_runtime::override_contract_clock;
 
     let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
     let mut oracle = RuntimeOracle::standalone(wasm, vec![NONDETERMINISTIC_SUMMARY]).await?;

--- a/crates/core/src/conformance/wasm_tests.rs
+++ b/crates/core/src/conformance/wasm_tests.rs
@@ -486,3 +486,89 @@ async fn verifier_matches_real_wasm_for_every_planted_defect()
 
     Ok(())
 }
+
+/// The contract-visible clock is controllable end to end, through real wasmtime.
+///
+/// This asserts on what the PIPELINE emits — the bytes a real compiled contract
+/// produces — not on the helper that was edited. A unit test of `contract_now()`
+/// would pass even if the host binding never called it, which is the exact shape
+/// of guard this project has repeatedly written and then found unable to fail.
+///
+/// Mode 4 (`NONDETERMINISTIC_SUMMARY`) appends the host clock's nanosecond
+/// timestamp to its summary, so its output is a direct readout of what the
+/// contract believes the time to be.
+///
+/// This is also a regression test for a real dead end: an earlier attempt
+/// overrode a thread-local read directly by `utc_now`, which never worked
+/// because contract WASM executes on a dedicated blocking thread
+/// (`execute_wasm_blocking`), never on the calling thread — measured: the guard
+/// installed on one `ThreadId` while the contract call ran on another. The fix
+/// carries the override across that boundary explicitly; this test would fail
+/// against the broken thread-local-only version.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_contract_sees_the_overridden_clock_through_real_wasm()
+-> Result<(), Box<dyn std::error::Error>> {
+    use std::time::Duration;
+
+    use super::oracle::ConformanceOracle;
+    use crate::util::time_source::{DynTimeSource, SharedMockTimeSource};
+    use crate::wasm_runtime::native_api::time::override_contract_clock;
+
+    let wasm = crate::wasm_runtime::tests::get_test_module("test_contract_conformance")?;
+    let mut oracle = RuntimeOracle::standalone(wasm, vec![NONDETERMINISTIC_SUMMARY]).await?;
+    let state = [1u8, 2, 3];
+
+    // CONTROL, and it is load-bearing: with no override this contract reads the
+    // real clock, so two summaries must DIFFER. Without this the assertions below
+    // would also pass against a contract that ignored the clock entirely, and the
+    // test would be measuring nothing.
+    let real_a = oracle.summarize_state(&state)?;
+    let real_b = oracle.summarize_state(&state)?;
+    assert_ne!(
+        real_a, real_b,
+        "control failed: mode 4 is supposed to read the host clock, so two \
+         summaries should differ. Every assertion below is vacuous if this holds."
+    );
+
+    let clock = SharedMockTimeSource::new();
+
+    // Pinned clock: the same two calls must now AGREE. This is what proves the
+    // override actually reaches the contract through the linker and host binding.
+    let (pinned_a, pinned_b) = {
+        let _guard = override_contract_clock(Arc::new(clock.clone()) as DynTimeSource);
+        (
+            oracle.summarize_state(&state)?,
+            oracle.summarize_state(&state)?,
+        )
+    };
+    assert_eq!(
+        pinned_a, pinned_b,
+        "two summaries taken under a pinned clock differ, so the contract is \
+         still reading the real clock and the override is not reaching it"
+    );
+
+    // Advancing the mock must move what the contract sees. A pin that only ever
+    // freezes could be satisfied by a stuck clock; this shows the value tracks
+    // the source, which is what `update_determinism` will need in order to place
+    // two merges an hour apart deliberately.
+    let advanced = {
+        let _guard = override_contract_clock(Arc::new(clock.clone()) as DynTimeSource);
+        clock.advance_time(Duration::from_secs(3600));
+        oracle.summarize_state(&state)?
+    };
+    assert_ne!(
+        pinned_a, advanced,
+        "advancing the injected clock did not change what the contract saw"
+    );
+
+    // The guard must restore the real clock, or one test would silently pin the
+    // clock for everything that ran after it on this thread.
+    let restored_a = oracle.summarize_state(&state)?;
+    let restored_b = oracle.summarize_state(&state)?;
+    assert_ne!(
+        restored_a, restored_b,
+        "the real clock was not restored when the guard dropped"
+    );
+
+    Ok(())
+}

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -7,7 +7,7 @@ pub(crate) mod engine;
 mod error;
 pub(crate) mod mock_state_storage;
 mod module_cache;
-mod native_api;
+pub(crate) mod native_api;
 mod runtime;
 pub mod secret_export;
 pub mod secret_snapshots;

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -7,7 +7,7 @@ pub(crate) mod engine;
 mod error;
 pub(crate) mod mock_state_storage;
 mod module_cache;
-pub(crate) mod native_api;
+mod native_api;
 mod runtime;
 pub mod secret_export;
 pub mod secret_snapshots;
@@ -80,6 +80,14 @@ pub(crate) use native_api::{
     new_delegate_context_cache, new_delegate_counter, new_inherited_origins,
     release_created_delegate_slot,
 };
+// Narrow re-export rather than making `native_api` crate-visible: only the
+// conformance test driver (outside the `wasm_runtime` subtree) needs the
+// clock-override primitive, and widening the whole module would also expose
+// unrelated delegate-context/inherited-origins internals crate-wide. Gated to
+// test builds — production code that needs it (`execute_wasm_blocking`) is a
+// descendant of `wasm_runtime` and reaches `native_api::time` directly.
+#[cfg(test)]
+pub(crate) use native_api::time::override_contract_clock;
 // Only constructed by name in test code (e.g. resolve_message_origin tests);
 // production read/write paths access the entry through the DashMap without
 // naming the type, so gate the re-export to avoid an unused-import warning.

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2358,12 +2358,21 @@ where
     let started_at_ms = Arc::new(AtomicU64::new(0));
     let started_for_guest = Arc::clone(&started);
     let started_at_for_guest = Arc::clone(&started_at_ms);
+    // Contract WASM runs on a dedicated blocking thread (spawn_blocking, or a
+    // plain std::thread — see the match below), never on the calling thread, so
+    // a contract-clock override set by a test on the CALLER's thread would not
+    // otherwise be visible to `native_api::time::utc_now`. Capture it here, on
+    // the calling thread, and re-install it for the guest's thread only, for
+    // the duration of this one call. Production never overrides the clock, so
+    // this reads and forwards `None` — a no-op.
+    let clock_override = native_api::time::current_contract_clock_override();
     let f = move || {
         // Record started_at BEFORE flipping `started`, so the poll loop that
         // observes started==true (SeqCst) is guaranteed to read a valid
         // started_at.
         started_at_for_guest.store(start.elapsed().as_millis() as u64, Ordering::SeqCst);
         started_for_guest.store(true, Ordering::SeqCst);
+        let _clock_guard = clock_override.map(native_api::time::override_contract_clock);
         f()
     };
 

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1091,9 +1091,95 @@ pub(super) mod rand {
     }
 }
 
-pub(super) mod time {
+pub(crate) mod time {
     use super::*;
     use chrono::{DateTime, Utc as UtcOriginal};
+    use std::cell::RefCell;
+
+    use crate::util::time_source::DynTimeSource;
+
+    thread_local! {
+        /// Overrides the wall clock handed to a contract by [`utc_now`], for this
+        /// thread only. `None` — the production state — means the real clock.
+        ///
+        /// Contract WASM execution runs on a dedicated blocking thread (see
+        /// `execute_wasm_blocking` in `engine/wasmtime_engine.rs`), never on the
+        /// caller's thread, so this slot is only ever populated by that funnel
+        /// carrying an override captured from the calling thread across the
+        /// `spawn_blocking` boundary — never set directly from contract-call code.
+        static CONTRACT_CLOCK: RefCell<Option<DynTimeSource>> = const { RefCell::new(None) };
+    }
+
+    /// The wall-clock instant a contract sees.
+    ///
+    /// Routed through [`DynTimeSource`] rather than calling `Utc::now()` directly
+    /// so that a test CAN control what a contract believes the time to be.
+    /// `.claude/rules/testing.md` forbids a bare `now()` everywhere else in
+    /// `crates/core`; this was the one remaining exception.
+    ///
+    /// Why it matters beyond the rule: `update_determinism` detects a
+    /// clock-reading contract by calling merge twice and comparing bytes, so it
+    /// only fires when an expiry boundary happens to fall inside the few hundred
+    /// milliseconds between those two calls. Against a contract with hour-scale
+    /// windows nothing crosses a boundary and it reads clean — so a clean verdict
+    /// could not be told apart from "we did not catch it". With an injectable
+    /// clock the two calls can be placed an hour apart deliberately and any
+    /// clock reader is caught by construction. See #5465 and #5462.
+    fn contract_now() -> DateTime<UtcOriginal> {
+        // Read the override out before falling back, so the `RefCell` borrow has
+        // ended by the time anything else runs.
+        let overridden = CONTRACT_CLOCK.with(|slot| {
+            slot.borrow()
+                .as_ref()
+                .map(|source| DateTime::<UtcOriginal>::from(source.system_time_now()))
+        });
+        overridden.unwrap_or_else(UtcOriginal::now)
+    }
+
+    /// Restores the previous contract clock when dropped.
+    ///
+    /// Restores the PREVIOUS value rather than clearing, so nesting is safe and an
+    /// inner override cannot silently unset an outer one.
+    #[must_use = "the override is reverted as soon as this guard is dropped"]
+    pub(crate) struct ContractClockGuard {
+        previous: Option<DynTimeSource>,
+    }
+
+    impl Drop for ContractClockGuard {
+        fn drop(&mut self) {
+            let previous = self.previous.take();
+            CONTRACT_CLOCK.with(|slot| *slot.borrow_mut() = previous);
+        }
+    }
+
+    /// Make contracts executed ON THIS THREAD read `source` instead of the real
+    /// clock, until the returned guard drops.
+    ///
+    /// This is the low-level primitive `execute_wasm_blocking` uses to carry an
+    /// override across the `spawn_blocking`/dedicated-thread boundary — see
+    /// [`current_contract_clock_override`]. Test code should call this on
+    /// whichever thread actually invokes the contract call (e.g. the test's own
+    /// thread when driving a `RuntimeOracle` synchronously); the funnel then
+    /// propagates it to the worker thread that runs the WASM.
+    pub(crate) fn override_contract_clock(source: DynTimeSource) -> ContractClockGuard {
+        let previous = CONTRACT_CLOCK.with(|slot| slot.borrow_mut().replace(source));
+        ContractClockGuard { previous }
+    }
+
+    /// Read this thread's current override, if any, so it can be carried across
+    /// to the thread that will actually execute the contract.
+    ///
+    /// Contract execution deliberately runs on a different thread from the
+    /// caller (`spawn_blocking` on a multi-thread runtime, a dedicated
+    /// `std::thread` otherwise — `execute_wasm_blocking`, the #4441 whole-node
+    /// hang fix), so a thread-local override installed on the calling thread
+    /// never reaches `utc_now` on its own. `execute_wasm_blocking` calls this on
+    /// the calling thread, then re-installs the result on the worker thread for
+    /// the duration of that one call, so production (which never overrides)
+    /// forwards `None` and pays nothing.
+    pub(crate) fn current_contract_clock_override() -> Option<DynTimeSource> {
+        CONTRACT_CLOCK.with(|slot| slot.borrow().clone())
+    }
 
     pub(crate) fn utc_now(id: i64, ptr: i64) {
         if id == -1 {
@@ -1104,7 +1190,7 @@ pub(super) mod time {
             return;
         }
         let info = MEM_ADDR.get(&id).expect("instance mem space not recorded");
-        let now = UtcOriginal::now();
+        let now = contract_now();
         let Some(ptr) = validate_and_compute_ptr::<DateTime<UtcOriginal>>(
             ptr,
             info.start_ptr,

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -1091,7 +1091,7 @@ pub(super) mod rand {
     }
 }
 
-pub(crate) mod time {
+pub(super) mod time {
     use super::*;
     use chrono::{DateTime, Utc as UtcOriginal};
     use std::cell::RefCell;
@@ -1114,8 +1114,9 @@ pub(crate) mod time {
     ///
     /// Routed through [`DynTimeSource`] rather than calling `Utc::now()` directly
     /// so that a test CAN control what a contract believes the time to be.
-    /// `.claude/rules/testing.md` forbids a bare `now()` everywhere else in
-    /// `crates/core`; this was the one remaining exception.
+    /// `.claude/rules/testing.md` requires a `TimeSource` rather than a bare
+    /// `now()`; this was the one call reachable from WASM guest code that still
+    /// called the real clock directly.
     ///
     /// Why it matters beyond the rule: `update_determinism` detects a
     /// clock-reading contract by calling merge twice and comparing bytes, so it
@@ -1140,13 +1141,37 @@ pub(crate) mod time {
     ///
     /// Restores the PREVIOUS value rather than clearing, so nesting is safe and an
     /// inner override cannot silently unset an outer one.
+    ///
+    /// **Must be dropped on the thread it was created on.** The override is a
+    /// THREAD-LOCAL, so this guard is only sound when created and dropped on the
+    /// same OS thread — e.g. held across synchronous calls only, never across an
+    /// `.await` point on a multi-thread runtime, where tokio's work-stealing
+    /// scheduler may resume the task on a different worker thread. `Drop` checks
+    /// this and refuses to restore across a thread change (see below) rather
+    /// than silently corrupting whichever thread's clock it lands on.
     #[must_use = "the override is reverted as soon as this guard is dropped"]
     pub(crate) struct ContractClockGuard {
         previous: Option<DynTimeSource>,
+        installed_on: std::thread::ThreadId,
     }
 
     impl Drop for ContractClockGuard {
         fn drop(&mut self) {
+            if std::thread::current().id() != self.installed_on {
+                // Restoring `previous` here would write it into THIS thread's
+                // slot, not the thread that installed it — corrupting whatever
+                // this thread's own clock state was, while the installing
+                // thread's override is never restored at all. Neither thread can
+                // be made correct from here, so refuse and surface it loudly
+                // instead of silently corrupting one of them.
+                tracing::error!(
+                    "ContractClockGuard dropped on a different thread than it was \
+                     installed on — the override was NOT restored on either \
+                     thread. This guard must not be held across an .await point \
+                     on a multi-thread runtime."
+                );
+                return;
+            }
             let previous = self.previous.take();
             CONTRACT_CLOCK.with(|slot| *slot.borrow_mut() = previous);
         }
@@ -1160,10 +1185,14 @@ pub(crate) mod time {
     /// [`current_contract_clock_override`]. Test code should call this on
     /// whichever thread actually invokes the contract call (e.g. the test's own
     /// thread when driving a `RuntimeOracle` synchronously); the funnel then
-    /// propagates it to the worker thread that runs the WASM.
+    /// propagates it to the worker thread that runs the WASM. See
+    /// [`ContractClockGuard`]'s docs for why the guard must not cross threads.
     pub(crate) fn override_contract_clock(source: DynTimeSource) -> ContractClockGuard {
         let previous = CONTRACT_CLOCK.with(|slot| slot.borrow_mut().replace(source));
-        ContractClockGuard { previous }
+        ContractClockGuard {
+            previous,
+            installed_on: std::thread::current().id(),
+        }
     }
 
     /// Read this thread's current override, if any, so it can be carried across
@@ -1205,6 +1234,88 @@ pub(crate) mod time {
         unsafe {
             ptr.write(now);
         };
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::util::time_source::SharedMockTimeSource;
+
+        /// Cheap, no-wasmtime pin for the claim in [`ContractClockGuard`]'s doc
+        /// comment: nesting restores the PREVIOUS value, not `None` — an inner
+        /// override cannot silently unset an outer one.
+        #[test]
+        fn nested_overrides_restore_in_lifo_order() {
+            assert!(
+                current_contract_clock_override().is_none(),
+                "test thread must start with no override, or this test proves nothing"
+            );
+
+            let outer = Arc::new(SharedMockTimeSource::new()) as DynTimeSource;
+            let outer_guard = override_contract_clock(Arc::clone(&outer));
+            assert!(Arc::ptr_eq(
+                &current_contract_clock_override().expect("outer override missing"),
+                &outer
+            ));
+
+            {
+                let inner = Arc::new(SharedMockTimeSource::new()) as DynTimeSource;
+                let _inner_guard = override_contract_clock(Arc::clone(&inner));
+                assert!(Arc::ptr_eq(
+                    &current_contract_clock_override().expect("inner override missing"),
+                    &inner
+                ));
+            } // inner guard drops here
+
+            assert!(
+                Arc::ptr_eq(
+                    &current_contract_clock_override().expect("outer override was not restored"),
+                    &outer
+                ),
+                "dropping the inner guard must restore the outer override, not clear it"
+            );
+
+            drop(outer_guard);
+            assert!(
+                current_contract_clock_override().is_none(),
+                "dropping the outermost guard must restore the real-clock state (None)"
+            );
+        }
+
+        /// A guard dropped on a different thread than it was created on must NOT
+        /// restore its `previous` value into that thread's slot — doing so would
+        /// silently corrupt whichever thread's clock state it lands on. Pins the
+        /// refusal added to `ContractClockGuard::drop`.
+        #[test]
+        fn guard_dropped_on_a_different_thread_does_not_corrupt_that_threads_clock() {
+            let creator_clock = Arc::new(SharedMockTimeSource::new()) as DynTimeSource;
+            let guard = override_contract_clock(Arc::clone(&creator_clock));
+
+            let other_thread_clock = Arc::new(SharedMockTimeSource::new()) as DynTimeSource;
+            std::thread::spawn(move || {
+                assert!(
+                    current_contract_clock_override().is_none(),
+                    "a fresh OS thread must start with no override"
+                );
+                let other_guard = override_contract_clock(Arc::clone(&other_thread_clock));
+
+                // Drop the OTHER thread's guard here, on THIS thread — the misuse
+                // this test exists to catch.
+                drop(guard);
+
+                assert!(
+                    Arc::ptr_eq(
+                        &current_contract_clock_override()
+                            .expect("this thread's own override must survive"),
+                        &other_thread_clock
+                    ),
+                    "a cross-thread drop must not overwrite this thread's own override"
+                );
+                drop(other_guard);
+            })
+            .join()
+            .unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Step 2 of the host-clock deprecation plan in #5465: `utc_now` (the `freenet_time::__frnt__time__utc_now` host function) called `chrono::Utc::now()` directly, in violation of `.claude/rules/testing.md`'s "no bare `now()` in `crates/core`" rule, and — more importantly — leaving clock-dependence undetectable by construction. `update_determinism` currently finds a clock-reading contract only by merging twice and comparing bytes, so it only fires when an expiry boundary happens to fall inside the few hundred milliseconds between the two calls (#5462). A contract with hour-scale windows reads clean, and a clean verdict can't be told apart from "we didn't catch it."

An earlier attempt at this (branch `worktree-clock-timesource`, commit `fe5da3691`, referenced in #5465's decision comment) tried a thread-local override modelled on `GlobalRng` and does **not work**: contract WASM execution deliberately runs on a dedicated blocking thread (`execute_wasm_blocking`, the #4441 whole-node hang fix), never on the caller's thread. Measured there: the override installed on `ThreadId(2)`, the contract ran on `ThreadId(21)`.

## Approach

`execute_wasm_blocking` is the single funnel both `call_2i64_blocking` and `call_3i64_blocking` go through — and those are the only two call modes contract execution uses (`validate_state`, `update_state`, `summarize_state`, `get_state_delta`). Delegates use different call modes (`call_3i64`, `call_3i64_async_imports`) that never reach this funnel, so this change only touches contracts, matching the issue's "keep it for delegates" framing.

The fix captures the calling thread's clock override (a thread-local, `None` in production — nothing in production code ever calls `override_contract_clock`) right before the blocking closure is built, and re-installs it inside the closure, which runs on the worker thread, for the duration of that one call. Production forwards `None`, which is a no-op: contracts still see the real wall clock, unchanged.

No contract-visible behavior change and no contract keys move — this only changes what a *test* can control.

## Testing

Added `a_contract_sees_the_overridden_clock_through_real_wasm` in `crates/core/src/conformance/wasm_tests.rs`: drives a real compiled contract (`test_contract_conformance`, mode 4 — `NONDETERMINISTIC_SUMMARY`, which appends the host clock's nanosecond timestamp to its summary) through `RuntimeOracle` end to end, with:
- a control proving the contract reads the real clock at all (two summaries differ with no override),
- proof the override reaches the contract through the linker and host binding (two summaries agree once pinned),
- proof the value tracks the injected source (advancing the mock clock changes what the contract sees),
- proof the guard restores the real clock on drop.

This is a regression test for the dead end above — it fails against the broken thread-local-only version and passes against this fix.

`cargo test -p freenet --lib wasm_runtime` (562 passed) and `cargo test -p freenet --lib conformance` (270 passed) both green; `cargo fmt` + `cargo clippy -- -D warnings` clean.

Refs #5465, #5462

[AI-assisted - Claude]