### PR TITLE
test(transport): add floor-lowered companion guard for GATEWAY_ACK_VERSION_MIN_VERSION

### DIFF
--- a/crates/core/src/transport/connection_handler/version_cmp.rs
+++ b/crates/core/src/transport/connection_handler/version_cmp.rs
@@ -287,6 +287,29 @@ mod tests {
         }
     }
 
+    /// Companion to the marker guard: the floor must never drop to or below a
+    /// release known NOT to carry `AckConnectionV2`.
+    ///
+    /// Kept alongside the marker test rather than replaced by it, because the
+    /// two catch different mistakes: this one catches the floor being
+    /// LOWERED (e.g. someone "fixing" a gate that seems not to fire), the
+    /// marker one catches the RELEASE advancing past a stationary floor. Once
+    /// `ACK_VERSION_SHIPPED_IN` is `Some(...)`, the marker test's only
+    /// remaining assertion is `shipped == floor` — trivially true forever —
+    /// so without this companion nothing catches the floor being lowered.
+    /// Mirrors `hash_first_floor_stays_above_every_release_without_the_variants`.
+    #[test]
+    fn ack_version_floor_stays_above_every_release_without_the_variants() {
+        /// Last release that does NOT carry the `AckConnectionV2` variant.
+        const LAST_RELEASE_WITHOUT_VARIANTS: (u8, u8, u16) = (0, 2, 119);
+        assert!(
+            GATEWAY_ACK_VERSION_MIN_VERSION > LAST_RELEASE_WITHOUT_VARIANTS,
+            "GATEWAY_ACK_VERSION_MIN_VERSION ({GATEWAY_ACK_VERSION_MIN_VERSION:?}) dropped to \
+             or below {LAST_RELEASE_WITHOUT_VARIANTS:?}, a release with no AckConnectionV2 \
+             variant index. Sending it to those peers means the handshake never completes.",
+        );
+    }
+
     #[test]
     fn test_parse_semver() {
         assert_eq!(parse_semver("0.1.152"), (0, 1, 152));

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -303,12 +303,15 @@ Current wire-gated floors:
   gateway, and the release cascade upgrades the gateways FIRST.
 
   Guarded by a marker exactly like `HASH_FIRST_SHIPPED_IN`:
-  `ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)>`, currently `None`, checked by
+  `ACK_VERSION_SHIPPED_IN: Option<(u8, u8, u16)>`, now `Some((0, 2, 120))`
+  (this feature shipped in 0.2.120), checked by
   `version_cmp.rs::ack_version_floor_tracks_the_shipping_release`. When a
-  release bump raises `CARGO_PKG_VERSION` to `(0, 2, 120)`, that test fails
+  release bump raises `CARGO_PKG_VERSION` to a new floor, that test fails
   until the releaser consciously either sets
   `ACK_VERSION_SHIPPED_IN = Some(GATEWAY_ACK_VERSION_MIN_VERSION)` (this release
   carries it) or raises the floor (it does not).
+  `ack_version_floor_stays_above_every_release_without_the_variants` is the
+  companion that catches the floor being *lowered*.
 
   Note the emission gate reads the peer's version from the intro packet it just
   parsed, never from a cached value, so unlike the floors above there is no

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -334,10 +334,10 @@ Current wire-gated floors:
   did nothing.
 
   Guarded by a marker exactly like `HASH_FIRST_SHIPPED_IN`:
-  `BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)>`, currently `None`,
-  checked by
+  `BROADCAST_TARGET_LIST_SHIPPED_IN: Option<(u8, u8, u16)>`, now
+  `Some((0, 2, 120))` (this feature shipped in 0.2.120), checked by
   `connection_manager.rs::broadcast_target_list_floor_tracks_the_shipping_release`.
-  When a release bump raises `CARGO_PKG_VERSION` to `(0, 2, 120)`, that test
+  When a release bump raises `CARGO_PKG_VERSION` to a new floor, that test
   fails until the releaser consciously either sets
   `BROADCAST_TARGET_LIST_SHIPPED_IN = Some(BROADCAST_TARGET_LIST_MIN_VERSION)`
   (this release carries it) or raises the floor (it does not).


### PR DESCRIPTION
## Problem

#5167 added `GATEWAY_ACK_VERSION_MIN_VERSION` with the usual staleness marker, `ACK_VERSION_SHIPPED_IN`, guarded by `ack_version_floor_tracks_the_shipping_release`. That marker is now flipped to `Some((0, 2, 120))` (0.2.120 shipped, the crate is at 0.2.133), so the marker test's only remaining assertion is `shipped == floor` — trivially true forever. Nothing catches the floor being *lowered* from this point on.

This floor is more severe than the other three wire-gated floors in this file (hash-first, broadcast-target-list): it gates the connection ack itself, so a peer that can't decode it never completes the handshake at all, and the release cascade upgrades gateways first — a lowered floor here would break every pre-floor node's ability to connect to any upgraded gateway.

## Approach

Add `ack_version_floor_stays_above_every_release_without_the_variants`, mirroring the existing `hash_first_floor_stays_above_every_release_without_the_variants` companion test (same shape, per the issue's own instructions: copy rather than invent). It asserts `GATEWAY_ACK_VERSION_MIN_VERSION > (0, 2, 119)`, the last release with no `AckConnectionV2` variant.

Also updated `docs/RELEASING.md`'s ack-version section, which still described the marker as `None` and had no mention of a companion test (unlike the hash-first and broadcast-target-list sections, which both name theirs).

Did not implement the issue's secondary, explicitly optional suggestion (asserting `shipped <= crate_version` in the `Some` branch, mirroring hash-first's symmetric check) — that laxness is currently load-bearing for the "flip marker before bump" release procedure the 0.2.120 release used, and whether to forgo that procedure for future releases is a release-process call outside this issue's scope.

## Testing

New test verified failing under a deliberate mutation (floor set to `(0, 2, 119)`) and passing on HEAD: `cargo test -p freenet --lib transport::connection_handler::version_cmp::tests::ack_version_floor` — 2/2 pass on HEAD, 2/2 fail under the mutation (the marker test also correctly fails since `shipped` no longer equals the mutated floor).

Closes freenet/freenet-core#5174

[AI-assisted - Claude]