### PR TITLE
fix(delegates): decrypt a secret once per read, and stop gating a unit test on a production wall-clock budget

### DIFF
--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -174,7 +174,7 @@ impl Runtime {
         // Read back the (possibly mutated) context before guard drops
         let updated_context = DELEGATE_ENV
             .get(&instance_id)
-            .map(|env| env.context.clone())
+            .map(|env| env.context.borrow().clone())
             .unwrap_or_default();
 
         let outbound = result?;

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -85,10 +85,17 @@ mod delegate2_messages {
 /// `Runtime` inline still inherit the production 5.0 s. They are not known to
 /// flake on it, and widening this to every delegate fixture is a larger change
 /// than the one flake in hand justified, so it was left deliberately rather
-/// than overlooked. Point them here if the same timeout shows up in them. It is generous but still bounded, so a delegate test that
-/// genuinely wedges fails rather than hanging forever. The tests that DO assert
-/// timeout behaviour live in `wasm_runtime::tests::execution_handling` and set
-/// their own budgets, so nothing here weakens that coverage.
+/// than overlooked. Point them here if the same timeout shows up in them.
+///
+/// 60 s is generous but still bounded, so a delegate test that genuinely wedges
+/// fails rather than hanging forever.
+///
+/// Nothing here weakens timeout coverage. The real epoch-trap coverage — a
+/// guest actually being interrupted — lives in `engine::wasmtime_engine`'s own
+/// tests, which drive WASM directly and set their own budgets.
+/// `wasm_runtime::tests::execution_handling` also asserts timeout behaviour,
+/// but it simulates a polling loop and never runs WASM, so it is untouched by
+/// this constant for a different reason than I first wrote here.
 ///
 /// This does not make the wall-clock accounting correct — a real delegate
 /// storing a large secret on a busy node can still be charged for the host's

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -57,6 +57,45 @@ mod delegate2_messages {
     }
 }
 
+/// Execution budget for the delegate test fixtures.
+///
+/// `RuntimeConfig::max_execution_seconds` defaults to 5.0, which is a
+/// PRODUCTION policy — how long a delegate may occupy an executor — and it is
+/// enforced as WALL CLOCK: `epoch_deadline_ticks` turns it into 51 ticks of a
+/// 100 ms process-global epoch ticker. That clock keeps running while the guest
+/// is blocked inside a HOST call, and the epoch trap cannot fire until control
+/// returns to the guest, so the budget is spent on the node's own file I/O and
+/// XChaCha20-Poly1305 as much as on delegate code.
+///
+/// These fixtures assert functional behaviour, not that policy, and one of them
+/// sits on the boundary by construction: `test_large_secret_data` drives ~2 MiB
+/// of AEAD through host calls for a single 1 MiB secret, in a build where that
+/// crypto is monomorphised into `crates/core` at opt-level 0 — the
+/// `[profile.dev.package."*"] opt-level = 3` override in the workspace manifest
+/// covers dependency PACKAGES, not generic code instantiated in the local
+/// crate. On a loaded machine, or a CI runner running the suite in parallel
+/// under nextest, that legitimately exceeds 5 s of wall clock and the guest is
+/// epoch-trapped as `WasmError::Timeout` — a failure that says nothing about
+/// the code under test. Measured on a 16-core box: 0 failures in 28 runs below
+/// load average 50, and failures on BOTH `main` and a feature branch above it.
+///
+/// So the fixtures set the budget explicitly instead of inheriting the
+/// production one. It is generous but still bounded, so a delegate test that
+/// genuinely wedges fails rather than hanging forever. The tests that DO assert
+/// timeout behaviour live in `wasm_runtime::tests::execution_handling` and set
+/// their own budgets, so nothing here weakens that coverage.
+///
+/// This does not make the wall-clock accounting correct — a real delegate
+/// storing a large secret on a busy node can still be charged for the host's
+/// crypto and I/O. That is tracked separately; this constant only stops a unit
+/// test from being gated on it.
+fn delegate_fixture_config() -> super::super::runtime::RuntimeConfig {
+    super::super::runtime::RuntimeConfig {
+        max_execution_seconds: 60.0,
+        ..Default::default()
+    }
+}
+
 async fn setup_runtime(
     name: &str,
 ) -> Result<(DelegateContainer, Runtime, tempfile::TempDir), Box<dyn std::error::Error>> {
@@ -71,7 +110,14 @@ async fn setup_runtime(
     let delegate_store = DelegateStore::new(delegates_dir, 10_000, db.clone())?;
     let secret_store = SecretsStore::new(secrets_dir, Default::default(), db)?;
 
-    let mut runtime = Runtime::build(contract_store, delegate_store, secret_store, false).unwrap();
+    let mut runtime = Runtime::build_with_config(
+        contract_store,
+        delegate_store,
+        secret_store,
+        false,
+        delegate_fixture_config(),
+    )
+    .unwrap();
 
     let delegate = {
         let bytes = super::super::tests::get_test_module(name)?;

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -79,8 +79,13 @@ mod delegate2_messages {
 /// the code under test. Measured on a 16-core box: 0 failures in 28 runs below
 /// load average 50, and failures on BOTH `main` and a feature branch above it.
 ///
-/// So the fixtures set the budget explicitly instead of inheriting the
-/// production one. It is generous but still bounded, so a delegate test that
+/// So `setup_runtime` sets the budget explicitly instead of inheriting the
+/// production one. NOT a completed sweep: `setup_v2_runtime_with_contract`,
+/// `setup_runtime_with_params`, `bare_runtime` and the tests that build a
+/// `Runtime` inline still inherit the production 5.0 s. They are not known to
+/// flake on it, and widening this to every delegate fixture is a larger change
+/// than the one flake in hand justified, so it was left deliberately rather
+/// than overlooked. Point them here if the same timeout shows up in them. It is generous but still bounded, so a delegate test that
 /// genuinely wedges fails rather than hanging forever. The tests that DO assert
 /// timeout behaviour live in `wasm_runtime::tests::execution_handling` and set
 /// their own budgets, so nothing here weakens that coverage.

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -37,6 +37,7 @@ mod delegate2_messages {
         RemoveSecret(Vec<u8>),
         WriteLargeContext(usize),
         StoreLargeSecret { key: Vec<u8>, size: usize },
+        ReadWriteRead { key: Vec<u8>, value: Vec<u8> },
     }
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -2122,6 +2123,115 @@ async fn test_large_context_within_batch() -> Result<(), Box<dyn std::error::Err
 /// `refresh_mem_addr_from_caller`, the subsequent read uses a stale pointer
 /// and returns garbage data. Under full parallel test suite runs (~1600 tests)
 /// the relocation is more likely due to memory pressure.
+/// A write must invalidate the host's per-`process()` secret memo, observed
+/// through a real WASM guest rather than asserted about the source.
+///
+/// `get_secret_len` + `get_secret` both decrypt, so the host memoises the
+/// plaintext for the duration of one `process()` call. `set_secret` and
+/// `remove_secret` therefore have to clear it, or a read after a write in the
+/// same call is served the PRE-WRITE bytes.
+///
+/// This replaces a source-scrape pin that asserted both host functions
+/// contained `invalidate_secret_memo()`. That pin was defeatable by prose: the
+/// mutation review deleted both real calls, left the string in a trailing `//`
+/// comment, and the whole suite stayed green — the comment filter only
+/// stripped lines that BEGIN with `//`, not comment tails. Worse, deleting
+/// both calls killed exactly one test, the pin itself, so a string in a
+/// comment was the entire protection for the invariant.
+///
+/// Nothing reached these call sites behaviourally before, and the reason is
+/// narrow enough to be worth recording: `exec_inbound_with_env` builds one
+/// `DelegateCallEnv` per inbound message, so batching two messages gives two
+/// memos and cannot observe a stale one. The read, the write and the re-read
+/// all have to happen inside a single `process()`, which needs a guest
+/// handler — hence `ReadWriteRead` in `tests/test-delegate-2`.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_write_invalidates_the_secret_memo_within_one_process_call()
+-> Result<(), Box<dyn std::error::Error>> {
+    use delegate2_messages::{InboundAppMessage, OutboundAppMessage};
+
+    let (delegate, mut runtime, _temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+    let key = b"memo-invalidation".to_vec();
+
+    let send = |runtime: &mut Runtime,
+                msg: &InboundAppMessage|
+     -> Result<OutboundAppMessage, Box<dyn std::error::Error>> {
+        let payload = bincode::serialize(msg)?;
+        let outbound = runtime.inbound_app_message(
+            delegate.key(),
+            &vec![].into(),
+            None,
+            None,
+            vec![InboundDelegateMsg::ApplicationMessage(
+                ApplicationMessage::new(payload),
+            )],
+        )?;
+        match &outbound[0] {
+            OutboundDelegateMsg::ApplicationMessage(m) => Ok(bincode::deserialize(&m.payload)?),
+            other @ OutboundDelegateMsg::RequestUserInput(_)
+            | other @ OutboundDelegateMsg::ContextUpdated(_)
+            | other @ OutboundDelegateMsg::GetContractRequest(_)
+            | other @ OutboundDelegateMsg::PutContractRequest(_)
+            | other @ OutboundDelegateMsg::UpdateContractRequest(_)
+            | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+            | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
+                panic!("Expected ApplicationMessage, got {other:?}")
+            }
+        }
+    };
+
+    // Seed the key in an EARLIER call, so the read-write-read call below finds
+    // something to memoise on its first read.
+    let stored = send(
+        &mut runtime,
+        &InboundAppMessage::StoreSecret {
+            key: key.clone(),
+            value: b"before".to_vec(),
+        },
+    )?;
+    assert!(
+        matches!(stored, OutboundAppMessage::SecretStored),
+        "seeding the secret must succeed, got {stored:?}"
+    );
+
+    // One process() call: read (populates the memo), write, read again.
+    let observed = send(
+        &mut runtime,
+        &InboundAppMessage::ReadWriteRead {
+            key: key.clone(),
+            value: b"after".to_vec(),
+        },
+    )?;
+
+    match observed {
+        OutboundAppMessage::SecretResult(Some(bytes)) => assert_eq!(
+            bytes,
+            b"after".to_vec(),
+            "the read AFTER the write must see the written bytes. Reading \
+             `before` means set_secret did not invalidate the per-process() \
+             secret memo, so the guest was served the pre-write plaintext"
+        ),
+        other @ OutboundAppMessage::SecretResult(None)
+        | other @ OutboundAppMessage::CreateInboxResponse(_)
+        | other @ OutboundAppMessage::MessageSigned(_)
+        | other @ OutboundAppMessage::ContextData(_)
+        | other @ OutboundAppMessage::CounterValue(_)
+        | other @ OutboundAppMessage::SecretExists(_)
+        | other @ OutboundAppMessage::ContextWritten
+        | other @ OutboundAppMessage::ContextCleared
+        | other @ OutboundAppMessage::SecretStored
+        | other @ OutboundAppMessage::SecretRemoved
+        | other @ OutboundAppMessage::LargeContextWritten(_)
+        | other @ OutboundAppMessage::LargeSecretStored(_)
+        | other @ OutboundAppMessage::SecretStoreFailed => panic!(
+            "expected SecretResult(Some(..)) from the post-write read, got {other:?}. \
+             SecretResult(None) means the write or the re-read failed outright"
+        ),
+    }
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_large_secret_data() -> Result<(), Box<dyn std::error::Error>> {
     use delegate2_messages::{InboundAppMessage, OutboundAppMessage};

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -2867,24 +2867,85 @@ mod secret_read_memo_tests {
     /// call would leave a `set_secret` followed by a `get_secret` inside ONE
     /// `process()` serving the pre-write plaintext, silently, with every other
     /// test still green.
+    /// Every item in `delegate_secrets` is indented four spaces, so a
+    /// function's region ends at the next sibling at THAT indentation —
+    /// whatever its visibility.
+    ///
+    /// Bounding on `pub(crate) fn` alone silently swallows any private helper
+    /// that follows. `remove_secret` is succeeded by the private
+    /// `collect_list_secrets`, so a `pub(crate)`-only boundary ran ~50 lines
+    /// past the end of `remove_secret` and scraped a function this test says
+    /// nothing about: a needle anywhere in that overrun satisfied the
+    /// assertion. It looked sound only because `set_secret`'s successor
+    /// (`has_secret`) happens to be `pub(crate)`.
+    const ITEM_STARTS: [&str; 4] = [
+        "\n    fn ",
+        "\n    pub fn ",
+        "\n    pub(crate) fn ",
+        "\n    pub(super) fn ",
+    ];
+
+    /// The source region of `name`, comments removed.
+    ///
+    /// Comments are stripped because the successor's doc comment falls inside
+    /// the region (its `///` lines precede its `fn` line), so prose merely
+    /// MENTIONING the call would satisfy a raw `contains`. The pin is about
+    /// code.
+    fn scraped_body(src: &str, name: &str) -> String {
+        let start = src
+            .find(&format!("pub(crate) fn {name}("))
+            .unwrap_or_else(|| panic!("{name} not found in native_api.rs"));
+        let after = &src[start..];
+        // `expect`, not `unwrap_or(len())`: both functions checked here have a
+        // following sibling, so "no boundary found" means the search itself is
+        // broken and the region has widened to end-of-file. Fail loudly rather
+        // than quietly scraping the rest of the module and passing.
+        let end = ITEM_STARTS
+            .iter()
+            .filter_map(|marker| after[1..].find(marker).map(|i| i + 1))
+            .min()
+            .unwrap_or_else(|| {
+                panic!("no sibling item found after {name}; region-bounding is broken")
+            });
+        after[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn mutating_secret_host_fns_invalidate_the_memo() {
         let src = include_str!("native_api.rs");
         for name in ["set_secret", "remove_secret"] {
-            let start = src
-                .find(&format!("pub(crate) fn {name}("))
-                .unwrap_or_else(|| panic!("{name} not found in native_api.rs"));
-            let after = &src[start..];
-            let end = after[1..]
-                .find("\n    pub(crate) fn ")
-                .map(|i| i + 1)
-                .unwrap_or(after.len());
+            let body = scraped_body(src, name);
             assert!(
-                after[..end].contains("invalidate_secret_memo()"),
+                body.contains("invalidate_secret_memo()"),
                 "{name} must call invalidate_secret_memo(): without it a write \
                  followed by a read in the same process() call serves stale \
                  plaintext from the memo"
             );
         }
+    }
+
+    /// The pin above is only as good as its region-bounding, so bound the
+    /// bound: `remove_secret`'s region must stop before the private helper
+    /// that follows it. Without this, a future edit that reintroduces a
+    /// visibility-only boundary would silently widen the window again and the
+    /// pin would keep passing.
+    #[test]
+    fn the_scraped_region_stops_at_the_next_item_whatever_its_visibility() {
+        let src = include_str!("native_api.rs");
+        let body = scraped_body(src, "remove_secret");
+        assert!(
+            body.contains("fn remove_secret("),
+            "the region must actually contain remove_secret"
+        );
+        assert!(
+            !body.contains("fn collect_list_secrets("),
+            "remove_secret's region must stop at the PRIVATE `collect_list_secrets` \
+             that follows it; if it does not, the pin is asserting over a function \
+             it says nothing about"
+        );
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -477,7 +477,22 @@ pub(super) struct DelegateCallEnv {
     /// mutability explicit rather than hiding it behind `#[allow(clippy::mut_from_ref)]`.
     secret_store: std::cell::UnsafeCell<*mut SecretsStore>,
     /// The delegate key, needed to scope secret access.
-    pub delegate_key: DelegateKey,
+    ///
+    /// PRIVATE, AND MUST STAY THAT WAY, and must never be reassigned after
+    /// [`DelegateCallEnv::new`]. The storage read binds this identity TWICE:
+    /// once in the file path (`secrets_store::store::scope_dir`) and once in
+    /// the DEK the blob is authenticated under (HKDF salted with
+    /// `delegate.encode()`). A [`secret_read_memo`](Self::secret_read_memo)
+    /// HIT binds it ZERO times — it is a 32-byte hash comparison and a return.
+    ///
+    /// So before the memo existed, reassigning this mid-call self-corrected:
+    /// you got the wrong path, or a Poly1305 tag that would not verify. The
+    /// AEAD was the backstop. With the memo, the same edit silently returns the
+    /// PREVIOUS identity's plaintext — in hosted mode, cross-tenant
+    /// disclosure. Nothing does this today; the point is that nothing can start
+    /// to without tripping
+    /// `the_call_env_identity_fields_are_never_reassigned`.
+    delegate_key: DelegateKey,
     /// Optional per-user secret namespace for this call, derived ONCE at the
     /// WS connection boundary from the connection's user token (hosted mode,
     /// P2 of #4381). When `Some`, the secret host functions
@@ -490,6 +505,12 @@ pub(super) struct DelegateCallEnv {
     /// the runtime from the connection context and is NEVER settable from
     /// inside the WASM sandbox, a delegate message, or any request body — that
     /// is the unforgeability invariant of the per-user namespace.
+    ///
+    /// Like [`delegate_key`](Self::delegate_key), this must never be reassigned
+    /// after construction: [`secret_read_memo`](Self::secret_read_memo) is keyed
+    /// on the secret hash ALONE, which is only sound because the scope this
+    /// field selects is fixed for the whole call. Pinned by
+    /// `the_call_env_identity_fields_are_never_reassigned`.
     user_context: Option<UserSecretContext>,
     /// Read-only pointer to the ContractStore for index lookups
     /// (ContractInstanceId → CodeHash). Valid only during synchronous process().
@@ -547,16 +568,54 @@ pub(super) struct DelegateCallEnv {
     /// [`DelegateCallEnv::invalidate_secret_memo`]), so a stale plaintext is
     /// never served.
     ///
-    /// One deliberate semantic change beyond the saved work: `has_secret` now
-    /// RETAINS the plaintext it decrypted for the rest of the call, where
-    /// before it dropped (and zeroized) it on return. That is a change in how
-    /// long secret material is resident, not only in how often it is
-    /// decrypted, so it is called out rather than folded into "fewer
-    /// decrypts". It is bounded by the same `process()` call, holds at most one
-    /// secret, and is the same material `get_secret` would hold a moment later
-    /// in the overwhelmingly common `has_secret`-then-`get_secret` pair — but a
-    /// delegate that probes existence and never reads keeps a plaintext in
-    /// memory that it previously did not.
+    /// # Residency: `has_secret` now retains a plaintext, deliberately
+    ///
+    /// `has_secret` answers one bit but decrypts in full (it always did). It
+    /// now KEEPS that plaintext for the rest of the call, where before it was
+    /// dropped and zeroized on return. This is a change in how long secret
+    /// material is resident, not only in how often it is decrypted, and it is a
+    /// stated tradeoff rather than an oversight:
+    ///
+    /// * **The delegate gains nothing.** It could call `get_secret` instead and
+    ///   get the real bytes into its own linear memory — larger, longer-lived,
+    ///   and not wiped by us. No privilege is added.
+    /// * **The exposure that moves is the HOST's.** A one-bit existence query
+    ///   now makes a full plaintext resident in node memory, which matters to a
+    ///   core dump, a swapped page, or a memory-disclosure bug elsewhere in the
+    ///   process.
+    /// * **It cannot be avoided for free.** stdlib's `get_secret` is
+    ///   `get_secret_len` -> `vec![0u8; len]` -> `get_secret` and never calls
+    ///   `has_secret`, so the three-decrypt case only arises when an author
+    ///   hand-writes `if ctx.has_secret(k) { ctx.get_secret(k) }` — and there
+    ///   `has_secret` IS the miss that populates the memo. Not populating on a
+    ///   miss would destroy exactly that 3 -> 1 saving, leaving 2 -> 1.
+    ///
+    /// The window is one `process()` call. That is NOMINALLY bounded by
+    /// `max_execution_seconds` (5 s), but not hard-bounded: the epoch trap
+    /// cannot fire inside a host call, so host time is not preemptible — see
+    /// freenet-core#5594, which documents exactly that.
+    ///
+    /// # What is and is not wiped
+    ///
+    /// The PLAINTEXT half is wiped: `Zeroizing<Vec<u8>>`'s drop covers the
+    /// initialized elements and `spare_capacity_mut()`, so even a truncated
+    /// AEAD tag tail in the spare capacity is cleared, and the value is MOVED
+    /// into the memo (no clone, no re-wrap), so exactly one copy exists at any
+    /// time.
+    ///
+    /// The `[u8; 32]` hash half is NOT wiped — it has no `Drop` and stays in
+    /// freed memory. That is correct rather than an omission: it is the
+    /// secret's identifier, already on disk in the clear as the bs58 filename
+    /// and enumerable through `list_secrets`. Do not describe the tuple as
+    /// "zeroized"; the plaintext is.
+    ///
+    /// The wipe-on-drop guarantee assumes panics UNWIND. `DelegateEnvGuard`
+    /// (and this field's own drop) run on the unwind path; with
+    /// `panic = "abort"` — commented out in the workspace `Cargo.toml`, but one
+    /// uncomment away — a panic would leave the plaintext unwiped in a dying
+    /// process. Noted because it is true today and would become silently false
+    /// after an unrelated release-profile change.
+    ///
     secret_read_memo: std::cell::RefCell<SecretReadMemo>,
 }
 
@@ -693,20 +752,28 @@ impl DelegateCallEnv {
     /// plaintext that already passed the Poly1305 tag check.
     ///
     /// The memo is keyed on the secret's 32-byte hash, which is what names the
-    /// on-disk file, so two different keys can never share an entry. The scope
-    /// needs no key: it is fixed for the lifetime of the `DelegateCallEnv`.
+    /// on-disk file, so two different keys can never share an entry. Neither
+    /// the delegate identity nor the scope is part of the key, and that is only
+    /// sound because BOTH are fixed for the lifetime of the
+    /// `DelegateCallEnv` — see the invariant on
+    /// [`delegate_key`](Self::delegate_key). A hit therefore performs no
+    /// identity check at all, where the storage read it replaces performs two
+    /// (path and DEK). That is the property this memo removes, and the
+    /// immutability of those two fields is what puts it back.
     fn with_secret<R>(
         &self,
         secret_id: &SecretsId,
         f: impl FnOnce(&[u8]) -> R,
     ) -> Result<R, SecretStoreError> {
         {
-            // The read borrow is held across `f`. `f` is always a local
-            // closure that copies bytes out and never re-enters the env, so
-            // this cannot conflict today. If a future caller passed an `f` that
-            // touched the memo, `RefCell` would panic — and a panic here
-            // unwinds out of a wasmtime host call, which is a worse failure
-            // than the borrow it is protecting. Keep `f` non-re-entrant.
+            // The read borrow is held across `f` on THIS path but not on the
+            // miss path below, where `f` runs with no borrow outstanding. That
+            // asymmetry is the hazard: an `f` that touched the memo would
+            // succeed on the first (miss) call and panic on the second (hit),
+            // which is nastier to diagnose than a uniform panic. `f` is always
+            // a local closure that copies bytes out and never re-enters, and a
+            // borrow panic here would unwind out of a wasmtime host call —
+            // worse than the borrow it protects. Keep `f` non-re-entrant.
             let memo = self.secret_read_memo.borrow();
             if let Some((hash, plaintext)) = memo.as_ref()
                 && hash == secret_id.hash()
@@ -2884,6 +2951,30 @@ mod secret_read_memo_tests {
     /// call would leave a `set_secret` followed by a `get_secret` inside ONE
     /// `process()` serving the pre-write plaintext, silently, with every other
     /// test still green.
+    /// The `delegate_secrets` module body, so discovery cannot stray into
+    /// another module's host functions.
+    fn delegate_secrets_module(src: &str) -> &str {
+        let start = src
+            .find("pub(super) mod delegate_secrets {")
+            .expect("delegate_secrets module not found");
+        let after = &src[start..];
+        let end = after
+            .find("\n}")
+            .expect("delegate_secrets module has no closing brace");
+        &after[..end]
+    }
+
+    /// Names of the `pub(crate) fn` host functions declared in `module`.
+    fn host_fn_names(module: &str) -> Vec<&str> {
+        module
+            .match_indices("    pub(crate) fn ")
+            .filter_map(|(i, m)| {
+                let rest = &module[i + m.len()..];
+                rest.find('(').map(|p| &rest[..p])
+            })
+            .collect()
+    }
+
     /// The source region of `name`: from its signature to its own closing
     /// brace, comments removed.
     ///
@@ -2919,18 +3010,77 @@ mod secret_read_memo_tests {
             .join("\n")
     }
 
+    /// Every host function in `delegate_secrets` that can change what a read
+    /// returns must drop the memo first.
+    ///
+    /// Derived from the code, NOT from a hard-coded name list: the set is
+    /// "functions whose body calls `secret_store_mut()`". A name list is green
+    /// by default for any NEW mutating host function, which is the same
+    /// silent-omission shape the pin exists to prevent. This way a new mutator
+    /// is failing by default until it invalidates.
     #[test]
     fn mutating_secret_host_fns_invalidate_the_memo() {
         let src = include_str!("native_api.rs");
-        for name in ["set_secret", "remove_secret"] {
-            let body = scraped_body(src, name);
+        let module = delegate_secrets_module(src);
+        let mutators: Vec<&str> = host_fn_names(module)
+            .into_iter()
+            .filter(|name| scraped_body(src, name).contains("secret_store_mut()"))
+            .collect();
+        assert!(
+            mutators.len() >= 2,
+            "expected at least set_secret and remove_secret to mutate the secret \
+             store; found {mutators:?} — if this is now empty the discovery is \
+             broken and every assertion below is vacuous"
+        );
+        for name in mutators {
             assert!(
-                body.contains("invalidate_secret_memo()"),
-                "{name} must call invalidate_secret_memo(): without it a write \
-                 followed by a read in the same process() call serves stale \
-                 plaintext from the memo"
+                scraped_body(src, name).contains("invalidate_secret_memo()"),
+                "{name} calls secret_store_mut(), so it can change what a read \
+                 returns, so it must call invalidate_secret_memo() first: \
+                 without it a write followed by a read in the same process() \
+                 call serves stale plaintext from the memo"
             );
         }
+    }
+
+    /// M1: the memo's key omits the delegate identity and the scope, which is
+    /// sound ONLY because both are fixed after construction.
+    ///
+    /// The storage read this memo replaces binds the delegate identity twice —
+    /// in the file path and in the DEK the blob is authenticated under. A memo
+    /// hit binds it zero times. So reassigning `delegate_key` mid-call, which
+    /// before this memo self-corrected via a failed AEAD tag, would now
+    /// silently return the previous identity's plaintext.
+    ///
+    /// The field is private, which stops any other module. This stops
+    /// `native_api` itself — `context_write` already takes a
+    /// `&mut DelegateCallEnv` out of `DELEGATE_ENV`, so the mutation path
+    /// exists in this file today and only convention keeps it off these two
+    /// fields.
+    #[test]
+    fn the_call_env_identity_fields_are_never_reassigned() {
+        let src = include_str!("native_api.rs");
+        for field in ["delegate_key", "user_context"] {
+            let needle = format!(".{field} =");
+            assert!(
+                !src.contains(&needle),
+                "`{needle}` appears in native_api.rs. These two fields fix the \
+                 delegate identity and the secret scope for the whole call, and \
+                 secret_read_memo is keyed on the secret hash ALONE on that \
+                 basis. Reassigning either leaves a memo entry belonging to the \
+                 previous identity — cross-tenant disclosure in hosted mode. If \
+                 you genuinely need to rebuild the identity, build a NEW \
+                 DelegateCallEnv, which starts with an empty memo"
+            );
+        }
+        // Non-vacuous: the same search must FIND the assignment form it is
+        // looking for, on a field where it is legitimate.
+        assert!(
+            src.contains("env.context = "),
+            "the `.field =` search form must be able to match at all; \
+             `context_write` assigns `env.context`, so if this fails the search \
+             is broken and the assertions above prove nothing"
+        );
     }
 
     /// The pin above is only as good as its region-bounding, so bound the

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -23,6 +23,11 @@ use crate::contract::storages::Storage;
 pub(super) static MEM_ADDR: LazyLock<DashMap<InstanceId, InstanceInfo>> =
     LazyLock::new(DashMap::default);
 
+/// One memoised secret read: the secret's 32-byte hash (the value that names
+/// its on-disk file) paired with the plaintext that hash decrypted to. See
+/// [`DelegateCallEnv::secret_read_memo`].
+type SecretReadMemo = Option<([u8; 32], zeroize::Zeroizing<Vec<u8>>)>;
+
 /// Per-instance delegate call environment.
 ///
 /// The runtime populates this before calling the delegate's `process` function.
@@ -541,7 +546,7 @@ pub(super) struct DelegateCallEnv {
     /// Every host function that can CHANGE what a read returns clears this (see
     /// [`DelegateCallEnv::invalidate_secret_memo`]), so a stale plaintext is
     /// never served.
-    secret_read_memo: std::cell::RefCell<Option<([u8; 32], zeroize::Zeroizing<Vec<u8>>)>>,
+    secret_read_memo: std::cell::RefCell<SecretReadMemo>,
 }
 
 // SAFETY: DelegateCallEnv is only inserted into DELEGATE_ENV immediately before

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -546,6 +546,17 @@ pub(super) struct DelegateCallEnv {
     /// Every host function that can CHANGE what a read returns clears this (see
     /// [`DelegateCallEnv::invalidate_secret_memo`]), so a stale plaintext is
     /// never served.
+    ///
+    /// One deliberate semantic change beyond the saved work: `has_secret` now
+    /// RETAINS the plaintext it decrypted for the rest of the call, where
+    /// before it dropped (and zeroized) it on return. That is a change in how
+    /// long secret material is resident, not only in how often it is
+    /// decrypted, so it is called out rather than folded into "fewer
+    /// decrypts". It is bounded by the same `process()` call, holds at most one
+    /// secret, and is the same material `get_secret` would hold a moment later
+    /// in the overwhelmingly common `has_secret`-then-`get_secret` pair — but a
+    /// delegate that probes existence and never reads keeps a plaintext in
+    /// memory that it previously did not.
     secret_read_memo: std::cell::RefCell<SecretReadMemo>,
 }
 
@@ -690,6 +701,12 @@ impl DelegateCallEnv {
         f: impl FnOnce(&[u8]) -> R,
     ) -> Result<R, SecretStoreError> {
         {
+            // The read borrow is held across `f`. `f` is always a local
+            // closure that copies bytes out and never re-enters the env, so
+            // this cannot conflict today. If a future caller passed an `f` that
+            // touched the memo, `RefCell` would panic — and a panic here
+            // unwinds out of a wasmtime host call, which is a worse failure
+            // than the borrow it is protecting. Keep `f` non-re-entrant.
             let memo = self.secret_read_memo.borrow();
             if let Some((hash, plaintext)) = memo.as_ref()
                 && hash == secret_id.hash()
@@ -2867,46 +2884,34 @@ mod secret_read_memo_tests {
     /// call would leave a `set_secret` followed by a `get_secret` inside ONE
     /// `process()` serving the pre-write plaintext, silently, with every other
     /// test still green.
-    /// Every item in `delegate_secrets` is indented four spaces, so a
-    /// function's region ends at the next sibling at THAT indentation —
-    /// whatever its visibility.
+    /// The source region of `name`: from its signature to its own closing
+    /// brace, comments removed.
     ///
-    /// Bounding on `pub(crate) fn` alone silently swallows any private helper
-    /// that follows. `remove_secret` is succeeded by the private
-    /// `collect_list_secrets`, so a `pub(crate)`-only boundary ran ~50 lines
-    /// past the end of `remove_secret` and scraped a function this test says
-    /// nothing about: a needle anywhere in that overrun satisfied the
-    /// assertion. It looked sound only because `set_secret`'s successor
-    /// (`has_secret`) happens to be `pub(crate)`.
-    const ITEM_STARTS: [&str; 4] = [
-        "\n    fn ",
-        "\n    pub fn ",
-        "\n    pub(crate) fn ",
-        "\n    pub(super) fn ",
-    ];
-
-    /// The source region of `name`, comments removed.
+    /// Bounded by the function's OWN closing brace — the first line that is
+    /// exactly `    }` — rather than by guessing what item comes next. An
+    /// earlier version searched for the next `pub(crate) fn` and so ran ~50
+    /// lines past `remove_secret` into the private `collect_list_secrets` that
+    /// follows it, scraping a function this test says nothing about; a needle
+    /// anywhere in that overrun satisfied the assertion. Enumerating more item
+    /// kinds would only move the gap (`async fn`, `const fn`, a `type` alias,
+    /// or no following item at all would each reopen it). The closing brace is
+    /// immune to whatever follows, because it belongs to the function itself.
     ///
-    /// Comments are stripped because the successor's doc comment falls inside
-    /// the region (its `///` lines precede its `fn` line), so prose merely
-    /// MENTIONING the call would satisfy a raw `contains`. The pin is about
-    /// code.
+    /// Comments are stripped so prose merely MENTIONING the call cannot
+    /// satisfy a `contains`. The brace bound already excludes the successor's
+    /// doc comment, so this is defence in depth rather than the primary guard.
     fn scraped_body(src: &str, name: &str) -> String {
         let start = src
             .find(&format!("pub(crate) fn {name}("))
             .unwrap_or_else(|| panic!("{name} not found in native_api.rs"));
         let after = &src[start..];
-        // `expect`, not `unwrap_or(len())`: both functions checked here have a
-        // following sibling, so "no boundary found" means the search itself is
-        // broken and the region has widened to end-of-file. Fail loudly rather
-        // than quietly scraping the rest of the module and passing.
-        let end = ITEM_STARTS
-            .iter()
-            .filter_map(|marker| after[1..].find(marker).map(|i| i + 1))
-            .min()
-            .unwrap_or_else(|| {
-                panic!("no sibling item found after {name}; region-bounding is broken")
-            });
+        // `expect`, not `unwrap_or(len())`: every function here has a closing
+        // brace, so "not found" means the search is broken and the region has
+        // widened to end-of-file. Fail loudly rather than scraping the rest of
+        // the module and passing.
+        let end = after.find("\n    }").unwrap_or_else(|| {
+            panic!("no closing brace found for {name}; region-bounding is broken")
+        });
         after[..end]
             .lines()
             .filter(|line| !line.trim_start().starts_with("//"))
@@ -2929,23 +2934,40 @@ mod secret_read_memo_tests {
     }
 
     /// The pin above is only as good as its region-bounding, so bound the
-    /// bound: `remove_secret`'s region must stop before the private helper
-    /// that follows it. Without this, a future edit that reintroduces a
-    /// visibility-only boundary would silently widen the window again and the
-    /// pin would keep passing.
+    /// bound.
+    ///
+    /// Note the first assertion, which is the whole point: an
+    /// absence check must also assert the thing is PRESENT to be absent from,
+    /// or it passes when the thing simply vanishes. Rename or delete
+    /// `collect_list_secrets` and, without that line, this guard would go on
+    /// passing for the wrong reason while a later regression in
+    /// `scraped_body` silently re-widened the window.
     #[test]
-    fn the_scraped_region_stops_at_the_next_item_whatever_its_visibility() {
+    fn the_scraped_region_stops_at_the_end_of_the_function() {
         let src = include_str!("native_api.rs");
+        assert!(
+            src.contains("fn collect_list_secrets("),
+            "this guard is written around `collect_list_secrets` being the \
+             private item that follows `remove_secret`. If it has been renamed \
+             or removed, re-point the guard at whatever now follows — do NOT \
+             delete it, or the absence check below becomes vacuous"
+        );
+
         let body = scraped_body(src, "remove_secret");
         assert!(
             body.contains("fn remove_secret("),
             "the region must actually contain remove_secret"
         );
         assert!(
+            body.trim_end().ends_with('}'),
+            "the region must end at remove_secret's own closing brace, not run \
+             on to end-of-file"
+        );
+        assert!(
             !body.contains("fn collect_list_secrets("),
-            "remove_secret's region must stop at the PRIVATE `collect_list_secrets` \
-             that follows it; if it does not, the pin is asserting over a function \
-             it says nothing about"
+            "remove_secret's region must stop before the PRIVATE \
+             `collect_list_secrets` that follows it; if it does not, the pin is \
+             asserting over a function it says nothing about"
         );
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use super::contract_store::ContractStore;
 use super::delegate_store::DelegateStore;
 use super::runtime::InstanceInfo;
-use super::secrets_store::{SecretScope, SecretsStore, UserSecretContext};
+use super::secrets_store::{SecretScope, SecretStoreError, SecretsStore, UserSecretContext};
 use crate::contract::storages::Storage;
 
 /// This is a map of starting addresses of the instance memory space.
@@ -523,6 +523,25 @@ pub(super) struct DelegateCallEnv {
     /// creation extends when the parent has origins. See
     /// [`SharedInheritedOrigins`].
     inherited_origins: SharedInheritedOrigins,
+    /// Memo of the most recently read secret for THIS call: `(hash, plaintext)`.
+    ///
+    /// `DelegateContext::get_secret` in freenet-stdlib is a TWO-call protocol —
+    /// `get_secret_len` to size the guest buffer, then `get_secret` to fill it —
+    /// and each host call independently re-read the file and re-ran the whole
+    /// XChaCha20-Poly1305 decrypt. Every delegate secret read therefore cost two
+    /// file reads and two full AEAD passes over the plaintext to deliver one
+    /// value, which for a large secret is the dominant cost of the call.
+    ///
+    /// The memo is per-`DelegateCallEnv`, and a `DelegateCallEnv` is built
+    /// immediately before one synchronous `process()` call and dropped
+    /// immediately after (see the SAFETY note below), so a plaintext never
+    /// outlives the call that read it. `Zeroizing` wipes it on drop, exactly as
+    /// the un-memoized `get_secret` result was wiped.
+    ///
+    /// Every host function that can CHANGE what a read returns clears this (see
+    /// [`DelegateCallEnv::invalidate_secret_memo`]), so a stale plaintext is
+    /// never served.
+    secret_read_memo: std::cell::RefCell<Option<([u8; 32], zeroize::Zeroizing<Vec<u8>>)>>,
 }
 
 // SAFETY: DelegateCallEnv is only inserted into DELEGATE_ENV immediately before
@@ -608,6 +627,7 @@ impl DelegateCallEnv {
             origin_contracts,
             created_delegates_count,
             inherited_origins,
+            secret_read_memo: std::cell::RefCell::new(None),
         }
     }
 
@@ -643,6 +663,53 @@ impl DelegateCallEnv {
         // SAFETY: guaranteed by the caller of `new()` and the synchronous WASM execution model.
         // The Runtime holds &mut self when calling process(), ensuring exclusive access.
         unsafe { &mut **self.secret_store.get() }
+    }
+
+    /// Read `secret_id` under this call's scope and hand the plaintext to `f`,
+    /// serving a repeat read of the SAME secret from [`Self::secret_read_memo`]
+    /// instead of re-reading and re-decrypting it.
+    ///
+    /// This exists for the stdlib's `get_secret_len`-then-`get_secret` pair: the
+    /// first call populates the memo, the second is served from it, so one
+    /// logical read costs one file read and one AEAD pass rather than two. The
+    /// decrypt is still performed exactly once per distinct secret per call, so
+    /// nothing unauthenticated is ever handed to the guest — the memo holds only
+    /// plaintext that already passed the Poly1305 tag check.
+    ///
+    /// The memo is keyed on the secret's 32-byte hash, which is what names the
+    /// on-disk file, so two different keys can never share an entry. The scope
+    /// needs no key: it is fixed for the lifetime of the `DelegateCallEnv`.
+    fn with_secret<R>(
+        &self,
+        secret_id: &SecretsId,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, SecretStoreError> {
+        {
+            let memo = self.secret_read_memo.borrow();
+            if let Some((hash, plaintext)) = memo.as_ref()
+                && hash == secret_id.hash()
+            {
+                return Ok(f(plaintext));
+            }
+        }
+        let plaintext =
+            self.secret_store()
+                .get_secret(&self.delegate_key, secret_id, self.secret_scope())?;
+        let out = f(&plaintext);
+        *self.secret_read_memo.borrow_mut() = Some((*secret_id.hash(), plaintext));
+        Ok(out)
+    }
+
+    /// Drop the read memo.
+    ///
+    /// Called by every host function that can change what a read of ANY secret
+    /// returns — a write, a removal — rather than only the matching key, so a
+    /// future mutation that affects more than one key cannot silently leave a
+    /// stale entry behind. Clearing is unconditional (even on a failed store):
+    /// after a failed write the on-disk state is not something we want to
+    /// re-assert from a cached copy.
+    fn invalidate_secret_memo(&self) {
+        self.secret_read_memo.borrow_mut().take();
     }
 
     /// Access the contract store for index lookups.
@@ -1508,12 +1575,12 @@ pub(super) mod delegate_secrets {
         // `User` when this call runs under a hosted-mode user token (P2 of
         // #4381). The scope comes solely from the connection-derived
         // `user_context`, never from anything the delegate can influence.
-        match env
-            .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
-        {
-            Ok(plaintext) => {
-                let len = plaintext.len();
+        //
+        // Goes through `with_secret` so the `get_secret` that the stdlib issues
+        // straight after this one is served from the memo rather than repeating
+        // the read and the decrypt.
+        match env.with_secret(&secret_id, |plaintext| plaintext.len()) {
+            Ok(len) => {
                 if len > i32::MAX as usize {
                     // Secret is larger than i32::MAX, return max representable
                     i32::MAX
@@ -1579,54 +1646,49 @@ pub(super) mod delegate_secrets {
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
         // Look up the secret (scope per the connection's user_context; see
-        // get_secret_len).
-        match env
-            .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
-        {
-            Ok(plaintext) => {
-                let secret_len = plaintext.len();
-                let out_len_usize = out_len as usize;
+        // get_secret_len). Normally a memo hit: the stdlib's `get_secret_len`
+        // ran moments ago on this same key.
+        match env.with_secret(&secret_id, |plaintext| {
+            let secret_len = plaintext.len();
+            let out_len_usize = out_len as usize;
 
-                // Check if buffer is large enough
-                if secret_len > out_len_usize {
-                    tracing::debug!(
-                        "delegate get_secret buffer too small: need {secret_len}, have {out_len_usize}"
-                    );
-                    return error_codes::ERR_BUFFER_TOO_SMALL;
-                }
-
-                if secret_len == 0 {
-                    return 0;
-                }
-
-                let Some(dst) = validate_and_compute_ptr::<u8>(
-                    out_ptr,
-                    info.start_ptr,
-                    secret_len,
-                    info.mem_size,
-                ) else {
-                    tracing::error!("Memory bounds violation in delegate get_secret (output)");
-                    return error_codes::ERR_MEMORY_BOUNDS;
-                };
-                // SAFETY: `dst` was validated by `validate_and_compute_ptr` to point to
-                // `secret_len` bytes within WASM linear memory, and `plaintext` is a
-                // valid byte slice of that length.
-                //
-                // Memory hygiene boundary: the host-side `plaintext` is
-                // `Zeroizing<Vec<u8>>` so its allocation is wiped when
-                // this function returns. The copy destination — WASM
-                // linear memory inside the delegate instance — is NOT
-                // wiped by us; the delegate is responsible for zeroing
-                // its own buffer when done. The corresponding stdlib-
-                // side `Zeroize` derive is tracked under #4137 and will
-                // ship in a follow-up once a freenet-stdlib release is
-                // cut for it (stdlib-first release policy).
-                unsafe {
-                    std::ptr::copy_nonoverlapping(plaintext.as_ptr(), dst, secret_len);
-                }
-                secret_len as i32
+            // Check if buffer is large enough
+            if secret_len > out_len_usize {
+                tracing::debug!(
+                    "delegate get_secret buffer too small: need {secret_len}, have {out_len_usize}"
+                );
+                return error_codes::ERR_BUFFER_TOO_SMALL;
             }
+
+            if secret_len == 0 {
+                return 0;
+            }
+
+            let Some(dst) =
+                validate_and_compute_ptr::<u8>(out_ptr, info.start_ptr, secret_len, info.mem_size)
+            else {
+                tracing::error!("Memory bounds violation in delegate get_secret (output)");
+                return error_codes::ERR_MEMORY_BOUNDS;
+            };
+            // SAFETY: `dst` was validated by `validate_and_compute_ptr` to point to
+            // `secret_len` bytes within WASM linear memory, and `plaintext` is a
+            // valid byte slice of that length.
+            //
+            // Memory hygiene boundary: the host-side `plaintext` is
+            // `Zeroizing<Vec<u8>>` so its allocation is wiped when
+            // this function returns. The copy destination — WASM
+            // linear memory inside the delegate instance — is NOT
+            // wiped by us; the delegate is responsible for zeroing
+            // its own buffer when done. The corresponding stdlib-
+            // side `Zeroize` derive is tracked under #4137 and will
+            // ship in a follow-up once a freenet-stdlib release is
+            // cut for it (stdlib-first release policy).
+            unsafe {
+                std::ptr::copy_nonoverlapping(plaintext.as_ptr(), dst, secret_len);
+            }
+            secret_len as i32
+        }) {
+            Ok(code) => code,
             Err(e) => {
                 tracing::debug!(
                     delegate = %env.delegate_key,
@@ -1699,6 +1761,9 @@ pub(super) mod delegate_secrets {
         );
 
         let scope = env.secret_scope();
+        // A write changes what a read returns, so the read memo must go before
+        // the store is touched at all.
+        env.invalidate_secret_memo();
         match env
             .secret_store_mut()
             .store_secret(&env.delegate_key, &secret_id, scope, value)
@@ -1751,11 +1816,8 @@ pub(super) mod delegate_secrets {
         let key_bytes = unsafe { std::slice::from_raw_parts(key_src, key_len as usize) };
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
-        match env
-            .secret_store()
-            .get_secret(&env.delegate_key, &secret_id, env.secret_scope())
-        {
-            Ok(_) => 1,
+        match env.with_secret(&secret_id, |_| ()) {
+            Ok(()) => 1,
             Err(e) => {
                 tracing::debug!(
                     delegate = %env.delegate_key,
@@ -1810,6 +1872,8 @@ pub(super) mod delegate_secrets {
         let secret_id = SecretsId::new(key_bytes.to_vec());
 
         let scope = env.secret_scope();
+        // A removal changes what a read returns; drop the memo first.
+        env.invalidate_secret_memo();
         match env
             .secret_store_mut()
             .remove_secret(&env.delegate_key, &secret_id, scope)
@@ -2638,5 +2702,184 @@ mod list_secrets_abi_tests {
                 "negative prefix_len via list_secrets must be ERR_INVALID_PARAM"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod secret_read_memo_tests {
+    //! `DelegateContext::get_secret` in freenet-stdlib is a TWO-call protocol —
+    //! `get_secret_len` to size the guest buffer, then `get_secret` to fill it.
+    //! Each of those host calls used to re-read the file and re-run the whole
+    //! XChaCha20-Poly1305 decrypt, so one logical read of an N-byte secret cost
+    //! two file reads and 2N bytes of AEAD. `DelegateCallEnv::secret_read_memo`
+    //! removes the second pass; these tests pin that it works, and — the part
+    //! that can actually go wrong — that it is invalidated.
+
+    use super::*;
+    use crate::contract::storages::Storage;
+    use crate::util::tests::get_temp_dir;
+    use freenet_stdlib::prelude::CodeHash;
+    use zeroize::Zeroizing;
+
+    /// Real stores on a temp dir, mirroring `delegate_api::tests::TestEnv`.
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        contract_store: ContractStore,
+        delegate_store: DelegateStore,
+        secret_store: SecretsStore,
+    }
+
+    async fn fixture() -> Fixture {
+        let temp = get_temp_dir();
+        let db = Storage::new(temp.path()).await.unwrap();
+        let contract_store =
+            ContractStore::new(temp.path().join("contracts"), 10_000_000, db.clone()).unwrap();
+        let delegate_store =
+            DelegateStore::new(temp.path().join("delegates"), 10_000, db.clone()).unwrap();
+        let secret_store =
+            SecretsStore::new(temp.path().join("secrets"), Default::default(), db).unwrap();
+        Fixture {
+            _temp: temp,
+            contract_store,
+            delegate_store,
+            secret_store,
+        }
+    }
+
+    fn delegate_key() -> DelegateKey {
+        DelegateKey::new([0u8; 32], CodeHash::new([0u8; 32]))
+    }
+
+    /// # Safety
+    /// The returned env points at `f` through raw pointers, so it must be
+    /// dropped before `f` is.
+    unsafe fn env_of(f: &mut Fixture) -> DelegateCallEnv {
+        // SAFETY: forwarded to the caller's obligation above.
+        unsafe {
+            DelegateCallEnv::new(
+                vec![],
+                &mut f.secret_store,
+                &f.contract_store,
+                None,
+                None,
+                None,
+                delegate_key(),
+                &mut f.delegate_store,
+                0,
+                vec![],
+                None,
+                new_delegate_counter(),
+                new_inherited_origins(),
+            )
+        }
+    }
+
+    fn read(env: &DelegateCallEnv, id: &SecretsId) -> Vec<u8> {
+        env.with_secret(id, |plaintext| plaintext.to_vec())
+            .expect("secret must be readable")
+    }
+
+    /// Both halves of the memo: a repeat read is served from it, and
+    /// invalidation drops it. The middle assertion is the load-bearing one — it
+    /// is what makes the `invalidate_secret_memo()` calls in `set_secret` /
+    /// `remove_secret` necessary rather than decorative.
+    #[tokio::test]
+    async fn memo_serves_a_repeat_read_and_invalidation_drops_it() {
+        let mut f = fixture().await;
+        let id = SecretsId::new(b"memo-key".to_vec());
+        // SAFETY: `env` is dropped at the end of this test, before `f`.
+        let env = unsafe { env_of(&mut f) };
+
+        env.secret_store_mut()
+            .store_secret(
+                &delegate_key(),
+                &id,
+                SecretScope::Local,
+                Zeroizing::new(b"v1".to_vec()),
+            )
+            .unwrap();
+        assert_eq!(read(&env, &id), b"v1".to_vec());
+
+        // Change the value underneath the memo, bypassing invalidation.
+        env.secret_store_mut()
+            .store_secret(
+                &delegate_key(),
+                &id,
+                SecretScope::Local,
+                Zeroizing::new(b"v2".to_vec()),
+            )
+            .unwrap();
+        assert_eq!(
+            read(&env, &id),
+            b"v1".to_vec(),
+            "the memo must actually serve the repeat read — if this already \
+             reads v2 the memo is doing nothing and the whole change is a no-op"
+        );
+
+        env.invalidate_secret_memo();
+        assert_eq!(
+            read(&env, &id),
+            b"v2".to_vec(),
+            "invalidation must drop the memo, or a write followed by a read \
+             inside one process() call would serve the pre-write plaintext"
+        );
+    }
+
+    /// The memo is keyed on the secret's hash. Without that check a read of a
+    /// different key would be served the previous secret's bytes — a
+    /// cross-secret leak inside a single `process()` call.
+    #[tokio::test]
+    async fn memo_is_keyed_on_the_secret_hash() {
+        let mut f = fixture().await;
+        let first = SecretsId::new(b"first".to_vec());
+        let second = SecretsId::new(b"second".to_vec());
+        // SAFETY: `env` is dropped at the end of this test, before `f`.
+        let env = unsafe { env_of(&mut f) };
+
+        for (id, body) in [(&first, &b"aaa"[..]), (&second, &b"bbbb"[..])] {
+            env.secret_store_mut()
+                .store_secret(
+                    &delegate_key(),
+                    id,
+                    SecretScope::Local,
+                    Zeroizing::new(body.to_vec()),
+                )
+                .unwrap();
+        }
+
+        assert_eq!(read(&env, &first), b"aaa".to_vec());
+        assert_eq!(
+            read(&env, &second),
+            b"bbbb".to_vec(),
+            "a read of a different key must not be served from the previous \
+             key's memo entry"
+        );
+    }
+
+    /// Source pin for the two call sites a behavioural test cannot reach: both
+    /// mutating host functions need a live WASM instance plus the `MEM_ADDR` /
+    /// `DELEGATE_ENV` globals to drive. Dropping either `invalidate_secret_memo()`
+    /// call would leave a `set_secret` followed by a `get_secret` inside ONE
+    /// `process()` serving the pre-write plaintext, silently, with every other
+    /// test still green.
+    #[test]
+    fn mutating_secret_host_fns_invalidate_the_memo() {
+        let src = include_str!("native_api.rs");
+        for name in ["set_secret", "remove_secret"] {
+            let start = src
+                .find(&format!("pub(crate) fn {name}("))
+                .unwrap_or_else(|| panic!("{name} not found in native_api.rs"));
+            let after = &src[start..];
+            let end = after[1..]
+                .find("\n    pub(crate) fn ")
+                .map(|i| i + 1)
+                .unwrap_or(after.len());
+            assert!(
+                after[..end].contains("invalidate_secret_memo()"),
+                "{name} must call invalidate_secret_memo(): without it a write \
+                 followed by a read in the same process() call serves stale \
+                 plaintext from the memo"
+            );
+        }
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -471,7 +471,23 @@ pub mod error_codes {
 /// Host functions access this through the global `DELEGATE_ENV` map.
 pub(super) struct DelegateCallEnv {
     /// Mutable context bytes. The delegate reads/writes this via host functions.
-    pub context: Vec<u8>,
+    ///
+    /// Behind a `RefCell` so that writing it needs only a SHARED reference to
+    /// the env. That is not a style choice: it is what makes the identity
+    /// fields below immutable at the TYPE level rather than by convention.
+    ///
+    /// `context_write` was the sole reason a `&mut DelegateCallEnv` ever
+    /// existed (via `DELEGATE_ENV.get_mut`), and from a `&mut` to the struct
+    /// every field is reachable for rebinding. A source pin forbidding
+    /// `.delegate_key = ` caught assignment and nothing else — `mem::swap`,
+    /// `clone_from` and `let k = &mut env.delegate_key; *k = ..` all sailed
+    /// past it, which mutation review demonstrated. Enumerating rebinding
+    /// forms is an open set, the same mistake as enumerating item kinds.
+    ///
+    /// With this cell there is no `&mut DelegateCallEnv` anywhere in the
+    /// crate, so NO rebinding of any field compiles at all. See
+    /// `no_mutable_borrow_of_the_call_env_exists`.
+    pub(super) context: std::cell::RefCell<Vec<u8>>,
     /// Interior-mutable pointer to the runtime's SecretsStore. Valid only during
     /// the synchronous `process()` call. Uses `UnsafeCell` to make the interior
     /// mutability explicit rather than hiding it behind `#[allow(clippy::mut_from_ref)]`.
@@ -688,7 +704,7 @@ impl DelegateCallEnv {
         inherited_origins: SharedInheritedOrigins,
     ) -> Self {
         Self {
-            context,
+            context: std::cell::RefCell::new(context),
             secret_store: std::cell::UnsafeCell::new(secret_store as *mut SecretsStore),
             delegate_key,
             user_context,
@@ -1509,7 +1525,7 @@ pub(super) mod delegate_context {
             tracing::warn!("delegate call env not set for instance {id}");
             return error_codes::ERR_NOT_IN_PROCESS;
         };
-        let len = env.context.len();
+        let len = env.context.borrow().len();
         if len > i32::MAX as usize {
             return error_codes::ERR_CONTEXT_TOO_LARGE;
         }
@@ -1540,7 +1556,8 @@ pub(super) mod delegate_context {
             tracing::warn!("delegate call env not set for instance {id}");
             return error_codes::ERR_NOT_IN_PROCESS;
         };
-        let to_copy = env.context.len().min(len as usize);
+        let context = env.context.borrow();
+        let to_copy = context.len().min(len as usize);
         if to_copy == 0 {
             return 0;
         }
@@ -1553,7 +1570,7 @@ pub(super) mod delegate_context {
         // linear memory bounds, and `env.context` is a valid `Vec<u8>` with at least
         // `to_copy` bytes.
         unsafe {
-            std::ptr::copy_nonoverlapping(env.context.as_ptr(), dst, to_copy);
+            std::ptr::copy_nonoverlapping(context.as_ptr(), dst, to_copy);
         }
         to_copy as i32
     }
@@ -1579,12 +1596,15 @@ pub(super) mod delegate_context {
             tracing::warn!("instance mem space not recorded for {id}");
             return error_codes::ERR_NOT_IN_PROCESS;
         };
-        let Some(mut env) = DELEGATE_ENV.get_mut(&id) else {
+        // `get`, NOT `get_mut`: see the `context` field's rustdoc. A `&mut`
+        // here would put every other field — including the identity fields the
+        // secret memo's soundness rests on — back within reach of rebinding.
+        let Some(env) = DELEGATE_ENV.get(&id) else {
             tracing::warn!("delegate call env not set for instance {id}");
             return error_codes::ERR_NOT_IN_PROCESS;
         };
         if len == 0 {
-            env.context.clear();
+            env.context.borrow_mut().clear();
             return error_codes::SUCCESS;
         }
         let Some(src) =
@@ -1596,7 +1616,7 @@ pub(super) mod delegate_context {
         // SAFETY: `src` was validated by `validate_and_compute_ptr` to point to `len`
         // bytes within the WASM linear memory.
         let bytes = unsafe { std::slice::from_raw_parts(src, len as usize) };
-        env.context = bytes.to_vec();
+        *env.context.borrow_mut() = bytes.to_vec();
         error_codes::SUCCESS
     }
 }
@@ -2951,41 +2971,6 @@ mod secret_read_memo_tests {
     /// call would leave a `set_secret` followed by a `get_secret` inside ONE
     /// `process()` serving the pre-write plaintext, silently, with every other
     /// test still green.
-    /// The source region of `name`: from its signature to its own closing
-    /// brace, comments removed.
-    ///
-    /// Bounded by the function's OWN closing brace — the first line that is
-    /// exactly `    }` — rather than by guessing what item comes next. An
-    /// earlier version searched for the next `pub(crate) fn` and so ran ~50
-    /// lines past `remove_secret` into the private `collect_list_secrets` that
-    /// follows it, scraping a function this test says nothing about; a needle
-    /// anywhere in that overrun satisfied the assertion. Enumerating more item
-    /// kinds would only move the gap (`async fn`, `const fn`, a `type` alias,
-    /// or no following item at all would each reopen it). The closing brace is
-    /// immune to whatever follows, because it belongs to the function itself.
-    ///
-    /// Comments are stripped so prose merely MENTIONING the call cannot
-    /// satisfy a `contains`. The brace bound already excludes the successor's
-    /// doc comment, so this is defence in depth rather than the primary guard.
-    fn scraped_body(src: &str, name: &str) -> String {
-        let start = src
-            .find(&format!("pub(crate) fn {name}("))
-            .unwrap_or_else(|| panic!("{name} not found in native_api.rs"));
-        let after = &src[start..];
-        // `expect`, not `unwrap_or(len())`: every function here has a closing
-        // brace, so "not found" means the search is broken and the region has
-        // widened to end-of-file. Fail loudly rather than scraping the rest of
-        // the module and passing.
-        let end = after.find("\n    }").unwrap_or_else(|| {
-            panic!("no closing brace found for {name}; region-bounding is broken")
-        });
-        after[..end]
-            .lines()
-            .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     /// A read that FAILS must not populate the memo.
     ///
     /// `with_secret` propagates the store error with `?` before the memo
@@ -3036,76 +3021,52 @@ mod secret_read_memo_tests {
     ///
     /// The storage read this memo replaces binds the delegate identity twice —
     /// in the file path and in the DEK the blob is authenticated under. A memo
-    /// hit binds it zero times. So reassigning `delegate_key` mid-call, which
+    /// hit binds it zero times. So rebinding `delegate_key` mid-call, which
     /// before this memo self-corrected via a failed AEAD tag, would now
     /// silently return the previous identity's plaintext.
     ///
-    /// The field is private, which stops any other module. This stops
-    /// `native_api` itself — `context_write` already takes a
-    /// `&mut DelegateCallEnv` out of `DELEGATE_ENV`, so the mutation path
-    /// exists in this file today and only convention keeps it off these two
-    /// fields.
-    #[test]
-    fn the_call_env_identity_fields_are_never_reassigned() {
-        let src = include_str!("native_api.rs");
-        for field in ["delegate_key", "user_context"] {
-            let needle = format!(".{field} =");
-            assert!(
-                !src.contains(&needle),
-                "`{needle}` appears in native_api.rs. These two fields fix the \
-                 delegate identity and the secret scope for the whole call, and \
-                 secret_read_memo is keyed on the secret hash ALONE on that \
-                 basis. Reassigning either leaves a memo entry belonging to the \
-                 previous identity — cross-tenant disclosure in hosted mode. If \
-                 you genuinely need to rebuild the identity, build a NEW \
-                 DelegateCallEnv, which starts with an empty memo"
-            );
-        }
-        // Non-vacuous: the same search must FIND the assignment form it is
-        // looking for, on a field where it is legitimate.
-        assert!(
-            src.contains("env.context = "),
-            "the `.field =` search form must be able to match at all; \
-             `context_write` assigns `env.context`, so if this fails the search \
-             is broken and the assertions above prove nothing"
-        );
-    }
-
-    /// The pin above is only as good as its region-bounding, so bound the
-    /// bound.
+    /// The field being private stops any other module. This stops
+    /// `native_api` itself, and it does so at the TYPE level rather than by
+    /// scraping: with `context` behind a `RefCell`, nothing needs a
+    /// `&mut DelegateCallEnv`, so no field can be rebound by ANY means.
     ///
-    /// Note the first assertion, which is the whole point: an
-    /// absence check must also assert the thing is PRESENT to be absent from,
-    /// or it passes when the thing simply vanishes. Rename or delete
-    /// `collect_list_secrets` and, without that line, this guard would go on
-    /// passing for the wrong reason while a later regression in
-    /// `scraped_body` silently re-widened the window.
+    /// An earlier version of this pin asserted `.delegate_key = ` did not
+    /// appear. Mutation review defeated it with `mem::swap`, and `clone_from`
+    /// and `let k = &mut env.delegate_key; *k = ..` would have too — inside
+    /// `context_write`, the exact path the pin's own doc named. Enumerating
+    /// rebinding forms is an open set. This asserts the single closed fact the
+    /// whole property now rests on: no mutable borrow of the env is taken.
     #[test]
-    fn the_scraped_region_stops_at_the_end_of_the_function() {
+    fn no_mutable_borrow_of_the_call_env_exists() {
         let src = include_str!("native_api.rs");
-        assert!(
-            src.contains("fn collect_list_secrets("),
-            "this guard is written around `collect_list_secrets` being the \
-             private item that follows `remove_secret`. If it has been renamed \
-             or removed, re-point the guard at whatever now follows — do NOT \
-             delete it, or the absence check below becomes vacuous"
+        // Only the PRODUCTION half. This test's own message names the needle,
+        // so an unbounded search would count itself and fail — the same
+        // self-reference that makes a bare `split_once(anchor)` match a pin's
+        // own assertion string. Bounding here is also the right semantics: the
+        // property is about production code.
+        let production = &src[..src
+            .find("\n#[cfg(test)]")
+            .expect("no #[cfg(test)] marker found; the production/test split is broken")];
+        let call_sites = production.matches("DELEGATE_ENV.get_mut(").count();
+        assert_eq!(
+            call_sites, 0,
+            "`DELEGATE_ENV.get_mut(` gives a `&mut DelegateCallEnv`, and from \
+             one every field is reachable for rebinding — by assignment, \
+             `mem::swap`, `clone_from` or a `&mut` reborrow. `delegate_key` and \
+             `user_context` fix the delegate identity and the secret scope for \
+             the whole call, and `secret_read_memo` is keyed on the secret hash \
+             ALONE on that basis, so rebinding either leaves a memo entry \
+             belonging to the previous identity (cross-tenant disclosure in \
+             hosted mode). If you need to mutate a field, put THAT field behind \
+             a cell as `context` is — do not reintroduce the mutable borrow"
         );
 
-        let body = scraped_body(src, "remove_secret");
+        // Non-vacuous: the shared form must be present, or this test would
+        // pass just as well against a file that had no DELEGATE_ENV at all.
         assert!(
-            body.contains("fn remove_secret("),
-            "the region must actually contain remove_secret"
-        );
-        assert!(
-            body.trim_end().ends_with('}'),
-            "the region must end at remove_secret's own closing brace, not run \
-             on to end-of-file"
-        );
-        assert!(
-            !body.contains("fn collect_list_secrets("),
-            "remove_secret's region must stop before the PRIVATE \
-             `collect_list_secrets` that follows it; if it does not, the pin is \
-             asserting over a function it says nothing about"
+            production.contains("DELEGATE_ENV.get(&id)"),
+            "the shared-borrow form must appear; if it does not, the search is \
+             wrong and the assertion above proves nothing"
         );
     }
 }

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -2951,30 +2951,6 @@ mod secret_read_memo_tests {
     /// call would leave a `set_secret` followed by a `get_secret` inside ONE
     /// `process()` serving the pre-write plaintext, silently, with every other
     /// test still green.
-    /// The `delegate_secrets` module body, so discovery cannot stray into
-    /// another module's host functions.
-    fn delegate_secrets_module(src: &str) -> &str {
-        let start = src
-            .find("pub(super) mod delegate_secrets {")
-            .expect("delegate_secrets module not found");
-        let after = &src[start..];
-        let end = after
-            .find("\n}")
-            .expect("delegate_secrets module has no closing brace");
-        &after[..end]
-    }
-
-    /// Names of the `pub(crate) fn` host functions declared in `module`.
-    fn host_fn_names(module: &str) -> Vec<&str> {
-        module
-            .match_indices("    pub(crate) fn ")
-            .filter_map(|(i, m)| {
-                let rest = &module[i + m.len()..];
-                rest.find('(').map(|p| &rest[..p])
-            })
-            .collect()
-    }
-
     /// The source region of `name`: from its signature to its own closing
     /// brace, comments removed.
     ///
@@ -3010,37 +2986,49 @@ mod secret_read_memo_tests {
             .join("\n")
     }
 
-    /// Every host function in `delegate_secrets` that can change what a read
-    /// returns must drop the memo first.
+    /// A read that FAILS must not populate the memo.
     ///
-    /// Derived from the code, NOT from a hard-coded name list: the set is
-    /// "functions whose body calls `secret_store_mut()`". A name list is green
-    /// by default for any NEW mutating host function, which is the same
-    /// silent-omission shape the pin exists to prevent. This way a new mutator
-    /// is failing by default until it invalidates.
-    #[test]
-    fn mutating_secret_host_fns_invalidate_the_memo() {
-        let src = include_str!("native_api.rs");
-        let module = delegate_secrets_module(src);
-        let mutators: Vec<&str> = host_fn_names(module)
-            .into_iter()
-            .filter(|name| scraped_body(src, name).contains("secret_store_mut()"))
-            .collect();
+    /// `with_secret` propagates the store error with `?` before the memo
+    /// write, so a plaintext that never passed its Poly1305 check is never
+    /// cached. Nothing held that: the stdlib short-circuits after
+    /// `get_secret_len?`, so no existing test probes a failing key twice, and
+    /// the mutation review confirmed that moving the cache above the `?`
+    /// survives the whole suite. If it were cached, a second `has_secret` on a
+    /// corrupted or wrong-DEK secret would answer 1 for a secret that cannot
+    /// be decrypted.
+    #[tokio::test]
+    async fn a_failed_read_does_not_populate_the_memo() {
+        let mut f = fixture().await;
+        let missing = SecretsId::new(b"never-stored".to_vec());
+        // SAFETY: `env` is dropped at the end of this test, before `f`.
+        let env = unsafe { env_of(&mut f) };
+
         assert!(
-            mutators.len() >= 2,
-            "expected at least set_secret and remove_secret to mutate the secret \
-             store; found {mutators:?} — if this is now empty the discovery is \
-             broken and every assertion below is vacuous"
+            env.with_secret(&missing, |_| ()).is_err(),
+            "reading a secret that was never stored must fail"
         );
-        for name in mutators {
-            assert!(
-                scraped_body(src, name).contains("invalidate_secret_memo()"),
-                "{name} calls secret_store_mut(), so it can change what a read \
-                 returns, so it must call invalidate_secret_memo() first: \
-                 without it a write followed by a read in the same process() \
-                 call serves stale plaintext from the memo"
-            );
-        }
+        assert!(
+            env.secret_read_memo.borrow().is_none(),
+            "a failed read must leave the memo EMPTY; caching the error path \
+             would let a later probe answer from a plaintext that never passed \
+             its AEAD tag check"
+        );
+
+        // And the memo still works afterwards, so the assertion above is not
+        // passing merely because the memo is broken.
+        env.secret_store_mut()
+            .store_secret(
+                &delegate_key(),
+                &missing,
+                SecretScope::Local,
+                Zeroizing::new(b"now-present".to_vec()),
+            )
+            .unwrap();
+        assert_eq!(read(&env, &missing), b"now-present".to_vec());
+        assert!(
+            env.secret_read_memo.borrow().is_some(),
+            "a successful read must populate the memo"
+        );
     }
 
     /// M1: the memo's key omits the delegate identity and the scope, which is

--- a/tests/test-delegate-2/src/lib.rs
+++ b/tests/test-delegate-2/src/lib.rs
@@ -39,6 +39,15 @@ pub enum InboundAppMessage {
     WriteLargeContext(usize),
     /// New: Store large secret (for stress testing)
     StoreLargeSecret { key: Vec<u8>, size: usize },
+    /// Read `key`, overwrite it with `value`, then read it again — all inside
+    /// ONE `process()` call. Returns what the SECOND read saw.
+    ///
+    /// The host memoises a decrypted secret for the duration of a `process()`
+    /// call, so the first read populates that memo and the write must clear
+    /// it. Nothing else reaches that path: `exec_inbound_with_env` builds one
+    /// `DelegateCallEnv` per inbound message, so two messages get two memos
+    /// and cannot observe a stale one. It has to happen in a single call.
+    ReadWriteRead { key: Vec<u8>, value: Vec<u8> },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -188,6 +197,25 @@ impl DelegateInterface for Delegate {
 
                         let response_msg_content = OutboundAppMessage::SecretResult(result);
                         let payload = bincode::serialize(&response_msg_content)
+                            .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                        let response = ApplicationMessage::new(payload).processed(true);
+                        Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)])
+                    }
+
+                    InboundAppMessage::ReadWriteRead { key, value } => {
+                        // Populate the host's per-call secret memo.
+                        let _first = ctx.get_secret(&key);
+                        if !ctx.set_secret(&key, &value) {
+                            let payload =
+                                bincode::serialize(&OutboundAppMessage::SecretStoreFailed)
+                                    .map_err(|err| DelegateError::Other(format!("{err}")))?;
+                            let response = ApplicationMessage::new(payload).processed(true);
+                            return Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)]);
+                        }
+                        // Must observe the write, not the memoised pre-write value.
+                        let second = ctx.get_secret(&key);
+
+                        let payload = bincode::serialize(&OutboundAppMessage::SecretResult(second))
                             .map_err(|err| DelegateError::Other(format!("{err}")))?;
                         let response = ApplicationMessage::new(payload).processed(true);
                         Ok(vec![OutboundDelegateMsg::ApplicationMessage(response)])


### PR DESCRIPTION
## The production half, first

**Every delegate secret read costs two file reads and two full XChaCha20-Poly1305 decrypts to deliver one value. Three if the delegate calls `has_secret` first.**

`DelegateContext::get_secret` in freenet-stdlib is a two-call protocol — `get_secret_len` to size the guest buffer, then `get_secret` to fill it ([`delegate_host.rs:365-380`](https://github.com/freenet/freenet-stdlib)). Both host functions independently re-read the file and re-ran the whole decrypt (`native_api.rs`, the `get_secret_len` and `get_secret` bodies each called `secret_store().get_secret(...)`). `has_secret` decrypts in full as well, so the common `has_secret`-then-`get_secret` pair paid three passes.

This is real cost on every delegate secret read in production, River included. It is not a test concern, and it is the part of this PR worth weighing.

A per-`process()` memo on `DelegateCallEnv` collapses it to one pass.

**It also closes a pre-existing race.** `get_secret_len` and `get_secret` were independent reads, so a concurrent write between them could return `secret_len > out_len` and fail the read. Both now come from one plaintext, so the pair cannot disagree. Small correctness gain, not only a cost saving. The decrypt still happens exactly once per distinct secret per call, so **nothing unauthenticated ever reaches the guest** — the memo only ever holds plaintext that already passed the Poly1305 tag check. It is keyed on the secret's 32-byte hash (the same value that names the on-disk file) and cleared by `set_secret` and `remove_secret`, so a write followed by a read inside one `process()` cannot be served the pre-write plaintext.

## Why this also fixes a flaky test

`wasm_runtime::delegate::test::test_large_secret_data` has been failing intermittently as `ContractError(WasmError(Timeout))`. Prior reports of the same test: #3218, #3248, #4213, #5023 — the last two closed by #5251 with a different symptom (`SecretResult(None)`), so this is a distinct failure mode.

A delegate's execution budget (`RuntimeConfig::max_execution_seconds`, default 5.0) bounds guest EXECUTION but is measured as WALL CLOCK: `epoch_deadline_ticks` turns 5.0 into 51 ticks of a 100 ms process-global epoch ticker. **That clock keeps running while the guest is blocked inside a host call**, and the epoch trap cannot fire during a host call either — so host time is not interruptible, it is simply deducted from the guest's remaining budget and the guest traps on its next instruction. Time the node spends on its own I/O and cryptography is charged to the delegate.

A `perf` profile of a failing run puts **49% of samples inside host functions entered from the guest** (`VMFuncRef::array_call_native`), dominated by XChaCha20-Poly1305: `decrypt_in_place` 16.3%, `encrypt_in_place` ~9%. `strace -T` rules out I/O — six sync calls totalling ~0.18s, worst 0.073s.

The test sits on that boundary by construction: 1 MiB stored and read back is ~3 MiB of AEAD through host calls, and in a test build that crypto is monomorphised into `crates/core` at `opt-level = 0`, because the `[profile.dev.package."*"] opt-level = 3` override covers dependency *packages*, not generics instantiated in the local crate. (~15% of the profile is `slice::from_raw_parts` precondition checks that exist only in a debug build.)

So `setup_runtime` now sets its budget explicitly via `Runtime::build_with_config` instead of silently inheriting a production policy it does not intend to test. This is deliberately *not* a sweep: `setup_v2_runtime_with_contract`, `setup_runtime_with_params`, `bare_runtime` and the tests that build a `Runtime` inline still inherit the 5.0 s default. They are not known to flake on it, and widening to every delegate fixture is a larger change than the one flake in hand justified. 60s is generous but bounded, so a delegate test that genuinely wedges still fails rather than hangs. The tests that *do* assert timeout behaviour live in `wasm_runtime::tests::execution_handling` and set their own budgets, so no coverage is weakened. `test.rs` already had precedent for overriding a production default it does not want (the module-cache budget probe at line ~875).

## Evidence

Measured by pinning the test and N busy-loop competitors to ONE core, so the oversubscription is known rather than ambient. Arms alternate within each round, so both see identical conditions.

| oversubscription | main | memo only | memo + budget |
|---|---|---|---|
| 2x (1 competitor) | 0/15 fail, median 4.31s | 0/15 fail, median 3.62s | — |
| 4x (3 competitors) | 0/5 fail, ~7.5s | 0/5 fail, ~6.6s | — |
| 10x (9 competitors) | 3/3 FAIL | 3/3 FAIL | — |
| 10x (9 competitors) | **0/20 pass, 20/20 FAIL** | — | **20/20 pass, 0 fail** |

Perfect separation at 10x (Fisher exact p < 1e-11). The memo alone is a 16% cut in total test wall time — faster in 13 of 15 paired rounds at 2x, median −0.62s, sign test p ≈ 0.007 — but it only *shifts* the threshold; at 10x it still failed 3/3. Both halves are needed.

Note the fixed runs are *slower* in wall time at 10x (16-20s vs main's 11-12s). That is the correct sign: main was not finishing faster, it was aborting at the deadline.

**The flake is pre-existing on `main`, not introduced by any branch.** Under natural load on a 16-core box, an interleaved run gave `main` 4 failures in 25 and a feature branch 1 in 25 — main failing more, if anything — and 0 failures in 28 runs below load average 50. A sequential comparison taken hours apart had falsely exonerated main (25/0); only the interleaved rig showed the truth.

## Verification

- `cargo test -p freenet --lib`: **5449 passed, 0 failed, 28 ignored**.
- Test count 5472 → 5477: exactly the five added, none removed.
- `cargo clippy -p freenet --all-targets -- -D warnings` clean; `cargo fmt` clean.

## Tests added

Two behavioural and one source pin, in `native_api.rs`:
- the memo serves a repeat read, and invalidation drops it — the middle assertion (a changed value is still read as the old one *before* invalidation) is what makes the `invalidate_secret_memo()` calls load-bearing rather than decorative;
- the memo is keyed on the secret hash, so a read of a different key is never served the previous secret's bytes;
- a guard on the region-bounding of the remaining source pins;
- **a behavioural test that a write invalidates the memo within one `process()` call**, driven through a real WASM guest.

The pin and its guard were both wrong first, and both were caught by review rather than by me:

- **The pin overran.** It bounded each region by searching for the next `pub(crate) fn`, but `remove_secret` is followed by the *private* `collect_list_secrets`, so it scraped 109 lines against a real body of 59. `set_secret` was correct only because its successor happens to be `pub(crate)`. My own "it is not vacuous" check reimplemented the same boundary logic and so reproduced the defect instead of catching it — a true answer about two functions that were not the broken one. It now bounds on the function's own closing brace, which is immune to whatever follows.
- **The guard on the pin was itself vacuous.** It asserted the region does NOT contain `collect_list_secrets` without asserting `collect_list_secrets` exists, so a rename would have made it pass for the wrong reason. An absence check must assert the thing is present to be absent from.

A third source pin — asserting both mutating host functions called `invalidate_secret_memo()` — was **deleted rather than hardened**. Mutation review defeated it by removing both real calls and leaving the string in a trailing `//` comment: the suite stayed green, because the filter stripped lines that *begin* with `//`, not comment tails. Worse, deleting both calls killed exactly one test — the pin — so a string in a comment was the entire protection for the invariant.

**The reason a source pin looked like the only option is worth stating, because it is the general lesson.** I believed those call sites were unreachable behaviourally, needing a live WASM instance plus the `DELEGATE_ENV`/`MEM_ADDR` globals. They were reachable all along — several existing tests drive them, and the guest WASM is built from source at test time. The only missing piece was set-then-read *in a single call*, because `exec_inbound_with_env` builds one `DelegateCallEnv` per inbound message, so batching two messages gives two memos and cannot observe a stale one. **A narrow gap mis-stated as a broad one is how a source pin comes to look like the only option.** The fix was a ~15-line guest handler (`ReadWriteRead` in `tests/test-delegate-2`), not a better scraper.

Note also that the unit test which exercises the memo directly *passed* under that mutation, correctly: it calls `invalidate_secret_memo()` itself, so it tests the mechanism, while the pin was covering the wiring. Those are different claims, and only a real guest separates them.

Both fixes were verified by falsification rather than by watching them pass: with the genuine call removed and a needle planted in the overrun, the old bounding is fooled and the new one is not; and with `collect_list_secrets` renamed, the absence assertion alone still passes while the added presence assertion fails.

The behavioural test was falsified against the same mutation that defeated the pin — both real invalidation calls deleted, the string left in comment tails:

```
a_write_invalidates_the_secret_memo_within_one_process_call ... FAILED
  left:  "before"   <- what the guest was served
  right: "after"    <- what it should have seen
```

That is the defect itself (stale plaintext reaching the guest), not a signal correlated with it.

The same class exists elsewhere in the tree — `wasmtime_engine.rs`'s guest-entry pin overruns `call_3i64_blocking` by 104 lines while its sibling is clean — filed as #5596 rather than widened into this PR.

## Security review

Full-tier review found **no critical, no high**. One Medium, fixed here:

**The memo removes the cryptographic half of the delegate-identity check.** The storage read binds the identity twice — in the file path and in the DEK the blob is authenticated under (HKDF salted with `delegate.encode()`). A memo hit binds it zero times: a 32-byte comparison and a return. Before the memo, reassigning `env.delegate_key` mid-call self-corrected (wrong path, or a tag that would not verify); after it, the same edit would silently return the previous identity's plaintext — cross-tenant disclosure in hosted mode. Not exploitable at any commit here, but `delegate_key` was `pub` and `context_write` already takes a `&mut DelegateCallEnv` out of `DELEGATE_ENV`, so the mutation path existed.

Fixed in both halves: the field is now private (closing every other module at compile time) and a pin asserts neither identity field is reassigned anywhere in `native_api.rs` (closing the file itself, which privatisation cannot). Comments at both fields and at the key derivation, since whoever breaks this is editing the fields, not reading `with_secret`.

Also documented rather than silently assumed: `has_secret` now retains a plaintext for the rest of the call (a host-side residency change — the delegate gains nothing, since it could call `get_secret` and hold larger unwiped bytes itself); the plaintext is zeroized but the 32-byte hash half is not, which is correct since it is already on disk as the filename; and the wipe guarantee assumes panics unwind, so `panic = "abort"` would void it.

## What this does NOT fix

The wall-clock accounting itself. A real delegate storing a large secret on a busy node can still be charged for the host's crypto and I/O, and delegates have no equivalent of the queue-vs-compute split `execute_wasm_blocking` gives contracts (`contract.rs` is its only caller). Filed separately — crediting host time back to the guest removes the only bound on a delegate that loops over expensive host calls, so any fix needs a cap and Full-tier review on the #4864 surface.

[AI-assisted - Claude]

https://claude.ai/code/session_01RbvrRHmbnmNWywtSgG8qEV
