### PR TITLE
fix(delegates): give delegate WASM execution the wall-clock backstop and panic capture contracts already had (#5480)

### DIFF
--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -74,9 +74,18 @@ Two consequences for anything touching the delegate path:
   `JoinHandle::abort()` cannot stop a `spawn_blocking` closure that has started.
   Ask "is a guest still running", not "is its env still registered" — those are
   different facts (`native_api::LIVE_DELEGATE_GUESTS`).
-- **Delegate host functions run on a blocking-pool thread**, so they find their
-  env through a thread-local installed on THAT thread by `GuestDelegateInstance`,
-  not on the caller's.
+- **During `process()`, delegate host functions run on a blocking-pool thread**,
+  so they find their env through a thread-local installed on THAT thread by
+  `GuestDelegateInstance`, not on the caller's.
+
+  Scope that to `process()` and no further. Buffer setup and instantiation —
+  `initiate_buffer`, `call_void`, `instantiate_and_init` — still enter the guest
+  with `block_on_async(func.call_async(...))` INLINE on the calling thread, with
+  no `execute_wasm_blocking` and no `GuestDelegateInstance`. That is why
+  `exec_inbound_with_env` still sets `CURRENT_DELEGATE_INSTANCE` on the calling
+  thread at all, as `DelegateEnvGuard`'s rustdoc explains. "Nothing
+  delegate-related runs on the calling thread" is false and would produce a wrong
+  call about exactly those paths.
 
 The pins `every_guest_entry_is_preceded_by_arm_epoch_deadline` and
 `blocking_paths_arm_epoch_inside_the_closure` enforce the single-body structure.

--- a/.claude/rules/contracts.md
+++ b/.claude/rules/contracts.md
@@ -54,11 +54,32 @@ V2: Async host functions — delegates call contract methods directly:
 
 ### WASM Call Modes
 
+All four guest entry points share ONE body, `call_typed_blocking` in
+`engine/wasmtime_engine.rs`. Delegates ran "sync, on the calling thread" until
+#5480; they no longer do, and nothing should reintroduce a per-entry-point copy.
+
 ```
-call_3i64()              — Sync, same thread (delegates V1)
-call_3i64_async_imports() — For modules with async host function imports (delegates V2)
-call_*_blocking()        — spawn_blocking + timeout (contracts)
+call_3i64()               — delegates V1
+call_3i64_async_imports() — delegates V2 (modules with async host-function imports)
+call_2i64_blocking()      — contracts
+call_3i64_blocking()      — contracts
+        ↓ all four
+call_typed_blocking()     — spawn_blocking + wall-clock backstop + panic capture
 ```
+
+Two consequences for anything touching the delegate path:
+
+- **A delegate guest can outlive its call.** On the wall-clock-timeout path
+  `exec_inbound_with_env` returns while the guest is still running, because
+  `JoinHandle::abort()` cannot stop a `spawn_blocking` closure that has started.
+  Ask "is a guest still running", not "is its env still registered" — those are
+  different facts (`native_api::LIVE_DELEGATE_GUESTS`).
+- **Delegate host functions run on a blocking-pool thread**, so they find their
+  env through a thread-local installed on THAT thread by `GuestDelegateInstance`,
+  not on the caller's.
+
+The pins `every_guest_entry_is_preceded_by_arm_epoch_deadline` and
+`blocking_paths_arm_epoch_inside_the_closure` enforce the single-body structure.
 
 ## WASM Execution Rules
 

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -155,10 +155,34 @@ impl Runtime {
             )
         };
 
-        debug_assert!(
-            !DELEGATE_ENV.contains_key(&instance_id),
-            "Instance ID {instance_id} already exists in DELEGATE_ENV - this indicates a bug"
-        );
+        // HARD check, deliberately not `debug_assert!`: since #5480 this is a
+        // MEMORY-SAFETY invariant, not a tidiness one, and it must hold in
+        // release builds.
+        //
+        // A delegate guest now runs on a `spawn_blocking` worker, and on the
+        // wall-clock timeout path it KEEPS RUNNING after this function returns
+        // (`JoinHandle::abort()` cannot stop a `spawn_blocking` closure). One
+        // `RunningInstance` id is shared by every message in a batch (see
+        // `interface.rs`), so this insert runs once per message under the SAME
+        // id. If an env were inserted while a previous message's guest were
+        // still abandoned and running, that guest's `DELEGATE_ENV.get(&id)`
+        // would resolve to the NEW env and dereference its raw store pointers
+        // while this thread holds `&mut` to the very same stores -- aliasing UB
+        // across two threads.
+        //
+        // Today the batch loop aborts on the first error, so this is
+        // unreachable. That is an accident of control flow, not a guarantee: an
+        // edit making the loop error-tolerant ("collect errors and continue",
+        // "retry the message") would silently reintroduce it. Fail closed so
+        // such an edit gets an error instead of undefined behaviour.
+        if DELEGATE_ENV.contains_key(&instance_id) {
+            return Err(anyhow::anyhow!(
+                "delegate instance {instance_id} is already active in DELEGATE_ENV; \
+                 refusing to re-enter it while a previous guest may still be running \
+                 on an abandoned blocking thread (#5480)"
+            )
+            .into());
+        }
 
         DELEGATE_ENV.insert(instance_id, env);
         CURRENT_DELEGATE_INSTANCE.with(|c| c.set(instance_id));

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -576,6 +576,42 @@ impl Runtime {
 
 #[cfg(test)]
 mod pins {
+    /// Bound `exec_inbound_with_env`'s body, failing closed if the window is
+    /// truncated.
+    ///
+    /// Shared by the pins below so they cannot drift apart, and so a truncated
+    /// window fails ONE place loudly rather than making each pin vacuous
+    /// independently. A "must be present" lookup over a shortened window misses
+    /// and reports the property violated; a "must be absent" one passes over
+    /// nothing. Both are wrong, and balanced braces is the cheap structural
+    /// check that catches either.
+    fn scrape_exec_inbound_with_env(src: &str) -> &str {
+        let start = src
+            .find("fn exec_inbound_with_env(")
+            .expect("`exec_inbound_with_env` not found — this pin has drifted");
+        // Bound at the next method so a later occurrence cannot satisfy an
+        // assertion about this one.
+        let rest = &src[start..];
+        let end = ["\n    pub(super) fn ", "\n    fn ", "\n}"]
+            .iter()
+            .filter_map(|needle| rest.find(needle))
+            .min()
+            .map(|off| start + off)
+            .unwrap_or(src.len());
+        let body = &src[start..end];
+
+        let opens = body.matches('{').count();
+        let closes = body.matches('}').count();
+        assert_eq!(
+            opens, closes,
+            "`exec_inbound_with_env`: scraped window is truncated ({opens} `{{` vs \
+             {closes} `}}`), so any pin over it is unreliable. Widen the end \
+             delimiters; do NOT delete the check."
+        );
+
+        body
+    }
+
     /// Source-scrape pin (#5480): in `exec_inbound_with_env`, the `?` that
     /// propagates the call's result MUST come BEFORE the `context` read-back.
     ///
@@ -593,32 +629,63 @@ mod pins {
     /// Below the `?` the read is reached only on success, which means
     /// `execute_wasm_blocking` joined the guest closure and the guest is
     /// provably finished.
+    /// Source-scrape pin (#5480 review): `DelegateEnvGuard` must be constructed
+    /// as a LOCAL of `exec_inbound_with_env`.
+    ///
+    /// This is the fact that makes the merged #5554 safe, and until this pin
+    /// nothing checked it. #5554 parks delegates off the serial
+    /// `contract_handling` loop, so a delegate's round trip can span two loop
+    /// iterations; its own comment notes the serial loop was the ONLY thing
+    /// guaranteeing one `process()` per delegate. What keeps that sound is that
+    /// the guard drops HERE, inside this function, so `DELEGATE_ENV` is cleared
+    /// before the `Err` reaches `inbound_app_message`, before
+    /// `DelegateRunOutcome::Failed`, and therefore before a park can release a
+    /// queued run for the same delegate.
+    ///
+    /// The realistic regression is not deletion but HOISTING: moving the guard
+    /// up into `inbound_app_message` so one guard spans the whole batch reads
+    /// like an efficiency win — one insert/remove per batch instead of per
+    /// message — and would put an abandoned guest's writes back within reach of
+    /// a queued run.
+    ///
+    /// `LIVE_DELEGATE_GUESTS` does NOT cover this. It is keyed by instance id,
+    /// and a fresh run for the same delegate gets a fresh `RunningInstance` with
+    /// a fresh id, so the set never observes the overlap. The scope of one local
+    /// variable is the whole protection.
+    #[test]
+    fn the_env_guard_is_constructed_inside_exec_inbound_with_env() {
+        let src = include_str!("execution.rs");
+        let body = scrape_exec_inbound_with_env(src);
+
+        assert!(
+            body.contains("let _guard = DelegateEnvGuard::new(instance_id);"),
+            "`exec_inbound_with_env` must construct its `DelegateEnvGuard` \
+             itself. If this guard has been hoisted into `inbound_app_message` \
+             so one covers a whole batch, the env now outlives the call that \
+             created it and #5554's park can release a queued run for the same \
+             delegate while an abandoned guest is still writing (#5480, #5554)"
+        );
+
+        // The construction must also precede the guest call it protects —
+        // present but below `exec_inbound` would clean up an env that was never
+        // guarded during execution.
+        let guard = body
+            .find("let _guard = DelegateEnvGuard::new(instance_id);")
+            .expect("checked above");
+        let call = body
+            .find("self.exec_inbound(")
+            .expect("`exec_inbound_with_env` must call `exec_inbound`");
+        assert!(
+            guard < call,
+            "the `DelegateEnvGuard` must be constructed BEFORE `exec_inbound`, \
+             so it covers the guest call rather than trailing it"
+        );
+    }
+
     #[test]
     fn context_readback_happens_after_the_result_is_propagated() {
         let src = include_str!("execution.rs");
-        let start = src
-            .find("fn exec_inbound_with_env(")
-            .expect("`exec_inbound_with_env` not found — this pin has drifted");
-        // Bound at the next method so a later `?` cannot satisfy the assertion.
-        let rest = &src[start..];
-        let end = ["\n    pub(super) fn ", "\n    fn ", "\n}"]
-            .iter()
-            .filter_map(|needle| rest.find(needle))
-            .min()
-            .map(|off| start + off)
-            .unwrap_or(src.len());
-        let body = &src[start..end];
-
-        // Fail closed if the window was truncated: a shortened window would let
-        // the "read-back is present" lookup miss and turn this pin vacuous.
-        let opens = body.matches('{').count();
-        let closes = body.matches('}').count();
-        assert_eq!(
-            opens, closes,
-            "`exec_inbound_with_env`: scraped window is truncated ({opens} `{{` vs \
-             {closes} `}}`), so this pin would pass vacuously. Widen the end \
-             delimiters; do NOT delete the check."
-        );
+        let body = scrape_exec_inbound_with_env(src);
 
         let propagate = body
             .find("let outbound = result?;")

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -16,9 +16,25 @@ use super::super::secrets_store::UserSecretContext;
 use super::super::{Runtime, RuntimeResult};
 use super::error::DelegateExecError;
 
-/// RAII guard that ensures cleanup of delegate environment state.
-/// When dropped, it clears the thread-local instance ID and removes the
-/// entry from the global DELEGATE_ENV map.
+/// RAII guard that removes the instance's entry from the global `DELEGATE_ENV`
+/// map on every exit path, including a panic.
+///
+/// That removal is the load-bearing half, and it is what bounds the lifetime of
+/// the raw store pointers the env holds: `DashMap::remove` takes the shard WRITE
+/// lock, so it waits for any host call still holding a `Ref` before returning.
+///
+/// It also clears `CURRENT_DELEGATE_INSTANCE`, but note what that does and does
+/// not do since #5480. The thread-local a delegate host function actually reads
+/// is the one on the BLOCKING-POOL thread running the guest, installed and
+/// cleared by `GuestDelegateInstance` in `wasmtime_engine.rs`. This clear (and
+/// the matching `set` in `exec_inbound_with_env`) touches the CALLING thread's
+/// copy, which no host function consults on the delegate path.
+///
+/// They are kept rather than deleted because they cost nothing and keep the
+/// calling thread's thread-local honest for any path that ever runs a guest
+/// inline. Do not read them as the mechanism that makes host-function dispatch
+/// work — that is `GuestDelegateInstance`, and a change there is what would
+/// break dispatch.
 pub(super) struct DelegateEnvGuard {
     instance_id: InstanceId,
 }

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -10,7 +10,8 @@ use crate::wasm_runtime::delegate_api::DelegateApiVersion;
 
 use super::super::engine::{InstanceHandle, WasmEngine};
 use super::super::native_api::{
-    CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, InstanceId, LIVE_DELEGATE_GUESTS,
+    CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, DelegateEnvSlot, InstanceId,
+    LIVE_DELEGATE_GUESTS,
 };
 use super::super::secrets_store::UserSecretContext;
 use super::super::{Runtime, RuntimeResult};
@@ -211,7 +212,7 @@ impl Runtime {
             .into());
         }
 
-        DELEGATE_ENV.insert(instance_id, env);
+        DELEGATE_ENV.insert(instance_id, DelegateEnvSlot::new(env));
         CURRENT_DELEGATE_INSTANCE.with(|c| c.set(instance_id));
 
         // Create RAII guard to ensure cleanup on all exit paths (including panic)

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -195,13 +195,38 @@ impl Runtime {
         // V1 delegates use synchronous call.
         let result = self.exec_inbound(params, origin, msg, handle, api_version);
 
-        // Read back the (possibly mutated) context before guard drops
+        // Propagate the error BEFORE reading the context back. The `?` is
+        // deliberately ahead of the read, not behind it (#5480).
+        //
+        // On the wall-clock-timeout path this thread returns while the guest is
+        // STILL RUNNING on an abandoned blocking-pool thread, because
+        // `JoinHandle::abort()` cannot stop a `spawn_blocking` closure. Reading
+        // `context` here would therefore be a genuinely concurrent access to a
+        // field the abandoned guest can still write through `context_write`.
+        //
+        // It is not a data race as the field stands today -- the only mutator
+        // takes `DELEGATE_ENV.get_mut`, a shard WRITE lock, which excludes this
+        // `get` -- but that is a property of one call site in `native_api`, not
+        // of anything checked here. Moving any future `context` mutator to a
+        // shared borrow (an interior-mutability wrapper, say) would silently
+        // turn this line into a cross-thread race with no `unsafe` at either
+        // end. See the `unsafe impl Send/Sync for DelegateCallEnv` note.
+        //
+        // The read is pure waste on every error path regardless: `result?` used
+        // to discard it a line later. Skipping it costs nothing, removes the
+        // only concurrent touch of the env from this thread, and lets the
+        // SAFETY argument rest on "the guest thread alone reaches the env"
+        // rather than on a per-field exception.
+        let outbound = result?;
+
+        // Reached only on success, which means `execute_wasm_blocking` joined
+        // the guest closure: the guest has finished and nothing else can be
+        // touching the env.
         let updated_context = DELEGATE_ENV
             .get(&instance_id)
             .map(|env| env.context.borrow().clone())
             .unwrap_or_default();
 
-        let outbound = result?;
         Ok((outbound, updated_context))
     }
 

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -10,7 +10,7 @@ use crate::wasm_runtime::delegate_api::DelegateApiVersion;
 
 use super::super::engine::{InstanceHandle, WasmEngine};
 use super::super::native_api::{
-    CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, InstanceId,
+    CURRENT_DELEGATE_INSTANCE, DELEGATE_ENV, DelegateCallEnv, InstanceId, LIVE_DELEGATE_GUESTS,
 };
 use super::super::secrets_store::UserSecretContext;
 use super::super::{Runtime, RuntimeResult};
@@ -191,11 +191,22 @@ impl Runtime {
         // edit making the loop error-tolerant ("collect errors and continue",
         // "retry the message") would silently reintroduce it. Fail closed so
         // such an edit gets an error instead of undefined behaviour.
-        if DELEGATE_ENV.contains_key(&instance_id) {
+        //
+        // BOTH halves are needed, and `DELEGATE_ENV` alone is the WRONG test.
+        // `DelegateEnvGuard::drop` removes the env on every exit path of this
+        // function INCLUDING the wall-clock-timeout `Err`, so by the time a
+        // caller sees that error the entry is already gone while the guest is
+        // still running on an abandoned blocking thread. `contains_key` asks
+        // "is an env registered"; the question that matters is "is a guest
+        // running", and those diverged the moment the guest could outlive the
+        // call. `LIVE_DELEGATE_GUESTS` answers the second one — without it this
+        // check would read false in precisely the scenario its own comment
+        // above describes.
+        if DELEGATE_ENV.contains_key(&instance_id) || LIVE_DELEGATE_GUESTS.contains(&instance_id) {
             return Err(anyhow::anyhow!(
-                "delegate instance {instance_id} is already active in DELEGATE_ENV; \
-                 refusing to re-enter it while a previous guest may still be running \
-                 on an abandoned blocking thread (#5480)"
+                "delegate instance {instance_id} is already active (env registered, or a \
+                 guest still running on an abandoned blocking thread); refusing to \
+                 re-enter it (#5480)"
             )
             .into());
         }

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -204,13 +204,21 @@ impl Runtime {
         // `context` here would therefore be a genuinely concurrent access to a
         // field the abandoned guest can still write through `context_write`.
         //
-        // It is not a data race as the field stands today -- the only mutator
-        // takes `DELEGATE_ENV.get_mut`, a shard WRITE lock, which excludes this
-        // `get` -- but that is a property of one call site in `native_api`, not
-        // of anything checked here. Moving any future `context` mutator to a
-        // shared borrow (an interior-mutability wrapper, say) would silently
-        // turn this line into a cross-thread race with no `unsafe` at either
-        // end. See the `unsafe impl Send/Sync for DelegateCallEnv` note.
+        // That IS a data race if the read happens above the `?`, and it became
+        // one in #5593: `context` is now a `RefCell<Vec<u8>>` and
+        // `context_write` mutates it through `DELEGATE_ENV.get` -- a shard READ
+        // lock -- plus `borrow_mut()`. Shard read locks are SHARED, so nothing
+        // separates the two threads any more. `RefCell`'s borrow flag is a
+        // non-atomic `Cell<isize>`, so its own runtime check cannot detect the
+        // overlap; and `to_vec()` reallocating the `Vec` while `clone()` reads
+        // it is a use-after-free of the old buffer. `RefCell` is `!Sync`, but
+        // the `unsafe impl Sync for DelegateCallEnv` overrides that, so the
+        // compiler says nothing and there is no `unsafe` at either edit site.
+        //
+        // Before #5593 the mutator took `get_mut`, a shard WRITE lock, and the
+        // ordering here did not matter. That was one call site's habit rather
+        // than an invariant, which is exactly why it stopped holding. Do not
+        // restore the habit as the defence; keep the read below the `?`.
         //
         // The read is pure waste on every error path regardless: `result?` used
         // to discard it a line later. Skipping it costs nothing, removes the
@@ -535,5 +543,69 @@ impl Runtime {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod pins {
+    /// Source-scrape pin (#5480): in `exec_inbound_with_env`, the `?` that
+    /// propagates the call's result MUST come BEFORE the `context` read-back.
+    ///
+    /// This is an ordering the compiler cannot enforce and that reads as a
+    /// harmless rearrangement. It is not. On the wall-clock-timeout path the
+    /// creating thread returns while the guest is still running on an abandoned
+    /// `spawn_blocking` thread, so a read placed above the `?` runs concurrently
+    /// with `native_api`'s `context_write`. Since #5593 both sides take only a
+    /// SHARED `DELEGATE_ENV.get` and reach the `Vec` through a `RefCell`, whose
+    /// borrow flag is a non-atomic `Cell<isize>` — a data race that `RefCell`'s
+    /// own check cannot detect, that `!Sync` would normally catch, and that the
+    /// `unsafe impl Sync for DelegateCallEnv` suppresses. Neither edit site
+    /// needs `unsafe`, so nothing else would flag the change.
+    ///
+    /// Below the `?` the read is reached only on success, which means
+    /// `execute_wasm_blocking` joined the guest closure and the guest is
+    /// provably finished.
+    #[test]
+    fn context_readback_happens_after_the_result_is_propagated() {
+        let src = include_str!("execution.rs");
+        let start = src
+            .find("fn exec_inbound_with_env(")
+            .expect("`exec_inbound_with_env` not found — this pin has drifted");
+        // Bound at the next method so a later `?` cannot satisfy the assertion.
+        let rest = &src[start..];
+        let end = ["\n    pub(super) fn ", "\n    fn ", "\n}"]
+            .iter()
+            .filter_map(|needle| rest.find(needle))
+            .min()
+            .map(|off| start + off)
+            .unwrap_or(src.len());
+        let body = &src[start..end];
+
+        // Fail closed if the window was truncated: a shortened window would let
+        // the "read-back is present" lookup miss and turn this pin vacuous.
+        let opens = body.matches('{').count();
+        let closes = body.matches('}').count();
+        assert_eq!(
+            opens, closes,
+            "`exec_inbound_with_env`: scraped window is truncated ({opens} `{{` vs \
+             {closes} `}}`), so this pin would pass vacuously. Widen the end \
+             delimiters; do NOT delete the check."
+        );
+
+        let propagate = body
+            .find("let outbound = result?;")
+            .expect("`exec_inbound_with_env` must propagate the call result with `?`");
+        let readback = body
+            .find("DELEGATE_ENV\n            .get(&instance_id)")
+            .expect("`exec_inbound_with_env` must read the context back from DELEGATE_ENV");
+
+        assert!(
+            propagate < readback,
+            "the `context` read-back must sit AFTER `let outbound = result?;`. Above \
+             it, the read runs on the wall-clock-timeout path while the guest is \
+             still live on an abandoned blocking thread, racing `context_write` on \
+             a `RefCell` that `unsafe impl Sync` has stripped the protection from \
+             (#5480, #5593). Nothing but this pin would catch the move."
+        );
     }
 }

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -4943,7 +4943,7 @@ mod hosted_user_secrets {
 #[tokio::test]
 async fn reentering_a_live_instance_id_fails_closed() -> Result<(), Box<dyn std::error::Error>> {
     use super::super::engine::InstanceHandle;
-    use super::super::native_api::{DELEGATE_ENV, DelegateCallEnv};
+    use super::super::native_api::{DELEGATE_ENV, DelegateCallEnv, DelegateEnvSlot};
 
     let (delegate, mut runtime, _temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
 
@@ -4997,7 +4997,7 @@ async fn reentering_a_live_instance_id_fails_closed() -> Result<(), Box<dyn std:
             runtime.inherited_origins.clone(),
         )
     };
-    DELEGATE_ENV.insert(LIVE_ID, env);
+    DELEGATE_ENV.insert(LIVE_ID, DelegateEnvSlot::new(env));
 
     let result = runtime.exec_inbound_with_env(
         delegate.key(),
@@ -5093,6 +5093,72 @@ async fn reentering_an_id_with_a_live_guest_fails_closed_even_with_no_env()
     assert!(
         rendered.contains("already active"),
         "expected the re-entry guard's error, got: {rendered}"
+    );
+
+    Ok(())
+}
+
+/// REGRESSION (#5480 review): `exec_inbound_with_env` must have finished its
+/// cleanup by the time it RETURNS — on the error path as much as the success
+/// path — not merely "eventually".
+///
+/// This pins the fact that makes the #5554 interaction safe, and which nothing
+/// else states. #5554 parks delegates off the serial `contract_handling` loop,
+/// so a delegate's round trip can now span two loop iterations; its own comment
+/// notes that the serial loop was the ONLY thing guaranteeing one `process()`
+/// per delegate. What keeps that sound is ordering: `_guard` is a local of
+/// `exec_inbound_with_env`, so `DELEGATE_ENV` is cleared strictly before the
+/// `Err` reaches `inbound_app_message`, before `DelegateRunOutcome::Failed`, and
+/// therefore before a park can release a queued run for the same delegate.
+///
+/// That is the placement of one local variable, load-bearing across two merged
+/// changes, and until this test nothing checked it. A `std::mem::forget(_guard)`
+/// — or hoisting the guard into the caller to "clean up once per batch" — would
+/// leave the entry live past the return with no other alarm.
+#[tokio::test]
+async fn env_cleanup_completes_before_the_call_returns() -> Result<(), Box<dyn std::error::Error>> {
+    use super::super::engine::InstanceHandle;
+    use super::super::native_api::{DELEGATE_ENV, LIVE_DELEGATE_GUESTS};
+
+    let (delegate, mut runtime, _temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+
+    const ID: i64 = i64::MAX - 54802;
+
+    let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::ReadContext)?;
+    let msg = InboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(payload));
+    let handle = InstanceHandle { id: ID };
+    let params: Parameters = vec![].into();
+
+    // Fails inside `exec_inbound` (no engine instance under this handle), which
+    // is the path that matters: the guard must still have run.
+    let result = runtime.exec_inbound_with_env(
+        delegate.key(),
+        &params,
+        None,
+        None,
+        &msg,
+        Vec::new(),
+        &handle,
+        ID,
+        DelegateApiVersion::V2,
+    );
+    assert!(
+        result.is_err(),
+        "fixture precondition: this call is expected to fail, so the assertions \
+         below are about the ERROR path"
+    );
+
+    assert!(
+        !DELEGATE_ENV.contains_key(&ID),
+        "`exec_inbound_with_env` returned with its DELEGATE_ENV entry still \
+         present. `_guard` must drop inside this function, before the error \
+         reaches `inbound_app_message` and before #5554's park can release a \
+         queued run for the same delegate"
+    );
+    assert!(
+        !LIVE_DELEGATE_GUESTS.contains(&ID),
+        "no guest ever started for this call, so nothing may be left registered \
+         as live — a stale entry here would refuse every later call on this id"
     );
 
     Ok(())

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -5026,3 +5026,74 @@ async fn reentering_a_live_instance_id_fails_closed() -> Result<(), Box<dyn std:
 
     Ok(())
 }
+
+/// REGRESSION (#5480 review, F1): re-entry must be refused while a guest is
+/// still running, EVEN THOUGH its `DELEGATE_ENV` entry has already been removed.
+///
+/// This is the case the first version of the guard could not see.
+/// `DelegateEnvGuard::drop` removes the env on every exit path of
+/// `exec_inbound_with_env`, including the wall-clock-timeout `Err` — and on that
+/// path the guest is still running on an abandoned `spawn_blocking` thread,
+/// since `abort()` cannot stop a closure that has started. So by the time the
+/// batch loop sees the error, `DELEGATE_ENV.contains_key(id)` is already false
+/// while the dangerous condition — a live guest holding raw pointers to this
+/// runtime's stores — is still true.
+///
+/// A check on `DELEGATE_ENV` alone therefore reads false in exactly the
+/// scenario the guard exists for. `LIVE_DELEGATE_GUESTS` tracks the guest's own
+/// lifetime instead, which is the fact that matters.
+///
+/// Simulated by registering the id directly: reproducing it through a real
+/// abandoned guest would need an error-tolerant batch loop, which is precisely
+/// the future edit this guard is here to catch and which does not exist yet.
+#[tokio::test]
+async fn reentering_an_id_with_a_live_guest_fails_closed_even_with_no_env()
+-> Result<(), Box<dyn std::error::Error>> {
+    use super::super::engine::InstanceHandle;
+    use super::super::native_api::{DELEGATE_ENV, LIVE_DELEGATE_GUESTS};
+
+    let (delegate, mut runtime, _temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+
+    const LIVE_ID: i64 = i64::MAX - 54801;
+
+    let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::ReadContext)?;
+    let msg = InboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(payload));
+    let handle = InstanceHandle { id: LIVE_ID };
+    let params: Parameters = vec![].into();
+
+    // The env is absent, exactly as `DelegateEnvGuard::drop` leaves it after a
+    // wall-clock timeout. Only the guest registration remains.
+    assert!(
+        !DELEGATE_ENV.contains_key(&LIVE_ID),
+        "precondition: no env under LIVE_ID, so a DELEGATE_ENV-only check would pass"
+    );
+    LIVE_DELEGATE_GUESTS.insert(LIVE_ID);
+
+    let result = runtime.exec_inbound_with_env(
+        delegate.key(),
+        &params,
+        None,
+        None,
+        &msg,
+        Vec::new(),
+        &handle,
+        LIVE_ID,
+        DelegateApiVersion::V2,
+    );
+
+    // Clear before asserting so a failure cannot strand a live-guest marker in
+    // the process-global set for every later test in this binary.
+    LIVE_DELEGATE_GUESTS.remove(&LIVE_ID);
+
+    let err = result.expect_err(
+        "re-entry must be refused while a guest is still live, even with the env already \
+         removed (#5480 review F1)",
+    );
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("already active"),
+        "expected the re-entry guard's error, got: {rendered}"
+    );
+
+    Ok(())
+}

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -4919,3 +4919,110 @@ mod hosted_user_secrets {
         Ok(())
     }
 }
+
+/// REGRESSION (#5480): re-entering an instance id whose `DelegateCallEnv` is
+/// still live must FAIL CLOSED, in release builds too.
+///
+/// This is the release-visible half of the change that promoted a
+/// `debug_assert!` to a hard `Err`. The assert compiled out in release, so
+/// before #5480 the only thing preventing re-entry was the batch loop in
+/// `interface.rs` aborting on the first error — control flow, not a guarantee.
+///
+/// It became memory safety when the guest moved off the calling thread. One
+/// `RunningInstance` id is shared by every message in a batch, and on the
+/// wall-clock-timeout path the previous message's guest is still running on an
+/// abandoned `spawn_blocking` thread (`abort()` cannot stop one). Inserting a
+/// new env under that id would make the abandoned guest's
+/// `DELEGATE_ENV.get(&id)` resolve to the NEW env and dereference its raw store
+/// pointers while this thread holds `&mut` to the very same stores — aliasing
+/// UB across two threads, with no `unsafe` at the edit site that caused it.
+///
+/// Unreachable today. That is exactly why it needs a test: an edit making the
+/// batch loop error-tolerant ("collect errors and continue", "retry the
+/// message") would reintroduce it silently, and nothing else would object.
+#[tokio::test]
+async fn reentering_a_live_instance_id_fails_closed() -> Result<(), Box<dyn std::error::Error>> {
+    use super::super::engine::InstanceHandle;
+    use super::super::native_api::{DELEGATE_ENV, DelegateCallEnv};
+
+    let (delegate, mut runtime, _temp_dir) = setup_runtime(TEST_DELEGATE_2).await?;
+
+    // Far above anything `next_instance_id` will hand out: it is a monotonic
+    // counter starting at 0, incremented once per instance.
+    const LIVE_ID: i64 = i64::MAX - 5480;
+
+    let payload = bincode::serialize(&delegate2_messages::InboundAppMessage::ReadContext)?;
+    let msg = InboundDelegateMsg::ApplicationMessage(ApplicationMessage::new(payload));
+    let handle = InstanceHandle { id: LIVE_ID };
+    let params: Parameters = vec![].into();
+
+    // CONTROL: with LIVE_ID unoccupied the guard must not fire. This call fails
+    // for an unrelated reason (no engine instance under that handle), which is
+    // the point — it proves the assertion below distinguishes the re-entry
+    // guard from "this call failed somehow", rather than passing on any error.
+    let control = runtime.exec_inbound_with_env(
+        delegate.key(),
+        &params,
+        None,
+        None,
+        &msg,
+        Vec::new(),
+        &handle,
+        LIVE_ID,
+        DelegateApiVersion::V2,
+    );
+    let control_msg = format!("{:?}", control.err());
+    assert!(
+        !control_msg.contains("already active"),
+        "control call must not trip the re-entry guard, got: {control_msg}"
+    );
+
+    // Occupy LIVE_ID exactly as an abandoned guest's env would.
+    // SAFETY: the env is removed below before `runtime` (which owns the stores
+    // these pointers address) is dropped, and no guest ever runs against it.
+    let env = unsafe {
+        DelegateCallEnv::new(
+            Vec::new(),
+            &mut runtime.secret_store,
+            &runtime.contract_store,
+            runtime.state_store_db.clone(),
+            runtime.state_write_callback.clone(),
+            runtime.state_admit_callback.clone(),
+            delegate.key().clone(),
+            &mut runtime.delegate_store,
+            0,
+            Vec::new(),
+            None,
+            runtime.created_delegates_count.clone(),
+            runtime.inherited_origins.clone(),
+        )
+    };
+    DELEGATE_ENV.insert(LIVE_ID, env);
+
+    let result = runtime.exec_inbound_with_env(
+        delegate.key(),
+        &params,
+        None,
+        None,
+        &msg,
+        Vec::new(),
+        &handle,
+        LIVE_ID,
+        DelegateApiVersion::V2,
+    );
+
+    // Remove before asserting: a panicking assert would otherwise leave a stale
+    // env in the process-global map for every later test in this binary.
+    DELEGATE_ENV.remove(&LIVE_ID);
+
+    let err = result.expect_err(
+        "re-entering an instance id with a live env must fail closed, not proceed (#5480)",
+    );
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("already active"),
+        "expected the re-entry guard's error, got: {rendered}"
+    );
+
+    Ok(())
+}

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2994,7 +2994,30 @@ mod tests {
         .min()
         .map(|off| start + fn_name.len() + off)
         .unwrap_or(src.len());
-        &src[start..end]
+        let body = &src[start..end];
+
+        // Fail closed if the window was TRUNCATED. `scrape_body` bounds a window
+        // at BOTH ends, and an item added inside a method (or a `}` at column 0
+        // inside a string or macro) moves the end delimiter earlier. Every
+        // "this must be ABSENT" assertion then passes vacuously over the
+        // shortened window while the thing it forbids sits just past the new
+        // boundary.
+        //
+        // A delete-mutation cannot catch this: it validates the assertion while
+        // ASSUMING the window, so it reports the pin healthy in exactly the case
+        // where the window is intact. The structural check has to be separate.
+        // A complete method body has balanced braces; a truncated one does not.
+        let opens = body.matches('{').count();
+        let closes = body.matches('}').count();
+        assert_eq!(
+            opens, closes,
+            "`{fn_name}`: scraped body has {opens} `{{` but {closes} `}}` — the \
+             window is truncated, so any \"must be absent\" assertion over it is \
+             vacuous. Widen the end delimiters in `scrape_body`; do NOT delete \
+             the check."
+        );
+
+        body
     }
 
     /// Positions of every guest-entry call in a scraped body. Matches the

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1246,7 +1246,7 @@ impl WasmtimeEngine {
         delegate_instance: Option<i64>,
     ) -> Result<i64, WasmError>
     where
-        P: wasmtime::WasmParams + Send + 'static,
+        P: wasmtime::WasmParams + Send + Sync + 'static,
     {
         let enabled_metering = self.enabled_metering;
         let mut store = self
@@ -2808,50 +2808,93 @@ mod tests {
         );
     }
 
-    /// Source-scrape pin (#4864 review, fix 8 + round-4 P2): EVERY guest-entry
-    /// call site (`instantiate_async` / `call_async`) — not just the first — MUST
-    /// be preceded by an `arm_epoch_deadline(` since the previous guest entry in
-    /// the same function. The store is reused across calls, so a SECOND guest
-    /// call that is not re-armed inherits the first call's remaining epoch budget
-    /// (the `__frnt_set_id` case). This also future-proofs against a refactor
-    /// adding a guest-entry path without arming the deadline.
+    /// Bound a scraped method body: from `fn_name` to whichever comes first of
+    /// the next method or the end of the impl block.
+    fn scrape_body<'a>(src: &'a str, fn_name: &str) -> &'a str {
+        let start = src
+            .find(fn_name)
+            .unwrap_or_else(|| panic!("method `{fn_name}` not found"));
+        let rest = &src[start + fn_name.len()..];
+        let end = ["\n    fn ", "\n    pub(crate) fn ", "\n    pub(super) fn ", "\n}"]
+            .iter()
+            .filter_map(|needle| rest.find(needle))
+            .min()
+            .map(|off| start + fn_name.len() + off)
+            .unwrap_or(src.len());
+        &src[start..end]
+    }
+
+    /// Positions of every guest-entry call in a scraped body. Matches the
+    /// method-call syntax (leading dot + open paren) so a prose mention of
+    /// "call_async" in a doc comment is not counted as an entry.
+    fn guest_entries(body: &str) -> Vec<usize> {
+        let mut entries: Vec<usize> = body
+            .match_indices(".call_async(")
+            .chain(body.match_indices(".instantiate_async("))
+            .map(|(i, _)| i)
+            .collect();
+        entries.sort_unstable();
+        entries
+    }
+
+    /// Source-scrape pin (#4864 review, fix 8 + round-4 P2; extended by #5480):
+    /// EVERY guest-entry call site (`instantiate_async` / `call_async`) — not
+    /// just the first — MUST be preceded by an `arm_epoch_deadline(` since the
+    /// previous guest entry in the same function. The store is reused across
+    /// calls, so a SECOND guest call that is not re-armed inherits the first
+    /// call's remaining epoch budget (the `__frnt_set_id` case). This also
+    /// future-proofs against a refactor adding a guest-entry path without arming
+    /// the deadline.
+    ///
+    /// #5480 made this pin's original form VACUOUS for half its list. Once the
+    /// four public entry points became thin wrappers around
+    /// `call_typed_blocking`, their bodies no longer contain `.call_async(`, and
+    /// the old `if entries.is_empty() { continue }` silently skipped them — the
+    /// pin would have stayed green with every safeguard deleted. So the list is
+    /// now split, and NEITHER half can pass by being empty:
+    ///
+    /// - `GUEST_ENTRY_FNS` really do enter the guest: each must contain at least
+    ///   one entry, and every entry must be armed.
+    /// - `DELEGATING_ENTRY_FNS` must contain NO guest entry of their own and
+    ///   must hand off to `call_typed_blocking`, which is what keeps the
+    ///   safeguards on one mechanism instead of a fifth hand-rolled near-copy.
     #[test]
     fn every_guest_entry_is_preceded_by_arm_epoch_deadline() {
         let src = include_str!("wasmtime_engine.rs");
-        for fn_name in [
+
+        // Functions that legitimately contain a guest entry.
+        const GUEST_ENTRY_FNS: &[&str] = &[
             // #4864 round-9 item 2: create_instance's guest entries moved into
             // instantiate_and_init so the store can be recovered on a guest-entry
             // timeout; scrape the new home of those entries.
             "fn instantiate_and_init(",
             "fn initiate_buffer(",
             "fn call_void(",
+            // #5480: the single shared body for all four contract/delegate
+            // entry points.
+            "fn call_typed_blocking(",
+        ];
+
+        // The public entry points, which must NOT enter the guest themselves.
+        const DELEGATING_ENTRY_FNS: &[&str] = &[
             "fn call_3i64(",
             "fn call_3i64_async_imports(",
             "fn call_2i64_blocking(",
             "fn call_3i64_blocking(",
-        ] {
-            let start = src
-                .find(fn_name)
-                .unwrap_or_else(|| panic!("guest-entry method `{fn_name}` not found"));
-            let after = &src[start..];
-            let end = after
-                .find("\n    fn ")
-                .or_else(|| after.find("\n    pub(crate) fn "))
-                .unwrap_or(after.len());
-            let body = &after[..end];
+        ];
 
-            // Every guest-entry occurrence (both call kinds), sorted. Match the
-            // method-call syntax (leading dot + open paren) so a prose mention of
-            // "call_async" in a doc comment is not treated as an entry.
-            let mut entries: Vec<usize> = body
-                .match_indices(".call_async(")
-                .chain(body.match_indices(".instantiate_async("))
-                .map(|(i, _)| i)
-                .collect();
-            entries.sort_unstable();
-            if entries.is_empty() {
-                continue;
-            }
+        for fn_name in GUEST_ENTRY_FNS {
+            let body = scrape_body(src, fn_name);
+            let entries = guest_entries(body);
+            // NOT `continue` — an empty list here means the scrape has drifted
+            // off the real guest entry and the pin is measuring nothing.
+            assert!(
+                !entries.is_empty(),
+                "`{fn_name}` is listed as a guest-entry method but contains no \
+                 `.call_async(`/`.instantiate_async(` — either it stopped entering \
+                 the guest (move it to DELEGATING_ENTRY_FNS) or this pin has gone \
+                 vacuous (#5480)"
+            );
             // Real arm CALLS only (`arm_epoch_deadline(`), not prose/identifier
             // mentions like this pin's own name.
             let arms: Vec<usize> = body
@@ -2874,6 +2917,23 @@ mod tests {
                 );
                 prev = entry_pos;
             }
+        }
+
+        for fn_name in DELEGATING_ENTRY_FNS {
+            let body = scrape_body(src, fn_name);
+            let entries = guest_entries(body);
+            assert!(
+                entries.is_empty(),
+                "`{fn_name}` enters the guest directly (`.call_async(` / \
+                 `.instantiate_async(` at {entries:?}). Every entry point must go \
+                 through `call_typed_blocking` so it gets spawn_blocking, the \
+                 wall-clock backstop and panic capture — a hand-rolled copy is how \
+                 delegates drifted without them (#5480)"
+            );
+            assert!(
+                body.contains("self.call_typed_blocking("),
+                "`{fn_name}` must delegate to `call_typed_blocking` (#5480)"
+            );
         }
     }
 
@@ -3044,33 +3104,43 @@ mod tests {
     #[test]
     fn blocking_paths_arm_epoch_inside_the_closure() {
         let src = include_str!("wasmtime_engine.rs");
-        for fn_name in ["fn call_2i64_blocking(", "fn call_3i64_blocking("] {
-            let start = src
-                .find(fn_name)
-                .unwrap_or_else(|| panic!("`{fn_name}` not found"));
-            let rest = &src[start + fn_name.len()..];
-            // Bound the body at the next method or the impl close.
-            let end = ["\n    fn ", "\n}"]
-                .iter()
-                .filter_map(|needle| rest.find(needle))
-                .min()
-                .map(|i| start + fn_name.len() + i)
-                .unwrap_or(src.len());
-            let body = &src[start..end];
+        // #5480: all four entry points share ONE body, so this scrapes that
+        // body rather than the per-entry-point copies it replaced.
+        let fn_name = "fn call_typed_blocking(";
+        let body = scrape_body(src, fn_name);
 
-            let ewb = body
-                .find("execute_wasm_blocking(")
-                .unwrap_or_else(|| panic!("`{fn_name}` must call execute_wasm_blocking"));
-            let arm = body
-                .find("arm_epoch_deadline(")
-                .unwrap_or_else(|| panic!("`{fn_name}` must arm the epoch deadline"));
-            assert!(
-                arm > ewb,
-                "`{fn_name}`: arm_epoch_deadline must be INSIDE the execute_wasm_blocking \
-                 closure (after the call), not before it — else queue wait consumes the \
-                 epoch budget and a healthy contract is quarantined (#4864 round-7)"
-            );
-        }
+        let ewb = body
+            .find("execute_wasm_blocking(")
+            .unwrap_or_else(|| panic!("`{fn_name}` must call execute_wasm_blocking"));
+        let arm = body
+            .find("arm_epoch_deadline(")
+            .unwrap_or_else(|| panic!("`{fn_name}` must arm the epoch deadline"));
+        assert!(
+            arm > ewb,
+            "`{fn_name}`: arm_epoch_deadline must be INSIDE the execute_wasm_blocking \
+             closure (after the call), not before it — else queue wait consumes the \
+             epoch budget and a healthy contract is quarantined (#4864 round-7)"
+        );
+
+        // #5480: the delegate instance id must be installed on the thread that
+        // actually runs the guest, i.e. INSIDE the same closure. Installed
+        // outside it, it lands on the caller's thread and every delegate host
+        // function reads the default -1.
+        let install = body.find("GuestDelegateInstance::install").unwrap_or_else(|| {
+            panic!("`{fn_name}` must install the delegate instance id (#5480)")
+        });
+        assert!(
+            install > ewb,
+            "`{fn_name}`: GuestDelegateInstance::install must be INSIDE the \
+             execute_wasm_blocking closure — on the blocking-pool thread that runs \
+             the guest, not the caller's thread (#5480)"
+        );
+        assert!(
+            install < arm,
+            "`{fn_name}`: install the delegate instance id BEFORE arming the epoch \
+             deadline, so a guest that traps immediately still had its env reachable \
+             (#5480)"
+        );
     }
 
     /// REGRESSION (issue #4441 fix-up): with `offload_compilation = true` on a

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1222,7 +1222,7 @@ impl WasmtimeEngine {
     /// The wall-clock backstop is not redundant with the epoch trap. The epoch
     /// interrupt only fires at a guest instruction boundary, so it cannot cut off
     /// a blocking HOST function in flight (a ReDb read/write, a secret-store
-    /// fsync) — see [`epoch_deadline_trap`] — and if the epoch ticker thread dies
+    /// fsync) — see [`arm_epoch_deadline`] — and if the epoch ticker thread dies
     /// (#4864) it does not fire at all.
     ///
     /// **Every entry point routes through here rather than hand-rolling a copy.**
@@ -1285,8 +1285,20 @@ impl WasmtimeEngine {
         // closure can't borrow `self`.
         let epoch_ticks = self.epoch_deadline_ticks;
 
+        // Registered HERE, on the calling thread, not inside the closure: see
+        // `native_api::LIVE_DELEGATE_GUESTS`. Registering inside would leave a
+        // window on the `QueuedTimeout` path, where the abort can lose the race
+        // and the closure runs after this call has already returned.
+        let live_guest = delegate_instance.map(LiveGuestRegistration::register);
+
         let result = execute_wasm_blocking(
             move || {
+                // MOVED into the closure so it drops when the guest finishes,
+                // and equally when the closure is dropped UNRUN by `abort()`.
+                // The binding is load-bearing: an unmentioned capture would not
+                // be moved in at all under Rust 2021 disjoint capture, and the
+                // registration would clear on the calling thread instead.
+                let _live_guest = live_guest;
                 // Installed BEFORE the guest runs and cleared by its `Drop` on
                 // every exit path (including a panic), so a reused blocking-pool
                 // thread never carries a stale delegate id into the next job.
@@ -2231,6 +2243,36 @@ impl GuestDelegateInstance {
 impl Drop for GuestDelegateInstance {
     fn drop(&mut self) {
         native_api::CURRENT_DELEGATE_INSTANCE.with(|c| c.set(-1));
+    }
+}
+
+/// Marks an instance id as having a delegate guest that may still be executing,
+/// for as long as this value is alive.
+///
+/// Created on the CALLING thread and moved into the guest closure, so it clears
+/// on both outcomes: the closure running to completion (or unwinding), and the
+/// closure being dropped UNRUN when `abort()` beats it off the blocking-pool
+/// queue. See [`native_api::LIVE_DELEGATE_GUESTS`] for why neither half can move.
+///
+/// Distinct from [`GuestDelegateInstance`] on purpose. That one installs a
+/// THREAD-LOCAL and so must be constructed on the worker thread; this one is a
+/// process-global registration and must be constructed BEFORE the worker starts,
+/// or a `QueuedTimeout` whose abort loses the race leaves a window where the
+/// next message sees no live guest.
+struct LiveGuestRegistration {
+    instance_id: i64,
+}
+
+impl LiveGuestRegistration {
+    fn register(instance_id: i64) -> Self {
+        native_api::LIVE_DELEGATE_GUESTS.insert(instance_id);
+        Self { instance_id }
+    }
+}
+
+impl Drop for LiveGuestRegistration {
+    fn drop(&mut self) {
+        native_api::LIVE_DELEGATE_GUESTS.remove(&self.instance_id);
     }
 }
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2651,6 +2651,27 @@ mod tests {
         );
     }
 
+    /// Run a test body that deliberately leaves a guest spinning on an abandoned
+    /// blocking-pool thread, WITHOUT waiting for that thread at teardown.
+    ///
+    /// `#[tokio::test]` drops its runtime at the end, and `Runtime::drop` waits
+    /// for blocking tasks that have already started. Since the whole point of
+    /// these tests is that the wall-clock backstop returns while the guest runs
+    /// on, that wait would (a) add the full epoch budget to every run and, worse,
+    /// (b) HANG FOREVER instead of failing if the epoch ticker thread were dead
+    /// -- which is exactly the #4864 scenario these tests exist to cover. A
+    /// zero-timeout shutdown detaches the thread instead; the epoch trap still
+    /// reaps it in the background.
+    fn run_abandoning_guest_test(body: impl FnOnce()) {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("test runtime must build");
+        rt.block_on(async { body() });
+        rt.shutdown_timeout(Duration::from_millis(0));
+    }
+
     /// Drive ONE delegate entry point with a guest that never returns, under a
     /// SHORT wall clock and a deliberately LONG epoch deadline, and assert it
     /// still comes back promptly.
@@ -2718,16 +2739,16 @@ mod tests {
 
     /// REGRESSION (#5480): the V1 delegate entry must have the wall-clock
     /// backstop that contract execution already had.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn delegate_v1_entry_has_wall_clock_backstop() {
-        assert_delegate_entry_has_wall_clock_backstop(false);
+    #[test]
+    fn delegate_v1_entry_has_wall_clock_backstop() {
+        run_abandoning_guest_test(|| assert_delegate_entry_has_wall_clock_backstop(false));
     }
 
     /// REGRESSION (#5480): same for the V2 delegate entry, which additionally
     /// has the larger async host-function surface.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn delegate_v2_entry_has_wall_clock_backstop() {
-        assert_delegate_entry_has_wall_clock_backstop(true);
+    #[test]
+    fn delegate_v2_entry_has_wall_clock_backstop() {
+        run_abandoning_guest_test(|| assert_delegate_entry_has_wall_clock_backstop(true));
     }
 
     /// WAT whose exported entry immediately calls an imported host function.
@@ -2761,12 +2782,15 @@ mod tests {
         let eng = store.engine().clone();
         let module = Module::new(&eng, HOST_PANIC_WAT.as_bytes()).expect("WAT must compile");
         let mut linker: Linker<HostState> = Linker::new(&eng);
+        // A named fn, not a closure: a closure whose body diverges infers `!`
+        // as its return type, and wasmtime's `IntoFunc` has no `WasmTy` impl for
+        // `!`. An elided `()` return resolves it, and unlike an explicit `-> ()`
+        // it does not trip `clippy::unused_unit`.
+        fn boom(_: Caller<'_, HostState>) {
+            panic!("deliberate host-function panic (#5480 panic-capture test)");
+        }
         linker
-            .func_wrap("freenet_test", "boom", |_: Caller<'_, HostState>| {
-                // Trailing semicolon so the closure's block types as `()` rather
-                // than `!`, which wasmtime's `IntoFunc` cannot resolve.
-                panic!("deliberate host-function panic (#5480 panic-capture test)");
-            })
+            .func_wrap("freenet_test", "boom", boom)
             .expect("registering the panicking host fn must succeed");
         let instance = block_on_async(linker.instantiate_async(&mut *store, &module))
             .expect("instantiation must succeed");

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1246,6 +1246,12 @@ impl WasmtimeEngine {
         delegate_instance: Option<i64>,
     ) -> Result<i64, WasmError>
     where
+        // `Sync` is REQUIRED and is not an over-claim, despite this change
+        // being about not over-claiming `Sync` elsewhere. It is wasmtime's own
+        // bound: `TypedFunc::<Params, Results>::call_async` requires
+        // `Params: Sync` (wasmtime-47.0.3 `runtime/func/typed.rs:135`).
+        // Removing it fails to compile at the `func.call_async` below —
+        // verified, not assumed. Do not "tidy" it away.
         P: wasmtime::WasmParams + Send + Sync + 'static,
     {
         let enabled_metering = self.enabled_metering;

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -1112,23 +1112,14 @@ impl WasmEngine for WasmtimeEngine {
         b: i64,
         c: i64,
     ) -> Result<i64, WasmError> {
-        let enabled_metering = self.enabled_metering;
-        let epoch_ticks = self.epoch_deadline_ticks;
-        let store = self
-            .store
-            .as_mut()
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
-        let instance = self
-            .instances
-            .get(&handle.id)
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("instance {} not found", handle.id)))?;
-        let func = instance
-            .get_typed_func::<(i64, i64, i64), i64>(&mut *store, name)
-            .map_err(|e| WasmError::Export(e.to_string()))?;
-        arm_epoch_deadline(store, epoch_ticks);
-        // Use call_async because async_support(true) is enabled in the engine Config
-        block_on_async(func.call_async(&mut *store, (a, b, c)))
-            .map_err(|e| classify_runtime_error(enabled_metering, store, e))
+        // V1 delegate `process()`. Routed through the SAME blocking helper as
+        // contract execution (#5480). Before that this ran `block_on_async`
+        // directly on the calling thread, so a delegate got the epoch trap and
+        // nothing else: no wall-clock backstop (so #4864's dead-ticker case left
+        // it with no preemption at all) and no panic capture. `Some(handle.id)`
+        // carries the delegate instance id onto the thread that runs the guest —
+        // see `GuestDelegateInstance`.
+        self.call_typed_blocking(handle, name, (a, b, c), Some(handle.id))
     }
 
     fn call_3i64_async_imports(
@@ -1139,30 +1130,15 @@ impl WasmEngine for WasmtimeEngine {
         b: i64,
         c: i64,
     ) -> Result<i64, WasmError> {
-        // Wasmtime's async host functions work seamlessly with call_async on the same Store.
-        //
-        // The async host functions (delegate_contracts) are registered via func_wrap_async,
-        // so we use call_async here. The closures complete synchronously (ReDb reads) but
-        // are registered as async to establish the pattern for future async operations.
-
-        let store = self
-            .store
-            .as_mut()
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
-
-        let instance = self
-            .instances
-            .get(&handle.id)
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("instance {} not found", handle.id)))?;
-
-        let func = instance
-            .get_typed_func::<(i64, i64, i64), i64>(&mut *store, name)
-            .map_err(|e| WasmError::Export(e.to_string()))?;
-
-        arm_epoch_deadline(store, self.epoch_deadline_ticks);
-        // Call the async-aware function using block_on_async
-        let result = block_on_async(func.call_async(&mut *store, (a, b, c)));
-        result.map_err(|e| classify_runtime_error(self.enabled_metering, store, e))
+        // V2 delegate `process()`. Identical mechanism to `call_3i64` — the
+        // engine has `async_support(true)`, so EVERY guest entry already goes
+        // through `call_async`; the V2-only part is that this module's imports
+        // include `freenet_delegate_contracts`, registered with
+        // `func_wrap_async`. Those host functions are plain synchronous bodies
+        // wrapped in `async move` with no `.await` point (see their registration
+        // in `create_backend_engine`), so they run on the blocking-pool thread
+        // exactly as they ran on the caller's.
+        self.call_typed_blocking(handle, name, (a, b, c), Some(handle.id))
     }
 
     fn call_2i64_blocking(
@@ -1172,76 +1148,7 @@ impl WasmEngine for WasmtimeEngine {
         a: i64,
         b: i64,
     ) -> Result<i64, WasmError> {
-        let enabled_metering = self.enabled_metering;
-        let mut store = self
-            .store
-            .take()
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
-
-        let instance = match self.instances.get(&handle.id) {
-            Some(i) => i,
-            None => {
-                self.store = Some(store);
-                return Err(WasmError::Other(anyhow::anyhow!(
-                    "instance {} not found",
-                    handle.id
-                )));
-            }
-        };
-
-        let func = match instance.get_typed_func::<(i64, i64), i64>(&mut store, name) {
-            Ok(f) => f,
-            Err(e) => {
-                self.store = Some(store);
-                return Err(WasmError::Export(e.to_string()));
-            }
-        };
-
-        // #4864 round-7: arm the epoch deadline INSIDE the blocking closure, as
-        // the guest's first act — NOT here, before the closure is enqueued.
-        // Arming before enqueue let the queue wait on a saturated blocking pool
-        // consume the epoch budget, so a queued job would insta-trap on start and
-        // a HEALTHY contract would be quarantined (contract-wide Timeout). Arming
-        // at guest-start makes the epoch budget (and the wall-clock backstop in
-        // execute_wasm_blocking) measure from when the guest actually runs. The
-        // wall-clock poll is a backstop; the epoch trap is what actually stops a
-        // runaway synchronous guest. Capture the tick budget by value since the
-        // closure can't borrow `self`.
-        let epoch_ticks = self.epoch_deadline_ticks;
-
-        let result = execute_wasm_blocking(
-            move || {
-                arm_epoch_deadline(&mut store, epoch_ticks);
-                // Use call_async because async_support(true) is enabled in the engine Config
-                let r = block_on_async(func.call_async(&mut store, (a, b)));
-                (r, store)
-            },
-            self.max_execution_seconds,
-        );
-
-        match result {
-            BlockingResult::Ok(value, store) => {
-                self.store = Some(store);
-                Ok(value)
-            }
-            BlockingResult::WasmError(err, mut store) => {
-                let wasm_err = classify_runtime_error(enabled_metering, &mut store, err);
-                self.store = Some(store);
-                Err(wasm_err)
-            }
-            BlockingResult::Timeout => {
-                self.recover_store();
-                Err(WasmError::Timeout)
-            }
-            BlockingResult::QueuedTimeout => {
-                self.recover_store();
-                Err(WasmError::SchedulerOverloaded)
-            }
-            BlockingResult::Panic(err) => {
-                self.recover_store();
-                Err(WasmError::Other(err))
-            }
-        }
+        self.call_typed_blocking(handle, name, (a, b), None)
     }
 
     fn call_3i64_blocking(
@@ -1252,73 +1159,7 @@ impl WasmEngine for WasmtimeEngine {
         b: i64,
         c: i64,
     ) -> Result<i64, WasmError> {
-        let enabled_metering = self.enabled_metering;
-        let mut store = self
-            .store
-            .take()
-            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
-
-        let instance = match self.instances.get(&handle.id) {
-            Some(i) => i,
-            None => {
-                self.store = Some(store);
-                return Err(WasmError::Other(anyhow::anyhow!(
-                    "instance {} not found",
-                    handle.id
-                )));
-            }
-        };
-
-        let func = match instance.get_typed_func::<(i64, i64, i64), i64>(&mut store, name) {
-            Ok(f) => f,
-            Err(e) => {
-                self.store = Some(store);
-                return Err(WasmError::Export(e.to_string()));
-            }
-        };
-
-        // #4864 round-7: arm the epoch deadline INSIDE the blocking closure, as
-        // the guest's first act — NOT here, before the closure is enqueued (see
-        // call_2i64_blocking for the full rationale). This is the primary contract
-        // merge/validate path, so a pre-enqueue arm consumed by queue wait would
-        // quarantine a healthy contract under blocking-pool saturation. The wall-
-        // clock poll only aborts the tokio task; the epoch trap is what actually
-        // stops a runaway synchronous guest that ignores the timeout.
-        let epoch_ticks = self.epoch_deadline_ticks;
-
-        let result = execute_wasm_blocking(
-            move || {
-                arm_epoch_deadline(&mut store, epoch_ticks);
-                // Use call_async because async_support(true) is enabled in the engine Config
-                let r = block_on_async(func.call_async(&mut store, (a, b, c)));
-                (r, store)
-            },
-            self.max_execution_seconds,
-        );
-
-        match result {
-            BlockingResult::Ok(value, store) => {
-                self.store = Some(store);
-                Ok(value)
-            }
-            BlockingResult::WasmError(err, mut store) => {
-                let wasm_err = classify_runtime_error(enabled_metering, &mut store, err);
-                self.store = Some(store);
-                Err(wasm_err)
-            }
-            BlockingResult::Timeout => {
-                self.recover_store();
-                Err(WasmError::Timeout)
-            }
-            BlockingResult::QueuedTimeout => {
-                self.recover_store();
-                Err(WasmError::SchedulerOverloaded)
-            }
-            BlockingResult::Panic(err) => {
-                self.recover_store();
-                Err(WasmError::Other(err))
-            }
-        }
+        self.call_typed_blocking(handle, name, (a, b, c), None)
     }
 }
 
@@ -1370,6 +1211,119 @@ fn refresh_mem_addr_from_caller(caller: &mut Caller<'_, HostState>, instance_id:
 }
 
 impl WasmtimeEngine {
+    /// Shared body for EVERY guest entry point that runs contract or delegate
+    /// code: resolve the typed export, then run the call under
+    /// [`execute_wasm_blocking`] so it gets all three safeguards at once —
+    /// `spawn_blocking` (a stuck guest occupies a pool thread, not the caller's),
+    /// the wall-clock backstop that aborts the task when the epoch trap cannot,
+    /// and panic capture that turns a host-side panic into a `Result` instead of
+    /// unwinding into the calling task.
+    ///
+    /// The wall-clock backstop is not redundant with the epoch trap. The epoch
+    /// interrupt only fires at a guest instruction boundary, so it cannot cut off
+    /// a blocking HOST function in flight (a ReDb read/write, a secret-store
+    /// fsync) — see [`epoch_deadline_trap`] — and if the epoch ticker thread dies
+    /// (#4864) it does not fire at all.
+    ///
+    /// **Every entry point routes through here rather than hand-rolling a copy.**
+    /// Delegate execution reaching `block_on_async` directly on the calling
+    /// thread, with none of the three safeguards, is precisely the drift a fifth
+    /// near-copy would reproduce (#5480), so
+    /// `blocking_paths_arm_epoch_inside_the_closure` pins that every entry point
+    /// delegates here and that the epoch arm lives inside this closure.
+    ///
+    /// `delegate_instance` is `Some(handle.id)` for a delegate `process()` call
+    /// and `None` for a contract. Delegate host functions locate their
+    /// `native_api::DelegateCallEnv` through the `CURRENT_DELEGATE_INSTANCE`
+    /// THREAD-LOCAL, so a guest running on a blocking-pool thread needs that id
+    /// installed on the thread that actually executes it — see
+    /// [`GuestDelegateInstance`].
+    fn call_typed_blocking<P>(
+        &mut self,
+        handle: &InstanceHandle,
+        name: &str,
+        args: P,
+        delegate_instance: Option<i64>,
+    ) -> Result<i64, WasmError>
+    where
+        P: wasmtime::WasmParams + Send + 'static,
+    {
+        let enabled_metering = self.enabled_metering;
+        let mut store = self
+            .store
+            .take()
+            .ok_or_else(|| WasmError::Other(anyhow::anyhow!("engine store not available")))?;
+
+        let instance = match self.instances.get(&handle.id) {
+            Some(i) => i,
+            None => {
+                self.store = Some(store);
+                return Err(WasmError::Other(anyhow::anyhow!(
+                    "instance {} not found",
+                    handle.id
+                )));
+            }
+        };
+
+        let func = match instance.get_typed_func::<P, i64>(&mut store, name) {
+            Ok(f) => f,
+            Err(e) => {
+                self.store = Some(store);
+                return Err(WasmError::Export(e.to_string()));
+            }
+        };
+
+        // #4864 round-7: arm the epoch deadline INSIDE the blocking closure, as
+        // the guest's first act — NOT here, before the closure is enqueued.
+        // Arming before enqueue let the queue wait on a saturated blocking pool
+        // consume the epoch budget, so a queued job would insta-trap on start and
+        // a HEALTHY contract would be quarantined (contract-wide Timeout). Arming
+        // at guest-start makes the epoch budget (and the wall-clock backstop in
+        // execute_wasm_blocking) measure from when the guest actually runs. The
+        // wall-clock poll is a backstop; the epoch trap is what actually stops a
+        // runaway synchronous guest. Capture the tick budget by value since the
+        // closure can't borrow `self`.
+        let epoch_ticks = self.epoch_deadline_ticks;
+
+        let result = execute_wasm_blocking(
+            move || {
+                // Installed BEFORE the guest runs and cleared by its `Drop` on
+                // every exit path (including a panic), so a reused blocking-pool
+                // thread never carries a stale delegate id into the next job.
+                let _delegate = delegate_instance.map(GuestDelegateInstance::install);
+                arm_epoch_deadline(&mut store, epoch_ticks);
+                // Use call_async because async_support(true) is enabled in the engine Config
+                let r = block_on_async(func.call_async(&mut store, args));
+                (r, store)
+            },
+            self.max_execution_seconds,
+        );
+
+        match result {
+            BlockingResult::Ok(value, store) => {
+                self.store = Some(store);
+                Ok(value)
+            }
+            BlockingResult::WasmError(err, mut store) => {
+                let wasm_err = classify_runtime_error(enabled_metering, &mut store, err);
+                self.store = Some(store);
+                Err(wasm_err)
+            }
+            BlockingResult::Timeout => {
+                self.recover_store();
+                Err(WasmError::Timeout)
+            }
+            BlockingResult::QueuedTimeout => {
+                self.recover_store();
+                Err(WasmError::SchedulerOverloaded)
+            }
+            BlockingResult::Panic(err) => {
+                self.recover_store();
+                Err(WasmError::Other(err))
+            }
+        }
+    }
+
     /// Check if a compiled module imports the streaming buffer host function.
     /// Contracts compiled against freenet-stdlib >= 0.3.4 import `freenet_contract_io`;
     /// older contracts do not and must use the legacy one-shot buffer protocol.
@@ -2247,6 +2201,37 @@ fn classify_runtime_error(
     }
     tracing::error!("WASM runtime error: {:?}", error);
     WasmError::Runtime(error.to_string())
+}
+
+/// Installs the executing delegate's instance id in the CURRENT thread's
+/// `CURRENT_DELEGATE_INSTANCE` thread-local for the duration of one guest call,
+/// clearing it on every exit path including a panic.
+///
+/// Every delegate host function — the `freenet_delegate_ctx`,
+/// `freenet_delegate_secrets`, `freenet_delegate_contracts` and
+/// `freenet_delegate_management` namespaces — reads that thread-local to find
+/// its entry in `native_api::DELEGATE_ENV`. Delegate guests now run on a
+/// blocking-pool thread (#5480) rather than the caller's, so the id must be
+/// installed on the thread that actually executes the guest; without it every
+/// delegate host function reads the default `-1` and fails.
+///
+/// The `Drop` is load-bearing, not tidiness: blocking-pool threads are reused,
+/// and the wall-clock backstop can return while the guest is still running, so
+/// an uncleared id would outlive its `DELEGATE_ENV` entry on a thread that later
+/// serves an unrelated job.
+struct GuestDelegateInstance;
+
+impl GuestDelegateInstance {
+    fn install(instance_id: i64) -> Self {
+        native_api::CURRENT_DELEGATE_INSTANCE.with(|c| c.set(instance_id));
+        Self
+    }
+}
+
+impl Drop for GuestDelegateInstance {
+    fn drop(&mut self) {
+        native_api::CURRENT_DELEGATE_INSTANCE.with(|c| c.set(-1));
+    }
 }
 
 // =============================================================================

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2651,6 +2651,137 @@ mod tests {
         );
     }
 
+    /// Drive ONE delegate entry point with a guest that never returns, under a
+    /// SHORT wall clock and a deliberately LONG epoch deadline, and assert it
+    /// still comes back promptly.
+    ///
+    /// The two deadlines are separated on purpose — a 0.5s wall clock against a
+    /// ~10s epoch budget — so only ONE mechanism can possibly return the call.
+    /// Before #5480 the delegate entries ran `block_on_async` directly on the
+    /// caller's thread and had NO wall-clock backstop, so this would hang until
+    /// the epoch fired; and #4864 exists because the epoch ticker thread dying
+    /// is a real scenario, which left delegates with no preemption at all.
+    ///
+    /// The epoch budget is long but FINITE on purpose: `spawn_blocking` closures
+    /// cannot be cancelled, so the abandoned guest thread outlives this call
+    /// (exactly as it already does for contracts). A finite epoch deadline means
+    /// it still terminates instead of spinning for the life of the test binary.
+    fn assert_delegate_entry_has_wall_clock_backstop(async_imports: bool) {
+        let config = RuntimeConfig {
+            enable_metering: false,
+            ..RuntimeConfig::default()
+        };
+        let mut engine = WasmtimeEngine::new(&config, false).expect("engine must build");
+        engine.max_execution_seconds = 0.5;
+        // ~10s of ticks: far beyond the wall clock, so a prompt return CANNOT
+        // be the epoch trap.
+        engine.epoch_deadline_ticks = 100;
+
+        const ID: i64 = 4242;
+        // Instantiate directly into the engine's own store so the entry point
+        // finds the instance, without needing the `__frnt_set_id` / memory
+        // exports that `create_instance` requires of a real contract.
+        let store = engine.store.as_mut().expect("engine store present");
+        let eng = store.engine().clone();
+        let module = Module::new(&eng, INFINITE_LOOP_WAT.as_bytes()).expect("WAT must compile");
+        let instance = block_on_async(Linker::new(&eng).instantiate_async(&mut *store, &module))
+            .expect("instantiation must succeed");
+        engine.instances.insert(ID, instance);
+
+        let handle = InstanceHandle { id: ID };
+        let entry = if async_imports {
+            "call_3i64_async_imports"
+        } else {
+            "call_3i64"
+        };
+        let start = std::time::Instant::now();
+        let result = if async_imports {
+            engine.call_3i64_async_imports(&handle, "spin", 0, 0, 0)
+        } else {
+            engine.call_3i64(&handle, "spin", 0, 0, 0)
+        };
+        let elapsed = start.elapsed();
+
+        let err = result.expect_err("a guest that never returns must not return Ok");
+        assert!(
+            matches!(err, WasmError::Timeout),
+            "`{entry}`: the wall-clock backstop must surface as WasmError::Timeout, got {err:?}"
+        );
+        // 5s is comfortably above the 0.5s wall clock and comfortably below the
+        // ~10s epoch budget, so a pass here can ONLY be the wall-clock backstop.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "`{entry}` took {elapsed:?}: the 0.5s wall-clock backstop did not fire, and the \
+             epoch budget (~10s) is too far out to have returned this (#5480)"
+        );
+    }
+
+    /// REGRESSION (#5480): the V1 delegate entry must have the wall-clock
+    /// backstop that contract execution already had.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_v1_entry_has_wall_clock_backstop() {
+        assert_delegate_entry_has_wall_clock_backstop(false);
+    }
+
+    /// REGRESSION (#5480): same for the V2 delegate entry, which additionally
+    /// has the larger async host-function surface.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_v2_entry_has_wall_clock_backstop() {
+        assert_delegate_entry_has_wall_clock_backstop(true);
+    }
+
+    /// WAT whose exported entry immediately calls an imported host function.
+    /// Paired below with a linker that panics inside that import, this is a
+    /// HOST-side panic during delegate execution — which is the case #5480
+    /// actually covers, since a WASM trap (unreachable, OOB, div-by-zero) is
+    /// already an `Err` and never a Rust panic.
+    const HOST_PANIC_WAT: &str = r#"
+        (module
+          (import "freenet_test" "boom" (func $boom))
+          (func (export "process") (param i64 i64 i64) (result i64)
+            (call $boom)
+            (i64.const 0)))
+    "#;
+
+    /// REGRESSION (#5480): a panic in a host function called during delegate
+    /// execution must come back as an `Err`, not unwind into the calling task.
+    /// There is no `catch_unwind` on the delegate path; the capture comes
+    /// entirely from routing through `execute_wasm_blocking`, whose
+    /// `spawn_blocking` join turns a panic into `BlockingResult::Panic`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_entry_captures_host_panic() {
+        let config = RuntimeConfig {
+            enable_metering: false,
+            ..RuntimeConfig::default()
+        };
+        let mut engine = WasmtimeEngine::new(&config, false).expect("engine must build");
+
+        const ID: i64 = 4343;
+        let store = engine.store.as_mut().expect("engine store present");
+        let eng = store.engine().clone();
+        let module = Module::new(&eng, HOST_PANIC_WAT.as_bytes()).expect("WAT must compile");
+        let mut linker: Linker<HostState> = Linker::new(&eng);
+        linker
+            .func_wrap("freenet_test", "boom", |_: Caller<'_, HostState>| {
+                // Trailing semicolon so the closure's block types as `()` rather
+                // than `!`, which wasmtime's `IntoFunc` cannot resolve.
+                panic!("deliberate host-function panic (#5480 panic-capture test)");
+            })
+            .expect("registering the panicking host fn must succeed");
+        let instance = block_on_async(linker.instantiate_async(&mut *store, &module))
+            .expect("instantiation must succeed");
+        engine.instances.insert(ID, instance);
+
+        let handle = InstanceHandle { id: ID };
+        let err = engine
+            .call_3i64(&handle, "process", 0, 0, 0)
+            .expect_err("a host panic must surface as an Err, not unwind into the caller");
+        assert!(
+            matches!(err, WasmError::Other(_)),
+            "a captured panic must surface as WasmError::Other, got {err:?}"
+        );
+    }
+
     /// #4864 review (fix 3): `epoch_deadline_ticks` = `ceil(secs / 100ms) + 1`,
     /// the `+ 1` a phase-safety margin so a free-running ticker never traps a
     /// guest EARLY. Boundary cases.
@@ -2815,12 +2946,17 @@ mod tests {
             .find(fn_name)
             .unwrap_or_else(|| panic!("method `{fn_name}` not found"));
         let rest = &src[start + fn_name.len()..];
-        let end = ["\n    fn ", "\n    pub(crate) fn ", "\n    pub(super) fn ", "\n}"]
-            .iter()
-            .filter_map(|needle| rest.find(needle))
-            .min()
-            .map(|off| start + fn_name.len() + off)
-            .unwrap_or(src.len());
+        let end = [
+            "\n    fn ",
+            "\n    pub(crate) fn ",
+            "\n    pub(super) fn ",
+            "\n}",
+        ]
+        .iter()
+        .filter_map(|needle| rest.find(needle))
+        .min()
+        .map(|off| start + fn_name.len() + off)
+        .unwrap_or(src.len());
         &src[start..end]
     }
 
@@ -3126,9 +3262,9 @@ mod tests {
         // actually runs the guest, i.e. INSIDE the same closure. Installed
         // outside it, it lands on the caller's thread and every delegate host
         // function reads the default -1.
-        let install = body.find("GuestDelegateInstance::install").unwrap_or_else(|| {
-            panic!("`{fn_name}` must install the delegate instance id (#5480)")
-        });
+        let install = body
+            .find("GuestDelegateInstance::install")
+            .unwrap_or_else(|| panic!("`{fn_name}` must install the delegate instance id (#5480)"));
         assert!(
             install > ewb,
             "`{fn_name}`: GuestDelegateInstance::install must be INSIDE the \

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2966,9 +2966,22 @@ mod tests {
     /// Bound a scraped method body: from `fn_name` to whichever comes first of
     /// the next method or the end of the impl block.
     fn scrape_body<'a>(src: &'a str, fn_name: &str) -> &'a str {
+        // These pins scrape the file that CONTAINS them, and the fn names they
+        // look for also appear here as string literals. If the search key misses
+        // the real definition, `find` silently lands on this module's own source
+        // and the pin then measures itself. That is how the first version of this
+        // pin failed: the definition is `fn call_typed_blocking<P>(`, so the
+        // `fn call_typed_blocking(` form never matched it. Fail loudly instead.
+        let tests_start = src.find("\nmod tests {").unwrap_or(src.len());
         let start = src
             .find(fn_name)
             .unwrap_or_else(|| panic!("method `{fn_name}` not found"));
+        assert!(
+            start < tests_start,
+            "`{fn_name}` matched inside the test module rather than at its \
+             definition — this pin is scraping its own source. Check for a generic \
+             parameter (`fn foo<P>(`), which makes the `(` form miss."
+        );
         let rest = &src[start + fn_name.len()..];
         let end = [
             "\n    fn ",
@@ -3032,7 +3045,7 @@ mod tests {
             "fn call_void(",
             // #5480: the single shared body for all four contract/delegate
             // entry points.
-            "fn call_typed_blocking(",
+            "fn call_typed_blocking<",
         ];
 
         // The public entry points, which must NOT enter the guest themselves.
@@ -3266,7 +3279,7 @@ mod tests {
         let src = include_str!("wasmtime_engine.rs");
         // #5480: all four entry points share ONE body, so this scrapes that
         // body rather than the per-entry-point copies it replaced.
-        let fn_name = "fn call_typed_blocking(";
+        let fn_name = "fn call_typed_blocking<";
         let body = scrape_body(src, fn_name);
 
         let ewb = body

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -2746,7 +2746,32 @@ mod tests {
         // be the epoch trap.
         engine.epoch_deadline_ticks = 100;
 
-        const ID: i64 = 4242;
+        // R2 (#5480 review): NOT a low hard-coded constant, and NOT shared
+        // between the two entry points.
+        //
+        // `create_instance` draws ids from `next_instance_id()`, a monotonic
+        // counter starting at 0, and one test in this binary calls it 10,001
+        // times. Since #5480 the id here is registered in the PROCESS-GLOBAL
+        // `LIVE_DELEGATE_GUESTS`, and the assertion at the end of this function
+        // is precisely that it is STILL registered when the call returns —
+        // because the abandoned guest holds it for the rest of its ~10s epoch
+        // budget, after this test has finished. A low id would therefore sit in
+        // that set waiting to collide with an allocator-issued one.
+        //
+        // The collision is the one case that would make a retained id a false
+        // positive rather than a harmless leak: ids are never recycled, so a
+        // retained id can otherwise only refuse re-entry to the instance whose
+        // guest is genuinely wedged, which is the correct answer.
+        //
+        // And it would be near-invisible. `cargo nextest` runs a process per
+        // test and never sees it; plain `cargo test` shares one process and
+        // does. CI uses nextest, so CI would stay green while the contributor
+        // following AGENTS.md hits it.
+        let id: i64 = if async_imports {
+            i64::MAX - 54803
+        } else {
+            i64::MAX - 54804
+        };
         // Instantiate directly into the engine's own store so the entry point
         // finds the instance, without needing the `__frnt_set_id` / memory
         // exports that `create_instance` requires of a real contract.
@@ -2755,9 +2780,9 @@ mod tests {
         let module = Module::new(&eng, INFINITE_LOOP_WAT.as_bytes()).expect("WAT must compile");
         let instance = block_on_async(Linker::new(&eng).instantiate_async(&mut *store, &module))
             .expect("instantiation must succeed");
-        engine.instances.insert(ID, instance);
+        engine.instances.insert(id, instance);
 
-        let handle = InstanceHandle { id: ID };
+        let handle = InstanceHandle { id };
         let entry = if async_imports {
             "call_3i64_async_imports"
         } else {
@@ -2782,6 +2807,36 @@ mod tests {
             elapsed < Duration::from_secs(5),
             "`{entry}` took {elapsed:?}: the 0.5s wall-clock backstop did not fire, and the \
              epoch budget (~10s) is too far out to have returned this (#5480)"
+        );
+
+        // R1 (#5480 review): the registration must OUTLIVE this call.
+        //
+        // The guest is still running on an abandoned blocking thread right now,
+        // and that is the entire basis of the re-entry guard in
+        // `exec_inbound_with_env`: if the registration cleared when this call
+        // returned, the guard would read false in exactly the scenario it exists
+        // for, which is the F1 defect this PR fixed.
+        //
+        // This pins the one link nothing else covered. Both source pins and both
+        // re-entry tests pass with `let _live_guest = live_guest;` DELETED from
+        // `call_typed_blocking`, because those tests populate the set by hand and
+        // so never exercise the registration path at all. Under Rust 2021
+        // disjoint capture an unmentioned capture is not moved into the closure,
+        // so deleting that binding drops the guard on the CALLING thread and
+        // restores F1 exactly — silently, and with no `unsafe` at the edit site.
+        //
+        // KNOWN GAP, not covered here: registering INSIDE the closure instead of
+        // moving the guard in leaves the `QueuedTimeout` window described at
+        // `native_api::LIVE_DELEGATE_GUESTS`, and this assertion still passes
+        // under that variant. Catching it deterministically needs control over
+        // blocking-pool scheduling, which the test harness does not offer.
+        assert!(
+            native_api::LIVE_DELEGATE_GUESTS.contains(&id),
+            "`{entry}`: the abandoned guest is still running, so its \
+             LIVE_DELEGATE_GUESTS registration must still be present after the \
+             wall-clock backstop returns. If this fails, the registration guard \
+             is being dropped on the calling thread instead of being moved into \
+             the guest closure (#5480 review R1)"
         );
     }
 
@@ -2825,7 +2880,11 @@ mod tests {
         };
         let mut engine = WasmtimeEngine::new(&config, false).expect("engine must build");
 
-        const ID: i64 = 4343;
+        // Same convention as the backstop tests above (R2): keep test ids far
+        // above anything `next_instance_id()` allocates. This one is cleared on
+        // the panic-unwind path rather than retained, but the collision risk
+        // while the test runs is identical.
+        const ID: i64 = i64::MAX - 54805;
         let store = engine.store.as_mut().expect("engine store present");
         let eng = store.engine().clone();
         let module = Module::new(&eng, HOST_PANIC_WAT.as_bytes()).expect("WAT must compile");

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -658,14 +658,53 @@ pub(super) struct DelegateCallEnv {
     secret_read_memo: std::cell::RefCell<SecretReadMemo>,
 }
 
-// SAFETY: DelegateCallEnv is only inserted into DELEGATE_ENV immediately before
-// a synchronous WASM process() call and removed immediately after. The raw pointer
-// to SecretsStore is valid for the entire duration because the Runtime (which owns
-// SecretsStore) is alive and on the same call stack. Wasmer's Singlepass compiler
-// executes WASM synchronously on the calling thread.
+// SAFETY: `DELEGATE_ENV` is a `static`, so its `DashMap` must be `Sync`, which
+// requires `DelegateCallEnv: Send + Sync`. This type holds raw pointers into the
+// `Runtime` that created it (`secret_store`, `contract_store`, `delegate_store`),
+// so these two impls are the whole basis for that soundness.
+//
+// The justification is NOT "WASM executes synchronously on the calling thread".
+// That was true when these impls were written and is FALSE since #5480: a
+// delegate guest now runs on a `spawn_blocking` worker, not on the thread that
+// built the env. Soundness rests on three properties instead, two of which the
+// compiler enforces:
+//
+//  1. VALIDITY. The pointers address fields of the `Runtime` whose `&mut self`
+//     frame is `delegate::execution::exec_inbound_with_env`. That frame is
+//     parked inside `execute_wasm_blocking` for the whole guest call, so the
+//     `Runtime` can be neither moved nor dropped while a guest can reach it.
+//
+//  2. EXCLUSIVITY. Exactly one thread ever dereferences them: the single thread
+//     running the guest. The creating thread is parked, and one guest call is
+//     one call stack, so two delegate host functions are never in flight at
+//     once. `DashMap` additionally serializes `get`/`get_mut` on the entry.
+//
+//  3. NO ESCAPE. Every reference derived from these pointers is produced by one
+//     of the four private accessors below (`secret_store`, `secret_store_mut`,
+//     `contract_store`, `delegate_store_mut`), each `&self -> &T`, so lifetime
+//     elision ties the result to the `Ref`/`RefMut` guard it came from. Nothing
+//     copies a raw pointer out: the fields are private and are dereferenced
+//     ONLY in those accessors. The borrow checker enforces this; it is not a
+//     convention a future edit can quietly break without `unsafe`.
+//
+// The wall-clock timeout added by #5480 is the one place 1 and 2 could break,
+// because the creating thread unparks while the guest thread keeps running
+// (`JoinHandle::abort()` cannot stop a `spawn_blocking` closure). Two things
+// close it:
+//
+//  - `DelegateEnvGuard::drop` removes the entry, and `DashMap::remove` takes
+//    the shard WRITE lock, so it waits for any in-flight host call's guard to
+//    release. That is precisely why that drop can block for the duration of one
+//    host call, and why property 3 above must hold for the wait to be enough.
+//  - After the remove returns, every later lookup by the abandoned thread
+//    misses. `INSTANCE_ID` (`wasm_runtime::runtime`) is a monotonic
+//    `AtomicI64`, so an id is NEVER reissued and a stale thread can never reach
+//    a LATER call's env. That non-reuse is load-bearing: keying instances by
+//    anything recycled (a pool slot, a code hash) would make these impls
+//    unsound, because the stale thread would alias the new call's `&mut`
+//    borrows of the very same stores.
 unsafe impl Send for DelegateCallEnv {}
-// SAFETY: Same rationale as Send above -- single-threaded synchronous WASM execution
-// means DelegateCallEnv is never accessed from multiple threads concurrently.
+// SAFETY: as for `Send` directly above -- the two are one argument.
 unsafe impl Sync for DelegateCallEnv {}
 
 /// Typed errors from `DelegateCallEnv` contract operations.

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -722,8 +722,9 @@ pub(super) struct DelegateCallEnv {
 //  4. NO ENV IS INSERTED UNDER AN ID WHOSE GUEST MAY STILL BE RUNNING. This is
 //     what stands between the design and an aliased `&mut SecretsStore` across
 //     two threads, and it needs BOTH halves:
-//      - Ids are not recycled. `INSTANCE_ID` (`wasm_runtime::runtime`) is a
-//        monotonic `AtomicI64`, so an abandoned thread's `get(&old_id)` misses
+//      - Ids are not recycled. `NEXT_INSTANCE_ID` (this module, allocated by
+//        `next_instance_id`) is a monotonic `AtomicI64`, so an abandoned
+//        thread's `get(&old_id)` misses
 //        rather than resolving to a LATER call's env. (`fetch_add` does wrap in
 //        principle. At one increment per instance that is not reachable in a
 //        process lifetime, but it is an assumption, not a proof.)

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -694,14 +694,20 @@ pub(super) struct DelegateCallEnv {
 //     runs only on the success path -- i.e. only once `execute_wasm_blocking`
 //     has JOINED the guest closure and the guest is provably finished.
 //
-//     Do not move it back above the `?`, and do not add a read of any other
-//     field beside it. `context` alone would survive such a move today, because
-//     its only mutator happens to take `get_mut` (a shard WRITE lock, which
-//     excludes the read-back's `get`) -- but that is one call site's habit, not
-//     an invariant this type enforces, and no other field has even that much.
-//     Giving `context` an interior-mutability wrapper, or reading a second
-//     field there, would be a cross-thread data race with no `unsafe` at the
-//     edit site to warn whoever writes it.
+//     DO NOT MOVE IT BACK ABOVE THE `?`, and do not add a read of any other
+//     field beside it. That is not a style preference: since #5593 `context` is
+//     a `RefCell<Vec<u8>>` whose mutator (`context_write`) takes `DELEGATE_ENV
+//     .get` -- a SHARED shard lock -- and then `borrow_mut()`. Above the `?`,
+//     the read-back's `get` + `borrow()` would run concurrently with that on
+//     the timeout path: a race on `RefCell`'s non-atomic borrow flag, which its
+//     own runtime check cannot detect, and a use-after-free of the `Vec` buffer
+//     when `to_vec()` reallocates under `clone()`.
+//
+//     Note how little would warn you. `RefCell<Vec<u8>>` is `!Sync`, so the
+//     compiler WOULD reject this type -- except that the `Sync` impl below
+//     overrides exactly that check, and neither edit site needs `unsafe`. The
+//     ordering of these two lines is load-bearing and nothing but this comment
+//     says so.
 //
 //  3. NO REFERENCE ESCAPES ITS GUARD. The four accessors are private and each is
 //     `&self -> &T`, so lifetime elision ties the result to the `Ref` that

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -37,6 +37,45 @@ type SecretReadMemo = Option<([u8; 32], zeroize::Zeroizing<Vec<u8>>)>;
 pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateCallEnv>> =
     LazyLock::new(DashMap::default);
 
+/// Instance ids whose delegate guest MAY STILL BE EXECUTING.
+///
+/// This exists because `DELEGATE_ENV` cannot answer the question that actually
+/// matters. `DelegateEnvGuard::drop` removes the env on EVERY exit path of
+/// `exec_inbound_with_env`, including the wall-clock-timeout `Err` — and on that
+/// path the guest is still running on an abandoned `spawn_blocking` thread,
+/// because `JoinHandle::abort()` cannot stop a closure that has started. So
+/// `DELEGATE_ENV.contains_key(id)` tests "is an env still registered", while the
+/// dangerous fact is "is a guest still running". Those were the same thing only
+/// while the guest could not outlive the call, which stopped being true in
+/// #5480.
+///
+/// One `RunningInstance` id is shared by every message in a batch
+/// (`delegate/interface.rs`), so without this an error-tolerant batch loop could
+/// insert a second env under an id whose first guest is still live, and the two
+/// threads would alias the same `SecretsStore`, `context` and
+/// `secret_read_memo`. The last of those holds decrypted secret plaintext, so
+/// the consequence is cross-value disclosure, not merely a panic.
+///
+/// LIFETIME. An entry is added on the CALLING thread before the guest closure is
+/// enqueued, and removed by a guard MOVED INTO that closure. That placement is
+/// deliberate and both halves matter:
+///
+///  - Adding it inside the closure would leave a gap. `execute_wasm_blocking`
+///    reports `QueuedTimeout` when its `started` flag is false, then aborts; if
+///    that abort loses the race the closure runs anyway, so a registration made
+///    inside it could land AFTER the caller had already returned and the next
+///    message had passed its check.
+///  - Removing it by dropping a captured guard covers both outcomes without a
+///    leak: if the closure runs, the guard drops when the guest finishes
+///    (including on panic-unwind); if `abort()` wins and the closure is dropped
+///    UNRUN, its captures drop with it and the id clears — correctly, since no
+///    guest ever ran.
+///
+/// The registration must therefore stay captured by the closure. Moving it out,
+/// or dropping it before the guest returns, silently reintroduces the hazard.
+pub(super) static LIVE_DELEGATE_GUESTS: LazyLock<dashmap::DashSet<InstanceId>> =
+    LazyLock::new(dashmap::DashSet::default);
+
 /// Global registry of delegate subscriptions to contracts.
 ///
 /// When a V2 delegate calls `subscribe_contract()`, the (contract, delegate) pair is
@@ -686,6 +725,24 @@ pub(super) struct DelegateCallEnv {
 //     happens-before that removal returns, which happens-before the pool moves
 //     the `Runtime`.
 //
+//     TWO THINGS THAT WRITE LOCK DOES NOT BUY.
+//
+//     It does not bound EFFECTS, only pointer validity. Between the wall clock
+//     firing and the removal completing, an abandoned guest can still finish a
+//     host call it had already entered — a `set_secret`, a
+//     `put_contract_state_sync`. Those writes land after the caller has been
+//     told the call timed out. That is not unsoundness, but do not read
+//     "removal bounds the dereferences" as "removal bounds what the guest did".
+//
+//     It is also a DEADLOCK EDGE. dashmap is writer-preferring, so once
+//     `remove` is waiting for the shard write lock, a new READ of that shard
+//     blocks behind it. A host function that took a second `DELEGATE_ENV.get`
+//     while already holding a `Ref` would therefore hang rather than merely
+//     contend. All 15 current call sites take exactly one guard and drop it
+//     before returning, which is the only reason this is safe today; a single
+//     nested `get` is the whole distance to a hung node. Keep every host
+//     function to one guard at a time.
+//
 //     THE CREATING THREAD MUST NOT TOUCH THE ENV WHILE A GUEST MAY STILL BE
 //     RUNNING. On the wall-clock-timeout path it returns with the guest still
 //     live on an abandoned blocking thread, so any access it makes there is a
@@ -731,15 +788,48 @@ pub(super) struct DelegateCallEnv {
 //      - One id IS reused WITHIN a batch. `delegate/interface.rs` creates a
 //        single `RunningInstance` and passes its id to `exec_inbound_with_env`
 //        for every message, so the insert runs again under the same id per
-//        message. The fail-closed `contains_key` check there is what makes that
-//        safe. Without it, an error-tolerant batch loop would re-insert under an
-//        id whose previous guest is still abandoned and running, and the two
-//        threads would alias the same stores.
+//        message. The fail-closed check there is what makes that safe. Without
+//        it, an error-tolerant batch loop would re-insert under an id whose
+//        previous guest is still abandoned and running, and the two threads
+//        would alias the same stores.
+//
+//        That check must consult `LIVE_DELEGATE_GUESTS`, not `DELEGATE_ENV`
+//        alone. `DelegateEnvGuard::drop` removes the env on EVERY exit path of
+//        `exec_inbound_with_env`, the wall-clock-timeout `Err` included, so
+//        `DELEGATE_ENV.contains_key` is already false at the moment the caller
+//        learns the call timed out — while the guest runs on. Presence of an env
+//        and liveness of a guest are different facts, and only the second one is
+//        dangerous.
 //
 // Keying instances by anything recycled (a pool slot, a code hash) breaks the
 // first half of 4 and makes these impls unsound.
+//
+// INTENDED END STATE: THE `Sync` IMPL SHOULD NOT EXIST. Read it as debt, not as
+// a settled design decision.
+//
+// `Send` is genuinely required. `Sync` is required only because
+// `DELEGATE_ENV` is a `DashMap`, and `DashMap<K, V>` demands `V: Send + Sync` to
+// be a `static`. Nothing in this crate ever wants to share a
+// `&DelegateCallEnv` between threads, so the impl buys no capability — it only
+// silences a check. The type now holds three separately `!Sync` fields
+// (`context`, `secret_read_memo`, `secret_store`/`delegate_store`), and the
+// silenced check is exactly the one that would have caught #5593 flipping
+// `context_write` from `get_mut` to `get`: `RefCell<Vec<u8>>` is `!Sync`
+// precisely so the compiler can object, and this impl is what stops it.
+//
+// The fix is structural rather than a better comment: move `DelegateCallEnv`
+// into wasmtime's `HostState`, which the `Store` already owns and hands to host
+// functions through `Caller`. That deletes this `Sync` impl, `DELEGATE_ENV`,
+// `CURRENT_DELEGATE_INSTANCE`, `LIVE_DELEGATE_GUESTS` and the whole
+// abandoned-guest hazard class in one move, because the env would then be owned
+// by the store the guest runs against instead of reachable from a process-global
+// map. Deliberately out of scope for #5480, which is about giving delegates the
+// safeguards contracts already have; tracked as the follow-up that retires the
+// reason this argument has to be written down at all.
 unsafe impl Send for DelegateCallEnv {}
-// SAFETY: as for `Send` directly above -- the two are one argument.
+// SAFETY: as for `Send` directly above -- the two are one argument. See the
+// "intended end state" note: this impl is debt, and only `DashMap`'s bound
+// requires it.
 unsafe impl Sync for DelegateCallEnv {}
 
 /// Typed errors from `DelegateCallEnv` contract operations.

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -3414,6 +3414,79 @@ mod secret_read_memo_tests {
     /// `context_write`, the exact path the pin's own doc named. Enumerating
     /// rebinding forms is an open set. This asserts the single closed fact the
     /// whole property now rests on: no mutable borrow of the env is taken.
+    /// COMPILE-TIME guard (#5480 review F2): every field of `DelegateCallEnv`
+    /// must be named here, so ADDING ONE IS A COMPILE ERROR.
+    ///
+    /// This closes the half of F2 that moving the `unsafe impl` to
+    /// `DelegateEnvSlot` does NOT close, and the distinction is worth being
+    /// precise about because it is easy to over-claim:
+    ///
+    ///  - The slot narrows the impl's REACH. `DelegateCallEnv` is itself
+    ///    `!Send`/`!Sync`, so code that tries to share or move one anywhere
+    ///    other than into `DELEGATE_ENV` is rejected by the compiler.
+    ///  - The slot does NOT narrow what the impl BLESSES. It wraps the whole
+    ///    struct, so a field added tomorrow with different thread-safety is
+    ///    still covered by `unsafe impl Sync for DelegateEnvSlot` exactly as it
+    ///    would have been by an impl on `DelegateCallEnv`. A comment cannot
+    ///    object to that; only the compiler can.
+    ///
+    /// Hence the rest pattern is DELIBERATELY ABSENT. Do not "fix" this by
+    /// adding `..` — that silently restores the hazard and is the one edit this
+    /// test exists to prevent. When it stops compiling, the right response is to
+    /// add the new field here AND revisit the numbered SAFETY argument above
+    /// `DelegateEnvSlot`, deciding which of its four points the field affects.
+    ///
+    /// The current fields divide as follows, which is the review this forces:
+    ///  - `!Sync` and load-bearing for the argument: `secret_store`,
+    ///    `delegate_store` (`UnsafeCell<*mut _>`), `contract_store`
+    ///    (`*const _`), `context` and `secret_read_memo` (`RefCell`),
+    ///    `creations_this_call` (`Cell`). Six, not three — an earlier draft of
+    ///    the SAFETY block miscounted, which is exactly the kind of slip that
+    ///    makes a reader stop trusting a soundness argument.
+    ///  - Plain owned data, safe by construction: everything else.
+    #[test]
+    fn every_call_env_field_is_named_in_the_safety_argument() {
+        #[allow(dead_code)]
+        fn exhaustive(env: &DelegateCallEnv) {
+            // NO `..` REST PATTERN. See this test's rustdoc.
+            let DelegateCallEnv {
+                context,
+                secret_store,
+                delegate_key,
+                user_context,
+                contract_store,
+                state_store_db,
+                state_write_callback,
+                state_admit_callback,
+                delegate_store,
+                creation_depth,
+                creations_this_call,
+                origin_contracts,
+                created_delegates_count,
+                inherited_origins,
+                secret_read_memo,
+            } = env;
+
+            let _ = (
+                context,
+                secret_store,
+                delegate_key,
+                user_context,
+                contract_store,
+                state_store_db,
+                state_write_callback,
+                state_admit_callback,
+                delegate_store,
+                creation_depth,
+                creations_this_call,
+                origin_contracts,
+                created_delegates_count,
+                inherited_origins,
+                secret_read_memo,
+            );
+        }
+    }
+
     #[test]
     fn no_mutable_borrow_of_the_call_env_exists() {
         let src = include_str!("native_api.rs");

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -34,7 +34,7 @@ type SecretReadMemo = Option<([u8; 32], zeroize::Zeroizing<Vec<u8>>)>;
 /// Host functions for context and secret access read/write through this.
 /// After `process` returns, the runtime reads back the (possibly mutated) context
 /// and removes the entry.
-pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateCallEnv>> =
+pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateEnvSlot>> =
     LazyLock::new(DashMap::default);
 
 /// Instance ids whose delegate guest MAY STILL BE EXECUTING.
@@ -804,33 +804,58 @@ pub(super) struct DelegateCallEnv {
 // Keying instances by anything recycled (a pool slot, a code hash) breaks the
 // first half of 4 and makes these impls unsound.
 //
-// INTENDED END STATE: THE `Sync` IMPL SHOULD NOT EXIST. Read it as debt, not as
-// a settled design decision.
+// WHY THIS LIVES ON A WRAPPER AND NOT ON `DelegateCallEnv` ITSELF. The bound
+// that forces an `unsafe impl` here is narrow and purely structural:
+// `DELEGATE_ENV` is a `static`, statics must be `Sync`, and `DashMap<K, V>` is
+// `Sync` only when `V: Send + Sync`. Nothing in this crate ever wants to SHARE a
+// `&DelegateCallEnv` between threads — every access is single-threaded under a
+// map guard, per 2 above. So the impl satisfies a container's bound; it does not
+// assert that the environment is safe to use concurrently, and putting it on
+// `DelegateCallEnv` said the second thing while meaning the first.
 //
-// `Send` is genuinely required. `Sync` is required only because
-// `DELEGATE_ENV` is a `DashMap`, and `DashMap<K, V>` demands `V: Send + Sync` to
-// be a `static`. Nothing in this crate ever wants to share a
-// `&DelegateCallEnv` between threads, so the impl buys no capability — it only
-// silences a check. The type now holds three separately `!Sync` fields
-// (`context`, `secret_read_memo`, `secret_store`/`delegate_store`), and the
-// silenced check is exactly the one that would have caught #5593 flipping
-// `context_write` from `get_mut` to `get`: `RefCell<Vec<u8>>` is `!Sync`
-// precisely so the compiler can object, and this impl is what stops it.
+// Confining it to `DelegateEnvSlot` leaves `DelegateCallEnv` itself `!Send` and
+// `!Sync`, so any FUTURE code that tries to share or move one for some other
+// reason is rejected by the compiler instead of being silently absorbed by an
+// impl written for `DashMap`. Only the one storage location opts out, and it is
+// the location whose safety argument is written above.
 //
-// The fix is structural rather than a better comment: move `DelegateCallEnv`
-// into wasmtime's `HostState`, which the `Store` already owns and hands to host
-// functions through `Caller`. That deletes this `Sync` impl, `DELEGATE_ENV`,
-// `CURRENT_DELEGATE_INSTANCE`, `LIVE_DELEGATE_GUESTS` and the whole
-// abandoned-guest hazard class in one move, because the env would then be owned
-// by the store the guest runs against instead of reachable from a process-global
-// map. Deliberately out of scope for #5480, which is about giving delegates the
-// safeguards contracts already have; tracked as the follow-up that retires the
-// reason this argument has to be written down at all.
-unsafe impl Send for DelegateCallEnv {}
-// SAFETY: as for `Send` directly above -- the two are one argument. See the
-// "intended end state" note: this impl is debt, and only `DashMap`'s bound
-// requires it.
-unsafe impl Sync for DelegateCallEnv {}
+// This is a narrowing, not the fix. The fix is to stop holding the environment
+// in a process-global map at all — move it into wasmtime's `HostState`, which
+// the `Store` already owns and hands to host functions through `Caller`, which
+// would delete this impl, `DELEGATE_ENV`, `CURRENT_DELEGATE_INSTANCE`,
+// `LIVE_DELEGATE_GUESTS` and the whole abandoned-guest hazard class together.
+// Tracked as #5604; out of scope for #5480.
+//
+// One correction worth recording, because the opposite is easy to assume: the
+// `RefCell<Vec<u8>>` that #5593 gave `context` is NOT why this type is `!Sync`,
+// and it is not what made these impls necessary. `UnsafeCell<*mut SecretsStore>`,
+// `UnsafeCell<*mut DelegateStore>` and `*const ContractStore` are each `!Sync`
+// on their own and all predate that PR. The `RefCell` was a fourth reason, not
+// the first. This impl has been suppressing the check for far longer than the
+// #5593/#5480 pair.
+pub(super) struct DelegateEnvSlot(DelegateCallEnv);
+
+impl DelegateEnvSlot {
+    pub(super) fn new(env: DelegateCallEnv) -> Self {
+        Self(env)
+    }
+}
+
+// SAFETY: the argument in points 1-4 above, which is what makes it sound to
+// reach a `DelegateCallEnv` through `DELEGATE_ENV` at all. These impls exist
+// solely to meet `DashMap`'s `V: Send + Sync` bound for that `static`; they are
+// NOT a claim that a `&DelegateCallEnv` may be shared across threads.
+unsafe impl Send for DelegateEnvSlot {}
+// SAFETY: as for `Send` directly above -- the two are one argument.
+unsafe impl Sync for DelegateEnvSlot {}
+
+impl std::ops::Deref for DelegateEnvSlot {
+    type Target = DelegateCallEnv;
+
+    fn deref(&self) -> &DelegateCallEnv {
+        &self.0
+    }
+}
 
 /// Typed errors from `DelegateCallEnv` contract operations.
 ///

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -664,45 +664,62 @@ pub(super) struct DelegateCallEnv {
 // so these two impls are the whole basis for that soundness.
 //
 // The justification is NOT "WASM executes synchronously on the calling thread".
-// That was true when these impls were written and is FALSE since #5480: a
-// delegate guest now runs on a `spawn_blocking` worker, not on the thread that
-// built the env. Soundness rests on three properties instead, two of which the
-// compiler enforces:
+// That was true when these impls were written and is FALSE since #5480: the
+// guest now runs on a `spawn_blocking` worker, and on the wall-clock timeout
+// path it KEEPS RUNNING after the creating thread has returned, because
+// `JoinHandle::abort()` cannot stop a `spawn_blocking` closure. The argument
+// below is stated for that abandoned-guest path, since it is the hard one.
 //
-//  1. VALIDITY. The pointers address fields of the `Runtime` whose `&mut self`
-//     frame is `delegate::execution::exec_inbound_with_env`. That frame is
-//     parked inside `execute_wasm_blocking` for the whole guest call, so the
-//     `Runtime` can be neither moved nor dropped while a guest can reach it.
+//  1. VALIDITY IS BOUNDED BY THE GUARD, NOT BY THE CALL. The pointers address
+//     fields of a `Runtime` owned by an `Executor` that the pool MOVES back into
+//     its slot once the call returns (`contract/executor/runtime/pool.rs`), and
+//     may drop and replace. A move alone invalidates all three. So they are
+//     valid only until `DelegateEnvGuard::drop` returns; after that they may
+//     dangle at any moment. Do not read this as "the `Runtime` stays put while a
+//     guest can reach it" -- it does not. What makes the path safe is 2 and 4.
 //
-//  2. EXCLUSIVITY. Exactly one thread ever dereferences them: the single thread
-//     running the guest. The creating thread is parked, and one guest call is
-//     one call stack, so two delegate host functions are never in flight at
-//     once. `DashMap` additionally serializes `get`/`get_mut` on the entry.
+//  2. ONLY THE GUEST THREAD DEREFERENCES THEM, AND ONLY UNDER A MAP GUARD.
+//     Every dereference is inside one of the four private accessors below, each
+//     reached through a `Ref`/`RefMut` from `DELEGATE_ENV`. `DashMap::remove`
+//     takes the shard WRITE lock, so `DelegateEnvGuard::drop` waits for any
+//     in-flight host call's guard to release; every dereference therefore
+//     happens-before that removal returns, which happens-before the pool moves
+//     the `Runtime`. NOTE that the creating thread is NOT parked on this path:
+//     it concurrently takes its own `Ref` to read back `context`
+//     (`delegate/execution.rs`). That is safe only because it touches `context`
+//     alone -- whose sole mutator goes through `get_mut`, a shard write lock --
+//     and never dereferences a raw pointer. Adding another field read there,
+//     e.g. of `creations_this_call`, would be a data race with no `unsafe` at
+//     the edit site.
 //
-//  3. NO ESCAPE. Every reference derived from these pointers is produced by one
-//     of the four private accessors below (`secret_store`, `secret_store_mut`,
-//     `contract_store`, `delegate_store_mut`), each `&self -> &T`, so lifetime
-//     elision ties the result to the `Ref`/`RefMut` guard it came from. Nothing
-//     copies a raw pointer out: the fields are private and are dereferenced
-//     ONLY in those accessors. The borrow checker enforces this; it is not a
-//     convention a future edit can quietly break without `unsafe`.
+//  3. NO REFERENCE ESCAPES ITS GUARD. The four accessors are private and each is
+//     `&self -> &T`, so lifetime elision ties the result to the `Ref` that
+//     produced it, and nothing copies a raw pointer out. Be precise about what
+//     that buys: the compiler enforces the EXTENT of the borrow, NOT its
+//     exclusivity. `secret_store_mut(&self) -> &mut SecretsStore` manufactures a
+//     `&mut` from a `&`, so two simultaneously-live `&mut SecretsStore` from one
+//     env would compile today with no `unsafe` at the call site. Every current
+//     caller holds one at a time in a statement-scoped temporary; THAT half is a
+//     convention these accessors do not check.
 //
-// The wall-clock timeout added by #5480 is the one place 1 and 2 could break,
-// because the creating thread unparks while the guest thread keeps running
-// (`JoinHandle::abort()` cannot stop a `spawn_blocking` closure). Two things
-// close it:
+//  4. NO ENV IS INSERTED UNDER AN ID WHOSE GUEST MAY STILL BE RUNNING. This is
+//     what stands between the design and an aliased `&mut SecretsStore` across
+//     two threads, and it needs BOTH halves:
+//      - Ids are not recycled. `INSTANCE_ID` (`wasm_runtime::runtime`) is a
+//        monotonic `AtomicI64`, so an abandoned thread's `get(&old_id)` misses
+//        rather than resolving to a LATER call's env. (`fetch_add` does wrap in
+//        principle. At one increment per instance that is not reachable in a
+//        process lifetime, but it is an assumption, not a proof.)
+//      - One id IS reused WITHIN a batch. `delegate/interface.rs` creates a
+//        single `RunningInstance` and passes its id to `exec_inbound_with_env`
+//        for every message, so the insert runs again under the same id per
+//        message. The fail-closed `contains_key` check there is what makes that
+//        safe. Without it, an error-tolerant batch loop would re-insert under an
+//        id whose previous guest is still abandoned and running, and the two
+//        threads would alias the same stores.
 //
-//  - `DelegateEnvGuard::drop` removes the entry, and `DashMap::remove` takes
-//    the shard WRITE lock, so it waits for any in-flight host call's guard to
-//    release. That is precisely why that drop can block for the duration of one
-//    host call, and why property 3 above must hold for the wait to be enough.
-//  - After the remove returns, every later lookup by the abandoned thread
-//    misses. `INSTANCE_ID` (`wasm_runtime::runtime`) is a monotonic
-//    `AtomicI64`, so an id is NEVER reissued and a stale thread can never reach
-//    a LATER call's env. That non-reuse is load-bearing: keying instances by
-//    anything recycled (a pool slot, a code hash) would make these impls
-//    unsound, because the stale thread would alias the new call's `&mut`
-//    borrows of the very same stores.
+// Keying instances by anything recycled (a pool slot, a code hash) breaks the
+// first half of 4 and makes these impls unsound.
 unsafe impl Send for DelegateCallEnv {}
 // SAFETY: as for `Send` directly above -- the two are one argument.
 unsafe impl Sync for DelegateCallEnv {}

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -684,13 +684,24 @@ pub(super) struct DelegateCallEnv {
 //     takes the shard WRITE lock, so `DelegateEnvGuard::drop` waits for any
 //     in-flight host call's guard to release; every dereference therefore
 //     happens-before that removal returns, which happens-before the pool moves
-//     the `Runtime`. NOTE that the creating thread is NOT parked on this path:
-//     it concurrently takes its own `Ref` to read back `context`
-//     (`delegate/execution.rs`). That is safe only because it touches `context`
-//     alone -- whose sole mutator goes through `get_mut`, a shard write lock --
-//     and never dereferences a raw pointer. Adding another field read there,
-//     e.g. of `creations_this_call`, would be a data race with no `unsafe` at
-//     the edit site.
+//     the `Runtime`.
+//
+//     THE CREATING THREAD MUST NOT TOUCH THE ENV WHILE A GUEST MAY STILL BE
+//     RUNNING. On the wall-clock-timeout path it returns with the guest still
+//     live on an abandoned blocking thread, so any access it makes there is a
+//     genuinely concurrent one. It makes exactly one access: the `context`
+//     read-back in `delegate/execution.rs`, and that sits AFTER the `?` so it
+//     runs only on the success path -- i.e. only once `execute_wasm_blocking`
+//     has JOINED the guest closure and the guest is provably finished.
+//
+//     Do not move it back above the `?`, and do not add a read of any other
+//     field beside it. `context` alone would survive such a move today, because
+//     its only mutator happens to take `get_mut` (a shard WRITE lock, which
+//     excludes the read-back's `get`) -- but that is one call site's habit, not
+//     an invariant this type enforces, and no other field has even that much.
+//     Giving `context` an interior-mutability wrapper, or reading a second
+//     field there, would be a cross-thread data race with no `unsafe` at the
+//     edit site to warn whoever writes it.
 //
 //  3. NO REFERENCE ESCAPES ITS GUARD. The four accessors are private and each is
 //     `&self -> &T`, so lifetime elision ties the result to the `Ref` that


### PR DESCRIPTION
Closes #5480.

Delegate WASM execution had none of the three safeguards contract execution already had. This routes all four guest entry points through one shared helper so they get them together.

## The gap

Contracts ran via `call_2i64_blocking` / `call_3i64_blocking`, which wrap the call in `execute_wasm_blocking`. Delegates (`call_3i64`, `call_3i64_async_imports`) called `block_on_async(func.call_async(...))` directly on the calling thread, so they got the epoch trap and nothing else:

- **no `spawn_blocking`** — a stuck guest occupied the caller's thread;
- **no wall-clock backstop** — the epoch trap only fires at a guest instruction boundary, so it cannot cut off a blocking *host* function in flight (a ReDb read, a secret-store fsync), and if the epoch ticker thread dies (#4864) it does not fire at all. Delegates fell back to nothing;
- **no panic capture** — a host-function panic unwound into the calling task.

## What changed

The four entry points now share one `call_typed_blocking<P>` in `wasmtime_engine.rs`, generic over the param tuple. `execute_wasm_blocking` was already the right mechanism; the issue asked for reuse rather than a fifth hand-rolled near-copy, and that is what this does.

Three things that were not obvious going in:

**`CURRENT_DELEGATE_INSTANCE` is a thread-local.** About 20 delegate host functions read it to find their `DelegateCallEnv`. Moving the guest to a blocking-pool thread naively makes every one of them read the default `-1`. A `GuestDelegateInstance` RAII guard installs `handle.id` *inside* the closure and clears it on every exit path including panic — blocking-pool threads are reused, and the wall-clock backstop can return while the guest runs on, so a leaked id would outlive its `DELEGATE_ENV` entry on a thread that later serves an unrelated job.

**`interface.rs` reuses one `RunningInstance` id for every message in a batch.** The only thing preventing re-entry while a previous message's guest was still running was a `?` aborting the batch loop, guarded by a `debug_assert!` that compiles out in release. Since the guest can now outlive the call, that became a memory-safety invariant, so it is a hard fail-closed check. It is unreachable today; the point is that an edit making the loop error-tolerant gets an error instead of aliasing UB.

**The `unsafe impl Send/Sync for DelegateCallEnv` justification was false.** It argued that WASM executes synchronously on the calling thread. That stopped being true here, and those impls are the whole basis for holding raw `Runtime` pointers in a `static` map. Rewritten to argue the hard case — the abandoned-guest path — and to name what a future edit must not do.

## The context read-back — #5593 merged mid-review and made this load-bearing

`exec_inbound_with_env` read `context` back *before* propagating the call's error, then discarded it on every error path. On the timeout path that is a genuinely concurrent access to a field the abandoned guest can still write through `context_write`.

When I first raised this it was a latent hazard: `context_write` took `DELEGATE_ENV.get_mut()`, a shard write lock that excluded the read-back's `get`. Not a race — but a property of one call site, not an invariant the type enforces.

**#5593 merged while this was in review and removed exactly that property.** `context` is now `RefCell<Vec<u8>>`, and `context_write` mutates it through `DELEGATE_ENV.get` — a *shared* shard lock — plus `borrow_mut()`. Two shared locks do not exclude each other, so above the `?` the two threads would run concurrently on:

- `RefCell`'s borrow flag, a non-atomic `Cell<isize>` — a data race its own runtime check cannot detect, because that check is unsynchronised;
- the `Vec` buffer itself — `to_vec()` reallocating under `clone()` is a use-after-free.

Worth noting how little would have warned anyone. `RefCell<Vec<u8>>` is `!Sync`, so the compiler would reject this type outright — except that `unsafe impl Sync for DelegateCallEnv` overrides precisely that check, and neither edit site needs `unsafe`. Each PR is locally correct and locally reviewable; only the combination is unsound.

This branch moves the read below the `?`. It is behaviour-preserving — `result?` discarded the value one line later, so the read was already dead work — and it means the read is reached only on success, i.e. only once `execute_wasm_blocking` has *joined* the guest closure and the guest is provably finished. That removes the creating thread's only concurrent touch of the env, so the safety argument rests on "the guest thread alone reaches the env" rather than on a per-field exception.

Because nothing in the compiler or the type system guards that ordering, it is pinned: `context_readback_happens_after_the_result_is_propagated` scrapes `exec_inbound_with_env` and asserts the `?` precedes the read-back, with a fail-closed brace-balance check so a truncated scrape window cannot pass vacuously. **Verified by making it fail** — with the two statements swapped it fails with its own message; restored, it passes.

I rebased onto `main` after #5593 landed. The two changes merged without conflict, and the comments I had written against the pre-#5593 code are corrected — they described a world that no longer exists, and left as-is would have told a reviewer the ordering was survivable when it no longer is.

## Verification

Rebased onto `main` from 51 commits behind, **no conflicts** — every commit applied cleanly. Rebased again onto #5593 after it merged, also with no conflicts.

At `ed626a922` (based on `68349dcdb`, which includes #5554), working tree clean:

- `cargo test -p freenet --lib` — **5524 passed, 0 failed**, 28 ignored.
- `cargo clippy -p freenet --all-targets -- -D warnings` — clean, exit 0.
- `cargo fmt --all -- --check` — clean.

The safeguards were **falsified, not assumed**. Reverting the two delegate entries to the pre-fix direct path:

| test | result under mutation |
|---|---|
| `delegate_v1_entry_has_wall_clock_backstop` | FAIL — took **10.008s**, the epoch budget, against a 0.5s wall clock |
| `delegate_v2_entry_has_wall_clock_backstop` | FAIL — took **10.008s** |
| `delegate_entry_captures_host_panic` | FAIL — the panic **propagated into the test thread** |
| `every_guest_entry_is_preceded_by_arm_epoch_deadline` | FAIL — caught the entry point leaving the shared helper |

The two deadlines are deliberately separated (0.5s wall clock vs ~10s epoch) so only one mechanism can return the call. The 10.008s figures confirm the tests measure the wall-clock backstop specifically and not the epoch trap.

Separately, replacing `GuestDelegateInstance::install` with a no-op fails **20 of 53** delegate tests, so the thread-local guard is load-bearing and already covered behaviourally.

## CI rule-review findings — all three addressed

The `rule-review` job flagged two warnings and one info on the first push. All three were real; none dismissed.

- **`INSTANCE_ID` (`wasm_runtime::runtime`) does not exist.** Correct — the id source is `NEXT_INSTANCE_ID` in `native_api`. That citation sits in the "ids are not recycled" half of the `unsafe impl` argument, so a reader checking the invariant would have failed to find it. Fixed.
- **The fail-closed re-entry guard had no test.** Also correct, and the more substantive of the two: promoting the `debug_assert!` to a hard `Err` is new release-visible behaviour that nothing drove red or green. `reentering_a_live_instance_id_fails_closed` now occupies an instance id with a live `DelegateCallEnv` and asserts the call is refused, with a control that runs the same call on an unoccupied id and asserts the guard does *not* fire. **Verified by making it fail**: with the guard short-circuited the test fails and falls through to exactly the control's error, which is what shows the two paths are genuinely distinguished rather than the test passing on any error.
- **(info) `DelegateEnvGuard`'s doc comment described dispatch that no longer works that way.** Since delegates run on a blocking-pool thread, the thread-local a host function reads is the one `GuestDelegateInstance` installs on the worker; this guard's set/clear touch the *calling* thread's copy, which nothing on the delegate path consults. I kept the pair — they cost nothing and stay honest for any inline path — but the doc no longer presents them as the mechanism. Worth acting on precisely because a vestigial set/clear is what would mislead someone auditing the thread-local wiring this PR changes.

## Soundness review round — one HIGH, fixed

An independent soundness review confirmed the context read-back fix is sufficient *completely*, not just for the path I found: `Ok`/`WasmError`/`Panic` all come from a completed join, and `Timeout`/`QueuedTimeout` are the only non-joined variants and both are `Err`, so the `?` sits below every non-joined outcome.

It found one HIGH, and it was in the fail-closed guard rather than the `unsafe impl`.

**F1 — the guard tested the wrong fact.** `DelegateEnvGuard::drop` removes the env on *every* exit path of `exec_inbound_with_env`, the wall-clock-timeout `Err` included. On that path the guest is still running on an abandoned `spawn_blocking` thread. So by the time a caller sees the timeout, `DELEGATE_ENV.contains_key(id)` is already false while the dangerous condition is still true. **The check asked "is an env registered"; the fact that matters is "is a guest running"** — and those stopped being the same thing the moment this PR let a guest outlive its call. The guard was structurally blind to the exact scenario its own comment named.

Fixed with `LIVE_DELEGATE_GUESTS`, which tracks the guest's own lifetime. One design note beyond the review's sketch: registering *inside* the guest closure leaves a real gap, because `QueuedTimeout` is reported when the `started` flag is false and then aborts — and if that abort loses the race the closure runs anyway, so a registration made inside it can land after the caller has returned and the next message has already passed its check. So the registration is made on the **calling thread** and **moved into** the closure. Dropping a captured guard then covers both outcomes with no leak: if the closure runs, it drops when the guest finishes (panic-unwind included); if `abort()` wins and the closure is dropped unrun, its captures drop with it and the id clears — correctly, since no guest ran.

Both halves are tested and both were mutation-verified: dropping the `LIVE_DELEGATE_GUESTS` clause fails the new test while the pre-existing one still passes, so the two tests genuinely cover different halves.

**F2 (MEDIUM) — `unsafe impl Sync` is named as debt, not fixed here.** `Send` is genuinely required; `Sync` is required *only* by `DashMap`'s `V: Send + Sync` bound, and nothing ever shares a `&DelegateCallEnv`. The impl buys no capability — it silences exactly the check that would have caught #5593's `get_mut`→`get` flip, since `RefCell<Vec<u8>>` is `!Sync` precisely so the compiler can object. The SAFETY block now names the structural fix (move `DelegateCallEnv` into wasmtime's `HostState`, deleting the `Sync` impl, `DELEGATE_ENV`, the thread-local and the abandoned-guest hazard class together) as the intended end state, so it stops reading as settled. Deliberately out of scope here.

**F3, F5, F6 also taken.** F3: `[`epoch_deadline_trap`]` is a wasmtime `Store` method, not an item in this crate — retargeted at `arm_epoch_deadline`. (Flagged because this branch had *already* shipped one citation to a symbol that did not exist.) F5: dashmap is writer-preferring, so the guard's `remove` blocks new reads of that shard — one nested `DELEGATE_ENV.get` inside a host call would hang rather than contend; safe across all 15 sites today, now documented as the constraint it is. F6: removal bounds pointer validity, not *effects* — an abandoned guest can still complete a `set_secret` or `put_contract_state_sync` it had already entered.

**Correction to my own #5554 note below.** I said the collision was on a "different map". That reasoning is wrong, and the conclusion happens to survive anyway. The collision would be on the same *delegate*, which is exactly #5554's unit. What actually makes it safe is **ordering**: `_guard` drops inside `exec_inbound_with_env`, strictly before the `Err` reaches `inbound_app_message`, before `DelegateRunOutcome::Failed`, before the park releases a queued run. The load-bearing fact is the placement of a local variable, and nothing pins it. F1's fix makes that robust rather than incidental.

## Second soundness round — F2/F4/F5/F6 and the #5554 pin

**F2 — narrowed, not removed.** The review's prescription does not compile, and that was confirmed independently: `DELEGATE_ENV` is a `static`, statics must be `Sync`, and `DashMap<K, V>` is `Sync` only when `V: Send + Sync`. Deleting the impl breaks the static. "Remove the `unsafe impl`" is really "stop holding this in a process-global map", which is **#5604** and out of scope here.

What is in scope is making the impl say what it means. The bound is narrow and structural — a container's requirement — but sitting on `DelegateCallEnv` it read as the far broader claim that the environment is safe to share across threads. It now sits on a `DelegateEnvSlot` newtype, so **`DelegateCallEnv` itself is `!Send` and `!Sync`** and a future attempt to share or move one for some other reason is rejected by the compiler rather than silently absorbed by an impl written for `DashMap`. Only the one storage location opts out, and it is the location whose safety argument is written directly above it.

One correction recorded in that comment, because the review had it backwards: the `RefCell<Vec<u8>>` from #5593 is **not** why the type is `!Sync`. `UnsafeCell<*mut SecretsStore>`, `UnsafeCell<*mut DelegateStore>` and `*const ContractStore` are each `!Sync` on their own and all predate it. The `RefCell` was a fourth reason, not the first — this impl has been suppressing the check far longer than the #5593/#5480 pair.

**F4 — left to #5603 deliberately.** It is the same defect: two citations of `the_call_env_identity_fields_are_never_reassigned`, a test that does not exist. #5603 already removes both, on the same lines. Fixing it here would conflict.

**The `P: Sync` nit does not hold.** `Sync` is wasmtime's own requirement — `TypedFunc::<Params, Results>::call_async` bounds `Params: Sync` (wasmtime-47.0.3 `runtime/func/typed.rs:135`) — and removing it fails to compile at the `call_async` call. Verified rather than assumed; the bound stays, now commented so it is not tidied away again.

**F6 — stated residual, by design.** Between the wall clock firing and `DELEGATE_ENV.remove` completing, an abandoned guest can still complete host calls with durable effects: `set_secret`, `remove_secret`, `put_contract_state_sync` / `update_contract_state_sync`. **So a delegate call reported to the executor as `WasmError::Timeout` may nonetheless have mutated the secrets store or contract state.** Not UB, and the window is short, but it is real: removal bounds pointer validity, not effects. Recorded here so it is a known residual rather than a surprise.

**F5** is documented at the guard as a deadlock edge — dashmap is writer-preferring, so `remove` waiting on the shard write lock blocks new reads of that shard; all 15 `DELEGATE_ENV.get` sites take exactly one guard today, and one nested `get` is the whole distance to a hang.

## #5554 has merged, and the fact that makes it safe is now pinned

#5554 landed on `main` while this was in review, so this PR is rebased onto it (cleanly, including `.claude/rules/contracts.md`, which both changes touch).

The reviewer found that interaction safe for a reason its author never stated and nothing checked: **ordering.** `_guard` is a local of `exec_inbound_with_env`, so `DELEGATE_ENV` is cleared strictly before the `Err` reaches `inbound_app_message`, before `DelegateRunOutcome::Failed`, and therefore before a park can release a queued run for the same delegate. That is the placement of one local variable, now load-bearing across two merged changes.

`env_cleanup_completes_before_the_call_returns` asserts it, and was verified by making it fail — `std::mem::forget(_guard)` trips it with its own message. (My earlier note in this PR said the #5554 collision was on a "different map". That reasoning was wrong: the collision would be on the same *delegate*, which is exactly #5554's unit. The conclusion survives; the reason is the ordering above.)

## Round-2 review — R1, R2, F2's second half, and the #5554 pin

**R1 — the capture binding was unprotected, and that was proved by mutation.** Deleting `let _live_guest = live_guest;` from `call_typed_blocking` left the whole suite green. That mutation restores F1 exactly: under Rust 2021 disjoint capture an unmentioned capture is not moved into the closure, so the registration guard drops on the *calling* thread and the id clears the moment the call returns — on the timeout path the guest then runs on with nothing recording it. Both source pins missed it, and so did both re-entry tests, **because they populate the set by hand and never exercise the registration path at all**. `LIVE_DELEGATE_GUESTS`'s own doc said "moving it out silently reintroduces the hazard" with nothing testing that sentence.

The assertion now lives in `assert_delegate_entry_has_wall_clock_backstop`, which already builds the exact state: after the wall-clock timeout the guest is still running, so its registration must still be present. Falsified both ways — with the binding deleted it fails on both V1 and V2 entry points.

**Known gap, stated rather than papered over:** registering *inside* the closure leaves the `QueuedTimeout` window described in `LIVE_DELEGATE_GUESTS`'s doc, and this assertion still passes under that variant. Catching it deterministically would need control over blocking-pool scheduling, which the harness does not offer.

**R2 — and the new pin demonstrated it rather than merely coexisting with it.** `const ID: i64 = 4242` was inside that same function, and the pin asserts the id is *still registered* when the call returns — so a low id sits in a process-global set for the abandoned guest's remaining ~10s epoch budget, while `create_instance` allocates from a counter starting at 0 and one test in this binary calls it 10,001 times. `cargo nextest` runs a process per test and never sees it; plain `cargo test` does. **CI stays green and the contributor following AGENTS.md is the one who hits it** — #4213 / #5023 in the same clothes.

This is also what makes the leak analysis sound rather than cosmetic. Because ids are never recycled, a retained id can only ever refuse re-entry to the instance whose guest is genuinely wedged, which is the correct answer — *unless* a hard-coded id collides with an allocator-issued one. That collision is the single exception, so closing it is what lets the reassuring analysis hold. V1 and V2 now take distinct high ids, as does the panic-capture test, which had the same defect.

**F2 — what the wrapper does and does not do.** Being precise, because it is easy to over-claim:

- The `DelegateEnvSlot` narrowing bounds the impl's **reach**: `DelegateCallEnv` is itself `!Send`/`!Sync`, so code trying to share or move one anywhere other than into `DELEGATE_ENV` is rejected by the compiler.
- It does **not** bound what the impl **blesses**. It wraps the whole struct, so **a field added tomorrow with different thread-safety is still covered**, exactly as it would have been by an impl on `DelegateCallEnv`. So the answer to the specific hazard is: the wrapper alone does not close it.

`every_call_env_field_is_named_in_the_safety_argument` closes that half — it destructures the env with **no `..` rest pattern**, so adding a field is now a compile error (E0027) and whoever adds it must revisit the numbered SAFETY argument. Verified by adding a field and watching the build fail. Its doc also carries the field classification, correcting an earlier draft's count: **six** `!Sync` fields, not three.

**#5554 pin.** `the_env_guard_is_constructed_inside_exec_inbound_with_env` asserts `DelegateEnvGuard` is a local of that function and precedes the guest call. `LIVE_DELEGATE_GUESTS` does **not** cover this — it is keyed by instance id, and a fresh run for the same delegate gets a fresh id, so the set never observes the overlap; the scope of one local variable is the whole protection. Falsified with the exact regression the reviewer named: hoisting the guard into `inbound_app_message` to span the batch turns it red.

**`contracts.md` scoped.** "Delegate host functions run on a blocking-pool thread" was true only during `process()`. `initiate_buffer`, `call_void` and `instantiate_and_init` still enter the guest inline on the calling thread (`wasmtime_engine.rs:1083`, `:1103`, `:1623`, `:1647`) — which is why `exec_inbound_with_env` sets `CURRENT_DELEGATE_INSTANCE` on the calling thread at all. A half-true claim in an agent-facing file propagates the same way the stale one did.

**F4 is not this PR's.** `native_api.rs:549` / `:568` still cite the phantom test; #5601 does not touch those lines and #5603 rewrites a region ~150 lines away. Left entirely alone.

## Review status — please read

This branch was Full-tier reviewed in August, including an external `codex` pass, and its source-scrape pins were mutation-verified. **That review is now 52 commits stale and predates both the read-back commit and the #5593 rebase. Treat it as evidence about the design, not as a passed gate on this content.** A fresh Full-tier review is needed: this touches concurrency and an `unsafe` soundness argument, so it is a high-risk surface regardless of diff size.

Two interactions worth a reviewer's attention:

- **#5593** — the `RefCell` interaction above. The head of that branch still has `context_write` taking a shared borrow.
- **#5554** — rewrites `contract.rs` and parks delegates off the serial loop. No textual conflict (its `native_api` diff is comment-only), but its own new comment states that the serial `contract_handling` loop is the *only* thing guaranteeing one `process()` per delegate, and parking a delegate mid-prompt spans two loop iterations. See the correction above for why this is safe today and why it rests on something unpinned.

Not merging or setting auto-merge; this is up for review.

[AI-assisted - Claude]

https://claude.ai/code/session_01RbvrRHmbnmNWywtSgG8qEV
