### PR TITLE
docs(delegates): cite the mechanism that actually holds field immutability

### DIFF
--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -505,9 +505,14 @@ pub(super) struct DelegateCallEnv {
     /// you got the wrong path, or a Poly1305 tag that would not verify. The
     /// AEAD was the backstop. With the memo, the same edit silently returns the
     /// PREVIOUS identity's plaintext — in hosted mode, cross-tenant
-    /// disclosure. Nothing does this today; the point is that nothing can start
-    /// to without tripping
-    /// `the_call_env_identity_fields_are_never_reassigned`.
+    /// disclosure.
+    ///
+    /// What holds it is the TYPE SYSTEM, not a convention: `context` is behind
+    /// a `RefCell`, so nothing needs a `&mut DelegateCallEnv`, so no field is
+    /// rebindable by any means — not assignment, not `mem::swap`, not
+    /// `clone_from`, not a `&mut` reborrow. Reintroducing a mutable borrow is
+    /// what would reopen this, and `no_mutable_borrow_of_the_call_env_exists`
+    /// is the pin over that one remaining route.
     delegate_key: DelegateKey,
     /// Optional per-user secret namespace for this call, derived ONCE at the
     /// WS connection boundary from the connection's user token (hosted mode,
@@ -525,8 +530,9 @@ pub(super) struct DelegateCallEnv {
     /// Like [`delegate_key`](Self::delegate_key), this must never be reassigned
     /// after construction: [`secret_read_memo`](Self::secret_read_memo) is keyed
     /// on the secret hash ALONE, which is only sound because the scope this
-    /// field selects is fixed for the whole call. Pinned by
-    /// `the_call_env_identity_fields_are_never_reassigned`.
+    /// field selects is fixed for the whole call. Held by the same mechanism:
+    /// no `&mut DelegateCallEnv` exists, so nothing can rebind this either.
+    /// See `no_mutable_borrow_of_the_call_env_exists`.
     user_context: Option<UserSecretContext>,
     /// Read-only pointer to the ContractStore for index lookups
     /// (ContractInstanceId → CodeHash). Valid only during synchronous process().


### PR DESCRIPTION
## Problem

Two SAFETY comments on `DelegateCallEnv`'s identity fields (`native_api.rs:510`, `:529`) cite `the_call_env_identity_fields_are_never_reassigned` as the pin guaranteeing those fields are never rebound. **That test does not exist** — zero occurrences of the `fn` on `main`, two references to it in doc comments.

A safety comment citing a guard that does not exist is worse than one citing no guard, because it stops the reader looking. This one sits in the SAFETY prose a soundness reviewer reads, and it was found by the reviewer of #5601 — whose `unsafe` argument rests on this same immutability invariant. The first cost of the stale reference was that reviewer having to establish from scratch whether the property was pinned at all.

## Why it happened

The test was deleted in #5593, and deleted correctly. It asserted `!src.contains(".delegate_key = ")` — assignment syntax only — and mutation review defeated it with `mem::swap`, which that scrape could never see.

The replacement was to remove the *capability* rather than enumerate its uses: `context` went behind a `RefCell`, so nothing needs a `&mut DelegateCallEnv`, and no field is rebindable by any means — not assignment, not `mem::swap`, not `clone_from`, not a `&mut` reborrow. It is a compile error now:

```
error[E0596]: cannot borrow data in dereference of
              `Ref<'_, i64, DelegateCallEnv>` as mutable
```

The test went with the approach it belonged to. These two references to it did not. So the comments described a guarantee held by a test that no longer exists, while the guarantee itself had in fact become *stronger*.

## Change

Comments only, no behaviour change. Both now cite the type-level mechanism, with `no_mutable_borrow_of_the_call_env_exists` named as the pin over the one remaining route — reintroducing the mutable borrow.

## Sweep

Checked the whole repository for references to everything #5593 retired, not just the one reported:

| retired in #5593 | dangling references |
|---|---|
| `the_call_env_identity_fields_are_never_reassigned` | 2 — fixed here |
| `mutating_secret_host_fns_invalidate_the_memo` | 0 |
| `the_scraped_region_stops_at_the_end_of_the_function` | 0 |
| `scraped_body` (helper) | 0 |

The three surviving references to `no_mutable_borrow_of_the_call_env_exists` all resolve to the real test at `native_api.rs:3215`.

## Testing

`cargo test -p freenet --lib` — 5478 passed, 0 failed, 28 ignored.
`cargo clippy -p freenet --all-targets -- -D warnings` — clean.

Refs #5593, #5601

[AI-assisted - Claude]

https://claude.ai/code/session_01RbvrRHmbnmNWywtSgG8qEV
