### PR TITLE
build: bump freenet-stdlib to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2099,7 +2099,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "freenet-test-network",
  "futures 0.3.32",
  "headers",
@@ -2223,7 +2223,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "freenet-test-network",
  "futures 0.3.32",
  "rand 0.9.4",
@@ -2243,7 +2243,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "serde_json",
 ]
 
@@ -2253,7 +2253,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.8.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62aeba7634d1ae5c2d02f78db33ee40442511858275be5be2099d24a13b2559"
+checksum = "292b74aee3af1918f555051bb404010e89fdb8e77080b0056f564681bec58b35"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2377,7 +2377,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "rand 0.9.4",
  "serde",
 ]
@@ -4247,7 +4247,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "futures 0.3.32",
  "hex",
  "rand 0.9.4",
@@ -6851,14 +6851,14 @@ dependencies = [
 name = "test-contract-delta-trap"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
 ]
 
 [[package]]
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "serde",
  "serde_json",
 ]
@@ -6868,21 +6868,21 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
 ]
 
 [[package]]
 name = "test-contract-requires-related"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.8.5",
+ "freenet-stdlib 0.10.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ zip = { version = "8", default-features = false, features = ["deflate", "time"] 
 # Exposure is FBS-only: `client_events/websocket.rs` falls back to
 # Flatbuffers when no encoding is specified, and every first-party client
 # (fdev, riverctl, River UI, the test harness) explicitly pins native.
-freenet-stdlib = "0.8.5"
+freenet-stdlib = "0.10.0"
 
 # Crypto (secrets-at-rest KEK + DEK derivation, see crates/core/src/config/kek.rs).
 # `sha2` is already declared above (workspace-wide); only `hkdf` and `keyring`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,8 +186,33 @@ muda = "0.19"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-# 0.8.4 adds `DelegateRequest::RegisterDelegateWithPredecessors` (stdlib PR #86),
-# consumed by the #4117 delegate secret copy-forward.
+# 0.10.0 adds three delegate wire variants, all APPENDED so existing tags are
+# unchanged (stdlib #98/#82). Core matches them explicitly rather than sweeping
+# them into a wildcard, but implements none of them yet:
+#   - `OutboundDelegateMsg::UnsubscribeContractRequest` — a delegate asking to
+#     drop a subscription. No core path behind it (#5600), so both dispatchers
+#     REJECT it with an explicit not-implemented error. A silent drop would
+#     strand the delegate on a response nobody sends and read as a successful
+#     unsubscribe while the subscription stayed live.
+#   - `InboundDelegateMsg::UnsubscribeContractResponse` — its answer, likewise
+#     never produced by core yet.
+#   - `InboundDelegateMsg::WakeupFired` — delivery of a wakeup scheduled via
+#     the new `__frnt__delegate__schedule_wakeup` host import (#5565). Core's
+#     wasmtime linker does not define that import and does not trap unknown
+#     imports, so a delegate that CALLS it fails at instantiation; one that
+#     merely links stdlib 0.10.0 without calling it is unaffected.
+#
+# 0.9.0 REMOVES `DelegateRequest::RegisterDelegateWithPredecessors` from the
+# wire (stdlib #91, GHSA-824h-7x5x-wfmf). Source-breaking, hence the minor bump.
+# Its node-side secret copy-forward was gated on an `origin_contract` any HTTP
+# client can forge, so the gate authorized nothing; #5199 had already disabled
+# the copy, leaving the variant registering exactly as `RegisterDelegate` does.
+# `SecretsStore::migrate_secrets` survives with its tests but now has NO caller.
+# Do NOT reintroduce a registration variant that copies secrets forward without
+# first making `origin_contract` attestable.
+#
+# 0.8.4 added that variant in the first place (stdlib PR #86), for the #4117
+# delegate secret copy-forward. Both are gone as of 0.9.0, above.
 #
 # 0.8.5 fixes the FlatBuffers client-request boundary (stdlib #85/#87/#88).
 # Behaviour changes for FBS clients, none for native ones:

--- a/apps/freenet-ping/app/tests/run_delegate_secret_isolation_e2e.rs
+++ b/apps/freenet-ping/app/tests/run_delegate_secret_isolation_e2e.rs
@@ -100,43 +100,40 @@ async fn delegate_app_msg(
     }
 }
 
-/// E2E test for `RegisterDelegateWithPredecessors`'s secret copy-forward,
-/// exercised end-to-end over token-less raw WebSocket connections.
+/// E2E test that a newly-registered delegate starts with an EMPTY secret
+/// namespace, exercised end-to-end over token-less raw WebSocket connections.
 ///
-/// A delegate's on-disk key is BLAKE3(code_hash || params), so any WASM
-/// rebuild (or, as here, a param change simulating one) mints a new key and
-/// a new, empty secret namespace. `DelegateRequest::RegisterDelegateWithPredecessors`
-/// was designed to carry Local-scope secrets forward from a list of
-/// predecessor keys into the newly-registered successor's namespace, gated by
-/// an H1 same-origin check in `SecretsStore::migrate_secrets` — but as of
-/// freenet/freenet-core#5198, the copy-forward call is UNCONDITIONALLY
-/// DISABLED at the handler level (`crates/core/src/contract/executor/runtime/delegates.rs`):
-/// `origin_contract` is forgeable by any HTTP client, so the H1 gate cannot
-/// actually authorize anything, and re-enabling the copy needs that fixed
-/// first. This test's raw WS connection carries no origin attestation at all
-/// (`origin_contract = None`), which was already unprivileged even before
-/// #5198 — so this test exercises the same observable outcome (copy refused)
-/// both before and after the fix, but for a different reason now (disabled
-/// entirely, not merely None-unprivileged).
+/// A delegate's on-disk key is BLAKE3(code_hash || params), so any WASM rebuild
+/// (or, as here, a param change simulating one) mints a new key and a new,
+/// empty secret namespace. `DelegateRequest::RegisterDelegateWithPredecessors`
+/// once carried Local-scope secrets forward from named predecessor keys into
+/// the newly-registered successor's namespace, gated by an H1 same-origin check
+/// in `SecretsStore::migrate_secrets`. freenet/freenet-core#5198 disabled that
+/// copy unconditionally — `origin_contract` is forgeable by any HTTP client, so
+/// the H1 gate could not authorize anything — and freenet-stdlib 0.9.0
+/// (freenet/freenet-stdlib#91) then removed the request variant from the wire
+/// altogether, so there is no longer any message that could ask for a copy.
 ///
-/// This test registers a "predecessor" delegate (test-delegate-2), stores a
-/// Local-scope secret in it via `set_secret` (exercised through the
-/// `StoreSecret` app message), then registers a "successor" delegate — same
-/// WASM, different params, so a DIFFERENT `DelegateKey` — via
-/// `RegisterDelegateWithPredecessors` naming the predecessor. It asserts that
-/// registration itself still succeeds (disabling the copy never fails
-/// registration), that the successor genuinely has NO migrated secret, and
-/// that the predecessor's own copy is untouched (no-delete invariant). The
-/// handler-level `register_delegate_with_predecessors_never_copies_secrets`
-/// test in `crates/core/src` covers the stronger claim directly (copy refused
-/// even when `origin_contract` DOES match the predecessor's recorded origin);
-/// this raw-WS harness has no way to attach any origin to a connection, so it
-/// only ever exercises the `None` case.
+/// This test asserted that the copy did not happen when it was asked for; it
+/// now asserts the property that outlived the request: registering a fresh
+/// delegate gives it NOTHING of another delegate's, and leaves that other
+/// delegate's secrets intact. That is the invariant a re-wired, properly-attested
+/// copy-forward path would have to opt out of deliberately, so it is worth
+/// keeping a live end-to-end check on it.
+///
+/// It registers one delegate (test-delegate-2), stores a Local-scope secret in
+/// it via `set_secret` (exercised through the `StoreSecret` app message), then
+/// registers a second delegate — same WASM, different params, so a DIFFERENT
+/// `DelegateKey`. It asserts that the second registration succeeds, that the
+/// second delegate resolves NO secret under the first delegate's `SecretsId`,
+/// and that the first delegate's own copy is untouched.
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> anyhow::Result<()> {
+async fn test_registering_a_delegate_does_not_inherit_another_delegates_secrets()
+-> anyhow::Result<()> {
     // Same WASM, different params => different DelegateKeys
     // (DelegateKey = BLAKE3(code_hash || params)), simulating a WASM rebuild
-    // that mints a new successor key while keeping the same delegate logic.
+    // that mints a new key while keeping the same delegate logic. `pred`/`succ`
+    // name the two generations that such a rebuild produces.
     let pred_params = Parameters::from(vec![1u8]);
     let pred_delegate = freenet::test_utils::load_delegate("test-delegate-2", pred_params.clone())?;
     let pred_key = pred_delegate.key().clone();
@@ -150,8 +147,8 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         "predecessor and successor must have different DelegateKeys"
     );
 
-    const SECRET_KEY: &[u8] = b"delegate-secret-copy-forward-e2e";
-    const SECRET_VALUE: &[u8] = b"secret-value-carried-across-rebuild";
+    const SECRET_KEY: &[u8] = b"delegate-secret-isolation-e2e";
+    const SECRET_VALUE: &[u8] = b"secret-value-that-must-not-cross-delegates";
 
     // Allocate unique IP for this test's gateway
     let base_node_idx = allocate_test_node_block(1);
@@ -224,8 +221,8 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
 
         // Step 2: Store a Local-scope secret in the predecessor (no user
         // token on this connection, so `set_secret` lands in `SecretScope::Local`
-        // — the only scope the node-side copy-forward can re-encrypt, since
-        // its DEK is derivable at rest from the delegate key + node KEK).
+        // — the scope whose DEK is derivable at rest from the delegate key +
+        // node KEK, i.e. the one a node-side copy could ever have re-encrypted).
         match delegate_app_msg(
             &mut client,
             &pred_key,
@@ -243,8 +240,8 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
             other => return Err(anyhow!("Expected SecretStored, got: {other:?}")),
         }
 
-        // Step 3: Read the secret back from the predecessor to confirm it's
-        // actually stored before we exercise the migration.
+        // Step 3: Read the secret back from the predecessor to confirm it is
+        // actually stored, so Step 5's negative result cannot pass vacuously.
         match delegate_app_msg(
             &mut client,
             &pred_key,
@@ -263,16 +260,16 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
             other => return Err(anyhow!("Expected SecretResult(Some(..)), got: {other:?}")),
         }
 
-        // Step 4: Register the successor delegate (different DelegateKey),
-        // naming the predecessor so the node runs the one-shot secret
-        // copy-forward as part of registration.
+        // Step 4: Register the successor delegate (different DelegateKey).
+        // There is no longer any request that could ask the node to carry the
+        // predecessor's secrets over: `RegisterDelegateWithPredecessors` was
+        // removed from the wire in freenet-stdlib 0.9.0.
         client
             .send(ClientRequest::DelegateOp(
-                DelegateRequest::RegisterDelegateWithPredecessors {
+                DelegateRequest::RegisterDelegate {
                     delegate: succ_delegate.clone(),
                     cipher: TEST_DELEGATE_CIPHER,
                     nonce: TEST_DELEGATE_NONCE,
-                    predecessors: vec![pred_key.clone()],
                 },
             ))
             .await?;
@@ -280,7 +277,7 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         match resp {
             HostResponse::DelegateResponse { key, .. } => {
                 assert_eq!(key, succ_key, "Key mismatch registering successor delegate");
-                tracing::info!("Registered successor delegate with predecessors: {key}");
+                tracing::info!("Registered successor delegate: {key}");
             }
             other => {
                 return Err(anyhow!(
@@ -289,13 +286,9 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
             }
         }
 
-        // Step 5: The successor must NOT resolve the migrated SecretsId.
-        // Copy-forward is unconditionally disabled (#5198), so this holds
-        // regardless of origin — this token-less connection additionally
-        // carries `origin_contract = None`, which was already unprivileged
-        // under the underlying H1 gate even before #5198. Registration
-        // itself still succeeded (Step 4): disabling the copy never fails
-        // registration.
+        // Step 5: The successor must NOT resolve the predecessor's SecretsId.
+        // Each delegate key owns its own secret namespace, and registration
+        // never populates a new one from an existing delegate's.
         match delegate_app_msg(
             &mut client,
             &succ_key,
@@ -306,22 +299,21 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         {
             OutboundAppMessage::SecretResult(None) => {
                 tracing::info!(
-                    "Successor correctly has NO migrated secret — copy-forward is disabled (#5198)"
+                    "Successor correctly resolves NO secret under the predecessor's SecretsId"
                 );
             }
             OutboundAppMessage::SecretResult(Some(value)) => {
                 return Err(anyhow!(
-                    "successor unexpectedly read a migrated secret ({} bytes) — copy-forward \
-                     must be unconditionally disabled (#5198)",
+                    "successor unexpectedly read another delegate's secret ({} bytes) — a \
+                     freshly-registered delegate must start with an EMPTY secret namespace",
                     value.len()
                 ));
             }
             other => return Err(anyhow!("Expected SecretResult, got: {other:?}")),
         }
 
-        // Step 6: No-delete invariant — the predecessor's own copy must still
-        // be readable; copy-forward only ever reads the predecessor, never
-        // mutates or deletes it.
+        // Step 6: The predecessor's own copy must still be readable — the
+        // successor's registration must not have moved, mutated or deleted it.
         match delegate_app_msg(
             &mut client,
             &pred_key,
@@ -333,9 +325,9 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
             OutboundAppMessage::SecretResult(Some(value)) => {
                 assert_eq!(
                     value, SECRET_VALUE,
-                    "predecessor secret must remain intact after copy-forward (no-delete invariant)"
+                    "predecessor secret must remain intact after the successor registers"
                 );
-                tracing::info!("Predecessor secret confirmed intact after copy-forward");
+                tracing::info!("Predecessor secret confirmed intact after successor registration");
             }
             other => {
                 return Err(anyhow!(
@@ -345,8 +337,8 @@ async fn test_delegate_secret_copy_forward_e2e_refuses_token_less_origin() -> an
         }
 
         tracing::info!(
-            "Delegate secret copy-forward E2E checks passed: registration succeeded, \
-             and the copy-forward (disabled, #5198) correctly copied nothing"
+            "Delegate secret isolation E2E checks passed: the second registration \
+             succeeded, inherited nothing, and left the first delegate's secret intact"
         );
         Ok::<_, anyhow::Error>(())
     });

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1696,6 +1696,14 @@ async fn process_open_request(
                                         "ContractNotification"
                                     }
                                     InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+                                    // Appended in stdlib 0.10.0. Core does not
+                                    // yet produce either (#5600 unsubscribe,
+                                    // #5565 wakeup), but an app may send one,
+                                    // and it should not read as "Unknown".
+                                    InboundDelegateMsg::UnsubscribeContractResponse(_) => {
+                                        "UnsubscribeContractResponse"
+                                    }
+                                    InboundDelegateMsg::WakeupFired { .. } => "WakeupFired",
                                     _ => "Unknown",
                                 })
                                 .collect();

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1640,26 +1640,25 @@ async fn process_open_request(
                     freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(key) => {
                         crate::contract::delegate_app_registry::remove_delegate(key);
                     }
-                    // RegisterDelegate and RegisterDelegateWithPredecessors both
-                    // INSTALL a delegate binary (admin ops), not an app
-                    // conversation, so neither registers a routing path — the
-                    // path is established by an ApplicationMessages request that
-                    // carries a notification channel (above), never by
-                    // registration. RegisterDelegateWithPredecessors's
-                    // node-side secret copy-forward (#4117) is unconditionally
-                    // disabled as of GHSA-824h-7x5x-wfmf (its origin_contract gate is
-                    // forgeable) — it was likewise never an app-routing event
-                    // even when active. Both are listed EXPLICITLY (not swept)
-                    // per this match's contract that
-                    // app-facing variants must be handled above the wildcard; the
-                    // wildcard remains ONLY to satisfy `#[non_exhaustive]` for
-                    // genuinely future variants (see git-workflow.md).
+                    // RegisterDelegate INSTALLS a delegate binary (an admin
+                    // op), not an app conversation, so it registers no routing
+                    // path — the path is established by an ApplicationMessages
+                    // request that carries a notification channel (above), never
+                    // by registration. It is listed EXPLICITLY (not swept) per
+                    // this match's contract that app-facing variants must be
+                    // handled above the wildcard; the wildcard remains ONLY to
+                    // satisfy `#[non_exhaustive]` for genuinely future variants
+                    // (see git-workflow.md).
+                    //
+                    // `RegisterDelegateWithPredecessors` was removed from the
+                    // wire in freenet-stdlib 0.9.0 (freenet/freenet-stdlib#91,
+                    // GHSA-824h-7x5x-wfmf): its node-side secret copy-forward
+                    // (#4117) was gated on a forgeable `origin_contract`, and
+                    // core had already disabled the copy in #5199. Do NOT
+                    // reintroduce a registration variant that copies secrets
+                    // forward without first making `origin_contract` attestable.
                     #[allow(clippy::wildcard_enum_match_arm)]
-                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. }
-                    | freenet_stdlib::client_api::DelegateRequest::RegisterDelegateWithPredecessors {
-                        ..
-                    }
-                    | _ => {}
+                    freenet_stdlib::client_api::DelegateRequest::RegisterDelegate { .. } | _ => {}
                 }
 
                 // Derive a short discriminant tag for the INFO logs, but only when INFO is
@@ -1711,9 +1710,6 @@ async fn process_open_request(
                         freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
                             ..
                         } => "RegisterDelegate".to_string(),
-                        freenet_stdlib::client_api::DelegateRequest::RegisterDelegateWithPredecessors {
-                            ..
-                        } => "RegisterDelegateWithPredecessors".to_string(),
                         freenet_stdlib::client_api::DelegateRequest::UnregisterDelegate(_) => {
                             "UnregisterDelegate".to_string()
                         }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -7151,6 +7151,94 @@ mod hol_4391_tests {
         }
     }
 
+    /// The executor loop's half of the same guarantee as
+    /// `unsubscribe_contract_request_fails_the_run_rather_than_being_dropped`
+    /// in `wasm_runtime::delegate::test`: an `UnsubscribeContractRequest` a
+    /// delegate emits must reach the CLIENT as a failure.
+    ///
+    /// freenet-stdlib 0.10.0 added the variant (freenet/freenet-stdlib#98) and
+    /// core has no unsubscribe path behind it yet (#5600). Both dispatchers are
+    /// pinned separately because they fail through different machinery and a
+    /// regression in either one alone would be invisible: `process_outbound`
+    /// returns `Err(DelegateExecError)`, while this loop returns
+    /// `DelegateRunOutcome::Failed(ExecutorError)`. The mock runtime does not
+    /// go through `process_outbound` at all, so this is the only cover for the
+    /// loop's arm.
+    ///
+    /// The assertion is on the error TEXT, not merely `is_err()`. `#5263`'s
+    /// test shows why: a delegate request against this handler can fail for
+    /// unrelated reasons (an exhausted script yields a generic error), so
+    /// asserting only that something failed would pass just as happily if the
+    /// unsubscribe arm were deleted tomorrow.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_unsubscribe_request_surfaces_not_implemented_to_the_client() {
+        let (send_halve, rcv_halve, _) = handler::contract_handler_channel();
+        let mut handler =
+            MockWasmContractHandler::new_test(rcv_halve, None, "del_unsub_5600").await;
+
+        // Script the delegate to emit exactly the request core cannot serve.
+        let contract_id = ContractInstanceId::new([21u8; 32]);
+        handler
+            .runtime_mut()
+            .delegate_script
+            .lock()
+            .unwrap()
+            .push_back(ScriptedRun::from(vec![
+                OutboundDelegateMsg::UnsubscribeContractRequest(
+                    freenet_stdlib::prelude::UnsubscribeContractRequest::new(contract_id),
+                ),
+            ]));
+
+        let delegate_key = DelegateKey::new([21u8; 32], CodeHash::new([22u8; 32]));
+        let event = ContractHandlerEvent::DelegateRequest {
+            req: DelegateRequest::ApplicationMessages {
+                key: delegate_key,
+                params: Parameters::from(vec![]),
+                inbound: vec![],
+            },
+            origin_contract: None,
+            connection_scope: crate::client_events::ConnectionScope::Local,
+            user_context: None,
+        };
+
+        let send_fut = send_halve.send_to_handler(event);
+        let recv_fut = async {
+            let (id, received, _priority) = handler
+                .channel()
+                .recv_from_sender()
+                .await
+                .expect("handler channel should be open");
+            handle_contract_event(
+                &mut handler,
+                id,
+                received,
+                &std::sync::Arc::new(user_input::AutoApprovePrompter),
+                None,
+                None,
+            )
+            .await
+            .expect("dispatch must not error");
+        };
+        let (send_res, ()) = tokio::join!(send_fut, recv_fut);
+
+        match send_res.expect("must receive a response") {
+            ContractHandlerEvent::DelegateResponse(result) => {
+                let err = result.expect_err(
+                    "an unsubscribe this node cannot serve must surface an ERROR to the \
+                     client; a success (even an empty one) reads as an unsubscribe that \
+                     happened, while the subscription is in fact still live",
+                );
+                let rendered = err.to_string();
+                assert!(
+                    rendered.contains("UnsubscribeContractRequest") && rendered.contains("5600"),
+                    "the client-visible failure must name the request and its tracking \
+                     issue, not a generic delegate error, got: {rendered}"
+                );
+            }
+            other => panic!("expected DelegateResponse, got {other}"),
+        }
+    }
+
     // ---- #5544: a parked delegate must not stall the loop, and must not be
     // ---- re-entered while parked.
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -820,11 +820,10 @@ where
     P: UserInputPrompter + 'static,
 {
     // Extract initial params from the request (only ApplicationMessages has params we need).
-    // The registration variants (including RegisterDelegateWithPredecessors,
-    // #4117) carry no params relevant here — registration's empty response exits
-    // the loop before params are read — but the new variant is listed EXPLICITLY
-    // for local consistency with this match's style; the wildcard remains only to
-    // satisfy `#[non_exhaustive]`.
+    // The registration variants carry no params relevant here — registration's
+    // empty response exits the loop before params are read — but they are listed
+    // EXPLICITLY for local consistency with this match's style; the wildcard
+    // remains only to satisfy `#[non_exhaustive]`.
     // GATE THE ORIGIN BEFORE ANY CONSUMER IN THIS FUNCTION
     // (GHSA-824h-7x5x-wfmf).
     //
@@ -847,10 +846,9 @@ where
 
     let initial_params = match &initial_req {
         DelegateRequest::ApplicationMessages { params, .. } => params.clone(),
-        DelegateRequest::RegisterDelegate { .. }
-        | DelegateRequest::RegisterDelegateWithPredecessors { .. }
-        | DelegateRequest::UnregisterDelegate(_)
-        | _ => Parameters::from(Vec::new()),
+        DelegateRequest::RegisterDelegate { .. } | DelegateRequest::UnregisterDelegate(_) | _ => {
+            Parameters::from(Vec::new())
+        }
     };
 
     let mut current_req = initial_req;
@@ -998,6 +996,25 @@ where
                 }
                 OutboundDelegateMsg::RequestUserInput(req) => {
                     user_input_requests.push(req);
+                }
+                // freenet-stdlib 0.10.0 added this variant (freenet/freenet-stdlib#98);
+                // core has no unsubscribe path behind it yet (tracked in #5600).
+                // `Runtime::process_outbound` already rejects it upstream, so on
+                // the real runtime this arm is unreachable; the mock runtime does
+                // not go through that path, so keep the same answer here. Fail
+                // rather than drop: a dropped request would leave the delegate
+                // waiting forever for an `UnsubscribeContractResponse` nobody
+                // sends, and would read as a successful unsubscribe while the
+                // subscription stays live.
+                OutboundDelegateMsg::UnsubscribeContractRequest(req) => {
+                    tracing::warn!(
+                        delegate_key = %delegate_key,
+                        contract_id = %req.contract_id,
+                        "Delegate requested UnsubscribeContractRequest, which this node does not implement yet (see #5600)"
+                    );
+                    return DelegateRunOutcome::Failed(ExecutorError::other(anyhow::anyhow!(
+                        "UnsubscribeContractRequest is not implemented by this node yet (#5600)"
+                    )));
                 }
                 other @ OutboundDelegateMsg::ApplicationMessage(_)
                 | other @ OutboundDelegateMsg::ContextUpdated(_) => {
@@ -3110,6 +3127,7 @@ fn route_notification_outbound(delegate_key: &DelegateKey, outbound: Vec<Outboun
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => {
                 tracing::warn!(
                     delegate = %delegate_key,

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -292,11 +292,6 @@ pub(super) fn request_bytes(req: &DelegateRequest<'static>) -> usize {
             inbound, params, ..
         } => inbound.iter().map(inbound_bytes).sum::<usize>() + params.as_ref().len(),
         DelegateRequest::RegisterDelegate { delegate, .. } => delegate_container_bytes(delegate),
-        DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate,
-            predecessors,
-            ..
-        } => delegate_container_bytes(delegate) + predecessors.len() * 64,
         DelegateRequest::UnregisterDelegate(_) | _ => 0,
     }
 }
@@ -364,6 +359,7 @@ fn outbound_bytes(msg: &OutboundDelegateMsg) -> usize {
         OutboundDelegateMsg::PutContractRequest(r) => r.state.as_ref().len() + ctx_len(&r.context),
         OutboundDelegateMsg::UpdateContractRequest(r) => ctx_len(&r.context),
         OutboundDelegateMsg::SubscribeContractRequest(r) => ctx_len(&r.context),
+        OutboundDelegateMsg::UnsubscribeContractRequest(r) => ctx_len(&r.context),
     }
 }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -334,6 +334,11 @@ fn inbound_bytes(msg: &InboundDelegateMsg<'static>) -> usize {
         InboundDelegateMsg::PutContractResponse(r) => ctx_len(&r.context),
         InboundDelegateMsg::UpdateContractResponse(r) => ctx_len(&r.context),
         InboundDelegateMsg::SubscribeContractResponse(r) => ctx_len(&r.context),
+        InboundDelegateMsg::UnsubscribeContractResponse(r) => ctx_len(&r.context),
+        // `tag` is bounded by stdlib's `MAX_WAKEUP_TAG_LEN`, but charge it
+        // rather than assume: this arm exists precisely so nothing goes
+        // uncounted. Carries no context by design.
+        InboundDelegateMsg::WakeupFired { tag } => tag.len(),
         // Required by `#[non_exhaustive]`. A new variant that carries bytes
         // MUST be added above; this arm is the only thing between it and going
         // uncounted, which is why the list is written out rather than delegated.

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -171,6 +171,9 @@ fn inbound_kind(msg: &InboundDelegateMsg<'_>) -> &'static str {
         InboundDelegateMsg::SubscribeContractResponse(_) => "SubscribeContractResponse",
         InboundDelegateMsg::ContractNotification(_) => "ContractNotification",
         InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+        // Appended in stdlib 0.10.0.
+        InboundDelegateMsg::UnsubscribeContractResponse(_) => "UnsubscribeContractResponse",
+        InboundDelegateMsg::WakeupFired { .. } => "WakeupFired",
         _ => "Other",
     }
 }

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -512,7 +512,6 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
             }
             DelegateRequest::RegisterDelegate { .. }
             | DelegateRequest::UnregisterDelegate(_)
-            | DelegateRequest::RegisterDelegateWithPredecessors { .. }
             | _ => Vec::new(),
         };
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2131,241 +2131,18 @@ mod remove_contract_tests {
         }
     }
 
-    /// Handler-level (GHSA-824h-7x5x-wfmf): `RegisterDelegateWithPredecessors`
-    /// NEVER copies a predecessor's secrets, even when the registering request's
-    /// `origin_contract` exactly matches the predecessor's recorded
-    /// first-registration origin (the one case the H1 same-origin gate in
-    /// `SecretsStore::migrate_secrets` would otherwise allow). The copy-forward
-    /// call is disabled at the handler level because `origin_contract` itself is
-    /// forgeable by any HTTP client (see GHSA-824h-7x5x-wfmf) — so even a "matching" origin
-    /// proves nothing. Registration still succeeds, exactly as plain
-    /// `RegisterDelegate` would. This replaces the pre-advisory test asserting the
-    /// copy DID happen on a matching origin.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn register_delegate_with_predecessors_never_copies_secrets() {
-        use crate::wasm_runtime::SecretScope;
-        use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
-        use freenet_stdlib::prelude::{
-            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
-        };
-        use zeroize::Zeroizing;
-
-        const ORIGIN: [u8; 32] = [0x11u8; 32];
-
-        let temp_dir = crate::util::tests::get_temp_dir();
-        let db = Storage::new(temp_dir.path()).await.expect("create db");
-        let contract_store =
-            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
-                .expect("create contract store");
-        let delegate_store =
-            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
-                .expect("create delegate store");
-        let secrets_dir = temp_dir.path().join("secrets");
-        let mut secrets_store =
-            SecretsStore::new(secrets_dir.clone(), Default::default(), db.clone())
-                .expect("create secrets store");
-
-        // Same params, different code == an ABI bump that mints a new key.
-        let pred = Delegate::from((&vec![0u8].into(), &vec![1u8].into()));
-        let succ = Delegate::from((&vec![0u8].into(), &vec![2u8].into()));
-
-        // Seed a predecessor Local secret under its DERIVED DEK (the at-rest
-        // path) BEFORE moving the secrets store into the runtime.
-        let secret_id = SecretsId::new(b"room:alice".to_vec());
-        secrets_store
-            .store_secret(
-                pred.key(),
-                &secret_id,
-                SecretScope::Local,
-                Zeroizing::new(b"profile".to_vec()),
-            )
-            .expect("seed predecessor secret");
-
-        // Record the predecessor's FIRST-registration origin (H1 same-origin
-        // gate): the migrating registration below must present this SAME origin
-        // for the copy to be allowed.
-        secrets_store
-            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
-            .unwrap();
-
-        let successor_secret_path = secrets_dir
-            .join(succ.key().encode())
-            .join(secret_id.encode());
-        assert!(
-            !successor_secret_path.exists(),
-            "successor secret must not exist before migration"
-        );
-
-        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
-        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
-            .expect("build runtime");
-        let mut executor = Executor::new(
-            state_store,
-            || Ok(()),
-            crate::contract::executor::OperationMode::Local,
-            runtime,
-            None,
-        )
-        .await
-        .expect("create executor");
-
-        let origin_contract = ContractInstanceId::new(ORIGIN);
-
-        let req = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: vec![pred.key().clone()],
-        };
-        let resp = executor
-            .delegate_request(
-                req,
-                Some(&origin_contract),
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("register-with-predecessors must succeed");
-        let HostResponse::DelegateResponse { key, .. } = &resp else {
-            panic!("expected DelegateResponse, got {resp:?}");
-        };
-        assert_eq!(key, succ.key(), "response carries the successor key");
-
-        // The predecessor's Local secret must NOT be copied — the copy-forward
-        // is unconditionally disabled (GHSA-824h-7x5x-wfmf), even though the supplied
-        // `origin_contract` matches the predecessor's recorded origin exactly
-        // (the one case the underlying H1 gate would otherwise have allowed).
-        assert!(
-            !successor_secret_path.exists(),
-            "successor secret file must NOT exist: copy-forward is disabled (GHSA-824h-7x5x-wfmf) \
-             regardless of origin_contract"
-        );
-
-        // The predecessor's own secret is untouched (registration never mutates
-        // or deletes a predecessor's data, disabled copy-forward or not).
-        let predecessor_secret_path = secrets_dir
-            .join(pred.key().encode())
-            .join(secret_id.encode());
-        assert!(
-            predecessor_secret_path.exists(),
-            "predecessor secret must remain untouched"
-        );
-    }
-
-    /// Regression test for GHSA-824h-7x5x-wfmf, directory-level: a
-    /// predecessor holding MULTIPLE Local secrets, named in a
-    /// `RegisterDelegateWithPredecessors` request with a matching
-    /// `origin_contract`, must leave the successor's on-disk secrets
-    /// directory completely absent (or empty) — not merely missing one
-    /// known secret ID. This is stronger than
-    /// `register_delegate_with_predecessors_never_copies_secrets`, which
-    /// only checks a single secret path; a copy-forward bug that mis-copies
-    /// a DIFFERENT secret ID than the one under test would slip past a
-    /// single-path check but not a whole-directory scan.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn register_delegate_with_predecessors_successor_dir_stays_empty() {
-        use crate::wasm_runtime::SecretScope;
-        use freenet_stdlib::client_api::{DelegateRequest, HostResponse};
-        use freenet_stdlib::prelude::{
-            ContractInstanceId, Delegate, DelegateContainer, DelegateWasmAPIVersion, SecretsId,
-        };
-        use zeroize::Zeroizing;
-
-        const ORIGIN: [u8; 32] = [0x22u8; 32];
-
-        let temp_dir = crate::util::tests::get_temp_dir();
-        let db = Storage::new(temp_dir.path()).await.expect("create db");
-        let contract_store =
-            ContractStore::new(temp_dir.path().join("contracts"), 10_000, db.clone())
-                .expect("create contract store");
-        let delegate_store =
-            DelegateStore::new(temp_dir.path().join("delegate"), 10_000, db.clone())
-                .expect("create delegate store");
-        let secrets_dir = temp_dir.path().join("secrets");
-        let mut secrets_store =
-            SecretsStore::new(secrets_dir.clone(), Default::default(), db.clone())
-                .expect("create secrets store");
-
-        let pred = Delegate::from((&vec![9u8].into(), &vec![1u8].into()));
-        let succ = Delegate::from((&vec![9u8].into(), &vec![2u8].into()));
-
-        // Seed THREE Local secrets under the predecessor.
-        for i in 0u8..3 {
-            secrets_store
-                .store_secret(
-                    pred.key(),
-                    &SecretsId::new(format!("secret-{i}").into_bytes()),
-                    SecretScope::Local,
-                    Zeroizing::new(format!("value-{i}").into_bytes()),
-                )
-                .expect("seed predecessor secret");
-        }
-        secrets_store
-            .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
-            .unwrap();
-
-        let successor_secrets_dir = secrets_dir.join(succ.key().encode());
-        assert!(
-            !successor_secrets_dir.exists(),
-            "successor secrets directory must not exist before registration"
-        );
-
-        let state_store = StateStore::new(db, 10_000_000).expect("create state store");
-        let runtime = Runtime::build(contract_store, delegate_store, secrets_store, false)
-            .expect("build runtime");
-        let mut executor = Executor::new(
-            state_store,
-            || Ok(()),
-            crate::contract::executor::OperationMode::Local,
-            runtime,
-            None,
-        )
-        .await
-        .expect("create executor");
-
-        let origin_contract = ContractInstanceId::new(ORIGIN);
-        let req = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: vec![pred.key().clone()],
-        };
-        let resp = executor
-            .delegate_request(
-                req,
-                Some(&origin_contract),
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("register-with-predecessors must succeed");
-        assert!(matches!(resp, HostResponse::DelegateResponse { .. }));
-
-        // Whole-directory check: NOTHING was copied into the successor's
-        // namespace, whether the directory was never created or was created
-        // empty.
-        let successor_has_any_secret = successor_secrets_dir
-            .read_dir()
-            .map(|mut entries| entries.next().is_some())
-            .unwrap_or(false);
-        assert!(
-            !successor_has_any_secret,
-            "successor secrets directory must be absent or empty: copy-forward is \
-             disabled (GHSA-824h-7x5x-wfmf) regardless of origin_contract or predecessor secret count"
-        );
-    }
-
     /// Handler-level (#4117 H1, persistence-succeeds-before-usable): if the
     /// first-writer origin record cannot be DURABLY persisted, the WHOLE
-    /// registration is aborted — for BOTH the plain `RegisterDelegate` and the
-    /// `RegisterDelegateWithPredecessors` variants. The delegate is NOT
-    /// registered (no `.reg` file) and no predecessor secret is copied, so a
-    /// registered-but-recordless delegate (a claimable first-writer slot an
+    /// registration is aborted. The delegate is NOT registered (no `.reg` file),
+    /// so a registered-but-recordless delegate (a claimable first-writer slot an
     /// attacker could later name as its own) can never exist. Once the disk
-    /// recovers, the app's retry registers and records normally (copy-forward
-    /// itself is unconditionally disabled, GHSA-824h-7x5x-wfmf, so it never copies — see
-    /// the final assertion). Uses the fault-injecting redb backend to fail the
-    /// origin-record write on demand.
+    /// recovers, the app's retry registers and records normally. Uses the
+    /// fault-injecting redb backend to fail the origin-record write on demand.
+    ///
+    /// This test used to drive the same property through
+    /// `RegisterDelegateWithPredecessors` as well; that wire variant was removed
+    /// in freenet-stdlib 0.9.0 (freenet/freenet-stdlib#91), so only the plain
+    /// `RegisterDelegate` path remains — which is the whole surface now.
     #[cfg(feature = "redb")]
     #[tokio::test(flavor = "multi_thread")]
     // Shares the process-global `POISON_RECOVERY_TRIGGERED` counter with the
@@ -2406,8 +2183,9 @@ mod remove_contract_tests {
         let pred = Delegate::from((&vec![0u8].into(), &vec![1u8].into()));
         let succ = Delegate::from((&vec![0u8].into(), &vec![2u8].into()));
 
-        // Seed a predecessor Local secret + its first-registration origin WHILE the
-        // backend is healthy (both must exist for the copy to be allowed later).
+        // Seed an unrelated delegate's Local secret + its first-registration
+        // origin WHILE the backend is healthy: it is the bystander whose data
+        // must survive the failed registrations below untouched.
         let secret_id = SecretsId::new(b"room:alice".to_vec());
         secrets_store
             .store_secret(
@@ -2446,12 +2224,11 @@ mod remove_contract_tests {
         // ---- The disk now fails: the successor's origin-record write cannot persist.
         backend.start_failing();
 
-        // (a) RegisterDelegateWithPredecessors MUST abort: no register, no copy.
-        let req = DelegateRequest::RegisterDelegateWithPredecessors {
+        // (a) RegisterDelegate MUST abort: nothing registered, nothing written.
+        let req = DelegateRequest::RegisterDelegate {
             delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
             cipher: [7u8; 32],
             nonce: [9u8; 24],
-            predecessors: vec![pred.key().clone()],
         };
         assert!(
             executor
@@ -2471,10 +2248,12 @@ mod remove_contract_tests {
         );
         assert!(
             !succ_secret_path.exists(),
-            "an aborted registration must copy NOTHING"
+            "an aborted registration must write NOTHING"
         );
 
-        // (b) Plain RegisterDelegate MUST abort under the SAME failure (both variants).
+        // (b) A SECOND, independent delegate must abort under the SAME failure,
+        // so the abort is a property of the failed origin-record write and not
+        // of anything specific to `succ`.
         let plain = Delegate::from((&vec![0u8].into(), &vec![3u8].into()));
         let plain_reg_path = delegate_dir
             .join(plain.key().encode())
@@ -2501,10 +2280,10 @@ mod remove_contract_tests {
             "an aborted RegisterDelegate must register NOTHING"
         );
 
-        // The predecessor's own secret is untouched throughout.
+        // The bystander delegate's own secret is untouched throughout.
         assert!(
             pred_secret_path.exists(),
-            "the predecessor's own secret must survive the failed migrating registrations"
+            "an unrelated delegate's secret must survive the failed registrations"
         );
 
         // ---- Recovery: the disk heals (a fresh handle over a healthy backend);
@@ -2521,7 +2300,7 @@ mod remove_contract_tests {
                 .expect("create secrets store 2");
         // The origin table lived in the failed DB; on a real node it persists
         // across the restart, but here the fresh handle starts empty, so
-        // re-establish the predecessor's origin as the app's retry would.
+        // re-establish the bystander's origin as the app's retry would.
         secrets_store2
             .record_delegate_registration_origin(pred.key(), Some(ORIGIN))
             .expect("re-record predecessor origin after recovery");
@@ -2538,11 +2317,10 @@ mod remove_contract_tests {
         .await
         .expect("create executor 2");
 
-        let req2 = DelegateRequest::RegisterDelegateWithPredecessors {
+        let req2 = DelegateRequest::RegisterDelegate {
             delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ.clone())),
             cipher: [7u8; 32],
             nonce: [9u8; 24],
-            predecessors: vec![pred.key().clone()],
         };
         executor2
             .delegate_request(
@@ -2557,213 +2335,16 @@ mod remove_contract_tests {
             succ_reg_path.exists(),
             "after recovery the successor IS registered (.reg present)"
         );
-        // Copy-forward is unconditionally disabled (GHSA-824h-7x5x-wfmf): the retry succeeds
-        // (registration itself was only ever blocked by the origin-record
-        // write failure, now healed), but no secret is ever copied.
+        // Registration was only ever blocked by the origin-record write failure,
+        // now healed. Registering a delegate never creates secrets for it, and
+        // no node-side path copies another delegate's secrets forward — the
+        // request variant that once could was removed in freenet-stdlib 0.9.0.
         assert!(
             !succ_secret_path.exists(),
-            "the predecessor secret must NOT be copied forward: copy-forward is disabled (GHSA-824h-7x5x-wfmf)"
+            "registration must not create any secret for the newly-registered delegate"
         );
     }
 
-    /// #4117 P2b/M1: the predecessor-list bound is TWO-tiered and enforced
-    /// through the real `Executor::delegate_request` path (not just the pure
-    /// dedupe fn). The cap is on the UNIQUE count, matching the docstrings:
-    ///   - 65 DISTINCT predecessors (> the deduped cap of 64) → request REJECTED,
-    ///     nothing registered (silent truncation would strand older generations);
-    ///   - a duplicate-heavy list whose UNIQUE count is within the cap → ACCEPTED
-    ///     (duplicates dropped, not counted);
-    ///   - a raw list past the DoS sanity bound → REJECTED up front regardless of
-    ///     unique count.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn register_with_predecessors_cap_is_on_unique_count_end_to_end() {
-        use super::delegates::{MAX_MIGRATION_PREDECESSORS, MAX_MIGRATION_PREDECESSORS_RAW};
-        use freenet_stdlib::client_api::DelegateRequest;
-        use freenet_stdlib::prelude::{Delegate, DelegateContainer, DelegateWasmAPIVersion};
-
-        let (mut executor, _contracts_dir, temp_dir) = build_disk_executor("pred-cap").await;
-        let delegate_dir = temp_dir.path().join("delegate");
-
-        let make_pred = |i: u8| {
-            Delegate::from((&vec![i].into(), &vec![0u8].into()))
-                .key()
-                .clone()
-        };
-        let reg_path =
-            |succ: &Delegate| delegate_dir.join(succ.key().encode()).with_extension("reg");
-
-        // (1) 65 UNIQUE predecessors > the deduped cap of 64 → REJECTED.
-        let succ_over = Delegate::from((&vec![0u8].into(), &vec![0xA1u8].into()));
-        let over: Vec<_> = (0u8..=64).map(make_pred).collect(); // 65 distinct
-        assert_eq!(over.len(), MAX_MIGRATION_PREDECESSORS + 1);
-        let req_over = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_over.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: over,
-        };
-        assert!(
-            executor
-                .delegate_request(
-                    req_over,
-                    None,
-                    None,
-                    crate::client_events::ConnectionScope::Local,
-                    None
-                )
-                .is_err(),
-            "an over-cap UNIQUE predecessor list must be rejected"
-        );
-        assert!(
-            !reg_path(&succ_over).exists(),
-            "a rejected over-cap request must register NOTHING"
-        );
-
-        // (2) A duplicate-heavy list whose UNIQUE count (3) is within the cap →
-        //     ACCEPTED (duplicates dropped, not counted).
-        let succ_ok = Delegate::from((&vec![0u8].into(), &vec![0xB2u8].into()));
-        let mut dupes: Vec<_> = Vec::new();
-        for _ in 0..40 {
-            dupes.push(make_pred(1));
-            dupes.push(make_pred(2));
-            dupes.push(make_pred(3));
-        } // 120 raw, 3 unique
-        assert!(
-            dupes.len() > MAX_MIGRATION_PREDECESSORS
-                && dupes.len() <= MAX_MIGRATION_PREDECESSORS_RAW,
-            "the duplicate-heavy list must exceed the deduped cap in RAW length \
-             yet stay under the raw sanity bound, to isolate the dedupe semantics"
-        );
-        let req_ok = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_ok.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: dupes,
-        };
-        executor
-            .delegate_request(
-                req_ok,
-                None,
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("a duplicate-heavy but under-cap-UNIQUE list must be accepted");
-        assert!(
-            reg_path(&succ_ok).exists(),
-            "an accepted request must register the successor"
-        );
-
-        // (3) A raw list past the DoS sanity bound → REJECTED up front regardless
-        //     of unique count (all identical here: unique = 1, raw > the bound).
-        let succ_raw = Delegate::from((&vec![0u8].into(), &vec![0xC3u8].into()));
-        let raw_huge = vec![make_pred(7); MAX_MIGRATION_PREDECESSORS_RAW + 1];
-        let req_raw = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_raw.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: raw_huge,
-        };
-        assert!(
-            executor
-                .delegate_request(
-                    req_raw,
-                    None,
-                    None,
-                    crate::client_events::ConnectionScope::Local,
-                    None
-                )
-                .is_err(),
-            "a raw list past the DoS sanity bound must be rejected even when unique count is small"
-        );
-        assert!(
-            !reg_path(&succ_raw).exists(),
-            "a rejected raw-oversize request must register NOTHING"
-        );
-
-        // (4) EXACTLY 64 UNIQUE predecessors (the at-cap boundary) → ACCEPTED.
-        let succ_at_cap = Delegate::from((&vec![0u8].into(), &vec![0xD4u8].into()));
-        let at_cap: Vec<_> = (0u8..64).map(make_pred).collect(); // 64 distinct
-        assert_eq!(at_cap.len(), MAX_MIGRATION_PREDECESSORS);
-        let req_at_cap = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_at_cap.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: at_cap,
-        };
-        executor
-            .delegate_request(
-                req_at_cap,
-                None,
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("an exactly-at-cap UNIQUE count (64) must be accepted");
-        assert!(
-            reg_path(&succ_at_cap).exists(),
-            "the at-cap boundary (64 unique) must register the successor"
-        );
-
-        // (5) EMPTY predecessor list → ACCEPTED, behaving like a plain
-        //     RegisterDelegate (successor registered, nothing to copy). Pins the
-        //     intended zero-predecessor semantics (the code does NOT reject empty).
-        let succ_empty = Delegate::from((&vec![0u8].into(), &vec![0xE5u8].into()));
-        let req_empty = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(succ_empty.clone())),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: Vec::new(),
-        };
-        executor
-            .delegate_request(
-                req_empty,
-                None,
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("an empty predecessor list must be accepted (plain-register equivalent)");
-        assert!(
-            reg_path(&succ_empty).exists(),
-            "an empty-predecessor request must register the successor"
-        );
-
-        // (6) A raw list at EXACTLY the sanity bound (1024) with a within-cap
-        //     UNIQUE count (64) → ACCEPTED (the raw-bound boundary: only > the
-        //     bound is rejected).
-        let succ_raw_boundary = Delegate::from((&vec![0u8].into(), &vec![0xF6u8].into()));
-        let mut raw_at_bound: Vec<_> = Vec::new();
-        for _ in 0..(MAX_MIGRATION_PREDECESSORS_RAW / MAX_MIGRATION_PREDECESSORS) {
-            for i in 0..MAX_MIGRATION_PREDECESSORS as u8 {
-                raw_at_bound.push(make_pred(i));
-            }
-        } // 16 * 64 = 1024 raw, 64 unique
-        assert_eq!(raw_at_bound.len(), MAX_MIGRATION_PREDECESSORS_RAW);
-        let req_raw_boundary = DelegateRequest::RegisterDelegateWithPredecessors {
-            delegate: DelegateContainer::Wasm(DelegateWasmAPIVersion::V1(
-                succ_raw_boundary.clone(),
-            )),
-            cipher: [7u8; 32],
-            nonce: [9u8; 24],
-            predecessors: raw_at_bound,
-        };
-        executor
-            .delegate_request(
-                req_raw_boundary,
-                None,
-                None,
-                crate::client_events::ConnectionScope::Local,
-                None,
-            )
-            .expect("a raw list at exactly the sanity bound (unique within cap) must be accepted");
-        assert!(
-            reg_path(&succ_raw_boundary).exists(),
-            "the raw-bound boundary (raw == 1024, 64 unique) must register the successor"
-        );
-    }
-
-    /// Core regression test: storing a contract makes its state retrievable
     /// and its `.wasm` blob present on disk; `remove_contract` reclaims both.
     #[tokio::test(flavor = "multi_thread")]
     async fn remove_contract_reclaims_state_and_wasm_from_disk() {

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -7,51 +7,6 @@
 
 use super::*;
 
-/// Upper bound on the number of UNIQUE predecessor delegate keys a single
-/// `RegisterDelegateWithPredecessors` request may drive copy-forward for
-/// (#4117 P2/M1). The predecessor list is client-controlled, and each
-/// predecessor drives synchronous marker/index/redb writes on the contract
-/// loop, so an unbounded (or duplicate-padded) list is a disk-growth / loop-
-/// stall amplification vector. 64 matches the delegate-lineage / probe-hop
-/// bound used by the app-side migration driver (`DEFAULT_MAX_PROBE_HOPS`): a
-/// realistic delegate never accumulates anywhere near 64 retired generations.
-/// This is the DEDUPED cap, enforced on the UNIQUE count: a request whose
-/// unique predecessor count exceeds it is REJECTED whole (never silently
-/// truncated, which would strand older generations — the client splits its
-/// request). Duplicates are dropped first and never count against it, so a
-/// duplicate-heavy but genuinely-small list is accepted. A separate, much
-/// larger raw-length sanity bound ([`MAX_MIGRATION_PREDECESSORS_RAW`]) rejects a
-/// giant list up front so the dedupe work itself stays bounded.
-pub(super) const MAX_MIGRATION_PREDECESSORS: usize = 64;
-
-/// Pre-dedupe SANITY bound on the RAW predecessor-list length: 16× the deduped
-/// cap [`MAX_MIGRATION_PREDECESSORS`]. This is pure DoS protection — it caps the
-/// dedupe / `HashSet`-insert work for a giant list BEFORE any per-element
-/// processing — NOT the semantic limit. No legitimate client comes anywhere
-/// near it: a realistic delegate has a handful of retired generations, and even
-/// a duplicate-heavy legitimate list stays far under 1024. The semantic limit
-/// is the deduped cap above; a list whose UNIQUE count is within the cap is
-/// accepted even when the raw list carried duplicates.
-pub(super) const MAX_MIGRATION_PREDECESSORS_RAW: usize = MAX_MIGRATION_PREDECESSORS * 16;
-
-/// Dedupe a client-supplied predecessor list, preserving newest-first order
-/// (#4117 P2/M1). A duplicate is pure waste (the migration is idempotent per
-/// pair), so it is dropped SILENTLY. The cap is enforced by the CALLER on the
-/// deduped length: over the cap, the whole request is REJECTED before
-/// registration (never silently truncated, which would strand older
-/// generations — the client is expected to split its request). Extracted as a
-/// free function so the dedupe is unit-testable without standing up an executor.
-fn dedupe_predecessors(predecessors: Vec<DelegateKey>) -> Vec<DelegateKey> {
-    let mut seen = std::collections::HashSet::new();
-    let mut out: Vec<DelegateKey> = Vec::with_capacity(predecessors.len());
-    for p in predecessors {
-        if seen.insert(p.clone()) {
-            out.push(p);
-        }
-    }
-    out
-}
-
 impl Executor<Runtime> {
     /// Export this hosted user's per-user delegate secrets into an encrypted
     /// bundle, sealed under the user's `token` (hosted-mode export, P3-live of
@@ -148,9 +103,8 @@ impl Executor<Runtime> {
             })
     }
 
-    /// Register a delegate and record its WebApp origin, shared by the
-    /// `RegisterDelegate` and `RegisterDelegateWithPredecessors` request arms so
-    /// the two cannot drift. Forwards the client-supplied cipher/nonce down to
+    /// Register a delegate and record its WebApp origin, for the
+    /// `RegisterDelegate` request arm. Forwards the client-supplied cipher/nonce down to
     /// `SecretsStore::register_delegate` (via `Runtime::register_delegate`,
     /// which is a pass-through); the store DISCARDS them and derives the
     /// per-delegate DEK from the node KEK instead, see
@@ -326,89 +280,6 @@ impl Executor<Runtime> {
                 }),
                 Err(err) => Err(err),
             },
-            DelegateRequest::RegisterDelegateWithPredecessors {
-                delegate,
-                cipher,
-                nonce,
-                predecessors,
-            } => {
-                // Bound the client-controlled predecessor list BEFORE registering
-                // (#4117 P2b/M1) with TWO tiers, so the DoS bound and the
-                // documented DEDUPED semantics both hold:
-                //   (a) a cheap pre-dedupe SANITY check on the RAW length rejects
-                //       a giant list up front, keeping the dedupe / HashSet work
-                //       itself bounded (a giant list can't burn the contract
-                //       loop just to be rejected);
-                //   (b) dedupe silently (a repeat is pure waste — migration is
-                //       idempotent per pair);
-                //   (c) enforce the real cap on the UNIQUE count, matching every
-                //       docstring and test. A duplicate-heavy but genuinely-small
-                //       list is ACCEPTED; an over-cap UNIQUE list is REJECTED
-                //       whole (silent truncation would strand older generations —
-                //       the client splits its request).
-                // Each predecessor drives synchronous marker/index/redb writes,
-                // so an unbounded list is a disk-growth / loop-stall vector.
-                if predecessors.len() > MAX_MIGRATION_PREDECESSORS_RAW {
-                    let key = delegate.key().clone();
-                    tracing::warn!(
-                        delegate_key = %key,
-                        predecessors = predecessors.len(),
-                        raw_cap = MAX_MIGRATION_PREDECESSORS_RAW,
-                        "RegisterDelegateWithPredecessors rejected: raw predecessor list too large (DoS sanity bound)"
-                    );
-                    return Err(ExecutorError::other(anyhow::anyhow!(
-                        "RegisterDelegateWithPredecessors: raw predecessor list of {} exceeds the sanity bound of {}",
-                        predecessors.len(),
-                        MAX_MIGRATION_PREDECESSORS_RAW
-                    )));
-                }
-                let deduped = dedupe_predecessors(predecessors);
-                if deduped.len() > MAX_MIGRATION_PREDECESSORS {
-                    let key = delegate.key().clone();
-                    tracing::warn!(
-                        delegate_key = %key,
-                        unique_predecessors = deduped.len(),
-                        cap = MAX_MIGRATION_PREDECESSORS,
-                        "RegisterDelegateWithPredecessors rejected: too many UNIQUE predecessors (split the request)"
-                    );
-                    return Err(ExecutorError::other(anyhow::anyhow!(
-                        "RegisterDelegateWithPredecessors: {} unique predecessors exceeds the cap of {}",
-                        deduped.len(),
-                        MAX_MIGRATION_PREDECESSORS
-                    )));
-                }
-
-                // SECURITY (GHSA-824h-7x5x-wfmf): the predecessor secret
-                // copy-forward below `self.runtime.migrate_delegate_secrets(...)`
-                // is INTENTIONALLY NEVER CALLED. `SecretsStore::migrate_secrets`
-                // gates the copy on `origin_contract` matching the predecessor's
-                // recorded first-registration origin, but `origin_contract` is
-                // forgeable by any HTTP client through the webapp-shell token
-                // issuance path (see GHSA-824h-7x5x-wfmf for the full exploit chain) — so the
-                // gate does not actually authorize anything. Do NOT re-enable
-                // this call without first hardening how `origin_contract` is
-                // attested; the gate itself remains sound given a trustworthy
-                // origin. The feature has zero known callers (every app in this
-                // ecosystem has its own client-driven secret-continuity
-                // mechanism instead), so disabling it changes no observed
-                // behavior. Registration proceeds exactly as `RegisterDelegate`.
-                if !deduped.is_empty() {
-                    tracing::warn!(
-                        delegate_key = %delegate.key(),
-                        predecessors = deduped.len(),
-                        "RegisterDelegateWithPredecessors: predecessor secret \
-                         copy-forward is disabled pending a security fix (see \
-                         GHSA-824h-7x5x-wfmf); registering the delegate \
-                         without migrating any secrets"
-                    );
-                }
-
-                self.register_delegate_and_record_origin(delegate, cipher, nonce, origin_contract)
-                    .map(|key| DelegateResponse {
-                        key,
-                        values: Vec::new(),
-                    })
-            }
             DelegateRequest::UnregisterDelegate(key) => {
                 self.delegate_origin_ids.remove(&key);
 
@@ -603,30 +474,6 @@ mod resolve_message_origin_tests {
     /// and both are gone. See #4813.
     fn origins() -> crate::wasm_runtime::SharedInheritedOrigins {
         crate::wasm_runtime::new_inherited_origins()
-    }
-
-    /// #4117 P2/M1: the predecessor list is deduped silently, preserving
-    /// newest-first order (first occurrence wins). The cap itself is enforced in
-    /// the handler on the deduped length (over-cap → the whole request is
-    /// rejected, never silently truncated).
-    #[test]
-    fn dedupe_predecessors_preserves_order_and_drops_duplicates() {
-        // Unique → unchanged, order preserved.
-        let keys: Vec<DelegateKey> = (0u8..5).map(dkey).collect();
-        assert_eq!(dedupe_predecessors(keys.clone()), keys);
-
-        // Duplicates dropped, first occurrence wins, order preserved.
-        let dupes = vec![dkey(1), dkey(2), dkey(1), dkey(3), dkey(2)];
-        assert_eq!(dedupe_predecessors(dupes), vec![dkey(1), dkey(2), dkey(3)]);
-
-        // Dedupe does not itself cap: a large unique list passes through (the
-        // handler rejects it against MAX_MIGRATION_PREDECESSORS).
-        let many: Vec<DelegateKey> = (0u8..200).map(dkey).collect();
-        assert_eq!(dedupe_predecessors(many).len(), 200);
-        // Compile-time tripwire: if MAX_MIGRATION_PREDECESSORS is ever raised to
-        // >= 200 this fails the build, so the "many" fixture above always stays
-        // large enough to actually exercise the over-cap scenario elsewhere.
-        const _: () = assert!(200 > MAX_MIGRATION_PREDECESSORS);
     }
 
     /// Caller delegate identity wins over a concurrently-supplied WebApp

--- a/crates/core/src/contract/storages/redb.rs
+++ b/crates/core/src/contract/storages/redb.rs
@@ -219,22 +219,23 @@ pub(crate) const MIGRATION_MARKER_TABLE: TableDefinition<&[u8], &[u8]> =
 
 /// Durable record of the web-app contract origins under which each delegate has
 /// been registered (#4117 H1 same-origin gate). Written on EVERY successful
-/// delegate registration (both `RegisterDelegate` and
-/// `RegisterDelegateWithPredecessors`). Copy-forward consults it: a predecessor's
-/// Local secrets are copied into a successor ONLY when the registering request's
-/// origin is among the predecessor's recorded origins (or both are the Admin/None
-/// class).
+/// delegate registration. `SecretsStore::migrate_secrets` consults it: a
+/// predecessor's Local secrets are copied into a successor ONLY when the
+/// registering request's origin is among the predecessor's recorded origins (or
+/// both are the Admin/None class).
 ///
 /// **This gate alone is NOT sufficient protection (GHSA-824h-7x5x-wfmf).**
 /// The registering request's `origin_contract` is itself forgeable by any HTTP
 /// client (see GHSA-824h-7x5x-wfmf for the exploit chain), so a malicious web-app CAN obtain
 /// a value that matches an unrelated victim delegate's recorded origin. The
-/// actual protection today is that the copy-forward's sole caller
-/// (`RegisterDelegateWithPredecessors`'s handler) is unconditionally disabled —
-/// this gate is not currently invoked in production at all. Do not treat this
-/// table as a sufficient authorization control if the copy-forward is ever
-/// re-wired; `origin_contract` attestation needs hardening first. See
-/// `SecretsStore::delegate_origins` and `SecretsStore::migrate_secrets`.
+/// actual protection today is that `migrate_secrets` has NO caller at all: its
+/// only network-reachable one was `DelegateRequest::RegisterDelegateWithPredecessors`,
+/// which #5199 disabled and freenet-stdlib 0.9.0 then removed from the wire
+/// entirely (freenet/freenet-stdlib#91) — so this gate is not invoked in
+/// production. Do not treat this table as a sufficient authorization control if
+/// a copy-forward is ever re-wired; `origin_contract` attestation needs
+/// hardening first. See `SecretsStore::delegate_origins` and
+/// `SecretsStore::migrate_secrets`.
 ///
 /// Key: DelegateKey (64 bytes)
 /// Value: `[has_admin_none: 1][N × ContractInstanceId(32)]` — `has_admin_none`

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -6146,9 +6146,6 @@ pub async fn run_local_node(
                 // if the token expired between WebSocket connect and this request)
                 let op_name = match op {
                     DelegateRequest::RegisterDelegate { .. } => "RegisterDelegate",
-                    DelegateRequest::RegisterDelegateWithPredecessors { .. } => {
-                        "RegisterDelegateWithPredecessors"
-                    }
                     DelegateRequest::ApplicationMessages { .. } => "ApplicationMessages",
                     DelegateRequest::UnregisterDelegate(_) => "UnregisterDelegate",
                     _ => "Unknown",

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -88,6 +88,7 @@ fn drain_remaining_with_attestation(
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_)) => results.push(msg),
         }
     }
@@ -382,6 +383,9 @@ impl Runtime {
                     OutboundDelegateMsg::SubscribeContractRequest(req) => {
                         format!("SubscribeContractRequest(contract={})", req.contract_id)
                     }
+                    OutboundDelegateMsg::UnsubscribeContractRequest(req) => {
+                        format!("UnsubscribeContractRequest(contract={})", req.contract_id)
+                    }
                     OutboundDelegateMsg::SendDelegateMessage(msg) => {
                         format!(
                             "SendDelegateMessage(target={}, payload_len={})",
@@ -426,6 +430,7 @@ impl Runtime {
                         OutboundDelegateMsg::PutContractRequest(r) => format!("PutContractReq({})", r.contract.key()),
                         OutboundDelegateMsg::UpdateContractRequest(r) => format!("UpdateContractReq({})", r.contract_id),
                         OutboundDelegateMsg::SubscribeContractRequest(r) => format!("SubscribeContractReq({})", r.contract_id),
+                        OutboundDelegateMsg::UnsubscribeContractRequest(r) => format!("UnsubscribeContractReq({})", r.contract_id),
                         OutboundDelegateMsg::SendDelegateMessage(m) => format!("SendDelegateMsg(target={})", m.target),
                     }
                 }).collect::<Vec<_>>()
@@ -548,6 +553,26 @@ impl Runtime {
                     context.clear();
                     context.extend_from_slice(ctx.as_ref());
                 }
+                // freenet-stdlib 0.10.0 added this variant (freenet/freenet-stdlib#98);
+                // core has no unsubscribe path behind it yet (tracked in #5600).
+                // Fail LOUDLY rather than drop it: silently swallowing the
+                // request would leave the delegate blocked forever on an
+                // `UnsubscribeContractResponse` that no one is going to send,
+                // and would make "unsubscribed" look successful while the
+                // subscription is still live.
+                OutboundDelegateMsg::UnsubscribeContractRequest(req) => {
+                    tracing::warn!(
+                        delegate_key = %delegate_key,
+                        contract_id = %req.contract_id,
+                        "Delegate requested UnsubscribeContractRequest, which this node does not \
+                         implement yet (see #5600); failing the delegate execution"
+                    );
+                    return Err(DelegateExecError::UnexpectedMessage(
+                        "UnsubscribeContractRequest is not implemented by this node yet (#5600)",
+                    )
+                    .into());
+                }
+
                 OutboundDelegateMsg::SendDelegateMessage(mut msg) if !msg.processed => {
                     tracing::debug!(
                         target_delegate = %msg.target,

--- a/crates/core/src/wasm_runtime/delegate/execution.rs
+++ b/crates/core/src/wasm_runtime/delegate/execution.rs
@@ -304,6 +304,9 @@ impl Runtime {
             InboundDelegateMsg::SubscribeContractResponse(_) => "SubscribeContractResponse",
             InboundDelegateMsg::ContractNotification(_) => "ContractNotification",
             InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+            // Appended in stdlib 0.10.0.
+            InboundDelegateMsg::UnsubscribeContractResponse(_) => "UnsubscribeContractResponse",
+            InboundDelegateMsg::WakeupFired { .. } => "WakeupFired",
             // `InboundDelegateMsg` is `#[non_exhaustive]` (stdlib 0.6.0+).
             // Future variants land here for tracing only — they still flow
             // through the wasm boundary as raw bincode below; classifying

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -254,6 +254,7 @@ async fn test_get_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
@@ -280,6 +281,7 @@ async fn test_get_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -337,6 +339,7 @@ async fn test_get_contract_not_found() -> Result<(), Box<dyn std::error::Error>>
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
@@ -359,6 +362,7 @@ async fn test_get_contract_not_found() -> Result<(), Box<dyn std::error::Error>>
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -418,6 +422,7 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected GetContractRequest, got {:?}", other)
         }
@@ -442,6 +447,7 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected GetContractRequest for contract2, got {:?}", other)
         }
@@ -466,6 +472,7 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected GetContractRequest for contract3, got {:?}", other)
         }
@@ -490,6 +497,7 @@ async fn test_multiple_contract_requests() -> Result<(), Box<dyn std::error::Err
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -559,6 +567,7 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => None,
         })
         .expect("Expected a GetContractRequest");
@@ -574,6 +583,7 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => None,
         })
         .expect("Expected an ApplicationMessage (Echo)");
@@ -618,6 +628,7 @@ async fn test_message_accumulation() -> Result<(), Box<dyn std::error::Error>> {
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -725,6 +736,7 @@ async fn test_context_persistence_within_call() -> Result<(), Box<dyn std::error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -739,6 +751,7 @@ async fn test_context_persistence_within_call() -> Result<(), Box<dyn std::error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -809,6 +822,7 @@ async fn test_context_persists_between_calls() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -836,6 +850,7 @@ async fn test_context_persists_between_calls() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1400,6 +1415,7 @@ async fn test_has_secret_host_function() -> Result<(), Box<dyn std::error::Error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1437,6 +1453,7 @@ async fn test_has_secret_host_function() -> Result<(), Box<dyn std::error::Error
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1477,6 +1494,7 @@ async fn test_get_nonexistent_secret() -> Result<(), Box<dyn std::error::Error>>
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1522,6 +1540,7 @@ async fn test_store_and_retrieve_secret() -> Result<(), Box<dyn std::error::Erro
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1546,6 +1565,7 @@ async fn test_store_and_retrieve_secret() -> Result<(), Box<dyn std::error::Erro
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1612,6 +1632,7 @@ async fn test_set_secret_failure_returns_secret_store_failed()
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1657,6 +1678,7 @@ async fn test_read_empty_context() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1725,6 +1747,7 @@ async fn test_context_clear() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1749,6 +1772,7 @@ async fn test_context_clear() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1809,6 +1833,7 @@ async fn test_context_shared_across_batch() -> Result<(), Box<dyn std::error::Er
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => {
                 panic!("Expected ApplicationMessage")
             }
@@ -1882,6 +1907,7 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1905,6 +1931,7 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1928,6 +1955,7 @@ async fn test_remove_secret_host_function() -> Result<(), Box<dyn std::error::Er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -1974,6 +2002,7 @@ async fn test_large_context_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -2015,6 +2044,7 @@ async fn test_large_context_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -2085,6 +2115,7 @@ async fn test_large_context_within_batch() -> Result<(), Box<dyn std::error::Err
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -2174,6 +2205,7 @@ async fn a_write_invalidates_the_secret_memo_within_one_process_call()
             | other @ OutboundDelegateMsg::PutContractRequest(_)
             | other @ OutboundDelegateMsg::UpdateContractRequest(_)
             | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+            | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
                 panic!("Expected ApplicationMessage, got {other:?}")
             }
@@ -2266,6 +2298,7 @@ async fn test_large_secret_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -2307,6 +2340,7 @@ async fn test_large_secret_data() -> Result<(), Box<dyn std::error::Error>> {
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage")
         }
@@ -2414,6 +2448,7 @@ async fn test_concurrent_delegate_execution() -> Result<(), Box<dyn std::error::
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => {
                 panic!("Expected ApplicationMessage")
             }
@@ -2494,6 +2529,7 @@ async fn test_concurrent_delegate_execution() -> Result<(), Box<dyn std::error::
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
             | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_)
             | OutboundDelegateMsg::SendDelegateMessage(_) => {
                 panic!("Expected ApplicationMessage")
             }
@@ -2743,6 +2779,7 @@ async fn test_v2_delegate_reads_contract_state() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -2833,6 +2870,7 @@ async fn test_v2_delegate_contract_not_found() -> Result<(), Box<dyn std::error:
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -2947,6 +2985,7 @@ fn send_v2_message(
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3156,6 +3195,7 @@ async fn test_put_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected PutContractRequest, got {:?}", other)
         }
@@ -3185,6 +3225,7 @@ async fn test_put_contract_request_response() -> Result<(), Box<dyn std::error::
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3245,6 +3286,7 @@ async fn test_update_contract_request_response() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected UpdateContractRequest, got {:?}", other)
         }
@@ -3274,6 +3316,7 @@ async fn test_update_contract_request_response() -> Result<(), Box<dyn std::erro
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3336,6 +3379,7 @@ async fn test_subscribe_contract_request_response() -> Result<(), Box<dyn std::e
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected SubscribeContractRequest, got {:?}", other)
         }
@@ -3365,6 +3409,7 @@ async fn test_subscribe_contract_request_response() -> Result<(), Box<dyn std::e
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3429,6 +3474,7 @@ async fn test_contract_notification_delivered() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3542,6 +3588,7 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::GetContractRequest(_)
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected SubscribeContractRequest, got {:?}", other)
         }
@@ -3608,6 +3655,7 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -3657,6 +3705,7 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         | other @ OutboundDelegateMsg::PutContractRequest(_)
         | other @ OutboundDelegateMsg::UpdateContractRequest(_)
         | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+        | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", other)
         }
@@ -4076,7 +4125,8 @@ async fn test_delegate_emits_send_delegate_message() -> Result<(), Box<dyn std::
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_) => None,
         })
         .expect("Expected SendDelegateMessage in outbound");
 
@@ -4132,6 +4182,7 @@ async fn test_delegate_receives_delegate_message() -> Result<(), Box<dyn std::er
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!("Expected ApplicationMessage, got {:?}", &outbound[0])
         }
@@ -4265,7 +4316,8 @@ async fn test_delegate_to_delegate_roundtrip() -> Result<(), Box<dyn std::error:
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_) => None,
         })
         .expect("Expected SendDelegateMessage from delegate A");
 
@@ -4291,6 +4343,7 @@ async fn test_delegate_to_delegate_roundtrip() -> Result<(), Box<dyn std::error:
         | OutboundDelegateMsg::PutContractRequest(_)
         | OutboundDelegateMsg::UpdateContractRequest(_)
         | OutboundDelegateMsg::SubscribeContractRequest(_)
+        | OutboundDelegateMsg::UnsubscribeContractRequest(_)
         | OutboundDelegateMsg::SendDelegateMessage(_) => {
             panic!(
                 "Expected ApplicationMessage from B, got {:?}",
@@ -4379,7 +4432,8 @@ async fn test_multiple_send_delegate_messages_all_attested()
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_) => None,
         })
         .collect();
 
@@ -4475,7 +4529,8 @@ async fn test_drain_behind_application_message_reattests_sender()
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_) => None,
         })
         .expect("SendDelegateMessage should be drained into results");
 
@@ -4536,7 +4591,8 @@ async fn test_drain_behind_get_contract_request_reattests_sender()
             | OutboundDelegateMsg::GetContractRequest(_)
             | OutboundDelegateMsg::PutContractRequest(_)
             | OutboundDelegateMsg::UpdateContractRequest(_)
-            | OutboundDelegateMsg::SubscribeContractRequest(_) => None,
+            | OutboundDelegateMsg::SubscribeContractRequest(_)
+            | OutboundDelegateMsg::UnsubscribeContractRequest(_) => None,
         })
         .expect("SendDelegateMessage should be drained into results");
 

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -5219,3 +5219,79 @@ async fn env_cleanup_completes_before_the_call_returns() -> Result<(), Box<dyn s
 
     Ok(())
 }
+
+/// A delegate that emits `UnsubscribeContractRequest` must FAIL the run, not
+/// have the request silently dropped.
+///
+/// freenet-stdlib 0.10.0 added the variant (freenet/freenet-stdlib#98); core
+/// has no unsubscribe path behind it yet (#5600). The choice of an explicit
+/// error over a quiet drop is the load-bearing decision here, and the two are
+/// indistinguishable from the delegate's side unless something pins it:
+///
+/// - a DROP returns `Ok` with the request absent from `results`, so the
+///   delegate waits forever for an `UnsubscribeContractResponse` nobody will
+///   send, and every observer reads the unsubscribe as having succeeded while
+///   the subscription is still live;
+/// - the ERROR reaches the client as a delegate execution failure naming
+///   #5600.
+///
+/// Asserting `results` stayed empty as well as `Err` is what makes this a real
+/// pin: a regression that forwarded the request onward as if it were handled
+/// would produce a non-empty `results`, and one that dropped it would produce
+/// `Ok`. Both `processed` states are covered, because core cannot honour either
+/// — it never sets `processed` on this variant, since it errors first.
+#[tokio::test(flavor = "multi_thread")]
+async fn unsubscribe_contract_request_fails_the_run_rather_than_being_dropped()
+-> Result<(), Box<dyn std::error::Error>> {
+    use std::collections::VecDeque;
+
+    for processed in [false, true] {
+        let (mut runtime, _temp_dir) = bare_runtime().await;
+
+        let delegate_key = DelegateKey::new([11u8; 32], CodeHash::new([12u8; 32]));
+        let contract_id = ContractInstanceId::new([13u8; 32]);
+
+        let mut req = UnsubscribeContractRequest::new(contract_id);
+        req.processed = processed;
+
+        let mut outbound: VecDeque<OutboundDelegateMsg> = VecDeque::new();
+        outbound.push_back(OutboundDelegateMsg::UnsubscribeContractRequest(req));
+
+        let handle = InstanceHandle { id: 0 };
+        let params: Parameters = vec![].into();
+        let mut context = Vec::new();
+        let mut results = Vec::new();
+        let outcome = runtime.process_outbound(
+            &delegate_key,
+            &handle,
+            0,
+            &params,
+            None,
+            &mut outbound,
+            &mut context,
+            &mut results,
+        );
+
+        let Err(err) = outcome else {
+            panic!(
+                "an unsubscribe core cannot serve must FAIL the run; returning Ok \
+                 strands the delegate on a response that will never arrive \
+                 (processed={processed})"
+            );
+        };
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("UnsubscribeContractRequest") && rendered.contains("5600"),
+            "the failure must name the request and its tracking issue so an operator \
+             can tell it from a delegate bug, got: {rendered}"
+        );
+        assert!(
+            results.is_empty(),
+            "a request core cannot serve must not be forwarded onward as though it \
+             had been handled, got {} result(s)",
+            results.len()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -1195,8 +1195,7 @@ impl Runtime {
     }
 
     /// One-shot, idempotent, Local-scope copy-forward of delegate secrets from
-    /// `predecessors` into `successor` (#4117), the node-side primitive behind
-    /// `DelegateRequest::RegisterDelegateWithPredecessors`. Another route to the
+    /// `predecessors` into `successor` (#4117). Another route to the
     /// `pub(super) secret_store` for a write from outside the `wasm_runtime`
     /// module (the executor lives in a different module tree and wraps secret
     /// access in `Runtime` methods, exactly as `register_delegate` /
@@ -1211,14 +1210,17 @@ impl Runtime {
     /// Runs ON the contract loop (serialized with delegate `store_secret`),
     /// mirroring the on-loop write discipline of `import_secret_bundle`.
     ///
-    /// UNREACHABLE as of GHSA-824h-7x5x-wfmf: the sole caller (the
-    /// `RegisterDelegateWithPredecessors` handler in
-    /// `crates/core/src/contract/executor/runtime/delegates.rs`) no longer
-    /// calls this, because the `origin_contract` this method's H1 gate relies
-    /// on is forgeable by any HTTP client — see GHSA-824h-7x5x-wfmf for the exploit chain.
+    /// HAS NO CALLER as of GHSA-824h-7x5x-wfmf. Its only one was the
+    /// `DelegateRequest::RegisterDelegateWithPredecessors` handler in
+    /// `crates/core/src/contract/executor/runtime/delegates.rs`: #5199 stopped
+    /// it calling this (the `origin_contract` the H1 gate relies on is forgeable
+    /// by any HTTP client — see GHSA-824h-7x5x-wfmf for the exploit chain), and
+    /// freenet-stdlib 0.9.0 then removed that request variant from the wire
+    /// altogether (freenet/freenet-stdlib#91), so the handler is gone too.
     /// Kept (not deleted) so the underlying `SecretsStore::migrate_secrets`
     /// mechanism, which is otherwise sound, is easy to re-wire once
-    /// `origin_contract` attestation is hardened.
+    /// `origin_contract` attestation is hardened. Re-wiring it needs a NEW,
+    /// properly-attested request path — do not restore the old variant.
     #[allow(dead_code)]
     pub(crate) fn migrate_delegate_secrets(
         &mut self,

--- a/crates/core/src/wasm_runtime/secrets_store/store.rs
+++ b/crates/core/src/wasm_runtime/secrets_store/store.rs
@@ -2566,19 +2566,21 @@ impl SecretsStore {
     /// the next registration (and picked up if its secrets arrive later); this
     /// also denies a client the ability to drive marker writes with bogus keys.
     ///
-    /// Runs synchronously on the caller (the contract loop, via the
-    /// `RegisterDelegateWithPredecessors` handler), mirroring the on-loop write
-    /// discipline of `store_secret` / the live bundle import. The work is bounded
-    /// by the predecessors' own on-disk secret count.
+    /// Designed to run synchronously on the contract loop, mirroring the on-loop
+    /// write discipline of `store_secret` / the live bundle import. The work is
+    /// bounded by the predecessors' own on-disk secret count.
     ///
-    /// UNREACHABLE FROM PRODUCTION as of GHSA-824h-7x5x-wfmf: the H1 gate
-    /// above is sound only if `origin_contract` is trustworthy, and it isn't —
-    /// any HTTP client can forge an `origin_contract` value for an arbitrary
-    /// public contract key (see GHSA-824h-7x5x-wfmf). The one caller
-    /// (`RegisterDelegateWithPredecessors`'s handler) no longer invokes this
-    /// method; it is kept, with its test suite, for potential reactivation once
-    /// `origin_contract` attestation is hardened. Do not re-wire a caller to
-    /// this method without first fixing that.
+    /// HAS NO CALLER as of GHSA-824h-7x5x-wfmf: the H1 gate above is sound only
+    /// if `origin_contract` is trustworthy, and it isn't — any HTTP client can
+    /// forge an `origin_contract` value for an arbitrary public contract key
+    /// (see GHSA-824h-7x5x-wfmf). Its one caller was the
+    /// `DelegateRequest::RegisterDelegateWithPredecessors` handler: #5199
+    /// stopped it invoking this method, and freenet-stdlib 0.9.0 removed that
+    /// request variant from the wire entirely (freenet/freenet-stdlib#91), so
+    /// nothing can reach it. The method is kept, with its test suite, for
+    /// potential reactivation once `origin_contract` attestation is hardened.
+    /// Re-wiring it means building a NEW, properly-attested request path — do
+    /// not restore the removed variant — and must not happen before that fix.
     pub fn migrate_secrets(
         &mut self,
         predecessors: &[DelegateKey],

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2319,6 +2319,7 @@ async fn test_delegate_request(ctx: &mut TestContext) -> TestResult {
                 | other @ OutboundDelegateMsg::PutContractRequest(_)
                 | other @ OutboundDelegateMsg::UpdateContractRequest(_)
                 | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+                | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
                 | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
                     bail!("Expected ApplicationMessage, got {:?}", other)
                 }
@@ -2479,6 +2480,7 @@ async fn test_attested_contract_passed_to_delegate(ctx: &mut TestContext) -> Tes
                 | other @ OutboundDelegateMsg::PutContractRequest(_)
                 | other @ OutboundDelegateMsg::UpdateContractRequest(_)
                 | other @ OutboundDelegateMsg::SubscribeContractRequest(_)
+                | other @ OutboundDelegateMsg::UnsubscribeContractRequest(_)
                 | other @ OutboundDelegateMsg::SendDelegateMessage(_) => {
                     bail!("Expected ApplicationMessage, got {:?}", other)
                 }


### PR DESCRIPTION
Bumps the workspace `freenet-stdlib` pin from `0.8.5` to `0.10.0` and does the
cleanup that #5201 tracked as a prerequisite. Version bump plus the minimum
needed to compile and pass tests — no core-side support for the new 0.10.0
features (see "Deliberately left for follow-up").

## What broke, and how it was fixed

### 1. `DelegateRequest::RegisterDelegateWithPredecessors` removed (stdlib 0.9.0)

freenet/freenet-stdlib#91 removed the variant from the wire
(GHSA-824h-7x5x-wfmf). Seven source sites and a pile of tests named it.

**No functionality is lost.** #5199 had already cut the only thing that
distinguished this variant from plain `RegisterDelegate`: its node-side secret
copy-forward was disabled unconditionally, because the `origin_contract` its
authorization gate depends on is forgeable by any HTTP client. Since #5199 the
arm registered the delegate *exactly* as `RegisterDelegate` does and warned. So
this removes a duplicate registration path and nothing else. It had no callers
anywhere in the ecosystem (River, ghostkeys and Atlas each carry their own
client-driven secret-continuity mechanism), which is why stdlib could drop it.

Removed:

- the match arms in `client_events.rs`, `contract.rs`, `node.rs`,
  `mock_wasm_runtime.rs`, `delegate_park.rs`, and the handler arm in
  `contract/executor/runtime/delegates.rs`;
- `MAX_MIGRATION_PREDECESSORS`, `MAX_MIGRATION_PREDECESSORS_RAW` and
  `dedupe_predecessors` — they existed solely to bound a client-controlled
  predecessor list, and no request can supply one any more;
- the tests that drove those bounds through the removed request.

**Kept**, as #5199 intended: `SecretsStore::migrate_secrets` and
`Runtime::migrate_delegate_secrets` with their full test suites. The underlying
mechanism (idempotence markers, immutable first-writer origin record,
fail-closed error handling) is sound; only the input its gate relies on is not.
Leaving it in place means a properly-attested path can re-use it later. Their
docs now say they have **no caller at all** and that re-wiring means building a
new attested request — not restoring the removed variant — rather than pointing
at a handler that no longer exists. The same correction is applied to
`DELEGATE_ORIGINS_TABLE`'s doc in `redb.rs` and the comment in
`client_events.rs`, which carries the "do not reintroduce this" note #5201 asked
for.

Two of the three regression tests #5201 flagged proved a negative about a
request that can no longer be sent, so they are gone. The third,
`register_aborts_when_origin_record_fails_then_recovers`, drove a still-live
property (a registration whose first-writer origin record cannot persist aborts
whole, and recovers on retry) through **both** registration variants; it now
drives it through `RegisterDelegate`, which is the whole surface. Coverage
intact.

The freenet-ping e2e test got the same treatment. It existed to prove the
copy-forward copied nothing; that scenario cannot be constructed now, but the
invariant beneath it outlives the request, so it is retargeted rather than
deleted: it registers a second delegate with plain `RegisterDelegate` and
asserts the new delegate inherits none of the first's secrets and leaves them
intact. Renamed via `git mv` (history preserved) to
`run_delegate_secret_isolation_e2e.rs`, since the old filename named a mechanism
that no longer exists. Nothing referenced it by name.

### 2. `OutboundDelegateMsg::UnsubscribeContractRequest` appended (stdlib 0.10.0)

freenet/freenet-stdlib#98. Six exhaustive matches in `src/` plus 56 fallback
arms across the delegate test module and `operations.rs`.

Core has no unsubscribe path yet (#5600). Both real dispatchers —
`Runtime::process_outbound` and the executor loop in `contract.rs` — **reject it
with an explicit not-implemented error** rather than dropping it. Dropping would
strand the delegate waiting forever on an `UnsubscribeContractResponse` nobody
sends, and would read as a successful unsubscribe while the subscription is
still live. The byte-accounting and logging sites handle it normally; the test
fallback arms treat it as any other unexpected message.

### 3. `InboundDelegateMsg::UnsubscribeContractResponse` and `WakeupFired` appended

These did not break the build (the four sites that classify inbound messages end
in a wildcard), but `clippy::wildcard_enum_match_arm` is denied in CI, so they
are now named explicitly. That is also what those sites ask for in their own
comments: the wildcard is meant to hold only genuinely-future variants.
`delegate_park::inbound_bytes` charges `WakeupFired`'s tag rather than counting
it as zero.

### Not breakage

freenet-stdlib #82's `ScheduleWakeup` is a WASM host import
(`__frnt__delegate__schedule_wakeup`), not an enum variant, so it needs no
compile-time change. #90/#92/#129/#130 are documentation. #94 is TypeScript-only.

## Deliberately left for follow-up

Per the scope discipline for this PR, none of 0.10.0's new features are
implemented core-side:

- **Unsubscribe (#5600).** A delegate that emits `UnsubscribeContractRequest`
  gets a clear "not implemented by this node yet (#5600)" error.
- **Scheduled wakeup (#5565).** Core's wasmtime linker does not define
  `__frnt__delegate__schedule_wakeup`, and the linker does not trap unknown
  imports, so a delegate that *calls* it fails at instantiation with an unknown-
  import error. A delegate that merely links stdlib 0.10.0 without calling it is
  unaffected — Rust emits no import for an uncalled `extern "C"` fn.
- **Subscribe pin reporting (#128).** `SubscribeContractResponse` is unchanged
  in shape; nothing to do at compile time.

## Verification

Run against `b49ca7cad614fb2f47df199e26f6bea48a2df37f`, with `git status --short` empty at that SHA:

- `cargo build` — clean
- `cargo fmt --all --check` — clean
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- `cargo test -p freenet --lib` — 5537 passed, 0 failed, 28 ignored

`Cargo.lock` changes only the `freenet-stdlib` version; 0.10.0 pulls in no new
transitive dependencies.

Closes #5201.

[AI-assisted - Claude]

https://claude.ai/code/session_01RbvrRHmbnmNWywtSgG8qEV
