### PR TITLE
docs(rules): load bug-prevention patterns for all of crates/core

### DIFF
--- a/.claude/rules/bug-prevention-patterns.md
+++ b/.claude/rules/bug-prevention-patterns.md
@@ -1,8 +1,6 @@
 ---
 paths:
-  - "crates/core/src/bin/**"
-  - "crates/core/src/conformance/**"
-  - "crates/core/src/contract/**"
+  - "crates/core/**"
   - "scripts/**"
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ When unsure which bucket a change is in, open an issue first.
 1. Is this in crates/core/?
    → Check .claude/rules/testing.md for DST requirements
    → Verify: TimeSource for time, GlobalRng for randomness
+   → Check .claude/rules/bug-prevention-patterns.md — patterns that have
+     already caused repeat production bugs in this crate
 
 2. Which module are you modifying?
    → ring/router/     → Check .claude/rules/ring.md
@@ -229,6 +231,7 @@ docs/architecture/    # Design docs
 | Transport | `.claude/rules/transport.md` |
 | Contracts | `.claude/rules/contracts.md` |
 | Browser assets (injected JS + its HTML/CSP wrappers) | `.claude/rules/browser-assets.md` |
+| All of `crates/core/` and `scripts/` | `.claude/rules/bug-prevention-patterns.md` |
 
 ### General Rules
 


### PR DESCRIPTION
## Problem

`.claude/rules/bug-prevention-patterns.md` opens by describing itself as "patterns that have caused repeat production bugs in this crate", but its `paths:` frontmatter scoped it to `crates/core/src/bin/**`, `crates/core/src/conformance/**`, `crates/core/src/contract/**` and `scripts/**`.

So it did not load for ordinary `crates/core` work — which is where most of the patterns it documents actually apply. An agent editing `crates/core/src/ring/` or `crates/core/src/operations/` never saw it.

## Approach

Widen to `crates/core/**` (which subsumes the three `src/` entries), keeping `scripts/**`.

Of the nine documented patterns, only two are specific to the old scope:

- `Command::spawn` after `FreeConsole()` / Windows autostart — `bin/`
- SIGPIPE under `pipefail` — `scripts/`

The other seven are core-wide: CI-gate log markers, proxy completion predicates, cross-test interference through process-global state, self-satisfying `include_str!` source-scrape pins, a count cap enforced by refusal, an uncounted refusal rendering as a clean zero, and manually-inlined originator side effects.

`crates/core/**` is the existing precedent in this directory — `testing.md` already uses exactly that.

## Trade-off (please push back if you disagree)

This is a 45 KB file, so it now loads for most `crates/core` sessions, alongside `testing.md`'s 15 KB. That is a real context cost. I think it is the right trade — a rule that does not load where its patterns apply is not doing anything — but if the context budget matters more, the better fix is splitting the file per-subsystem rather than re-narrowing it to paths its own contents do not match.

## Testing

Documentation/agent-config only; no code paths touched. The change is to `paths:` frontmatter.

Found during a review of unversioned agent configuration on the dev machine.

[AI-assisted - Claude]

https://claude.ai/code/session_013vjGPN34WyhLwGif5Y4sDf