### PR TITLE
feat(delegates): let V1 delegate GET and SUBSCRIBE reach the network (#5542)

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2498,9 +2498,10 @@ where
                         let owed_contract_ops: Vec<(
                             ContractInstanceId,
                             delegate_park::ContractOpKind,
+                            DelegateContext,
                         )> = pending_contract_ops
                             .iter()
-                            .map(|op| (op.contract_id, op.kind))
+                            .map(|op| (op.contract_id, op.kind, op.context.clone()))
                             .collect();
                         // SINKS CREATED BEFORE THE GUARD, AND SHARED WITH IT
                         // (#5544 F2). They used to be created inside the
@@ -4435,11 +4436,15 @@ where
     // budget). Same reasoning as the unresolved upserts above: the delegate is
     // TOLD rather than left waiting. `DelegateContext` is defaulted because the
     // `PendingContractOp` that carried it is gone by then.
-    for (contract_id, kind) in unresolved_contract_ops {
+    for (contract_id, kind, context) in unresolved_contract_ops {
         all_inbound.push(contract_op_response_msg(
             kind,
             contract_id,
-            DelegateContext::default(),
+            // The delegate's OWN context, carried through the guard, not
+            // `default()` (#5542 finding F7). An empty context reads to a
+            // delegate state machine as "start over" rather than "this
+            // operation failed".
+            context,
             delegate_park::ContractOpOutcome::Failed(
                 "delegate network contract operation did not complete: its \
                  off-loop work ended early"

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -768,6 +768,74 @@ fn contract_op_response_msg(
     }
 }
 
+/// Give back the local interest that resolved-but-dropped SUBSCRIBEs took
+/// (#5542 finding B3).
+///
+/// Called from the one path that discards a `DelegateResume` without running
+/// `apply_resolved_contract_op`: a resume whose park is gone, because the
+/// `PARK_TTL` backstop ended it without consuming the guard. That is reachable
+/// by NODE LOAD alone — no delegate behaviour is required — and each occurrence
+/// would otherwise cost one permanently unreleasable refcount.
+///
+/// Releases only for `(Subscribe, Subscribed)`, the same evidence
+/// `delegate_interest::record` gates on, so it can never decrement interest a
+/// different subscriber holds. Installs no `DELEGATE_SUBSCRIPTIONS` hook: the
+/// delegate is not told it is subscribed, and nothing advertises a delivery
+/// path that will not be served.
+///
+/// Logged at `warn!`, not `debug!`. The dropped resume is ordinary; a refcount
+/// leaving with it is not, and an operator seeing this repeatedly is seeing
+/// parks lose the race to the backstop.
+fn release_stranded_subscribe_interest<CH>(
+    contract_handler: &mut CH,
+    delegate_key: &DelegateKey,
+    contract_ops: &[delegate_park::ResolvedContractOp],
+) where
+    CH: ContractHandler + Send + 'static,
+{
+    let stranded: Vec<freenet_stdlib::prelude::ContractInstanceId> = contract_ops
+        .iter()
+        .filter(|resolved| {
+            matches!(
+                (resolved.pending.kind, &resolved.outcome),
+                (
+                    delegate_park::ContractOpKind::Subscribe,
+                    delegate_park::ContractOpOutcome::Subscribed
+                )
+            )
+        })
+        .map(|resolved| resolved.pending.contract_id)
+        .collect();
+    if stranded.is_empty() {
+        return;
+    }
+    let Some(op_manager) = contract_handler.executor().op_manager_handle() else {
+        tracing::warn!(
+            delegate = %delegate_key,
+            count = stranded.len(),
+            "Dropped resume carried resolved delegate subscribes but this \
+             executor has no OpManager, so their local interest cannot be \
+             released (#5542)"
+        );
+        return;
+    };
+    for contract_id in stranded {
+        let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            contract_id,
+            freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+        );
+        let lost_interest = op_manager.interest_manager.remove_local_client(&key);
+        tracing::warn!(
+            contract = %contract_id,
+            delegate = %delegate_key,
+            lost_interest,
+            "Released the local interest of a delegate SUBSCRIBE whose resume \
+             was dropped on epoch mismatch; without this the refcount could \
+             never be discharged (#5542 finding B3)"
+        );
+    }
+}
+
 /// Finish a resolved delegate network operation ON the loop (#5542).
 ///
 /// The network work happened off-loop; what is left is the part that must be
@@ -4130,6 +4198,32 @@ where
             "Resume for a park that no longer exists (force-resumed by the TTL \
              backstop, or already ended) — dropping"
         );
+        // DISCHARGE WHAT THE DROPPED OPS ALREADY TOOK (#5542 finding B3).
+        //
+        // Dropping the resume drops `contract_ops` with it, so
+        // `apply_resolved_contract_op` never runs and
+        // `delegate_interest::record` never runs. But a `Subscribed` outcome
+        // means `run_executor_subscribe` ALREADY called `add_local_client` —
+        // on the network path via `finalize_originator_subscribe`, or directly
+        // on the local-hit path. With no hold recorded, `release_delegate` and
+        // `release_contract` have nothing to discharge, so that refcount is
+        // stranded permanently: exactly the leak `wasm_runtime::delegate_interest`
+        // exists to close, arriving through a door this PR opened.
+        //
+        // Give it back directly rather than recording a hold and installing the
+        // notification hook. Absorbing would keep a live network subscription,
+        // which is tempting, but per-delegate exclusion queues an
+        // `UnregisterDelegate` BEHIND the park, so by the time a late resume
+        // arrives the delegate may already be gone — and installing its hook
+        // then resurrects a subscription for a delegate that no longer exists.
+        //
+        // This cannot over-release. It fires only on `Subscribed`, which is the
+        // same evidence `record` itself uses, and it releases through the
+        // instance-only key for the reason given at
+        // `delegate_subscribe_interest_handle`: `ContractKey`'s `Hash`/`Eq` are
+        // instance-only, so it resolves exactly the entry `add_local_client`
+        // created.
+        release_stranded_subscribe_interest(contract_handler, &delegate_key, &contract_ops);
         return 0;
     };
     // The resumed run itself, plus one per pending request drained below.
@@ -8341,6 +8435,100 @@ mod hol_4391_tests {
             task_monitor,
         ));
         (op_manager, guards)
+    }
+
+    /// #5542 finding B3/F2. A resolved SUBSCRIBE whose resume is dropped on
+    /// epoch mismatch must give back the interest it already took.
+    ///
+    /// `run_executor_subscribe` calls `add_local_client` before it returns, so
+    /// by the time the resume is built the refcount exists. If the park is gone
+    /// — the `PARK_TTL` backstop ended it without consuming the off-loop task's
+    /// guard, so that guard's resume still arrives —
+    /// `handle_delegate_resume` returns early and `apply_resolved_contract_op`
+    /// never runs, so `delegate_interest::record` never runs either. Nothing
+    /// could then discharge it: both release functions work from the hold map,
+    /// which has no entry for that pair.
+    ///
+    /// Reachable by NODE LOAD alone. No delegate behaviour is required, and the
+    /// delegate is the victim rather than the cause. The code at the early
+    /// return already documents that the path is reachable, having retracted an
+    /// earlier comment that claimed otherwise.
+    #[tokio::test]
+    async fn a_dropped_resume_gives_back_the_interest_its_subscribe_took() {
+        use delegate_park::{
+            ContractOpKind, ContractOpOutcome, PendingContractOp, ResolvedContractOp,
+        };
+        use freenet_stdlib::prelude::CodeHash;
+
+        let _guard = TEST_GUARD.lock().await;
+        let (op_manager, _guards) = build_op_manager("d5542-stale-resume").await;
+        let (_send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(
+            rcv_halve,
+            Some(op_manager.clone()),
+            "d5542_stale_resume",
+        )
+        .await;
+
+        let dkey = DelegateKey::new([51u8; 32], CodeHash::new([51u8; 32]));
+        let id = ContractInstanceId::new([52u8; 32]);
+        let full_key = ContractKey::from_id_and_code(id, CodeHash::new([53u8; 32]));
+
+        // What `run_executor_subscribe` did before the resume was built.
+        assert!(
+            op_manager.interest_manager.add_local_client(&full_key),
+            "the refcount this test is about must actually have been taken"
+        );
+
+        // A park context with NOTHING parked, so `take_matching` rejects the
+        // resume exactly as it does after the TTL backstop has ended the park.
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut park = delegate_park::DelegateParkCtx::new(tx);
+
+        let runs = handle_delegate_resume(
+            &mut handler,
+            &mut park,
+            &Arc::new(GatedPrompter {
+                gate: Arc::new(tokio::sync::Semaphore::new(0)),
+            }),
+            delegate_park::DelegateResume {
+                delegate_key: dkey.clone(),
+                epoch: 7,
+                cause: delegate_park::ResumeCause::Completed,
+                inbound: Vec::new(),
+                upserts: Vec::new(),
+                unresolved_upserts: Vec::new(),
+                contract_ops: vec![ResolvedContractOp {
+                    pending: PendingContractOp {
+                        contract_id: id,
+                        kind: ContractOpKind::Subscribe,
+                        context: DelegateContext::default(),
+                    },
+                    outcome: ContractOpOutcome::Subscribed,
+                }],
+                unresolved_contract_ops: Vec::new(),
+            },
+        )
+        .await;
+
+        assert_eq!(
+            runs, 0,
+            "this test is only meaningful while the resume is actually DROPPED; \
+             a non-zero run count means it was absorbed and the early return \
+             never ran"
+        );
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&full_key),
+            "a dropped resume must give back the local interest its resolved \
+             SUBSCRIBE already took; nothing else can ever discharge it, because \
+             no hold was recorded (#5542 finding B3)"
+        );
+        assert!(
+            !already_subscribed(&id, &dkey),
+            "and it must NOT install a notification hook: the delegate may be \
+             gone by now, and advertising a delivery path nothing will serve is \
+             the failure this PR exists to prevent"
+        );
     }
 
     /// #5542 finding B1/F1. The delegate network fan-out budget must span the

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -817,15 +817,40 @@ where
         // for a pair that never incremented would fall on interest a real
         // client holds, which is strictly worse than the leak.
         //
-        // The key is resolvable now precisely because the subscribe succeeded:
-        // `run_executor_subscribe` bootstrapped the body, so the contract is
-        // local. If it somehow is not, we cannot name the interest to release
-        // and must not guess.
-        match (
-            contract_handler.executor().lookup_key(&pending.contract_id),
-            contract_handler.executor().op_manager_handle(),
-        ) {
-            (Some(full_key), Some(op_manager)) => {
+        // The obligation is recorded whether or not the FULL key resolves, and
+        // that is load-bearing rather than defensive. `run_executor_subscribe`
+        // usually bootstraps the body, but `finalize_originator_subscribe` calls
+        // `add_local_client` OUTSIDE its `if have_body` guard
+        // (`operations/subscribe.rs`), so a subscribe whose
+        // `fetch_contract_if_missing` timed out inside its 2 s window takes the
+        // refcount and still returns `Ok(())` with no code blob stored. On that
+        // path `lookup_key` — which resolves through
+        // `ContractStore::code_hash_from_id` — is `None`. Recording only when
+        // it is `Some` therefore left the whole leak standing on the feature's
+        // PRIMARY path (a delegate subscribing to a contract this node has never
+        // seen), reported as a `warn!` and nothing else.
+        //
+        // Falling back to an instance-only key is exact, not a guess.
+        // `InterestManager::local_interests` is keyed by `ContractKey`, whose
+        // `Hash`/`Eq` are INSTANCE-ONLY (freenet-stdlib `contract_interface/
+        // key.rs`), and the hash index derives from `id().as_bytes()`
+        // (`ring::interest::contract_hash`), so `remove_local_client` and
+        // `cleanup_contract_if_no_interest` resolve exactly the entry
+        // `add_local_client` created with the full key. Same device as the
+        // `probe_key` in `node.rs`. The full key is still preferred where it is
+        // available, so logs and any future code-hash-sensitive consumer see the
+        // real one.
+        match contract_handler.executor().op_manager_handle() {
+            Some(op_manager) => {
+                let key = contract_handler
+                    .executor()
+                    .lookup_key(&pending.contract_id)
+                    .unwrap_or_else(|| {
+                        ContractKey::from_id_and_code(
+                            pending.contract_id,
+                            freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+                        )
+                    });
                 // WEAK, so an outstanding hold never keeps a shut-down node's
                 // `OpManager` alive. A hold that cannot upgrade has nothing
                 // left to release.
@@ -833,7 +858,7 @@ where
                 crate::wasm_runtime::delegate_interest::record(
                     pending.contract_id,
                     delegate_key.clone(),
-                    full_key,
+                    key,
                     std::sync::Arc::new(move |key: &ContractKey| {
                         if let Some(op_manager) = weak.upgrade() {
                             op_manager.interest_manager.remove_local_client(key);
@@ -841,13 +866,15 @@ where
                     }),
                 );
             }
-            _ => {
-                tracing::warn!(
+            None => {
+                // No `OpManager` means no `run_executor_subscribe` ran, so no
+                // refcount was taken and there is nothing to record. Reachable
+                // only from a test executor built without one.
+                tracing::debug!(
                     contract = %pending.contract_id,
                     delegate_key = %delegate_key,
-                    "Delegate subscribe succeeded but its local-interest hold could \
-                     not be recorded; that interest will not be released when the \
-                     subscription is dropped (#5542)"
+                    "Delegate subscribe resolved on an executor with no OpManager; \
+                     no local interest was taken, so none is recorded (#5542)"
                 );
             }
         }

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1382,10 +1382,27 @@ where
                 let contract_id = req.contract_id;
                 let context = req.context;
 
-                // Look up the full key from the instance id
-                let state = match contract_handler.executor().lookup_key(&contract_id) {
+                // LOCAL FIRST, and "local" means A STATE, not a known key.
+                //
+                // `lookup_key` answering `Some` says this node knows the
+                // contract's CODE; `fetch_contract` can still return
+                // `Ok((None, _))` for it, because the code and the state are
+                // separately present. That third shape is not a rare corner: it
+                // was observed on a live two-node run of
+                // `test_delegate_get_reaches_the_network_for_an_unseen_contract`,
+                // where the publishing peer's PUT had propagated the container
+                // to the delegate's node without its state, and it produced
+                // EXACTLY the #5542 symptom — a silent `state: None` the
+                // delegate cannot tell from an empty contract — while sailing
+                // past a fix that only handled the `lookup_key` miss.
+                //
+                // So all three local-miss shapes (no key, key but no state, key
+                // but a failing read) fall through to the same network path
+                // below. This mirrors `Executor::local_state_or_from_network`,
+                // which likewise treats a failed `state_store.get` as a miss
+                // rather than as an answer.
+                let local_state = match contract_handler.executor().lookup_key(&contract_id) {
                     Some(full_key) => {
-                        // Fetch the contract state
                         match contract_handler
                             .executor()
                             .fetch_contract(full_key, false)
@@ -1402,6 +1419,10 @@ where
                             }
                         }
                     }
+                    None => None,
+                };
+                let state = match local_state {
+                    Some(state) => Some(state),
                     None => {
                         // #5542. The contract is not in the local store, which
                         // until now ended the request: the delegate got
@@ -1590,14 +1611,78 @@ where
                         }
                     }
                     None => {
+                        // #5542 scope item 3, DECIDED rather than left to fall
+                        // out of the implementation.
+                        //
+                        // A delegate UPDATE for a contract this node does not
+                        // hold keeps FAILING -- and now ALSO self-heals in the
+                        // background, so the delegate's retry succeeds. That is
+                        // not a compromise between the two obvious options; it
+                        // is the contract a CLIENT UPDATE already has on this
+                        // node, and the reason to match it is that a delegate
+                        // should not be a second-class client.
+                        //
+                        // The client path (`operations/update.rs`, the
+                        // `phase = "auto_fetch_originator"` site) fails the
+                        // UPDATE and calls `try_auto_fetch_contract` with
+                        // `AutoFetchReason::Originator`, which is deliberately
+                        // NOT gated on `contract_in_use` -- "suppressing it
+                        // would strand the client's UPDATE behind a contract
+                        // that never gets fetched". A delegate is a local
+                        // originator with something waiting on the retry, which
+                        // is exactly the case that reason exists for.
+                        //
+                        // Why a SIBLING helper and not that function: it needs a
+                        // `sender_addr` to resolve a first-hop peer, and a
+                        // delegate UPDATE has no sender -- the delegate is the
+                        // originator, here. Handing it an address that resolves
+                        // to nothing makes it log, release its cooldown slot and
+                        // return, i.e. a silent no-op. It also takes a
+                        // `&ContractKey`, which a delegate cannot construct for
+                        // a contract it has never seen. See
+                        // `try_self_heal_fetch_for_local_originator`.
+                        //
+                        // NOT bootstrapped inline, and not parked like GET and
+                        // SUBSCRIBE. Bootstrapping would widen a delegate's
+                        // write reach in one step from "contracts this node
+                        // already holds" to "any contract in the keyspace,
+                        // named by instance id alone", on the same change that
+                        // first gives delegates network reach at all and before
+                        // #5543's containment ladder exists. PUT is not
+                        // comparable: it carries its own code, so a delegate can
+                        // only PUT contracts it can build.
+                        let healing = can_reach_network
+                            && contract_handler
+                                .executor()
+                                .op_manager_handle()
+                                .is_some_and(|op_manager| {
+                                    op_manager
+                                        .try_self_heal_fetch_for_local_originator(contract_id)
+                                });
                         tracing::debug!(
                             contract = %contract_id,
+                            healing,
                             "Contract not found locally for delegate UpdateContractRequest"
                         );
+                        // The message states the TIMESCALE, because the shared
+                        // cooldown is 5 minutes and a delegate that retries once
+                        // and gives up would otherwise be told to retry with no
+                        // idea that the answer may not be ready yet. When the
+                        // fetch was suppressed by that cooldown, say so rather
+                        // than promising a repair that is not running.
+                        let detail = if healing {
+                            "contract not known to this node; a background fetch has been \
+                             started, so retry shortly. GET or SUBSCRIBE it first to wait \
+                             for it deterministically (#5542)"
+                        } else {
+                            "contract not known to this node and no background fetch was \
+                             started (already attempted within the last 5 minutes, or this \
+                             node has no network handle). GET or SUBSCRIBE it first (#5542)"
+                        };
                         inbound_responses.push(InboundDelegateMsg::UpdateContractResponse(
                             UpdateContractResponse {
                                 contract_id,
-                                result: Err("Contract not found".to_string()),
+                                result: Err(detail.to_string()),
                                 context,
                             },
                         ));
@@ -1649,11 +1734,24 @@ where
                 let contract_id = req.contract_id;
                 let context = req.context;
 
-                let result = if contract_handler
-                    .executor()
-                    .lookup_key(&contract_id)
-                    .is_some()
-                {
+                // Same "local means A STATE, not a known key" test as the GET
+                // arm above, and for the same reason. Gating on `lookup_key`
+                // alone let a node that holds the contract's CODE but none of
+                // its state register the notification hook and answer `Ok`,
+                // taking no network subscription — so the delegate believed it
+                // was subscribed to a contract this node could not tell it
+                // anything about. That is the silent-on-both-sides failure
+                // #5467 describes, reachable without the local store being
+                // empty at all.
+                let has_local_state = match contract_handler.executor().lookup_key(&contract_id) {
+                    Some(full_key) => contract_handler
+                        .executor()
+                        .fetch_contract(full_key, false)
+                        .await
+                        .is_ok_and(|(state, _)| state.is_some()),
+                    None => false,
+                };
+                let result = if has_local_state {
                     // Contract is local: unchanged pre-#5542 behaviour. Register
                     // the notification hook and answer.
                     crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -990,7 +990,7 @@ where
                     delegate_key.clone(),
                     key,
                     delegate_interest_release_closure(&op_manager),
-                    std::sync::Arc::as_ptr(&op_manager) as usize,
+                    op_manager.node_identity,
                 );
             }
             None => {
@@ -1207,6 +1207,12 @@ struct RunSeed {
     /// found and fixed once in this file under #5544 S1. Declared as a loop
     /// local it reset on every one of up to `MAX_CONTRACT_REQUEST_ITERATIONS`
     /// iterations, so the real ceiling was 100x the documented one.
+    ///
+    /// Scope boundary, the same one `iterations` carries and for the same
+    /// reason: this bounds a ROUND-TRIP, including across parks. A contract
+    /// NOTIFICATION is a genuinely new invocation and starts a fresh budget,
+    /// which is correct — and is also why #5558, a delegate notified of its own
+    /// writes, is a separate unbounded loop that this does not close.
     self_heal_fetches_started: usize,
 }
 
@@ -2032,6 +2038,33 @@ where
                 // to a LOCAL contract take a fresh refcount on every repeat —
                 // the unbounded-demand failure this gate exists to prevent,
                 // reintroduced on the other branch.
+                // Computed ONCE for the whole arm, and consulted before the
+                // local branch as well as the network one (#5542 finding N2).
+                //
+                // B2 gated the three paths that reach the network. M4 then added
+                // an interest registration to the LOCAL branch, which emitted
+                // nothing when B2 was written, and it inherited no gate. That
+                // branch calls `broadcast_change_interests`, which is a real
+                // outbound wire effect: `operations.rs` -> `p2p_protoc.rs` ->
+                // `broadcast.rs` builds an `InterestSync { ChangeInterests }`
+                // and sends it to every connected peer, who then record this
+                // node as interested and add it to their UPDATE and
+                // summary/delta fan-out targets. The node would be soliciting
+                // inbound traffic for a contract it has banned, which is the
+                // narrow claim `contract_ban_list.rs` makes in as many words
+                // ("refuse to register interest").
+                //
+                // `add_local_client` also outlives the message: it is the
+                // refcount subscriber-primary eviction ranks on (hosting
+                // invariant 3), so leaving it ungated lets a delegate pin a
+                // banned contract resident indefinitely — against the strongest
+                // signal the node has that it wants the contract gone.
+                //
+                // Gated HERE and not downstream because by
+                // `handle_broadcast_change_interests` the payload is
+                // `Vec<u32>` interest hashes and the `ContractInstanceId` is
+                // gone.
+                let banned = delegate_network_op_banned(contract_handler, &contract_id);
                 let result = if already_subscribed(&contract_id, delegate_key) {
                     // ALREADY HELD, so re-asserting it must be a no-op.
                     //
@@ -2048,6 +2081,17 @@ where
                     // growing without bound, on the exact path #5467 exists to
                     // make trustworthy.
                     Ok(())
+                } else if banned {
+                    // Every subscribe path refuses a banned contract, local or
+                    // network. Before this the local branch answered `Ok` and
+                    // advertised interest for it.
+                    tracing::warn!(
+                        contract = %contract_id,
+                        delegate_key = %delegate_key,
+                        "Refusing a delegate SUBSCRIBE for a contract this node \
+                         has banned (#5542 finding N2)"
+                    );
+                    Err("this node has banned this contract (#5542)".to_string())
                 } else if let Some(full_key) = local_key {
                     // Contract is local, WITH state. Register the notification
                     // hook — and register DEMAND, which this branch did not do
@@ -2087,7 +2131,7 @@ where
                                 delegate_key.clone(),
                                 full_key,
                                 delegate_interest_release_closure(&op_manager),
-                                std::sync::Arc::as_ptr(&op_manager) as usize,
+                                op_manager.node_identity,
                             );
                             true
                         }
@@ -2109,7 +2153,7 @@ where
                     Ok(())
                 } else if parking.is_some()
                     && can_reach_network
-                    && !delegate_network_op_banned(contract_handler, &contract_id)
+                    && !banned
                     && pending_contract_ops.len() + self_heal_fetches_started
                         < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                     && !pending_contract_ops.iter().any(|op| {
@@ -2164,8 +2208,6 @@ where
                         "this node has no network handle"
                     } else if parking.is_none() {
                         "delegate parking is unavailable on this executor"
-                    } else if delegate_network_op_banned(contract_handler, &contract_id) {
-                        "this node has banned this contract (#5542 finding B2)"
                     } else if pending_contract_ops.iter().any(|op| {
                         op.contract_id == contract_id
                             && op.kind == delegate_park::ContractOpKind::Subscribe
@@ -8571,6 +8613,74 @@ mod hol_4391_tests {
     /// Build a real `OpManager` backed by a temp-dir `Config`, mirroring
     /// `client_events::tests::build_op_manager`. The returned guard bundle
     /// holds the channel endpoints open — drop it only when the test ends.
+    /// Like [`build_op_manager`] but hands back the event-loop notification
+    /// RECEIVER, so a test can assert on what the node actually emitted.
+    ///
+    /// That distinction matters for the ban gate: asserting the gate's source
+    /// text proves only that a call exists. `broadcast_change_interests` emits
+    /// `NodeEvent::BroadcastChangeInterests`, which `p2p_protoc` turns into an
+    /// `InterestSync { ChangeInterests }` sent to every connected peer, so the
+    /// event is the observable that corresponds to the wire effect.
+    async fn build_op_manager_with_events(
+        id: &str,
+    ) -> (
+        Arc<crate::node::OpManager>,
+        tokio::sync::mpsc::Receiver<
+            either::Either<crate::message::NetMessage, crate::message::NodeEvent>,
+        >,
+        Box<dyn std::any::Any>,
+    ) {
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::dev_tool::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+        let op_manager = Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+        let guards: Box<dyn std::any::Any> =
+            Box::new((ch_channel, wait_for_event, result_router_rx, task_monitor));
+        (op_manager, notification_rx.notifications_receiver, guards)
+    }
+
+    /// Whether a `BroadcastChangeInterests` was emitted, draining what is there.
+    fn emitted_change_interests(
+        rx: &mut tokio::sync::mpsc::Receiver<
+            either::Either<crate::message::NetMessage, crate::message::NodeEvent>,
+        >,
+    ) -> bool {
+        let mut seen = false;
+        while let Ok(item) = rx.try_recv() {
+            if matches!(
+                item,
+                either::Either::Right(crate::message::NodeEvent::BroadcastChangeInterests { .. })
+            ) {
+                seen = true;
+            }
+        }
+        seen
+    }
+
     async fn build_op_manager(id: &str) -> (Arc<crate::node::OpManager>, Box<dyn std::any::Any>) {
         let config_args = crate::config::ConfigArgs {
             id: Some(id.to_string()),
@@ -8611,6 +8721,140 @@ mod hol_4391_tests {
             task_monitor,
         ));
         (op_manager, guards)
+    }
+
+    /// #5542 findings M4 and N2, together, because they are two halves of one
+    /// branch and neither was covered.
+    ///
+    /// M4 made the local-state SUBSCRIBE branch register DEMAND, without which
+    /// the copy is zero-subscriber and is the first eviction victim under
+    /// hosting invariant 3 — the delegate's subscription dies silently. N2 is
+    /// that M4's registration inherited no ban gate, on the PR that added one
+    /// to the three sibling paths.
+    ///
+    /// The negative asserts the EMISSION does not happen, not that the gate's
+    /// source text exists. `broadcast_change_interests` emits
+    /// `BroadcastChangeInterests`, which `p2p_protoc` turns into an
+    /// `InterestSync { ChangeInterests }` sent to every connected peer, who then
+    /// record this node as interested and add it to their UPDATE fan-out. A
+    /// source-text assertion cannot tell whether that reaches the wire.
+    #[tokio::test]
+    async fn a_banned_local_contract_registers_no_demand_and_advertises_nothing() {
+        use freenet_stdlib::prelude::{ContractCode, Parameters, WrappedContract};
+
+        let _guard = TEST_GUARD.lock().await;
+        let (op_manager, mut events, _guards) =
+            build_op_manager_with_events("d5542-n2-local").await;
+        let (send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(
+            rcv_halve,
+            Some(op_manager.clone()),
+            "d5542_n2_local",
+        )
+        .await;
+
+        // Two contracts this node will HOLD, one of them banned. The keys are
+        // needed before the loop starts (to script the delegate), the PUTs need
+        // the loop running (they go through the handler channel), so build the
+        // contracts first and store them after the spawn.
+        let contracts: Vec<ContractContainer> = [0xC1u8, 0xC2u8]
+            .into_iter()
+            .map(|seed| {
+                ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+                    Arc::new(ContractCode::from(vec![seed; 32])),
+                    Parameters::from(vec![]),
+                )))
+            })
+            .collect();
+        let allowed_key = contracts[0].key();
+        let banned_key = contracts[1].key();
+        op_manager.ring.contract_ban_list.ban(
+            *banned_key.id(),
+            tokio::time::Instant::now() + Duration::from_secs(3600),
+            crate::ring::contract_ban_list::BanReason::AutoMad,
+        );
+
+        let script = handler.runtime_mut().delegate_script.clone();
+        for key in [banned_key, allowed_key] {
+            script.lock().unwrap().push_back(
+                vec![OutboundDelegateMsg::SubscribeContractRequest(
+                    freenet_stdlib::prelude::SubscribeContractRequest::new(*key.id()),
+                )]
+                .into(),
+            );
+            crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        }
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter {
+                gate: Arc::new(tokio::sync::Semaphore::new(0)),
+            },
+        ));
+
+        // Store both, so `lookup_key` resolves and `fetch_contract` returns
+        // state — which is what puts the SUBSCRIBE arm on the LOCAL branch, the
+        // branch this test is about.
+        for (seed, contract) in [0xC1u8, 0xC2u8].into_iter().zip(contracts) {
+            let resp = tokio::time::timeout(
+                Duration::from_secs(10),
+                put_local(&send, contract, WrappedState::new(vec![seed; 8])),
+            )
+            .await
+            .expect("PUT must not hang");
+            assert!(
+                matches!(resp, ContractHandlerEvent::PutResponse { .. }),
+                "expected a PutResponse, got {resp}"
+            );
+        }
+        // The PUTs themselves emit interest changes; drain so the assertion
+        // below is about the SUBSCRIBE and not about them.
+        let _ = emitted_change_interests(&mut events);
+
+        let dkey = test_delegate_key();
+        let _ = tokio::time::timeout(
+            Duration::from_secs(10),
+            send.send_to_handler(delegate_event(&dkey)),
+        )
+        .await
+        .expect("the round trip must terminate");
+
+        // The BANNED contract: no demand, and nothing advertised.
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&banned_key),
+            "a delegate must not register demand for a contract this node has \
+             banned; `add_local_client` is the refcount subscriber-primary \
+             eviction ranks on, so it pins the contract against the strongest \
+             signal the node has that it wants it gone (#5542 N2)"
+        );
+        assert!(
+            !already_subscribed(banned_key.id(), &dkey),
+            "and it must not install a notification hook for it either"
+        );
+
+        // The ALLOWED contract: demand registered AND advertised, so the
+        // negatives above are the ban and not a broken branch.
+        assert!(
+            op_manager.interest_manager.has_local_interest(&allowed_key),
+            "an unbanned local contract MUST register demand, or the copy is \
+             zero-subscriber and is evicted out from under the subscription \
+             (#5542 M4)"
+        );
+        assert!(
+            already_subscribed(allowed_key.id(), &dkey),
+            "and it must install the notification hook"
+        );
+        assert!(
+            emitted_change_interests(&mut events),
+            "registering demand must advertise it — this is the emission that \
+             becomes an InterestSync ChangeInterests on the wire, and if it \
+             never fires the positive assertions above prove less than they look"
+        );
+
+        handle.abort();
+        for key in [banned_key, allowed_key] {
+            crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        }
     }
 
     /// #5542 finding B2. A delegate must not be able to originate a network
@@ -8660,30 +8904,51 @@ mod hol_4391_tests {
         );
     }
 
-    /// #5542 finding B2, wiring half. Both delegate network-op admission sites
-    /// must consult the egress ban gate.
+    /// #5542 findings B2 and N2. Every delegate side effect that reaches the
+    /// network or registers demand must sit behind the egress ban gate.
     ///
-    /// The gate function being correct is worth nothing if an arm does not call
-    /// it, and that is the half that rots: a future arm is added, copies the
-    /// budget conjunct, and omits this one. Anchored on the call itself.
+    /// Counts the SIDE EFFECTS rather than the gates, which is the correction
+    /// N2 asked for. The previous version asserted an absolute number of gate
+    /// calls, so it could not notice the thing that actually went wrong: M4
+    /// added an `add_local_client` plus a `broadcast_change_interests` to a
+    /// branch that previously emitted nothing, and inherited no gate. A pin on
+    /// the gate count is blind to a new ungated side effect; a pin on the side
+    /// effects is not.
+    ///
+    /// This is a count-based approximation and is stated as one — it cannot
+    /// prove a given side effect is dominated by a given check. Its job is to
+    /// stop a fourth site being added without anyone revisiting the gating, and
+    /// the behavioural tests
+    /// (`a_banned_contract_refuses_delegate_originated_network_ops`,
+    /// `a_banned_local_contract_registers_no_demand_and_advertises_nothing`)
+    /// are what prove the gates actually fire.
     #[test]
-    fn both_delegate_network_admission_sites_consult_the_ban_gate() {
+    fn every_delegate_interest_side_effect_sits_behind_the_ban_gate() {
         let code = super::tests::production_code();
         let flat = code.split_whitespace().collect::<Vec<_>>().join(" ");
 
-        let gates = flat
-            .matches("< delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK")
-            .count();
-        let banned_checks = flat
-            .matches("!delegate_network_op_banned(contract_handler, &contract_id)")
-            .count();
+        let registers_demand = flat.matches("interest_manager.add_local_client(").count();
+        let starts_network_op = flat.matches("pending_contract_ops.push(").count();
+        let side_effects = registers_demand + starts_network_op;
         assert_eq!(
-            banned_checks, 2,
-            "the GET and SUBSCRIBE admission gates must each refuse a banned \
-             contract before parking a network operation for it; found \
-             {banned_checks} of the 2 required (there are {gates} fan-out gates \
-             in total, the third being the UPDATE self-heal, which is gated \
-             inside `try_self_heal_fetch_for_local_originator` instead)"
+            side_effects, 3,
+            "expected exactly three delegate-originated interest side effects in \
+             this file — the GET and SUBSCRIBE network admissions, and the \
+             local-state SUBSCRIBE branch's demand registration. Found \
+             {side_effects} ({registers_demand} demand registrations, \
+             {starts_network_op} network admissions). A NEW one must be gated by \
+             `delegate_network_op_banned` before it registers interest or \
+             advertises it, and must then update this count deliberately rather \
+             than by reflex — that is the whole point of it being pinned."
+        );
+
+        let gate_calls = flat.matches("delegate_network_op_banned(").count();
+        assert!(
+            gate_calls >= 2,
+            "the GET arm and the SUBSCRIBE arm must each consult the gate; found \
+             {gate_calls}. The SUBSCRIBE arm's single check covers both its \
+             local and its network branch, so this is a floor rather than an \
+             equality."
         );
     }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -775,10 +775,14 @@ fn contract_op_response_msg(
 /// insert — done HERE and only on success, so the registry never claims a
 /// delivery path that was not established, and so the registry has exactly one
 /// writer on this path.
-fn apply_resolved_contract_op(
+fn apply_resolved_contract_op<CH>(
+    contract_handler: &mut CH,
     resolved: delegate_park::ResolvedContractOp,
     delegate_key: &DelegateKey,
-) -> InboundDelegateMsg<'static> {
+) -> InboundDelegateMsg<'static>
+where
+    CH: ContractHandler + Send + 'static,
+{
     let delegate_park::ResolvedContractOp { pending, outcome } = resolved;
     if matches!(
         (pending.kind, &outcome),
@@ -791,6 +795,62 @@ fn apply_resolved_contract_op(
             .entry(pending.contract_id)
             .or_default()
             .insert(delegate_key.clone());
+        // RECORD THE OBLIGATION THIS SUBSCRIBE JUST INCURRED (#5542).
+        //
+        // `run_executor_subscribe` ended in
+        // `InterestManager::add_local_client`, a per-contract REFCOUNT that
+        // takes no client id. Nothing on any delegate path could give it back:
+        // the only decrement outside `ring/interest.rs` is keyed by `ClientId`
+        // and driven by a WebSocket disconnect, which a delegate never reaches.
+        // The permanent interest is not itself wrong — a delegate subscription
+        // is permanent — but three ordinary paths DROP a delegate subscription
+        // (`UnregisterDelegate`, contract removal, notification-channel-closed
+        // cleanup), and without this record they would leave the refcount
+        // standing forever, so `cleanup_contract_if_no_interest` never fires and
+        // the node holds demand nothing can retire.
+        //
+        // Recorded HERE and nowhere else, because this is the only site that
+        // takes a refcount: a subscribe answered from the local store takes
+        // none, and neither does the V2 `subscribe_contract_sync` host
+        // function. Driving release from the record rather than from the
+        // subscription set is what makes over-release impossible — a decrement
+        // for a pair that never incremented would fall on interest a real
+        // client holds, which is strictly worse than the leak.
+        //
+        // The key is resolvable now precisely because the subscribe succeeded:
+        // `run_executor_subscribe` bootstrapped the body, so the contract is
+        // local. If it somehow is not, we cannot name the interest to release
+        // and must not guess.
+        match (
+            contract_handler.executor().lookup_key(&pending.contract_id),
+            contract_handler.executor().op_manager_handle(),
+        ) {
+            (Some(full_key), Some(op_manager)) => {
+                // WEAK, so an outstanding hold never keeps a shut-down node's
+                // `OpManager` alive. A hold that cannot upgrade has nothing
+                // left to release.
+                let weak = std::sync::Arc::downgrade(&op_manager);
+                crate::wasm_runtime::delegate_interest::record(
+                    pending.contract_id,
+                    delegate_key.clone(),
+                    full_key,
+                    std::sync::Arc::new(move |key: &ContractKey| {
+                        if let Some(op_manager) = weak.upgrade() {
+                            op_manager.interest_manager.remove_local_client(key);
+                        }
+                    }),
+                );
+            }
+            _ => {
+                tracing::warn!(
+                    contract = %pending.contract_id,
+                    delegate_key = %delegate_key,
+                    "Delegate subscribe succeeded but its local-interest hold could \
+                     not be recorded; that interest will not be released when the \
+                     subscription is dropped (#5542)"
+                );
+            }
+        }
         tracing::debug!(
             contract = %pending.contract_id,
             delegate_key = %delegate_key,
@@ -823,25 +883,36 @@ fn apply_resolved_contract_op(
 /// background until `OPERATION_TTL` and leaks nothing; the same is already true
 /// of `Executor::local_state_or_from_network`.
 ///
-/// RESIDUAL, on the SUBSCRIBE branch only, stated because it is invisible from
-/// either side of the call. `run_executor_subscribe` reaches
-/// `finalize_originator_subscribe`, whose last side effects are
-/// `interest_manager.add_local_client` (a REFCOUNT — see the caller's
-/// `already_subscribed` gate) and then `broadcast_change_interests`. Cancelling
-/// the future between those two takes the refcount and returns no `Ok`, so this
-/// reports `Failed`, the caller installs no `DELEGATE_SUBSCRIPTIONS` hook, and a
-/// later retry passes `already_subscribed` and takes a SECOND refcount for one
-/// logical subscriber.
+/// RESIDUAL, on the SUBSCRIBE branch, and it is NARROWER than it first looks —
+/// but only because the broader case is now actually fixed, so read both halves
+/// before concluding anything from this note.
 ///
-/// Not compensated for here, deliberately. The only compensation available is
-/// `remove_local_client`, and this side of the call cannot tell whether
-/// `add_local_client` ran — so a decrement issued on the wrong branch would
-/// release an interest some OTHER subscriber holds, which is worse than the
-/// leak. Closing it properly means making the registration idempotent or
-/// transactional inside `subscribe`, which is a change to that operation rather
-/// than to this caller. The window is the tail of a 75 s budget and each
-/// occurrence costs one unreleased interest entry, so it is recorded rather
-/// than papered over.
+/// `run_executor_subscribe` reaches `finalize_originator_subscribe`, whose last
+/// side effects are `interest_manager.add_local_client` (a per-contract
+/// REFCOUNT, taking no client id, explicitly non-idempotent) and then
+/// `broadcast_change_interests`.
+///
+/// The BROAD case — that nothing on any delegate path could ever decrement what
+/// this takes, so the three ordinary paths that drop a delegate subscription
+/// left the interest standing forever — is closed by
+/// `wasm_runtime::delegate_interest`, which records the obligation at the point
+/// the caller installs the subscription hook and discharges it at all three
+/// removal sites. An earlier version of this note reasoned only about the
+/// cancellation window below and ASSUMED the success path was balanced. It was
+/// not; the balancing decrement is the client-disconnect sweep, and a delegate
+/// never reaches it.
+///
+/// What remains: cancelling the future BETWEEN `add_local_client` and its
+/// return takes the refcount while this reports `Failed`, so the caller
+/// installs no hook and records no obligation, and a later retry takes a second
+/// refcount for one logical subscriber. Still not compensated for, and for an
+/// unchanged reason: this side of the call cannot tell whether
+/// `add_local_client` ran, so a decrement on the wrong branch would release
+/// interest some OTHER subscriber holds — strictly worse than the leak.
+/// Closing it means making the registration transactional inside `subscribe`,
+/// which is a change to that operation rather than to this caller. The window
+/// is the tail of a 75 s budget and each occurrence costs one unreleased
+/// interest entry.
 async fn run_contract_op_off_loop(
     op_manager: std::sync::Arc<crate::node::OpManager>,
     pending: &delegate_park::PendingContractOp,
@@ -1652,13 +1723,11 @@ where
                         // comparable: it carries its own code, so a delegate can
                         // only PUT contracts it can build.
                         let healing = can_reach_network
-                            && contract_handler
-                                .executor()
-                                .op_manager_handle()
-                                .is_some_and(|op_manager| {
-                                    op_manager
-                                        .try_self_heal_fetch_for_local_originator(contract_id)
-                                });
+                            && contract_handler.executor().op_manager_handle().is_some_and(
+                                |op_manager| {
+                                    op_manager.try_self_heal_fetch_for_local_originator(contract_id)
+                                },
+                            );
                         tracing::debug!(
                             contract = %contract_id,
                             healing,
@@ -1778,8 +1847,7 @@ where
                     Ok(())
                 } else if parking.is_some()
                     && can_reach_network
-                    && pending_contract_ops.len()
-                        < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
+                    && pending_contract_ops.len() < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                     && !pending_contract_ops.iter().any(|op| {
                         op.contract_id == contract_id
                             && op.kind == delegate_park::ContractOpKind::Subscribe
@@ -2261,12 +2329,9 @@ where
                                         };
                                         let outcome =
                                             run_contract_op_off_loop(op_manager, &pending).await;
-                                        sink.lock()
-                                            .unwrap()
-                                            .push(delegate_park::ResolvedContractOp {
-                                                pending,
-                                                outcome,
-                                            });
+                                        sink.lock().unwrap().push(
+                                            delegate_park::ResolvedContractOp { pending, outcome },
+                                        );
                                     }
                                 }))
                                 .await;
@@ -2351,8 +2416,7 @@ where
                     pending.contract_id,
                     pending.context,
                     delegate_park::ContractOpOutcome::Failed(
-                        "no delegate park available for a network contract operation"
-                            .to_string(),
+                        "no delegate park available for a network contract operation".to_string(),
                     ),
                 );
                 inbound_responses.push(msg);
@@ -4047,7 +4111,11 @@ where
     // only on success, so the registry never advertises a delivery path that was
     // never established.
     for resolved in contract_ops {
-        all_inbound.push(apply_resolved_contract_op(resolved, &delegate_key));
+        all_inbound.push(apply_resolved_contract_op(
+            contract_handler,
+            resolved,
+            &delegate_key,
+        ));
     }
     // Network operations the off-loop task never resolved (panic, cancellation,
     // budget). Same reasoning as the unresolved upserts above: the delegate is
@@ -8054,10 +8122,9 @@ mod hol_4391_tests {
             ContractOpOutcome::Failed("boom".to_string()),
         );
         match get_failed {
-            InboundDelegateMsg::GetContractResponse(r) => assert!(
-                r.state.is_none(),
-                "a failed GET must not fabricate a state"
-            ),
+            InboundDelegateMsg::GetContractResponse(r) => {
+                assert!(r.state.is_none(), "a failed GET must not fabricate a state")
+            }
             other => panic!("a failed GET must still answer the delegate, got {other:?}"),
         }
 
@@ -8102,12 +8169,15 @@ mod hol_4391_tests {
     /// installed for a subscription that never got established gives a delegate
     /// that believes it is subscribed and then never hears anything — the
     /// silent-on-both-sides failure, one layer up.
-    #[test]
-    fn the_notification_hook_is_installed_only_on_a_successful_subscribe() {
+    #[tokio::test]
+    async fn the_notification_hook_is_installed_only_on_a_successful_subscribe() {
         use delegate_park::{
             ContractOpKind, ContractOpOutcome, PendingContractOp, ResolvedContractOp,
         };
-        let dkey = DelegateKey::new([21u8; 32], freenet_stdlib::prelude::CodeHash::new([21u8; 32]));
+        let dkey = DelegateKey::new(
+            [21u8; 32],
+            freenet_stdlib::prelude::CodeHash::new([21u8; 32]),
+        );
         let ok_id = ContractInstanceId::new([22u8; 32]);
         let bad_id = ContractInstanceId::new([23u8; 32]);
         // Global registry: use ids unique to this test so it does not race the
@@ -8115,7 +8185,9 @@ mod hol_4391_tests {
         crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&ok_id);
         crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
 
+        let (mut handler, _send) = build_handler(vec![]).await;
         let _ = apply_resolved_contract_op(
+            &mut handler,
             ResolvedContractOp {
                 pending: PendingContractOp {
                     contract_id: ok_id,
@@ -8127,6 +8199,7 @@ mod hol_4391_tests {
             &dkey,
         );
         let _ = apply_resolved_contract_op(
+            &mut handler,
             ResolvedContractOp {
                 pending: PendingContractOp {
                     contract_id: bad_id,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -822,6 +822,26 @@ fn apply_resolved_contract_op(
 /// told. A sub-op GET whose receiver is dropped that way continues in the
 /// background until `OPERATION_TTL` and leaks nothing; the same is already true
 /// of `Executor::local_state_or_from_network`.
+///
+/// RESIDUAL, on the SUBSCRIBE branch only, stated because it is invisible from
+/// either side of the call. `run_executor_subscribe` reaches
+/// `finalize_originator_subscribe`, whose last side effects are
+/// `interest_manager.add_local_client` (a REFCOUNT — see the caller's
+/// `already_subscribed` gate) and then `broadcast_change_interests`. Cancelling
+/// the future between those two takes the refcount and returns no `Ok`, so this
+/// reports `Failed`, the caller installs no `DELEGATE_SUBSCRIPTIONS` hook, and a
+/// later retry passes `already_subscribed` and takes a SECOND refcount for one
+/// logical subscriber.
+///
+/// Not compensated for here, deliberately. The only compensation available is
+/// `remove_local_client`, and this side of the call cannot tell whether
+/// `add_local_client` ran — so a decrement issued on the wrong branch would
+/// release an interest some OTHER subscriber holds, which is worse than the
+/// leak. Closing it properly means making the registration idempotent or
+/// transactional inside `subscribe`, which is a change to that operation rather
+/// than to this caller. The window is the tail of a 75 s budget and each
+/// occurrence costs one unreleased interest entry, so it is recorded rather
+/// than papered over.
 async fn run_contract_op_off_loop(
     op_manager: std::sync::Arc<crate::node::OpManager>,
     pending: &delegate_park::PendingContractOp,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -677,6 +677,193 @@ where
     upsert_response_msg(pending.is_put, contract_id, pending.context, result)
 }
 
+/// Whether `delegate_key` already holds a subscription to `contract_id`.
+///
+/// Extracted so the non-idempotency guard in the SUBSCRIBE arm has a name, and
+/// so it can be unit-tested without a running loop. See that call site for why
+/// the guard exists: `add_local_client` is a refcount, `DELEGATE_SUBSCRIPTIONS`
+/// is a set, and wiring the network path in without this makes a re-subscribe
+/// leak demand.
+fn already_subscribed(
+    contract_id: &freenet_stdlib::prelude::ContractInstanceId,
+    delegate_key: &DelegateKey,
+) -> bool {
+    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
+        .get(contract_id)
+        .is_some_and(|subs| subs.contains(delegate_key))
+}
+
+/// Build the terminal inbound message for a delegate network operation (#5542).
+///
+/// Pure, and deliberately separate from the code that RUNS the operation: the
+/// off-loop task, the resume handler and the `ParkGuard`'s
+/// panic/cancellation/timeout path all have to produce the same shapes, and
+/// three inlined copies is how a failure arm silently diverges from a success
+/// arm.
+fn contract_op_response_msg(
+    kind: delegate_park::ContractOpKind,
+    contract_id: freenet_stdlib::prelude::ContractInstanceId,
+    context: DelegateContext,
+    outcome: delegate_park::ContractOpOutcome,
+) -> InboundDelegateMsg<'static> {
+    use delegate_park::{ContractOpKind, ContractOpOutcome};
+    match (kind, outcome) {
+        (ContractOpKind::Get, ContractOpOutcome::Fetched(state)) => {
+            InboundDelegateMsg::GetContractResponse(GetContractResponse {
+                contract_id,
+                state,
+                context,
+            })
+        }
+        (ContractOpKind::Subscribe, ContractOpOutcome::Subscribed) => {
+            InboundDelegateMsg::SubscribeContractResponse(SubscribeContractResponse {
+                contract_id,
+                result: Ok(()),
+                context,
+            })
+        }
+        (ContractOpKind::Get, outcome) => {
+            // A GET that failed. `GetContractResponse` has no error channel, so
+            // this collapses to `state: None` and the delegate cannot tell it
+            // from a genuine NotFound — #5542 scope item 4, which needs a
+            // freenet-stdlib wire change. Logged at warn so the operator can,
+            // even though the delegate cannot.
+            if let ContractOpOutcome::Failed(err) = &outcome {
+                tracing::warn!(
+                    contract = %contract_id,
+                    error = %err,
+                    "Delegate network GET failed; the delegate is told \
+                     `state: None`, which it cannot distinguish from a genuine \
+                     NotFound (#5542 scope item 4)"
+                );
+            }
+            InboundDelegateMsg::GetContractResponse(GetContractResponse {
+                contract_id,
+                state: None,
+                context,
+            })
+        }
+        (ContractOpKind::Subscribe, outcome) => {
+            let err = match outcome {
+                ContractOpOutcome::Failed(err) => err,
+                // Unreachable by construction: only a GET produces `Fetched`.
+                // Reported rather than silently rewritten as a success, for the
+                // same reason the unexpected-response arm above is a failure.
+                other => {
+                    let _ = other;
+                    "delegate subscribe resolved with a non-subscribe outcome".to_string()
+                }
+            };
+            InboundDelegateMsg::SubscribeContractResponse(SubscribeContractResponse {
+                contract_id,
+                result: Err(err),
+                context,
+            })
+        }
+    }
+}
+
+/// Finish a resolved delegate network operation ON the loop (#5542).
+///
+/// The network work happened off-loop; what is left is the part that must be
+/// serial. For a successful SUBSCRIBE that is the `DELEGATE_SUBSCRIPTIONS`
+/// insert — done HERE and only on success, so the registry never claims a
+/// delivery path that was not established, and so the registry has exactly one
+/// writer on this path.
+fn apply_resolved_contract_op(
+    resolved: delegate_park::ResolvedContractOp,
+    delegate_key: &DelegateKey,
+) -> InboundDelegateMsg<'static> {
+    let delegate_park::ResolvedContractOp { pending, outcome } = resolved;
+    if matches!(
+        (pending.kind, &outcome),
+        (
+            delegate_park::ContractOpKind::Subscribe,
+            delegate_park::ContractOpOutcome::Subscribed
+        )
+    ) {
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
+            .entry(pending.contract_id)
+            .or_default()
+            .insert(delegate_key.clone());
+        tracing::debug!(
+            contract = %pending.contract_id,
+            delegate_key = %delegate_key,
+            "Delegate subscribed to a contract this node had not seen: body \
+             bootstrapped, network subscription established, demand registered \
+             and the notification hook installed (#5542)"
+        );
+    }
+    contract_op_response_msg(pending.kind, pending.contract_id, pending.context, outcome)
+}
+
+/// Run one delegate-originated network operation, OFF the serial loop (#5542).
+///
+/// Both entry points are the node-internal ones that already exist and already
+/// take a bare `ContractInstanceId`, which is all a delegate has:
+///
+/// * GET -> `start_sub_op_get(.., return_contract_code: true)`. The code is
+///   requested so the contract arrives complete and the full `ContractKey` can
+///   be formed locally, which is what makes the delegate's next operation on
+///   that contract an ordinary local hit.
+/// * SUBSCRIBE -> `run_executor_subscribe`, which bootstraps the body,
+///   registers demand and establishes the network subscription. NOT the client
+///   `Get { subscribe: true }` path: that one needs a subscription listener
+///   channel, a client id and a request id, none of which a delegate has.
+///
+/// No timeout of its own. The caller wraps the whole off-loop body in
+/// `PARK_WORK_BUDGET` (75 s, under `PARK_TTL`), so an operation that outruns
+/// the budget is reported as unresolved by the `ParkGuard` and the delegate is
+/// told. A sub-op GET whose receiver is dropped that way continues in the
+/// background until `OPERATION_TTL` and leaks nothing; the same is already true
+/// of `Executor::local_state_or_from_network`.
+async fn run_contract_op_off_loop(
+    op_manager: std::sync::Arc<crate::node::OpManager>,
+    pending: &delegate_park::PendingContractOp,
+) -> delegate_park::ContractOpOutcome {
+    use delegate_park::{ContractOpKind, ContractOpOutcome};
+    match pending.kind {
+        ContractOpKind::Get => {
+            let (_tx, rx) = crate::operations::get::op_ctx_task::start_sub_op_get(
+                &op_manager,
+                pending.contract_id,
+                /* return_contract_code */ true,
+            );
+            match rx.await {
+                Ok(crate::operations::get::op_ctx_task::SubOpGetOutcome::Found(result)) => {
+                    ContractOpOutcome::Fetched(Some(result.state))
+                }
+                Ok(crate::operations::get::op_ctx_task::SubOpGetOutcome::NotFound(reason)) => {
+                    tracing::debug!(
+                        contract = %pending.contract_id,
+                        %reason,
+                        "Delegate network GET: contract not found on the network"
+                    );
+                    ContractOpOutcome::Fetched(None)
+                }
+                Ok(crate::operations::get::op_ctx_task::SubOpGetOutcome::Infra(err)) => {
+                    ContractOpOutcome::Failed(err.to_string())
+                }
+                Err(_) => ContractOpOutcome::Failed("sub-op GET task dropped".to_string()),
+            }
+        }
+        ContractOpKind::Subscribe => {
+            let executor_tx =
+                crate::message::Transaction::new::<crate::operations::subscribe::SubscribeMsg>();
+            match crate::operations::subscribe::run_executor_subscribe(
+                op_manager,
+                pending.contract_id,
+                executor_tx,
+            )
+            .await
+            {
+                Ok(()) => ContractOpOutcome::Subscribed,
+                Err(err) => ContractOpOutcome::Failed(err.to_string()),
+            }
+        }
+    }
+}
+
 /// Drive the permission prompts for one delegate iteration and build the
 /// `UserResponse` messages to feed back.
 ///
@@ -1040,6 +1227,16 @@ where
         // node does not hold. Their network fetch is off-loaded with the rest of
         // this iteration's slow work rather than awaited here (#5544 stall 1).
         let mut deferred_upserts: Vec<delegate_park::PendingUpsert> = Vec::new();
+        // Delegate GET/SUBSCRIBE requests naming a contract this node has never
+        // seen. Off-loaded with the rest of this iteration's slow work for the
+        // same reason as `deferred_upserts` (#5542) — the work is a network
+        // operation and this is the serial loop.
+        let mut pending_contract_ops: Vec<delegate_park::PendingContractOp> = Vec::new();
+        // Whether this executor can reach the network at all. `None` on the
+        // mock/in-process executors used by unit tests and by
+        // `handle_delegate_notification`'s test seams; those keep the
+        // pre-#5542 local-only answers rather than pretending to have tried.
+        let can_reach_network = contract_handler.executor().op_manager_handle().is_some();
 
         // Process PUT requests (fire-and-forget: upsert state, send result back).
         // This calls upsert_contract_state which stores locally AND automatically
@@ -1181,9 +1378,58 @@ where
                         }
                     }
                     None => {
-                        tracing::debug!(
+                        // #5542. The contract is not in the local store, which
+                        // until now ended the request: the delegate got
+                        // `state: None` and no attempt was ever made to reach
+                        // the network. That is what made a delegate's whole
+                        // reason for existing conditional on a browser tab
+                        // being open to prime the store first.
+                        //
+                        // NOT awaited here. This runs on the serial
+                        // `contract_handling` loop, and a sub-op GET runs to
+                        // SUB_OP_FETCH_TIMEOUT (120 s) — awaiting it inline
+                        // would freeze every GET, PUT, UPDATE, subscribe
+                        // registration and notification delivery on the node
+                        // for that long. Park instead and answer on the
+                        // resumed run, carrying the delegate's own
+                        // `DelegateContext` across the gap.
+                        if parking.is_some()
+                            && can_reach_network
+                            && pending_contract_ops.len()
+                                < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
+                        {
+                            pending_contract_ops.push(delegate_park::PendingContractOp {
+                                contract_id,
+                                kind: delegate_park::ContractOpKind::Get,
+                                context,
+                            });
+                            continue;
+                        }
+                        // REFUSED, never run inline: see
+                        // `MAX_NETWORK_CONTRACT_OPS_PER_PARK` and #5544's note
+                        // at its own park-cap fallback, which says in terms
+                        // that the fallback is not inheritable by a delegate
+                        // operation that reaches the network.
+                        //
+                        // The refusal is INVISIBLE TO THE DELEGATE, and that is
+                        // a real limitation rather than an oversight:
+                        // `GetContractResponse` carries `Option<WrappedState>`
+                        // and no error channel, so a refusal, a network
+                        // NotFound and an unreachable network are all `None`.
+                        // Fixing that is #5542 scope item 4 and needs a
+                        // freenet-stdlib wire change; faking a distinction here
+                        // would be worse than naming the gap.
+                        tracing::warn!(
                             contract = %contract_id,
-                            "Contract not found locally for delegate GetContractRequest"
+                            delegate_key = %delegate_key,
+                            can_reach_network,
+                            parking = parking.is_some(),
+                            inflight = pending_contract_ops.len(),
+                            "Refusing a delegate GET for a contract this node has \
+                             not seen: no network reach, or past \
+                             MAX_NETWORK_CONTRACT_OPS_PER_PARK. Answering with \
+                             `state: None`, which the delegate cannot tell from \
+                             a genuine NotFound (#5542 scope item 4)"
                         );
                         None
                     }
@@ -1378,24 +1624,105 @@ where
                 let contract_id = req.contract_id;
                 let context = req.context;
 
-                // Validate contract existence before registering (matches V2 host function behavior)
                 let result = if contract_handler
                     .executor()
                     .lookup_key(&contract_id)
                     .is_some()
                 {
-                    // Register subscription in the global registry
+                    // Contract is local: unchanged pre-#5542 behaviour. Register
+                    // the notification hook and answer.
                     crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
                         .entry(contract_id)
                         .or_default()
                         .insert(delegate_key.clone());
                     Ok(())
+                } else if already_subscribed(&contract_id, delegate_key) {
+                    // ALREADY HELD, so re-asserting it must be a no-op.
+                    //
+                    // This gate is load-bearing and is not obvious from the
+                    // code it guards. `run_executor_subscribe` ends in
+                    // `InterestManager::add_local_client`, which is a REFCOUNT
+                    // and is explicitly NOT idempotent (see the
+                    // `!is_renewal` gate at `operations/subscribe.rs`). The
+                    // registry it feeds, `DELEGATE_SUBSCRIPTIONS`, is a
+                    // `HashSet` — so the pre-#5542 arm was idempotent for free
+                    // and a delegate re-subscribing in a loop cost nothing.
+                    // Wiring the network path in without this gate makes each
+                    // repeat take another interest refcount for one logical
+                    // subscriber: demand that is never released, growing
+                    // without bound, on the exact path #5467 exists to make
+                    // trustworthy.
+                    Ok(())
+                } else if parking.is_some()
+                    && can_reach_network
+                    && pending_contract_ops.len()
+                        < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
+                    && !pending_contract_ops.iter().any(|op| {
+                        op.contract_id == contract_id
+                            && op.kind == delegate_park::ContractOpKind::Subscribe
+                    })
+                {
+                    // #5542. Subscribing to a contract this node has never seen
+                    // is the PRIMARY use case, not an edge case: a delegate that
+                    // wants to learn about a per-address contract after the tab
+                    // is closed has no other way to name it.
+                    //
+                    // OPENING THIS GATE ALONE WOULD SHIP THE FEATURE SILENT.
+                    // The arm above does one thing — insert into
+                    // `DELEGATE_SUBSCRIPTIONS` — which is a local notification
+                    // hook that nothing in `ring/` reads. It establishes no
+                    // network subscription, so a delegate would subscribe
+                    // successfully to a contract it has never seen and then
+                    // never hear anything, which is #5467's silent-on-both-sides
+                    // failure reintroduced one layer up. Three things have to
+                    // happen together, and `run_executor_subscribe` is chosen
+                    // because it is the one entry point that does all three:
+                    //
+                    //   1. bootstrap the contract body
+                    //      (`finalize_originator_subscribe` ->
+                    //      `fetch_contract_if_missing` -> `start_sub_op_get`),
+                    //   2. register demand (`interest_manager.add_local_client`,
+                    //      so the contract is kept alive rather than evicted out
+                    //      from under the subscription),
+                    //   3. establish the real network subscription.
+                    //
+                    // The notification hook (the `DELEGATE_SUBSCRIPTIONS`
+                    // insert) is then done on the loop when the park resumes, and
+                    // ONLY on success — so a failed subscribe leaves no hook
+                    // claiming a delivery path that does not exist.
+                    //
+                    // The last conjunct de-duplicates WITHIN this round trip;
+                    // `already_subscribed` covers repeats ACROSS round trips.
+                    // Both are needed for the refcount argument above to hold.
+                    pending_contract_ops.push(delegate_park::PendingContractOp {
+                        contract_id,
+                        kind: delegate_park::ContractOpKind::Subscribe,
+                        context,
+                    });
+                    continue;
                 } else {
-                    tracing::debug!(
+                    // REFUSED, never inline — same rule as the GET arm above.
+                    // Unlike GET, `SubscribeContractResponse.result` is a
+                    // `Result<(), String>`, so this refusal IS visible to the
+                    // delegate and says which of the three reasons it was.
+                    let why = if !can_reach_network {
+                        "this node has no network handle"
+                    } else if parking.is_none() {
+                        "delegate parking is unavailable on this executor"
+                    } else {
+                        "too many delegate network operations already in flight \
+                         (MAX_NETWORK_CONTRACT_OPS_PER_PARK)"
+                    };
+                    tracing::warn!(
                         contract = %contract_id,
-                        "Contract not found locally for delegate SubscribeContractRequest"
+                        delegate_key = %delegate_key,
+                        why,
+                        "Refusing a delegate SUBSCRIBE for a contract this node \
+                         has not seen (#5542)"
                     );
-                    Err("Contract not found".to_string())
+                    Err(format!(
+                        "cannot subscribe to a contract this node has not seen: {why}"
+                    ))
                 };
 
                 inbound_responses.push(InboundDelegateMsg::SubscribeContractResponse(
@@ -1624,11 +1951,15 @@ where
         // `process_outbound` and the WASM `process()` call has returned — and
         // the deferrable upsert has already rolled back its partial work. All
         // that is needed is to re-enter the delegate when the results arrive.
-        if !user_input_requests.is_empty() || !deferred_upserts.is_empty() {
+        if !user_input_requests.is_empty()
+            || !deferred_upserts.is_empty()
+            || !pending_contract_ops.is_empty()
+        {
             tracing::debug!(
                 delegate_key = %delegate_key,
                 prompts = user_input_requests.len(),
                 deferred_upserts = deferred_upserts.len(),
+                network_contract_ops = pending_contract_ops.len(),
                 "Off-loading slow delegate work from the contract-handling loop"
             );
 
@@ -1662,7 +1993,11 @@ where
                 // continuation points at: the prompts and the deferred upserts
                 // live for exactly as long as the park, and a single upsert can
                 // own a full state plus related contracts plus code.
-                let task_bytes = delegate_park::task_bytes(&user_input_requests, &deferred_upserts);
+                let task_bytes = delegate_park::task_bytes(
+                    &user_input_requests,
+                    &deferred_upserts,
+                    &pending_contract_ops,
+                );
                 match ctx
                     .park
                     .park(delegate_key.clone(), continuation, task_bytes)
@@ -1678,6 +2013,18 @@ where
                             .iter()
                             .map(|u| (*u.key.id(), u.is_put))
                             .collect();
+                        // Third owed category (#5542). Same discipline as the
+                        // two above: what the park OWES is recorded here, so
+                        // the guard can synthesize a terminal response on
+                        // EVERY exit — including a panic or cancellation, which
+                        // reach `Drop` and never run the task's own cleanup.
+                        let owed_contract_ops: Vec<(
+                            ContractInstanceId,
+                            delegate_park::ContractOpKind,
+                        )> = pending_contract_ops
+                            .iter()
+                            .map(|op| (op.contract_id, op.kind))
+                            .collect();
                         // SINKS CREATED BEFORE THE GUARD, AND SHARED WITH IT
                         // (#5544 F2). They used to be created inside the
                         // spawned future, so `ParkGuard::drop` could not see
@@ -1692,6 +2039,9 @@ where
                         let fetch_sink: std::sync::Arc<
                             std::sync::Mutex<Vec<delegate_park::ResolvedUpsert>>,
                         > = Default::default();
+                        let net_op_sink: std::sync::Arc<
+                            std::sync::Mutex<Vec<delegate_park::ResolvedContractOp>>,
+                        > = Default::default();
                         let guard = delegate_park::ParkGuard::new(
                             ctx.park.resume_tx().clone(),
                             delegate_key.clone(),
@@ -1700,12 +2050,15 @@ where
                             owed_upserts,
                             answers_sink.clone(),
                             fetch_sink.clone(),
+                            owed_contract_ops,
+                            net_op_sink.clone(),
                         );
                         let prompter = std::sync::Arc::clone(prompter);
                         let key = delegate_key.clone();
                         let op_manager = contract_handler.executor().op_manager_handle();
                         let prompts = std::mem::take(&mut user_input_requests);
                         let upserts = std::mem::take(&mut deferred_upserts);
+                        let net_ops = std::mem::take(&mut pending_contract_ops);
                         // Fire-and-forget is safe precisely because of the
                         // guard: it delivers exactly one resume even if this
                         // task is dropped, panics or is cancelled, so the park
@@ -1747,6 +2100,54 @@ where
                                 }))
                                 .await;
                             };
+                            // Delegate GET/SUBSCRIBE that must reach the network
+                            // (#5542). Concurrent with the prompts and the
+                            // related fetches, and under the same
+                            // PARK_WORK_BUDGET: run sequentially they could sum
+                            // past PARK_TTL, at which point the loop's backstop
+                            // would force-resume while this task was still
+                            // running and discard its result.
+                            //
+                            // Results land in the SHARED sink as they complete,
+                            // not at the end, so a budget expiry or a panic
+                            // still delivers the ones that finished — the same
+                            // reason the two sinks above are shared with the
+                            // guard (#5544 F2).
+                            let network_ops = async {
+                                let op_manager = op_manager.clone();
+                                futures::future::join_all(net_ops.into_iter().map(|pending| {
+                                    let op_manager = op_manager.clone();
+                                    let sink = net_op_sink.clone();
+                                    async move {
+                                        let Some(op_manager) = op_manager else {
+                                            // Unreachable: the arms only enqueue
+                                            // when `can_reach_network`. Recorded
+                                            // as a failure rather than dropped,
+                                            // so the delegate is told either way.
+                                            sink.lock().unwrap().push(
+                                                delegate_park::ResolvedContractOp {
+                                                    outcome:
+                                                        delegate_park::ContractOpOutcome::Failed(
+                                                            "no op manager on this executor"
+                                                                .to_string(),
+                                                        ),
+                                                    pending,
+                                                },
+                                            );
+                                            return;
+                                        };
+                                        let outcome =
+                                            run_contract_op_off_loop(op_manager, &pending).await;
+                                        sink.lock()
+                                            .unwrap()
+                                            .push(delegate_park::ResolvedContractOp {
+                                                pending,
+                                                outcome,
+                                            });
+                                    }
+                                }))
+                                .await;
+                            };
                             let answers = async {
                                 if !prompts.is_empty() {
                                     run_user_input_prompts(
@@ -1762,7 +2163,7 @@ where
                             };
                             let done =
                                 tokio::time::timeout(delegate_park::PARK_WORK_BUDGET, async {
-                                    tokio::join!(answers, fetches)
+                                    tokio::join!(answers, fetches, network_ops)
                                 })
                                 .await;
                             // The guard reads the sinks itself, so this path
@@ -1807,6 +2208,32 @@ where
                 }
             }
 
+            // #5542 network operations are REFUSED here, never run inline —
+            // the one place this function's inline fallback does not apply, and
+            // the park-cap fallback below says why in its own comment: a
+            // delegate GET or SUBSCRIBE awaited on this loop is a network
+            // operation of up to 120 s, not a self-inflicted 10-60 s local
+            // wait. Refusing loudly is the whole point; dropping them would
+            // leave the delegate waiting for a response nobody would send.
+            for pending in std::mem::take(&mut pending_contract_ops) {
+                tracing::warn!(
+                    contract = %pending.contract_id,
+                    delegate_key = %delegate_key,
+                    "Delegate network contract operation refused: no park was \
+                     available (cap reached, or no parking context). Refused \
+                     rather than awaited on the serial loop (#5542)"
+                );
+                let msg = contract_op_response_msg(
+                    pending.kind,
+                    pending.contract_id,
+                    pending.context,
+                    delegate_park::ContractOpOutcome::Failed(
+                        "no delegate park available for a network contract operation"
+                            .to_string(),
+                    ),
+                );
+                inbound_responses.push(msg);
+            }
             // Inline fallback: no parking context (direct unit-test calls), or
             // the park cap was hit.
             for pending in std::mem::take(&mut deferred_upserts) {
@@ -2077,6 +2504,8 @@ where
                     // own guard still fires and is rejected on epoch, so
                     // nothing is answered twice.
                     unresolved_upserts: Vec::new(),
+                    contract_ops: Vec::new(),
+                    unresolved_contract_ops: Vec::new(),
                 },
             )
             .await;
@@ -3420,6 +3849,8 @@ where
         inbound,
         upserts,
         unresolved_upserts,
+        contract_ops,
+        unresolved_contract_ops,
     } = resume;
 
     let Some((continuation, pending)) = park.take_matching(&delegate_key, epoch) else {
@@ -3485,6 +3916,30 @@ where
             Err(ExecutorError::other(anyhow::anyhow!(
                 "delegate upsert did not complete: its off-loop work ended early"
             ))),
+        ));
+    }
+    // Delegate network GET/SUBSCRIBE results (#5542). Nothing has to be re-run
+    // on the loop for these — the network work is done — but a successful
+    // SUBSCRIBE installs its `DELEGATE_SUBSCRIPTIONS` hook here, on the loop and
+    // only on success, so the registry never advertises a delivery path that was
+    // never established.
+    for resolved in contract_ops {
+        all_inbound.push(apply_resolved_contract_op(resolved, &delegate_key));
+    }
+    // Network operations the off-loop task never resolved (panic, cancellation,
+    // budget). Same reasoning as the unresolved upserts above: the delegate is
+    // TOLD rather than left waiting. `DelegateContext` is defaulted because the
+    // `PendingContractOp` that carried it is gone by then.
+    for (contract_id, kind) in unresolved_contract_ops {
+        all_inbound.push(contract_op_response_msg(
+            kind,
+            contract_id,
+            DelegateContext::default(),
+            delegate_park::ContractOpOutcome::Failed(
+                "delegate network contract operation did not complete: its \
+                 off-loop work ended early"
+                    .to_string(),
+            ),
         ));
     }
     all_inbound.extend(inbound);

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -2612,10 +2612,9 @@ where
                                             pending.missing.clone(),
                                         )
                                         .await;
-                                        sink.lock().unwrap().push(delegate_park::ResolvedUpsert {
-                                            pending,
-                                            fetched,
-                                        });
+                                        sink.lock().unwrap_or_else(|e| e.into_inner()).push(
+                                            delegate_park::ResolvedUpsert { pending, fetched },
+                                        );
                                     }
                                 }))
                                 .await;
@@ -2644,7 +2643,7 @@ where
                                             // when `can_reach_network`. Recorded
                                             // as a failure rather than dropped,
                                             // so the delegate is told either way.
-                                            sink.lock().unwrap().push(
+                                            sink.lock().unwrap_or_else(|e| e.into_inner()).push(
                                                 delegate_park::ResolvedContractOp {
                                                     outcome:
                                                         delegate_park::ContractOpOutcome::Failed(
@@ -2658,7 +2657,7 @@ where
                                         };
                                         let outcome =
                                             run_contract_op_off_loop(op_manager, &pending).await;
-                                        sink.lock().unwrap().push(
+                                        sink.lock().unwrap_or_else(|e| e.into_inner()).push(
                                             delegate_park::ResolvedContractOp { pending, outcome },
                                         );
                                     }
@@ -8721,6 +8720,100 @@ mod hol_4391_tests {
             task_monitor,
         ));
         (op_manager, guards)
+    }
+
+    /// #5542. The SUBSCRIBE arm's `already_subscribed` gate must be tested
+    /// BEFORE the local-state branch, and this pins that ordering.
+    ///
+    /// The ordering is load-bearing and looks stylistic, which is the worst
+    /// case in this class: the regression and the correct code are textually
+    /// identical, so a reviewer sees a rearrangement rather than a defect.
+    /// Before M4 the local branch took no refcount, so testing the gate second
+    /// was harmless. M4 made that branch call `add_local_client`, and
+    /// `add_local_client` is a per-contract refcount that is explicitly NOT
+    /// idempotent — so with the arms in the other order a delegate
+    /// re-subscribing to a contract this node HOLDS takes a fresh refcount on
+    /// every repeat, which is the unbounded-demand failure the gate exists to
+    /// prevent, arriving on the branch nobody was watching.
+    ///
+    /// Asserts the CONSEQUENCE rather than a counter: subscribe twice, release
+    /// once through the ordinary `UnregisterDelegate` path, and require the
+    /// interest to be gone. Two refcounts for one logical subscriber survive a
+    /// single release, and nothing in the tree can ever discharge the excess —
+    /// which is the harm, not the count.
+    #[tokio::test]
+    async fn re_subscribing_to_a_local_contract_takes_no_further_demand() {
+        use freenet_stdlib::prelude::{ContractCode, Parameters, WrappedContract};
+
+        let _guard = TEST_GUARD.lock().await;
+        let (op_manager, _guards) = build_op_manager("d5542-resub").await;
+        let (send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler =
+            MockWasmContractHandler::new_test(rcv_halve, Some(op_manager.clone()), "d5542_resub")
+                .await;
+
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(ContractCode::from(vec![0xD4u8; 32])),
+            Parameters::from(vec![]),
+        )));
+        let key = contract.key();
+
+        // The SAME contract, subscribed twice in one round trip.
+        let script = handler.runtime_mut().delegate_script.clone();
+        for _ in 0..2 {
+            script.lock().unwrap().push_back(
+                vec![OutboundDelegateMsg::SubscribeContractRequest(
+                    freenet_stdlib::prelude::SubscribeContractRequest::new(*key.id()),
+                )]
+                .into(),
+            );
+        }
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter {
+                gate: Arc::new(tokio::sync::Semaphore::new(0)),
+            },
+        ));
+        let resp = tokio::time::timeout(
+            Duration::from_secs(10),
+            put_local(&send, contract, WrappedState::new(vec![7u8; 8])),
+        )
+        .await
+        .expect("PUT must not hang");
+        assert!(
+            matches!(resp, ContractHandlerEvent::PutResponse { .. }),
+            "expected a PutResponse, got {resp}"
+        );
+
+        let dkey = test_delegate_key();
+        let _ = tokio::time::timeout(
+            Duration::from_secs(10),
+            send.send_to_handler(delegate_event(&dkey)),
+        )
+        .await
+        .expect("the round trip must terminate");
+
+        assert!(
+            op_manager.interest_manager.has_local_interest(&key),
+            "the first subscribe must have registered demand, or this test \
+             proves nothing about the second"
+        );
+
+        // The ordinary removal path, exactly once.
+        crate::wasm_runtime::delegate_interest::release_delegate(&dkey);
+
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&key),
+            "two subscribes to one local contract must hold ONE refcount, so a \
+             single release discharges it. Interest still standing means the \
+             repeat took a second refcount that nothing can ever give back — \
+             `already_subscribed` is being tested AFTER the local branch"
+        );
+
+        handle.abort();
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
     }
 
     /// #5542 findings M4 and N2, together, because they are two halves of one

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -8079,7 +8079,7 @@ mod hol_4391_tests {
             .lock()
             .unwrap()
             .iter()
-            .any(|o| o.inbound_kinds.iter().any(|k| *k == "SubscribeContractResponse"));
+            .any(|o| o.inbound_kinds.contains(&"SubscribeContractResponse"));
         assert!(
             saw_response,
             "the delegate must be fed a SubscribeContractResponse even when the \

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1071,6 +1071,16 @@ struct RunSeed {
     /// and legitimately starts a fresh count — see the constant's rustdoc, and
     /// #5558 for the separate gap that leaves open.
     iterations: usize,
+    /// Fire-and-forget self-heal GETs already started, so
+    /// `MAX_NETWORK_CONTRACT_OPS_PER_PARK` bounds the whole round-trip and
+    /// neither a further iteration nor a park can reset it (#5542 finding B1).
+    ///
+    /// It rides HERE, beside `iterations`, because it is the same kind of
+    /// budget with the same failure mode, and that failure has already been
+    /// found and fixed once in this file under #5544 S1. Declared as a loop
+    /// local it reset on every one of up to `MAX_CONTRACT_REQUEST_ITERATIONS`
+    /// iterations, so the real ceiling was 100x the documented one.
+    self_heal_fetches_started: usize,
 }
 
 /// Outcome of one delegate run.
@@ -1167,6 +1177,7 @@ where
     let RunSeed {
         accumulated: mut accumulated_messages,
         mut iterations,
+        mut self_heal_fetches_started,
     } = seed;
 
     loop {
@@ -1355,25 +1366,20 @@ where
         // same reason as `deferred_upserts` (#5542) — the work is a network
         // operation and this is the serial loop.
         let mut pending_contract_ops: Vec<delegate_park::PendingContractOp> = Vec::new();
-        // Delegate-originated network operations started in this round trip that
-        // are NOT in `pending_contract_ops`: the UPDATE arm's self-heal fetches,
-        // which are fire-and-forget rather than parked (#5542, review finding
-        // 5A). They are counted alongside the parked ops against the SAME
-        // `MAX_NETWORK_CONTRACT_OPS_PER_PARK` budget.
+        // NOTE on `self_heal_fetches_started`: it is bound from `RunSeed` ABOVE
+        // this loop, deliberately. It counts the UPDATE arm's fire-and-forget
+        // self-heal GETs, which are not in `pending_contract_ops` because
+        // nothing parks them, and it shares the
+        // `MAX_NETWORK_CONTRACT_OPS_PER_PARK` budget with the parked ops so the
+        // documented node-wide ceiling of MAX_PARKED_DELEGATES (64) x 4 = 256
+        // is a statement about ALL delegate-originated network work.
         //
-        // Without this the PR's own fan-out argument does not hold. It declines
-        // to put a bound inside `start_sub_op_get` on the grounds that "each of
-        // its existing callers is bounded by itself", and bounds the delegate
-        // GET/SUBSCRIBE paths at 4 per park for a node-wide ceiling of
-        // MAX_PARKED_DELEGATES (64) x 4 = 256. The self-heal fetch is a new
-        // caller of `start_sub_op_get` that was NOT bounded by itself: one round
-        // trip emitting N `UpdateContractRequest`s for N DISTINCT unseen
-        // instance ids fired N background sub-op GETs, each running to
-        // OPERATION_TTL. The per-contract 5-minute cooldown does not bind across
-        // distinct ids, so nothing capped N. Sharing the budget restores the 256
-        // ceiling as a statement about all delegate-originated network work
-        // rather than only the parked half.
-        let mut self_heal_fetches_started = 0usize;
+        // Declaring it here — inside the loop, as the first version of this fix
+        // did — reset it on every iteration and made the real ceiling 100x the
+        // documented one. Do NOT move it back; the parked half tolerates a
+        // loop-local count only because parking ends the run, and the self-heal
+        // half has no such serialisation.
+        //
         // Whether this executor can reach the network at all. `None` on the
         // mock/in-process executors used by unit tests and by
         // `handle_delegate_notification`'s test seams; those keep the
@@ -2234,9 +2240,11 @@ where
                     inter_delegate,
                     accumulated: std::mem::take(&mut accumulated_messages),
                     inbound_so_far: std::mem::take(&mut inbound_responses),
-                    // Carry the count so the cap bounds the ROUND-TRIP, not
-                    // each leg (#5544 S1).
+                    // Carry the counts so the caps bound the ROUND-TRIP, not
+                    // each leg (#5544 S1 for iterations; #5542 finding B1 for
+                    // the fan-out budget).
                     iterations,
+                    self_heal_fetches_started,
                     // Attached by the caller right after we return `Parked` (it
                     // owns the channel), or carried straight through if this run
                     // is itself a resume that is parking again.
@@ -2454,6 +2462,7 @@ where
                         accumulated_messages = continuation.accumulated;
                         inbound_responses = continuation.inbound_so_far;
                         iterations = continuation.iterations;
+                        self_heal_fetches_started = continuation.self_heal_fetches_started;
                         *ctx.carried_responder = continuation.responder;
                     }
                 }
@@ -4137,6 +4146,7 @@ where
 
     let delegate_park::Continuation {
         iterations,
+        self_heal_fetches_started,
         params,
         origin_contract,
         connection_scope,
@@ -4233,6 +4243,7 @@ where
             RunSeed {
                 accumulated,
                 iterations,
+                self_heal_fetches_started,
             },
         )
         .await
@@ -8332,6 +8343,98 @@ mod hol_4391_tests {
         (op_manager, guards)
     }
 
+    /// #5542 finding B1/F1. The delegate network fan-out budget must span the
+    /// WHOLE round trip, not one iteration of it.
+    ///
+    /// BEHAVIOURAL on purpose. The defect this pins is the lexical SCOPE of a
+    /// binding, and the sibling source-scrape pin
+    /// (`every_delegate_network_operation_is_charged_against_the_park_budget`)
+    /// is structurally unable to see it: the gate text was right, the increment
+    /// was right, and the counter was declared inside the `loop {`, so it reset
+    /// on each of up to `MAX_CONTRACT_REQUEST_ITERATIONS` (100) iterations. The
+    /// scrape stayed green through the exact defect it was written to prevent.
+    /// A scrape can pin an API surface; it cannot pin a scope.
+    ///
+    /// The observable is `pending_contract_fetches`, which
+    /// `try_self_heal_fetch_for_local_originator` inserts into once per contract
+    /// it actually starts a fetch for. Every id here is distinct, so the map's
+    /// size IS the number of fire-and-forget GETs this round trip launched.
+    #[tokio::test]
+    async fn the_self_heal_fanout_budget_spans_the_whole_round_trip() {
+        use freenet_stdlib::prelude::{UpdateContractRequest, UpdateData};
+
+        let _guard = TEST_GUARD.lock().await;
+        let (op_manager, _guards) = build_op_manager("d5542-fanout").await;
+        // A connection is a precondition: without one the self-heal refuses
+        // before the budget is ever consulted (finding 5B), and the test would
+        // pass for the wrong reason.
+        let keypair = crate::transport::TransportKeypair::new();
+        op_manager.ring.connection_manager.add_connection(
+            crate::ring::Location::new(0.3),
+            "127.0.0.1:46001".parse().unwrap(),
+            keypair.public().clone(),
+            false,
+        );
+
+        let (send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler =
+            MockWasmContractHandler::new_test(rcv_halve, Some(op_manager.clone()), "d5542_fanout")
+                .await;
+        let script = handler.runtime_mut().delegate_script.clone();
+
+        // Three iterations, each asking to UPDATE four DISTINCT contracts this
+        // node has never seen. The store is empty, so every one takes the
+        // `None =>` self-heal branch.
+        const ITERATIONS: u8 = 3;
+        const PER_ITERATION: u8 = 4;
+        for i in 0..ITERATIONS {
+            let msgs: Vec<OutboundDelegateMsg> = (0..PER_ITERATION)
+                .map(|j| {
+                    let mut id = [0u8; 32];
+                    id[0] = 0xF0 + i;
+                    id[1] = j;
+                    OutboundDelegateMsg::UpdateContractRequest(UpdateContractRequest::new(
+                        ContractInstanceId::new(id),
+                        UpdateData::State(vec![1u8, 2, 3].into()),
+                    ))
+                })
+                .collect();
+            script.lock().unwrap().push_back(msgs.into());
+        }
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter {
+                gate: Arc::new(tokio::sync::Semaphore::new(0)),
+            },
+        ));
+        let key = test_delegate_key();
+        let _ = tokio::time::timeout(
+            Duration::from_secs(10),
+            send.send_to_handler(delegate_event(&key)),
+        )
+        .await
+        .expect("the round trip must terminate");
+
+        let started = op_manager.pending_contract_fetches.len();
+        handle.abort();
+        assert!(
+            started > 0,
+            "the test is vacuous unless at least one self-heal fetch started; \
+             got none, so the UPDATE arm never reached the network branch"
+        );
+        assert!(
+            started <= delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK,
+            "a single delegate round trip started {started} fire-and-forget \
+             network GETs against a per-round-trip budget of {}; the budget \
+             resets per ITERATION, so the real ceiling is that times \
+             MAX_CONTRACT_REQUEST_ITERATIONS ({}) rather than the documented \
+             node-wide 256 (#5542 finding B1)",
+            delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK,
+            MAX_CONTRACT_REQUEST_ITERATIONS,
+        );
+    }
+
     /// #5542 finding 5A. EVERY delegate-originated network operation started in
     /// one round trip is charged against `MAX_NETWORK_CONTRACT_OPS_PER_PARK` —
     /// including the UPDATE arm's self-heal fetch, which is fire-and-forget
@@ -9054,6 +9157,7 @@ mod hol_4391_tests {
     fn parked_continuation() -> delegate_park::Continuation {
         delegate_park::Continuation {
             iterations: 0,
+            self_heal_fetches_started: 0,
             params: Parameters::from(Vec::new()),
             origin_contract: None,
             connection_scope: crate::client_events::ConnectionScope::Local,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -746,11 +746,16 @@ fn contract_op_response_msg(
         (ContractOpKind::Subscribe, outcome) => {
             let err = match outcome {
                 ContractOpOutcome::Failed(err) => err,
-                // Unreachable by construction: only a GET produces `Fetched`.
-                // Reported rather than silently rewritten as a success, for the
-                // same reason the unexpected-response arm above is a failure.
-                other => {
-                    let _ = other;
+                // Unreachable by construction: only a GET produces `Fetched`,
+                // and `Subscribed` is taken by the arm above. Enumerated rather
+                // than wildcarded so a new outcome variant is a compile error
+                // here instead of silently landing in this string.
+                //
+                // Reported as a failure rather than silently rewritten as a
+                // success: telling a delegate its subscription is live when the
+                // node cannot say that is the class of lie #5263 removed from
+                // the delegate response path.
+                ContractOpOutcome::Fetched(_) | ContractOpOutcome::Subscribed => {
                     "delegate subscribe resolved with a non-subscribe outcome".to_string()
                 }
             };

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -768,6 +768,44 @@ fn contract_op_response_msg(
     }
 }
 
+/// The egress ban gate, applied to delegate-originated network operations
+/// (#5542 finding B2).
+///
+/// `reject_if_contract_banned` is called at the top of every CLIENT originator
+/// entry point — `start_client_put` / `_get` / `_subscribe` / `_update` — so
+/// that a banned contract's request is refused before it consumes this node's
+/// outbound resources. The invariant that gate exists to hold is stated at
+/// `operations.rs`: a banned contract can neither receive new state via this
+/// node nor transmit new state via it.
+///
+/// The delegate paths call the INTERNAL drivers — `start_sub_op_get` and
+/// `run_executor_subscribe` — rather than those client entry points, so they
+/// sat underneath the gate entirely. A delegate could originate GET, SUBSCRIBE
+/// and the UPDATE self-heal fetch for a contract this node has banned, which
+/// defeats the egress half of the invariant on a path the ban list cannot see.
+///
+/// Applied at ADMISSION rather than inside the drivers: putting it in
+/// `start_sub_op_get` would reshape all of its callers, including the
+/// phantom-repair path that restores a hosting invariant, which this PR
+/// deliberately declines to do. Refusing at admission also means the delegate
+/// gets the ordinary refusal it already understands rather than a driver-level
+/// error it has no channel for.
+///
+/// `false` when there is no `OpManager`: no network operation can start without
+/// one, so there is nothing to gate.
+fn delegate_network_op_banned<CH>(
+    contract_handler: &mut CH,
+    contract_id: &freenet_stdlib::prelude::ContractInstanceId,
+) -> bool
+where
+    CH: ContractHandler + Send + 'static,
+{
+    let Some(op_manager) = contract_handler.executor().op_manager_handle() else {
+        return false;
+    };
+    crate::operations::reject_if_contract_banned(&op_manager, contract_id).is_err()
+}
+
 /// Give back the local interest that resolved-but-dropped SUBSCRIBEs took
 /// (#5542 finding B3).
 ///
@@ -1632,6 +1670,7 @@ where
                         // `DelegateContext` across the gap.
                         if parking.is_some()
                             && can_reach_network
+                            && !delegate_network_op_banned(contract_handler, &contract_id)
                             && pending_contract_ops.len() + self_heal_fetches_started
                                 < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                         {
@@ -1983,6 +2022,7 @@ where
                     Ok(())
                 } else if parking.is_some()
                     && can_reach_network
+                    && !delegate_network_op_banned(contract_handler, &contract_id)
                     && pending_contract_ops.len() + self_heal_fetches_started
                         < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                     && !pending_contract_ops.iter().any(|op| {
@@ -2037,6 +2077,8 @@ where
                         "this node has no network handle"
                     } else if parking.is_none() {
                         "delegate parking is unavailable on this executor"
+                    } else if delegate_network_op_banned(contract_handler, &contract_id) {
+                        "this node has banned this contract (#5542 finding B2)"
                     } else {
                         "too many delegate network operations already in flight \
                          (MAX_NETWORK_CONTRACT_OPS_PER_PARK)"
@@ -8435,6 +8477,80 @@ mod hol_4391_tests {
             task_monitor,
         ));
         (op_manager, guards)
+    }
+
+    /// #5542 finding B2. A delegate must not be able to originate a network
+    /// operation for a contract this node has BANNED.
+    ///
+    /// `reject_if_contract_banned` runs at the top of every CLIENT originator
+    /// entry point (`start_client_put` / `_get` / `_subscribe` / `_update`), so
+    /// the egress half of the ban invariant held for everything that crossed
+    /// one. The delegate GET and SUBSCRIBE arms call the internal drivers
+    /// `start_sub_op_get` and `run_executor_subscribe` directly, crossing none
+    /// of them, so they sat underneath the gate entirely.
+    ///
+    /// COVERAGE SHAPE, stated rather than implied: this proves the gate
+    /// function against a real `ContractBanList` on a real `OpManager`, and the
+    /// companion pin below proves both admission sites call it. Driving the two
+    /// arms end-to-end would need the refusal to be distinguishable from an
+    /// admitted-then-failed network op at the delegate boundary, and it is not:
+    /// `GetContractResponse` has no error channel at all, and both outcomes
+    /// reach the delegate as a `SubscribeContractResponse`. The UPDATE arm's
+    /// equivalent IS covered behaviourally, in
+    /// `operations::update::tests::a_banned_contract_gets_no_delegate_self_heal_fetch`,
+    /// because its refusal is observable in `pending_contract_fetches`.
+    #[tokio::test]
+    async fn a_banned_contract_refuses_delegate_originated_network_ops() {
+        let (op_manager, _guards) = build_op_manager("d5542-ban").await;
+        let (_send, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler =
+            MockWasmContractHandler::new_test(rcv_halve, Some(op_manager.clone()), "d5542_ban")
+                .await;
+
+        let banned = ContractInstanceId::new([61u8; 32]);
+        let allowed = ContractInstanceId::new([62u8; 32]);
+        op_manager.ring.contract_ban_list.ban(
+            banned,
+            tokio::time::Instant::now() + Duration::from_secs(3600),
+            crate::ring::contract_ban_list::BanReason::AutoMad,
+        );
+
+        assert!(
+            delegate_network_op_banned(&mut handler, &banned),
+            "a banned contract must be refused a delegate-originated network op"
+        );
+        assert!(
+            !delegate_network_op_banned(&mut handler, &allowed),
+            "an unbanned contract must still be admitted, or the gate is refusing \
+             everything and proves nothing"
+        );
+    }
+
+    /// #5542 finding B2, wiring half. Both delegate network-op admission sites
+    /// must consult the egress ban gate.
+    ///
+    /// The gate function being correct is worth nothing if an arm does not call
+    /// it, and that is the half that rots: a future arm is added, copies the
+    /// budget conjunct, and omits this one. Anchored on the call itself.
+    #[test]
+    fn both_delegate_network_admission_sites_consult_the_ban_gate() {
+        let code = super::tests::production_code();
+        let flat = code.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let gates = flat
+            .matches("< delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK")
+            .count();
+        let banned_checks = flat
+            .matches("!delegate_network_op_banned(contract_handler, &contract_id)")
+            .count();
+        assert_eq!(
+            banned_checks, 2,
+            "the GET and SUBSCRIBE admission gates must each refuse a banned \
+             contract before parking a network operation for it; found \
+             {banned_checks} of the 2 required (there are {gates} fan-out gates \
+             in total, the third being the UPDATE self-heal, which is gated \
+             inside `try_self_heal_fetch_for_local_originator` instead)"
+        );
     }
 
     /// #5542 finding B3/F2. A resolved SUBSCRIBE whose resume is dropped on

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -768,6 +768,31 @@ fn contract_op_response_msg(
     }
 }
 
+/// The release half of a delegate-subscribe interest hold (#5542).
+///
+/// One constructor rather than two inline copies, because there are now two
+/// sites that take the refcount — the network path in
+/// `apply_resolved_contract_op` and the local-state path in the SUBSCRIBE arm —
+/// and a second hand-written copy is where the next divergence lives. That is
+/// the "manually-inlined originator side effects" row in
+/// `.claude/rules/bug-prevention-patterns.md`.
+///
+/// `Weak`, not `Arc`: the hold map is a process global, and a strong reference
+/// there would keep a shut-down node's `OpManager` alive for the life of the
+/// process. In the in-process multi-node harness that means every node ever
+/// built. A hold that cannot upgrade has nothing left to release, because the
+/// `InterestManager` it would decrement went with the `OpManager`.
+fn delegate_interest_release_closure(
+    op_manager: &std::sync::Arc<crate::node::OpManager>,
+) -> crate::wasm_runtime::delegate_interest::InterestRelease {
+    let weak = std::sync::Arc::downgrade(op_manager);
+    std::sync::Arc::new(move |key: &ContractKey| {
+        if let Some(op_manager) = weak.upgrade() {
+            op_manager.interest_manager.remove_local_client(key);
+        }
+    })
+}
+
 /// The egress ban gate, applied to delegate-originated network operations
 /// (#5542 finding B2).
 ///
@@ -960,16 +985,12 @@ where
                 // WEAK, so an outstanding hold never keeps a shut-down node's
                 // `OpManager` alive. A hold that cannot upgrade has nothing
                 // left to release.
-                let weak = std::sync::Arc::downgrade(&op_manager);
                 crate::wasm_runtime::delegate_interest::record(
                     pending.contract_id,
                     delegate_key.clone(),
                     key,
-                    std::sync::Arc::new(move |key: &ContractKey| {
-                        if let Some(op_manager) = weak.upgrade() {
-                            op_manager.interest_manager.remove_local_client(key);
-                        }
-                    }),
+                    delegate_interest_release_closure(&op_manager),
+                    std::sync::Arc::as_ptr(&op_manager) as usize,
                 );
             }
             None => {
@@ -1961,9 +1982,13 @@ where
         // 1. V2 delegates: subscribe_contract() host function (native_api.rs) registers
         //    during WASM execution and returns success/error synchronously.
         // 2. V1 delegates: emit SubscribeContractRequest in process() outbound, handled here.
-        // Both paths are idempotent — inserting the same (contract_id, delegate_key) twice
-        // is a no-op on the HashSet. After registration, the delegate receives
-        // ContractNotification messages when the subscribed contract's state changes.
+        // Re-asserting an ESTABLISHED subscription is idempotent: `already_subscribed`
+        // short-circuits it and the registry insert is a no-op. Two subscribes for the
+        // same NOT-yet-established contract in ONE invocation are not: the first is
+        // parked and the second is refused, naming that reason, because parking both
+        // would take two interest refcounts for one logical subscriber (#5542 M2).
+        // After registration, the delegate receives ContractNotification messages when
+        // the subscribed contract's state changes.
         //
         // TODO(#2830): UnsubscribeContractRequest is not yet handled. Delegates can
         // only unsubscribe implicitly via UnregisterDelegate cleanup.
@@ -1987,38 +2012,100 @@ where
                 // anything about. That is the silent-on-both-sides failure
                 // #5467 describes, reachable without the local store being
                 // empty at all.
-                let has_local_state = match contract_handler.executor().lookup_key(&contract_id) {
+                // The full key when this node holds BOTH the code and a state
+                // for it; `None` on all three local-miss shapes. Carried rather
+                // than reduced to a bool because the local branch below now
+                // needs the key to register demand (#5542 finding M4/F3).
+                let local_key = match contract_handler.executor().lookup_key(&contract_id) {
                     Some(full_key) => contract_handler
                         .executor()
                         .fetch_contract(full_key, false)
                         .await
-                        .is_ok_and(|(state, _)| state.is_some()),
-                    None => false,
+                        .ok()
+                        .and_then(|(state, _)| state.map(|_| full_key)),
+                    None => None,
                 };
-                let result = if has_local_state {
-                    // Contract is local: unchanged pre-#5542 behaviour. Register
-                    // the notification hook and answer.
+                // ORDER MATTERS: `already_subscribed` is tested FIRST, ahead of
+                // the local branch. It used to come second, which was harmless
+                // only while the local branch took no refcount. Now that it
+                // does, testing it second would let a delegate re-subscribing
+                // to a LOCAL contract take a fresh refcount on every repeat —
+                // the unbounded-demand failure this gate exists to prevent,
+                // reintroduced on the other branch.
+                let result = if already_subscribed(&contract_id, delegate_key) {
+                    // ALREADY HELD, so re-asserting it must be a no-op.
+                    //
+                    // This gate is load-bearing and is not obvious from the
+                    // code it guards. Both the network path and (since M4) the
+                    // local path end in `InterestManager::add_local_client`,
+                    // which is a REFCOUNT and is explicitly NOT idempotent (see
+                    // the `!is_renewal` gate at `operations/subscribe.rs`).
+                    // `DELEGATE_SUBSCRIPTIONS` is a map keyed by delegate, so
+                    // the pre-#5542 arm was idempotent for free and a delegate
+                    // re-subscribing in a loop cost nothing. Without this gate
+                    // each repeat takes another interest refcount for one
+                    // logical subscriber: demand that is never released,
+                    // growing without bound, on the exact path #5467 exists to
+                    // make trustworthy.
+                    Ok(())
+                } else if let Some(full_key) = local_key {
+                    // Contract is local, WITH state. Register the notification
+                    // hook — and register DEMAND, which this branch did not do
+                    // before (#5542 finding M4/F3).
+                    //
+                    // Without demand the copy is a zero-subscriber cached
+                    // contract, so under subscriber-primary eviction (hosting
+                    // invariant 3) it is the FIRST victim once capacity binds.
+                    // Eviction reclaims disk through
+                    // `ContractStore::remove_contract`, which wipes the
+                    // registry entry and releases any hold — and the delegate is
+                    // never told. That is #5467's silent-on-both-sides failure
+                    // on the branch this PR left unchanged, and it is the COMMON
+                    // case, because any client that has ever touched the
+                    // contract puts the node on this branch.
+                    //
+                    // This is also what the PR's own argument demands. It says
+                    // three things have to happen together — bootstrap the body,
+                    // register demand so the contract is not evicted out from
+                    // under the subscription, and establish the subscription.
+                    // On this branch the body is already here and the node is
+                    // already in the mesh for it, so item 2 was the only one
+                    // missing.
+                    let interest_registered = match contract_handler.executor().op_manager_handle()
+                    {
+                        Some(op_manager) => {
+                            if op_manager.interest_manager.add_local_client(&full_key) {
+                                crate::operations::broadcast_change_interests(
+                                    &op_manager,
+                                    vec![full_key],
+                                    vec![],
+                                )
+                                .await;
+                            }
+                            crate::wasm_runtime::delegate_interest::record(
+                                contract_id,
+                                delegate_key.clone(),
+                                full_key,
+                                delegate_interest_release_closure(&op_manager),
+                                std::sync::Arc::as_ptr(&op_manager) as usize,
+                            );
+                            true
+                        }
+                        // No `OpManager` means no eviction pressure worth
+                        // guarding against either: this is a mock/in-process
+                        // executor, so keep the pre-#5542 local-only answer.
+                        None => false,
+                    };
+                    tracing::debug!(
+                        contract = %contract_id,
+                        delegate_key = %delegate_key,
+                        interest_registered,
+                        "Delegate subscribed to a contract this node already holds"
+                    );
                     crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
                         .entry(contract_id)
                         .or_default()
                         .insert(delegate_key.clone());
-                    Ok(())
-                } else if already_subscribed(&contract_id, delegate_key) {
-                    // ALREADY HELD, so re-asserting it must be a no-op.
-                    //
-                    // This gate is load-bearing and is not obvious from the
-                    // code it guards. `run_executor_subscribe` ends in
-                    // `InterestManager::add_local_client`, which is a REFCOUNT
-                    // and is explicitly NOT idempotent (see the
-                    // `!is_renewal` gate at `operations/subscribe.rs`). The
-                    // registry it feeds, `DELEGATE_SUBSCRIPTIONS`, is a
-                    // `HashSet` — so the pre-#5542 arm was idempotent for free
-                    // and a delegate re-subscribing in a loop cost nothing.
-                    // Wiring the network path in without this gate makes each
-                    // repeat take another interest refcount for one logical
-                    // subscriber: demand that is never released, growing
-                    // without bound, on the exact path #5467 exists to make
-                    // trustworthy.
                     Ok(())
                 } else if parking.is_some()
                     && can_reach_network
@@ -2079,6 +2166,24 @@ where
                         "delegate parking is unavailable on this executor"
                     } else if delegate_network_op_banned(contract_handler, &contract_id) {
                         "this node has banned this contract (#5542 finding B2)"
+                    } else if pending_contract_ops.iter().any(|op| {
+                        op.contract_id == contract_id
+                            && op.kind == delegate_park::ContractOpKind::Subscribe
+                    }) {
+                        // #5542 finding M2. A delegate that emits two SUBSCRIBEs
+                        // for the same unseen contract in ONE invocation gets an
+                        // error for the second and a success for the first,
+                        // where the pre-#5542 `HashSet` arm was idempotent. The
+                        // duplicate cannot simply be answered `Ok`: nothing is
+                        // subscribed yet, and saying so before the network
+                        // subscribe exists is the lie #5263 removed from this
+                        // path. Nor can it be parked twice: two
+                        // `PendingContractOp`s for one pair would take two
+                        // interest refcounts for one logical subscriber. So it
+                        // is refused, but refused HONESTLY — the old text
+                        // blamed the fan-out cap, which was simply untrue.
+                        "a subscribe for this contract is already in flight in \
+                         this invocation; its response answers both"
                     } else {
                         "too many delegate network operations already in flight \
                          (MAX_NETWORK_CONTRACT_OPS_PER_PARK)"
@@ -5265,7 +5370,7 @@ pub(crate) enum ContractError {
 
 #[cfg(test)]
 #[allow(clippy::wildcard_enum_match_arm)]
-pub(crate) mod tests {
+mod tests {
     use super::*;
     use crate::config::GlobalExecutor;
     use std::time::Duration;
@@ -5405,8 +5510,17 @@ pub(crate) mod tests {
     ///    worse than no pin, because it reads as coverage.
     pub(super) fn production_code() -> String {
         let full = include_str!("contract.rs");
-        let prod = full.split("\nmod tests {").next().unwrap_or(full);
-        strip_comments(prod)
+        // `.expect`, not `.unwrap_or(full)`. Falling back to the whole file
+        // silently includes every test module, so each pin's own assertion
+        // literal can satisfy it and every pin here widens to vacuous with no
+        // signal at all. That happened during #5542's M1 work: `mod tests` was
+        // briefly renamed, this anchor stopped matching, and two pins went green
+        // over changes they exist to catch. Fail closed instead — a missing
+        // anchor is a broken pin, not a permissive one.
+        let cutoff = full
+            .find("\nmod tests {")
+            .expect("contract.rs must have a top-level `mod tests` for pins to cut at");
+        strip_comments(&full[..cutoff])
     }
 
     /// Remove `//` line comments and `/* */` block comments, preserving
@@ -6729,6 +6843,21 @@ pub(crate) mod tests {
 // local-store-hit GETs that need no network at all. These tests drive the REAL
 // `contract_handling` loop and assert the fix off-loads that wait so unrelated
 // work keeps draining.
+/// Source-pin helpers shared with pins in OTHER modules (#5542 M1).
+///
+/// Declared here, AFTER `mod tests`, on purpose: everything before that anchor
+/// is what `tests::production_code` hands to a scrape, and a helper living
+/// inside that slice would add its own text to every pin's haystack.
+#[cfg(test)]
+pub(crate) mod source_pin_util {
+    /// See [`super::tests::strip_comments`]. Re-exported so a pin in another
+    /// module gets the same comment stripping rather than a third copy of it —
+    /// the copies are what drift.
+    pub(crate) fn strip_comments(src: &str) -> String {
+        super::tests::strip_comments(src)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::wildcard_enum_match_arm)]
 // These tests intentionally discard `JoinHandle`/`timeout` results in cleanup

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -5265,7 +5265,7 @@ pub(crate) enum ContractError {
 
 #[cfg(test)]
 #[allow(clippy::wildcard_enum_match_arm)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::config::GlobalExecutor;
     use std::time::Duration;
@@ -5421,7 +5421,7 @@ mod tests {
     /// of that line is dropped; and Rust block comments nest, which this does
     /// not model. Either can only REMOVE text a pin looks for, turning a pin
     /// red rather than green — never the reverse.
-    pub(super) fn strip_comments(src: &str) -> String {
+    pub(crate) fn strip_comments(src: &str) -> String {
         enum S {
             Code,
             Line,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -8224,6 +8224,125 @@ mod hol_4391_tests {
         crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
     }
 
+    /// Build a real `OpManager` backed by a temp-dir `Config`, mirroring
+    /// `client_events::tests::build_op_manager`. The returned guard bundle
+    /// holds the channel endpoints open — drop it only when the test ends.
+    async fn build_op_manager(id: &str) -> (Arc<crate::node::OpManager>, Box<dyn std::any::Any>) {
+        let config_args = crate::config::ConfigArgs {
+            id: Some(id.to_string()),
+            mode: Some(crate::dev_tool::OperationMode::Local),
+            ..Default::default()
+        };
+        let node_config =
+            crate::node::NodeConfig::new(config_args.build().await.expect("build Config"))
+                .await
+                .expect("build NodeConfig");
+
+        let (notification_rx, notification_tx) = crate::node::event_loop_notification_channel();
+        let (ops_ch_channel, ch_channel, wait_for_event) =
+            crate::contract::contract_handler_channel();
+        let connection_manager = crate::ring::ConnectionManager::new(&node_config);
+        let (result_router_tx, result_router_rx) = tokio::sync::mpsc::channel(100);
+        let task_monitor = crate::node::background_task_monitor::BackgroundTaskMonitor::new();
+
+        let op_manager = Arc::new(
+            crate::node::OpManager::new(
+                notification_tx,
+                ops_ch_channel,
+                &node_config,
+                crate::tracing::DynamicRegister::new(vec![]),
+                connection_manager,
+                result_router_tx,
+                &task_monitor,
+            )
+            .expect("build OpManager"),
+        );
+        op_manager.ring.attach_op_manager(&op_manager);
+
+        let guards: Box<dyn std::any::Any> = Box::new((
+            notification_rx,
+            ch_channel,
+            wait_for_event,
+            result_router_rx,
+            task_monitor,
+        ));
+        (op_manager, guards)
+    }
+
+    /// #5542. The release obligation must be recorded for EVERY subscribe that
+    /// took a refcount — including one whose contract body never landed.
+    ///
+    /// `finalize_originator_subscribe` calls `add_local_client` OUTSIDE its
+    /// `if have_body` guard (`operations/subscribe.rs`), so a subscribe whose
+    /// `fetch_contract_if_missing` timed out still takes the refcount and still
+    /// returns `Ok(())`. On that path the executor's contract store holds no
+    /// code blob for the instance, so `lookup_key` — which resolves through
+    /// `ContractStore::code_hash_from_id` — returns `None`.
+    ///
+    /// Recording the obligation only when the full key resolves therefore left
+    /// exactly the leak this mechanism exists to close, on the feature's PRIMARY
+    /// path: a delegate subscribing to a contract this node has never seen,
+    /// inside a 2 s fetch window. It was reported as a `warn!` and nothing else.
+    #[tokio::test]
+    async fn a_subscribe_whose_body_never_landed_still_records_its_release_obligation() {
+        use delegate_park::{
+            ContractOpKind, ContractOpOutcome, PendingContractOp, ResolvedContractOp,
+        };
+        use freenet_stdlib::prelude::CodeHash;
+
+        let (op_manager, _guards) = build_op_manager("d5542-interest-hold").await;
+        let (send_halve, rcv_halve, _wait) = handler::contract_handler_channel();
+        let mut handler = MockWasmContractHandler::new_test(
+            rcv_halve,
+            Some(op_manager.clone()),
+            "d5542_interest_hold",
+        )
+        .await;
+        let _send = send_halve;
+
+        let dkey = DelegateKey::new([31u8; 32], CodeHash::new([31u8; 32]));
+        let id = ContractInstanceId::new([32u8; 32]);
+        // The key `add_local_client` was called with: the FULL key, carrying the
+        // real code hash, because the subscribe op knew it.
+        let full_key = ContractKey::from_id_and_code(id, CodeHash::new([33u8; 32]));
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&id);
+
+        // Stand in for what `run_executor_subscribe` did before returning Ok.
+        assert!(
+            op_manager.interest_manager.add_local_client(&full_key),
+            "the refcount this test is about must actually have been taken"
+        );
+        // ...and the body did NOT land, so the code blob is absent.
+        assert!(
+            handler.executor().lookup_key(&id).is_none(),
+            "this test is only meaningful while the full key is unresolvable"
+        );
+
+        let _ = apply_resolved_contract_op(
+            &mut handler,
+            ResolvedContractOp {
+                pending: PendingContractOp {
+                    contract_id: id,
+                    kind: ContractOpKind::Subscribe,
+                    context: DelegateContext::default(),
+                },
+                outcome: ContractOpOutcome::Subscribed,
+            },
+            &dkey,
+        );
+
+        // An ORDINARY removal path: unregistering the delegate.
+        crate::wasm_runtime::delegate_interest::release_delegate(&dkey);
+
+        assert!(
+            !op_manager.interest_manager.has_local_interest(&full_key),
+            "the local interest the subscribe took must be released when the \
+             subscription is dropped, even though the contract body never \
+             landed and the full `ContractKey` could not be resolved (#5542)"
+        );
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&id);
+    }
+
     /// #5542. A delegate SUBSCRIBE that cannot reach the network must still get
     /// a TERMINAL response, and the round-trip must complete.
     ///

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -7899,6 +7899,196 @@ mod hol_4391_tests {
         handle.abort();
     }
 
+    /// #5542. The mapping from a resolved network operation to the message the
+    /// delegate actually receives, covering every outcome including the ones
+    /// that cannot happen by construction.
+    ///
+    /// Pure and exhaustive on purpose: the off-loop task, the resume handler
+    /// and the `ParkGuard`'s panic path all funnel through this one function,
+    /// and the failure this pins is a failure arm quietly producing a SUCCESS
+    /// shape — telling a delegate its subscription is live when the node cannot
+    /// say that.
+    #[test]
+    #[allow(clippy::wildcard_enum_match_arm)]
+    fn contract_op_response_msg_maps_every_outcome() {
+        use delegate_park::{ContractOpKind, ContractOpOutcome};
+        let id = ContractInstanceId::new([4u8; 32]);
+        let ctx = DelegateContext::new(b"cont".to_vec());
+
+        let found = contract_op_response_msg(
+            ContractOpKind::Get,
+            id,
+            ctx.clone(),
+            ContractOpOutcome::Fetched(Some(WrappedState::new(b"hello".to_vec()))),
+        );
+        match found {
+            InboundDelegateMsg::GetContractResponse(r) => {
+                assert_eq!(r.state.as_deref(), Some(&b"hello"[..]));
+                assert_eq!(r.context.as_ref(), ctx.as_ref(), "context must round-trip");
+            }
+            other => panic!("a resolved GET must answer with GetContractResponse, got {other:?}"),
+        }
+
+        let get_failed = contract_op_response_msg(
+            ContractOpKind::Get,
+            id,
+            ctx.clone(),
+            ContractOpOutcome::Failed("boom".to_string()),
+        );
+        match get_failed {
+            InboundDelegateMsg::GetContractResponse(r) => assert!(
+                r.state.is_none(),
+                "a failed GET must not fabricate a state"
+            ),
+            other => panic!("a failed GET must still answer the delegate, got {other:?}"),
+        }
+
+        let subscribed = contract_op_response_msg(
+            ContractOpKind::Subscribe,
+            id,
+            ctx.clone(),
+            ContractOpOutcome::Subscribed,
+        );
+        match subscribed {
+            InboundDelegateMsg::SubscribeContractResponse(r) => {
+                assert!(r.result.is_ok(), "a completed subscribe must report Ok")
+            }
+            other => panic!("expected SubscribeContractResponse, got {other:?}"),
+        }
+
+        let sub_failed = contract_op_response_msg(
+            ContractOpKind::Subscribe,
+            id,
+            ctx,
+            ContractOpOutcome::Failed("no hosting peers".to_string()),
+        );
+        match sub_failed {
+            InboundDelegateMsg::SubscribeContractResponse(r) => {
+                let err = r
+                    .result
+                    .expect_err("a failed subscribe MUST NOT be reported as success");
+                assert!(
+                    err.contains("no hosting peers"),
+                    "the delegate must be told WHY, got {err:?}"
+                );
+            }
+            other => panic!("expected SubscribeContractResponse, got {other:?}"),
+        }
+    }
+
+    /// #5542. The `DELEGATE_SUBSCRIPTIONS` hook is installed ONLY when the
+    /// network subscription actually succeeded.
+    ///
+    /// This is the concrete form of the warning on the issue: that map is a
+    /// local notification hook and nothing in `ring/` reads it, so a hook
+    /// installed for a subscription that never got established gives a delegate
+    /// that believes it is subscribed and then never hears anything — the
+    /// silent-on-both-sides failure, one layer up.
+    #[test]
+    fn the_notification_hook_is_installed_only_on_a_successful_subscribe() {
+        use delegate_park::{
+            ContractOpKind, ContractOpOutcome, PendingContractOp, ResolvedContractOp,
+        };
+        let dkey = DelegateKey::new([21u8; 32], freenet_stdlib::prelude::CodeHash::new([21u8; 32]));
+        let ok_id = ContractInstanceId::new([22u8; 32]);
+        let bad_id = ContractInstanceId::new([23u8; 32]);
+        // Global registry: use ids unique to this test so it does not race the
+        // rest of the suite.
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&ok_id);
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
+
+        let _ = apply_resolved_contract_op(
+            ResolvedContractOp {
+                pending: PendingContractOp {
+                    contract_id: ok_id,
+                    kind: ContractOpKind::Subscribe,
+                    context: DelegateContext::default(),
+                },
+                outcome: ContractOpOutcome::Subscribed,
+            },
+            &dkey,
+        );
+        let _ = apply_resolved_contract_op(
+            ResolvedContractOp {
+                pending: PendingContractOp {
+                    contract_id: bad_id,
+                    kind: ContractOpKind::Subscribe,
+                    context: DelegateContext::default(),
+                },
+                outcome: ContractOpOutcome::Failed("network exhausted".to_string()),
+            },
+            &dkey,
+        );
+
+        assert!(
+            already_subscribed(&ok_id, &dkey),
+            "a successful subscribe must install the notification hook"
+        );
+        assert!(
+            !already_subscribed(&bad_id, &dkey),
+            "a FAILED subscribe must not install a hook: it would advertise a \
+             delivery path that was never established"
+        );
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&ok_id);
+        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
+    }
+
+    /// #5542. A delegate SUBSCRIBE that cannot reach the network must still get
+    /// a TERMINAL response, and the round-trip must complete.
+    ///
+    /// The executor here has no `OpManager` (`build_handler` passes `None`), so
+    /// the request is refused rather than parked. Refusing is the correct
+    /// behaviour — #5544's park-cap fallback to an inline wait is explicitly not
+    /// inheritable by an operation that reaches the network — but a refusal that
+    /// is DROPPED rather than answered leaves the delegate waiting forever for a
+    /// `SubscribeContractResponse` nobody will send. That is what this pins.
+    #[tokio::test]
+    async fn a_delegate_subscribe_that_cannot_reach_the_network_is_still_answered() {
+        let _guard = TEST_GUARD.lock().await;
+        let (mut handler, send) = build_handler(vec![]).await;
+        let script = handler.runtime_mut().delegate_script.clone();
+        let observations = handler.runtime_mut().delegate_observations.clone();
+        let unseen = ContractInstanceId::new([42u8; 32]);
+        script.lock().unwrap().push_back(
+            vec![OutboundDelegateMsg::SubscribeContractRequest(
+                freenet_stdlib::prelude::SubscribeContractRequest::new(unseen),
+            )]
+            .into(),
+        );
+
+        let handle = GlobalExecutor::spawn(contract_handling(
+            handler,
+            GatedPrompter {
+                gate: Arc::new(tokio::sync::Semaphore::new(0)),
+            },
+        ));
+        let key = test_delegate_key();
+        let resp = tokio::time::timeout(
+            Duration::from_secs(5),
+            send.send_to_handler(delegate_event(&key)),
+        )
+        .await
+        .expect("the round-trip must terminate, not hang on an unanswered subscribe")
+        .expect("handler responds");
+        assert!(
+            matches!(resp, ContractHandlerEvent::DelegateResponse(_)),
+            "expected a DelegateResponse, got {resp}"
+        );
+
+        let saw_response = observations
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|o| o.inbound_kinds.iter().any(|k| *k == "SubscribeContractResponse"));
+        assert!(
+            saw_response,
+            "the delegate must be fed a SubscribeContractResponse even when the \
+             subscribe is refused; dropping it leaves the delegate waiting for a \
+             response nobody will send"
+        );
+        handle.abort();
+    }
+
     /// A delegate that prompts TWICE parks, resumes, and parks again. Its
     /// client must still be answered exactly once, at the end.
     ///

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -1355,6 +1355,25 @@ where
         // same reason as `deferred_upserts` (#5542) — the work is a network
         // operation and this is the serial loop.
         let mut pending_contract_ops: Vec<delegate_park::PendingContractOp> = Vec::new();
+        // Delegate-originated network operations started in this round trip that
+        // are NOT in `pending_contract_ops`: the UPDATE arm's self-heal fetches,
+        // which are fire-and-forget rather than parked (#5542, review finding
+        // 5A). They are counted alongside the parked ops against the SAME
+        // `MAX_NETWORK_CONTRACT_OPS_PER_PARK` budget.
+        //
+        // Without this the PR's own fan-out argument does not hold. It declines
+        // to put a bound inside `start_sub_op_get` on the grounds that "each of
+        // its existing callers is bounded by itself", and bounds the delegate
+        // GET/SUBSCRIBE paths at 4 per park for a node-wide ceiling of
+        // MAX_PARKED_DELEGATES (64) x 4 = 256. The self-heal fetch is a new
+        // caller of `start_sub_op_get` that was NOT bounded by itself: one round
+        // trip emitting N `UpdateContractRequest`s for N DISTINCT unseen
+        // instance ids fired N background sub-op GETs, each running to
+        // OPERATION_TTL. The per-contract 5-minute cooldown does not bind across
+        // distinct ids, so nothing capped N. Sharing the budget restores the 256
+        // ceiling as a statement about all delegate-originated network work
+        // rather than only the parked half.
+        let mut self_heal_fetches_started = 0usize;
         // Whether this executor can reach the network at all. `None` on the
         // mock/in-process executors used by unit tests and by
         // `handle_delegate_notification`'s test seams; those keep the
@@ -1539,7 +1558,7 @@ where
                         // `DelegateContext` across the gap.
                         if parking.is_some()
                             && can_reach_network
-                            && pending_contract_ops.len()
+                            && pending_contract_ops.len() + self_heal_fetches_started
                                 < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                         {
                             pending_contract_ops.push(delegate_park::PendingContractOp {
@@ -1749,12 +1768,26 @@ where
                         // #5543's containment ladder exists. PUT is not
                         // comparable: it carries its own code, so a delegate can
                         // only PUT contracts it can build.
+                        // Charged against the SAME per-round-trip budget as the
+                        // parked GET/SUBSCRIBE ops (finding 5A; see
+                        // `self_heal_fetches_started`). Past the budget the
+                        // UPDATE still fails with the message below, exactly as
+                        // it does when the cooldown suppresses the fetch — the
+                        // delegate is never told a repair is running when none
+                        // is.
+                        let within_fanout_budget = pending_contract_ops.len()
+                            + self_heal_fetches_started
+                            < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK;
                         let healing = can_reach_network
+                            && within_fanout_budget
                             && contract_handler.executor().op_manager_handle().is_some_and(
                                 |op_manager| {
                                     op_manager.try_self_heal_fetch_for_local_originator(contract_id)
                                 },
                             );
+                        if healing {
+                            self_heal_fetches_started += 1;
+                        }
                         tracing::debug!(
                             contract = %contract_id,
                             healing,
@@ -1772,8 +1805,10 @@ where
                              for it deterministically (#5542)"
                         } else {
                             "contract not known to this node and no background fetch was \
-                             started (already attempted within the last 5 minutes, or this \
-                             node has no network handle). GET or SUBSCRIBE it first (#5542)"
+                             started (already attempted within the last 5 minutes, too many \
+                             delegate network operations already in flight, this node has no \
+                             network handle, or it has no connections). GET or SUBSCRIBE it \
+                             first (#5542)"
                         };
                         inbound_responses.push(InboundDelegateMsg::UpdateContractResponse(
                             UpdateContractResponse {
@@ -1874,7 +1909,8 @@ where
                     Ok(())
                 } else if parking.is_some()
                     && can_reach_network
-                    && pending_contract_ops.len() < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
+                    && pending_contract_ops.len() + self_heal_fetches_started
+                        < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                     && !pending_contract_ops.iter().any(|op| {
                         op.contract_id == contract_id
                             && op.kind == delegate_park::ContractOpKind::Subscribe
@@ -8294,6 +8330,61 @@ mod hol_4391_tests {
             task_monitor,
         ));
         (op_manager, guards)
+    }
+
+    /// #5542 finding 5A. EVERY delegate-originated network operation started in
+    /// one round trip is charged against `MAX_NETWORK_CONTRACT_OPS_PER_PARK` —
+    /// including the UPDATE arm's self-heal fetch, which is fire-and-forget
+    /// rather than parked and so does not appear in `pending_contract_ops`.
+    ///
+    /// This is what makes the PR's node-wide ceiling true. It declines to bound
+    /// `start_sub_op_get` internally on the grounds that "each of its existing
+    /// callers is bounded by itself"; the self-heal fetch was a new caller that
+    /// was not, so one round trip emitting N `UpdateContractRequest`s for N
+    /// distinct unseen instance ids fired N background GETs, each running to
+    /// OPERATION_TTL, with a per-contract cooldown that does not bind across
+    /// distinct ids.
+    ///
+    /// Source-scrape because the three gates sit inside one long `async fn` on
+    /// the serial loop and reaching the UPDATE arm's network branch needs a live
+    /// executor, a delegate script and a routable node. Anchored on the API
+    /// surface (the constant and the counter), not on surrounding prose, and it
+    /// asserts the counter is INCREMENTED as well as read — a budget whose
+    /// counter never rises is vacuous, which is the failure this shape invites.
+    #[test]
+    fn every_delegate_network_operation_is_charged_against_the_park_budget() {
+        let code = super::tests::production_code();
+        let flat = code.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        let bounds = flat
+            .matches("< delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK")
+            .count();
+        assert_eq!(
+            bounds, 3,
+            "expected exactly three per-round-trip fan-out gates (GET, UPDATE \
+             self-heal, SUBSCRIBE); a fourth delegate-originated network \
+             operation must join this budget rather than open a new one"
+        );
+
+        let charged = flat
+            .matches(
+                "pending_contract_ops.len() + self_heal_fetches_started \
+                 < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK",
+            )
+            .count();
+        assert_eq!(
+            charged, bounds,
+            "every fan-out gate must count the fire-and-forget self-heal fetches \
+             as well as the parked ops; a gate reading `pending_contract_ops.len()` \
+             alone lets the UPDATE arm's fetches escape the ceiling"
+        );
+
+        assert!(
+            flat.contains("if healing { self_heal_fetches_started += 1; }"),
+            "the counter must be incremented when a self-heal fetch actually \
+             starts, or the term above is permanently zero and the budget is \
+             vacuous while looking present"
+        );
     }
 
     /// #5542. The release obligation must be recorded for EVERY subscribe that

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -687,10 +687,33 @@ where
 fn already_subscribed(
     contract_id: &freenet_stdlib::prelude::ContractInstanceId,
     delegate_key: &DelegateKey,
+    op_manager: Option<&std::sync::Arc<crate::node::OpManager>>,
 ) -> bool {
-    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-        .get(contract_id)
-        .is_some_and(|subs| subs.contains(delegate_key))
+    match op_manager {
+        // PER-NODE, because the question is "has THIS node established it"
+        // (#5542, Codex P2). `DELEGATE_SUBSCRIPTIONS` is process-global and
+        // carries no node identity, so consulting it alone answers for the
+        // PROCESS: in an in-process multi-node run the second node to subscribe
+        // the same delegate to the same contract saw the first node's entry,
+        // short-circuited, and returned `Ok(())` having taken no refcount of its
+        // own and established no network subscription. The first-arrival
+        // process-global pattern from `testing.md`.
+        //
+        // Note the node-keyed hold map alone could not fix that: it made the
+        // RELEASE side per-node while this gate, one level above it, still
+        // answered from another node's registration and returned before any
+        // hold was recorded.
+        Some(op_manager) => crate::wasm_runtime::delegate_interest::holds(
+            contract_id,
+            delegate_key,
+            op_manager.node_identity,
+        ),
+        // No `OpManager`: no refcount can have been taken, so the registry is
+        // the only record there is, and a mock executor has exactly one node.
+        None => crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
+            .get(contract_id)
+            .is_some_and(|subs| subs.contains(delegate_key)),
+    }
 }
 
 /// Build the terminal inbound message for a delegate network operation (#5542).
@@ -1702,6 +1725,7 @@ where
                                 < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
                         {
                             pending_contract_ops.push(delegate_park::PendingContractOp {
+                                id: delegate_park::PendingContractOp::next_id(),
                                 contract_id,
                                 kind: delegate_park::ContractOpKind::Get,
                                 context,
@@ -2064,183 +2088,187 @@ where
                 // `handle_broadcast_change_interests` the payload is
                 // `Vec<u32>` interest hashes and the `ContractInstanceId` is
                 // gone.
+                let op_manager_for_gate = contract_handler.executor().op_manager_handle();
                 let banned = delegate_network_op_banned(contract_handler, &contract_id);
-                let result = if already_subscribed(&contract_id, delegate_key) {
-                    // ALREADY HELD, so re-asserting it must be a no-op.
-                    //
-                    // This gate is load-bearing and is not obvious from the
-                    // code it guards. Both the network path and (since M4) the
-                    // local path end in `InterestManager::add_local_client`,
-                    // which is a REFCOUNT and is explicitly NOT idempotent (see
-                    // the `!is_renewal` gate at `operations/subscribe.rs`).
-                    // `DELEGATE_SUBSCRIPTIONS` is a map keyed by delegate, so
-                    // the pre-#5542 arm was idempotent for free and a delegate
-                    // re-subscribing in a loop cost nothing. Without this gate
-                    // each repeat takes another interest refcount for one
-                    // logical subscriber: demand that is never released,
-                    // growing without bound, on the exact path #5467 exists to
-                    // make trustworthy.
-                    Ok(())
-                } else if banned {
-                    // Every subscribe path refuses a banned contract, local or
-                    // network. Before this the local branch answered `Ok` and
-                    // advertised interest for it.
-                    tracing::warn!(
-                        contract = %contract_id,
-                        delegate_key = %delegate_key,
-                        "Refusing a delegate SUBSCRIBE for a contract this node \
-                         has banned (#5542 finding N2)"
-                    );
-                    Err("this node has banned this contract (#5542)".to_string())
-                } else if let Some(full_key) = local_key {
-                    // Contract is local, WITH state. Register the notification
-                    // hook — and register DEMAND, which this branch did not do
-                    // before (#5542 finding M4/F3).
-                    //
-                    // Without demand the copy is a zero-subscriber cached
-                    // contract, so under subscriber-primary eviction (hosting
-                    // invariant 3) it is the FIRST victim once capacity binds.
-                    // Eviction reclaims disk through
-                    // `ContractStore::remove_contract`, which wipes the
-                    // registry entry and releases any hold — and the delegate is
-                    // never told. That is #5467's silent-on-both-sides failure
-                    // on the branch this PR left unchanged, and it is the COMMON
-                    // case, because any client that has ever touched the
-                    // contract puts the node on this branch.
-                    //
-                    // This is also what the PR's own argument demands. It says
-                    // three things have to happen together — bootstrap the body,
-                    // register demand so the contract is not evicted out from
-                    // under the subscription, and establish the subscription.
-                    // On this branch the body is already here and the node is
-                    // already in the mesh for it, so item 2 was the only one
-                    // missing.
-                    let interest_registered = match contract_handler.executor().op_manager_handle()
+                let result =
+                    if already_subscribed(&contract_id, delegate_key, op_manager_for_gate.as_ref())
                     {
-                        Some(op_manager) => {
-                            if op_manager.interest_manager.add_local_client(&full_key) {
-                                crate::operations::broadcast_change_interests(
-                                    &op_manager,
-                                    vec![full_key],
-                                    vec![],
-                                )
-                                .await;
-                            }
-                            crate::wasm_runtime::delegate_interest::record(
-                                contract_id,
-                                delegate_key.clone(),
-                                full_key,
-                                delegate_interest_release_closure(&op_manager),
-                                op_manager.node_identity,
-                            );
-                            true
-                        }
-                        // No `OpManager` means no eviction pressure worth
-                        // guarding against either: this is a mock/in-process
-                        // executor, so keep the pre-#5542 local-only answer.
-                        None => false,
-                    };
-                    tracing::debug!(
-                        contract = %contract_id,
-                        delegate_key = %delegate_key,
-                        interest_registered,
-                        "Delegate subscribed to a contract this node already holds"
-                    );
-                    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-                        .entry(contract_id)
-                        .or_default()
-                        .insert(delegate_key.clone());
-                    Ok(())
-                } else if parking.is_some()
-                    && can_reach_network
-                    && !banned
-                    && pending_contract_ops.len() + self_heal_fetches_started
-                        < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
-                    && !pending_contract_ops.iter().any(|op| {
-                        op.contract_id == contract_id
-                            && op.kind == delegate_park::ContractOpKind::Subscribe
-                    })
-                {
-                    // #5542. Subscribing to a contract this node has never seen
-                    // is the PRIMARY use case, not an edge case: a delegate that
-                    // wants to learn about a per-address contract after the tab
-                    // is closed has no other way to name it.
-                    //
-                    // OPENING THIS GATE ALONE WOULD SHIP THE FEATURE SILENT.
-                    // The arm above does one thing — insert into
-                    // `DELEGATE_SUBSCRIPTIONS` — which is a local notification
-                    // hook that nothing in `ring/` reads. It establishes no
-                    // network subscription, so a delegate would subscribe
-                    // successfully to a contract it has never seen and then
-                    // never hear anything, which is #5467's silent-on-both-sides
-                    // failure reintroduced one layer up. Three things have to
-                    // happen together, and `run_executor_subscribe` is chosen
-                    // because it is the one entry point that does all three:
-                    //
-                    //   1. bootstrap the contract body
-                    //      (`finalize_originator_subscribe` ->
-                    //      `fetch_contract_if_missing` -> `start_sub_op_get`),
-                    //   2. register demand (`interest_manager.add_local_client`,
-                    //      so the contract is kept alive rather than evicted out
-                    //      from under the subscription),
-                    //   3. establish the real network subscription.
-                    //
-                    // The notification hook (the `DELEGATE_SUBSCRIPTIONS`
-                    // insert) is then done on the loop when the park resumes, and
-                    // ONLY on success — so a failed subscribe leaves no hook
-                    // claiming a delivery path that does not exist.
-                    //
-                    // The last conjunct de-duplicates WITHIN this round trip;
-                    // `already_subscribed` covers repeats ACROSS round trips.
-                    // Both are needed for the refcount argument above to hold.
-                    pending_contract_ops.push(delegate_park::PendingContractOp {
-                        contract_id,
-                        kind: delegate_park::ContractOpKind::Subscribe,
-                        context,
-                    });
-                    continue;
-                } else {
-                    // REFUSED, never inline — same rule as the GET arm above.
-                    // Unlike GET, `SubscribeContractResponse.result` is a
-                    // `Result<(), String>`, so this refusal IS visible to the
-                    // delegate and says which of the three reasons it was.
-                    let why = if !can_reach_network {
-                        "this node has no network handle"
-                    } else if parking.is_none() {
-                        "delegate parking is unavailable on this executor"
-                    } else if pending_contract_ops.iter().any(|op| {
-                        op.contract_id == contract_id
-                            && op.kind == delegate_park::ContractOpKind::Subscribe
-                    }) {
-                        // #5542 finding M2. A delegate that emits two SUBSCRIBEs
-                        // for the same unseen contract in ONE invocation gets an
-                        // error for the second and a success for the first,
-                        // where the pre-#5542 `HashSet` arm was idempotent. The
-                        // duplicate cannot simply be answered `Ok`: nothing is
-                        // subscribed yet, and saying so before the network
-                        // subscribe exists is the lie #5263 removed from this
-                        // path. Nor can it be parked twice: two
-                        // `PendingContractOp`s for one pair would take two
-                        // interest refcounts for one logical subscriber. So it
-                        // is refused, but refused HONESTLY — the old text
-                        // blamed the fan-out cap, which was simply untrue.
-                        "a subscribe for this contract is already in flight in \
-                         this invocation; its response answers both"
+                        // ALREADY HELD, so re-asserting it must be a no-op.
+                        //
+                        // This gate is load-bearing and is not obvious from the
+                        // code it guards. Both the network path and (since M4) the
+                        // local path end in `InterestManager::add_local_client`,
+                        // which is a REFCOUNT and is explicitly NOT idempotent (see
+                        // the `!is_renewal` gate at `operations/subscribe.rs`).
+                        // `DELEGATE_SUBSCRIPTIONS` is a map keyed by delegate, so
+                        // the pre-#5542 arm was idempotent for free and a delegate
+                        // re-subscribing in a loop cost nothing. Without this gate
+                        // each repeat takes another interest refcount for one
+                        // logical subscriber: demand that is never released,
+                        // growing without bound, on the exact path #5467 exists to
+                        // make trustworthy.
+                        Ok(())
+                    } else if banned {
+                        // Every subscribe path refuses a banned contract, local or
+                        // network. Before this the local branch answered `Ok` and
+                        // advertised interest for it.
+                        tracing::warn!(
+                            contract = %contract_id,
+                            delegate_key = %delegate_key,
+                            "Refusing a delegate SUBSCRIBE for a contract this node \
+                             has banned (#5542 finding N2)"
+                        );
+                        Err("this node has banned this contract (#5542)".to_string())
+                    } else if let Some(full_key) = local_key {
+                        // Contract is local, WITH state. Register the notification
+                        // hook — and register DEMAND, which this branch did not do
+                        // before (#5542 finding M4/F3).
+                        //
+                        // Without demand the copy is a zero-subscriber cached
+                        // contract, so under subscriber-primary eviction (hosting
+                        // invariant 3) it is the FIRST victim once capacity binds.
+                        // Eviction reclaims disk through
+                        // `ContractStore::remove_contract`, which wipes the
+                        // registry entry and releases any hold — and the delegate is
+                        // never told. That is #5467's silent-on-both-sides failure
+                        // on the branch this PR left unchanged, and it is the COMMON
+                        // case, because any client that has ever touched the
+                        // contract puts the node on this branch.
+                        //
+                        // This is also what the PR's own argument demands. It says
+                        // three things have to happen together — bootstrap the body,
+                        // register demand so the contract is not evicted out from
+                        // under the subscription, and establish the subscription.
+                        // On this branch the body is already here and the node is
+                        // already in the mesh for it, so item 2 was the only one
+                        // missing.
+                        let interest_registered =
+                            match contract_handler.executor().op_manager_handle() {
+                                Some(op_manager) => {
+                                    if op_manager.interest_manager.add_local_client(&full_key) {
+                                        crate::operations::broadcast_change_interests(
+                                            &op_manager,
+                                            vec![full_key],
+                                            vec![],
+                                        )
+                                        .await;
+                                    }
+                                    crate::wasm_runtime::delegate_interest::record(
+                                        contract_id,
+                                        delegate_key.clone(),
+                                        full_key,
+                                        delegate_interest_release_closure(&op_manager),
+                                        op_manager.node_identity,
+                                    );
+                                    true
+                                }
+                                // No `OpManager` means no eviction pressure worth
+                                // guarding against either: this is a mock/in-process
+                                // executor, so keep the pre-#5542 local-only answer.
+                                None => false,
+                            };
+                        tracing::debug!(
+                            contract = %contract_id,
+                            delegate_key = %delegate_key,
+                            interest_registered,
+                            "Delegate subscribed to a contract this node already holds"
+                        );
+                        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
+                            .entry(contract_id)
+                            .or_default()
+                            .insert(delegate_key.clone());
+                        Ok(())
+                    } else if parking.is_some()
+                        && can_reach_network
+                        && !banned
+                        && pending_contract_ops.len() + self_heal_fetches_started
+                            < delegate_park::MAX_NETWORK_CONTRACT_OPS_PER_PARK
+                        && !pending_contract_ops.iter().any(|op| {
+                            op.contract_id == contract_id
+                                && op.kind == delegate_park::ContractOpKind::Subscribe
+                        })
+                    {
+                        // #5542. Subscribing to a contract this node has never seen
+                        // is the PRIMARY use case, not an edge case: a delegate that
+                        // wants to learn about a per-address contract after the tab
+                        // is closed has no other way to name it.
+                        //
+                        // OPENING THIS GATE ALONE WOULD SHIP THE FEATURE SILENT.
+                        // The arm above does one thing — insert into
+                        // `DELEGATE_SUBSCRIPTIONS` — which is a local notification
+                        // hook that nothing in `ring/` reads. It establishes no
+                        // network subscription, so a delegate would subscribe
+                        // successfully to a contract it has never seen and then
+                        // never hear anything, which is #5467's silent-on-both-sides
+                        // failure reintroduced one layer up. Three things have to
+                        // happen together, and `run_executor_subscribe` is chosen
+                        // because it is the one entry point that does all three:
+                        //
+                        //   1. bootstrap the contract body
+                        //      (`finalize_originator_subscribe` ->
+                        //      `fetch_contract_if_missing` -> `start_sub_op_get`),
+                        //   2. register demand (`interest_manager.add_local_client`,
+                        //      so the contract is kept alive rather than evicted out
+                        //      from under the subscription),
+                        //   3. establish the real network subscription.
+                        //
+                        // The notification hook (the `DELEGATE_SUBSCRIPTIONS`
+                        // insert) is then done on the loop when the park resumes, and
+                        // ONLY on success — so a failed subscribe leaves no hook
+                        // claiming a delivery path that does not exist.
+                        //
+                        // The last conjunct de-duplicates WITHIN this round trip;
+                        // `already_subscribed` covers repeats ACROSS round trips.
+                        // Both are needed for the refcount argument above to hold.
+                        pending_contract_ops.push(delegate_park::PendingContractOp {
+                            id: delegate_park::PendingContractOp::next_id(),
+                            contract_id,
+                            kind: delegate_park::ContractOpKind::Subscribe,
+                            context,
+                        });
+                        continue;
                     } else {
-                        "too many delegate network operations already in flight \
+                        // REFUSED, never inline — same rule as the GET arm above.
+                        // Unlike GET, `SubscribeContractResponse.result` is a
+                        // `Result<(), String>`, so this refusal IS visible to the
+                        // delegate and says which of the three reasons it was.
+                        let why = if !can_reach_network {
+                            "this node has no network handle"
+                        } else if parking.is_none() {
+                            "delegate parking is unavailable on this executor"
+                        } else if pending_contract_ops.iter().any(|op| {
+                            op.contract_id == contract_id
+                                && op.kind == delegate_park::ContractOpKind::Subscribe
+                        }) {
+                            // #5542 finding M2. A delegate that emits two SUBSCRIBEs
+                            // for the same unseen contract in ONE invocation gets an
+                            // error for the second and a success for the first,
+                            // where the pre-#5542 `HashSet` arm was idempotent. The
+                            // duplicate cannot simply be answered `Ok`: nothing is
+                            // subscribed yet, and saying so before the network
+                            // subscribe exists is the lie #5263 removed from this
+                            // path. Nor can it be parked twice: two
+                            // `PendingContractOp`s for one pair would take two
+                            // interest refcounts for one logical subscriber. So it
+                            // is refused, but refused HONESTLY — the old text
+                            // blamed the fan-out cap, which was simply untrue.
+                            "a subscribe for this contract is already in flight in \
+                         this invocation; its response answers both"
+                        } else {
+                            "too many delegate network operations already in flight \
                          (MAX_NETWORK_CONTRACT_OPS_PER_PARK)"
+                        };
+                        tracing::warn!(
+                            contract = %contract_id,
+                            delegate_key = %delegate_key,
+                            why,
+                            "Refusing a delegate SUBSCRIBE for a contract this node \
+                             has not seen (#5542)"
+                        );
+                        Err(format!(
+                            "cannot subscribe to a contract this node has not seen: {why}"
+                        ))
                     };
-                    tracing::warn!(
-                        contract = %contract_id,
-                        delegate_key = %delegate_key,
-                        why,
-                        "Refusing a delegate SUBSCRIBE for a contract this node \
-                         has not seen (#5542)"
-                    );
-                    Err(format!(
-                        "cannot subscribe to a contract this node has not seen: {why}"
-                    ))
-                };
 
                 inbound_responses.push(InboundDelegateMsg::SubscribeContractResponse(
                     SubscribeContractResponse {
@@ -2538,12 +2566,13 @@ where
                         // EVERY exit — including a panic or cancellation, which
                         // reach `Drop` and never run the task's own cleanup.
                         let owed_contract_ops: Vec<(
+                            u64,
                             ContractInstanceId,
                             delegate_park::ContractOpKind,
                             DelegateContext,
                         )> = pending_contract_ops
                             .iter()
-                            .map(|op| (op.contract_id, op.kind, op.context.clone()))
+                            .map(|op| (op.id, op.contract_id, op.kind, op.context.clone()))
                             .collect();
                         // SINKS CREATED BEFORE THE GUARD, AND SHARED WITH IT
                         // (#5544 F2). They used to be created inside the
@@ -8575,6 +8604,7 @@ mod hol_4391_tests {
             &mut handler,
             ResolvedContractOp {
                 pending: PendingContractOp {
+                    id: delegate_park::PendingContractOp::next_id(),
                     contract_id: ok_id,
                     kind: ContractOpKind::Subscribe,
                     context: DelegateContext::default(),
@@ -8587,6 +8617,7 @@ mod hol_4391_tests {
             &mut handler,
             ResolvedContractOp {
                 pending: PendingContractOp {
+                    id: delegate_park::PendingContractOp::next_id(),
                     contract_id: bad_id,
                     kind: ContractOpKind::Subscribe,
                     context: DelegateContext::default(),
@@ -8597,11 +8628,11 @@ mod hol_4391_tests {
         );
 
         assert!(
-            already_subscribed(&ok_id, &dkey),
+            already_subscribed(&ok_id, &dkey, None),
             "a successful subscribe must install the notification hook"
         );
         assert!(
-            !already_subscribed(&bad_id, &dkey),
+            !already_subscribed(&bad_id, &dkey, None),
             "a FAILED subscribe must not install a hook: it would advertise a \
              delivery path that was never established"
         );
@@ -8921,7 +8952,7 @@ mod hol_4391_tests {
              signal the node has that it wants it gone (#5542 N2)"
         );
         assert!(
-            !already_subscribed(banned_key.id(), &dkey),
+            !already_subscribed(banned_key.id(), &dkey, None),
             "and it must not install a notification hook for it either"
         );
 
@@ -8934,7 +8965,7 @@ mod hol_4391_tests {
              (#5542 M4)"
         );
         assert!(
-            already_subscribed(allowed_key.id(), &dkey),
+            already_subscribed(allowed_key.id(), &dkey, None),
             "and it must install the notification hook"
         );
         assert!(
@@ -9108,6 +9139,7 @@ mod hol_4391_tests {
                 unresolved_upserts: Vec::new(),
                 contract_ops: vec![ResolvedContractOp {
                     pending: PendingContractOp {
+                        id: delegate_park::PendingContractOp::next_id(),
                         contract_id: id,
                         kind: ContractOpKind::Subscribe,
                         context: DelegateContext::default(),
@@ -9132,7 +9164,7 @@ mod hol_4391_tests {
              no hold was recorded (#5542 finding B3)"
         );
         assert!(
-            !already_subscribed(&id, &dkey),
+            !already_subscribed(&id, &dkey, None),
             "and it must NOT install a notification hook: the delegate may be \
              gone by now, and advertising a delivery path nothing will serve is \
              the failure this PR exists to prevent"
@@ -9339,6 +9371,7 @@ mod hol_4391_tests {
             &mut handler,
             ResolvedContractOp {
                 pending: PendingContractOp {
+                    id: delegate_park::PendingContractOp::next_id(),
                     contract_id: id,
                     kind: ContractOpKind::Subscribe,
                     context: DelegateContext::default(),

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -696,12 +696,37 @@ pub(super) enum ContractOpKind {
 /// pure data - but the SUBSCRIBE registry insert is still done there, so
 /// `DELEGATE_SUBSCRIPTIONS` is only ever written from one place.
 pub(super) struct PendingContractOp {
+    /// Unique per request, for the lifetime of the process.
+    ///
+    /// Reconciliation used to match owed against resolved by
+    /// `(contract_id, kind)` COUNT. That is enough to get the NUMBER of
+    /// unresolved operations right, and not enough to get their IDENTITY right:
+    /// two GETs naming the same contract with DIFFERENT `DelegateContext`s are
+    /// interchangeable under that key, so if only the second completes, the
+    /// count consumes the FIRST owed entry, the real response carries the
+    /// second's context, and the synthesized failure carries the second's
+    /// context too. One request gets two answers and the other gets none, and
+    /// the delegate's own correlation state is what is swapped.
+    ///
+    /// That only became reachable when the context was added to the owed
+    /// entries (#5542 F7). Before it, every synthesized failure carried
+    /// `DelegateContext::default()`, so there was no identity to mismatch.
+    pub id: u64,
     pub contract_id: ContractInstanceId,
     pub kind: ContractOpKind,
     /// Echoed back to the delegate so it can match the response to its request.
     /// This is the continuation state that survives the park: the delegate's
     /// own `DelegateContext` round-trips through the response.
     pub context: DelegateContext,
+}
+
+impl PendingContractOp {
+    /// Next request id. Monotonic per process; only ever compared for equality
+    /// within one park's owed/resolved reconciliation.
+    pub(super) fn next_id() -> u64 {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
 }
 
 /// What a [`PendingContractOp`]'s network work produced.
@@ -814,7 +839,7 @@ struct ParkGuardPayload {
     /// corrupts it instead of merely failing an operation. The obligation is
     /// outstanding for up to PARK_WORK_BUDGET (75 s), so this is not a
     /// vanishing window.
-    owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind, DelegateContext)>,
+    owed_contract_ops: Vec<(u64, ContractInstanceId, ContractOpKind, DelegateContext)>,
     /// Where the off-loop task deposits finished network operations, shared with
     /// the task for the same reason as `answers` and `fetches`: so `Drop` can
     /// see work that completed before a panic or cancellation (#5544 F2).
@@ -831,7 +856,7 @@ impl ParkGuard {
         owed_upserts: Vec<(ContractInstanceId, bool)>,
         answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
         fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
-        owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind, DelegateContext)>,
+        owed_contract_ops: Vec<(u64, ContractInstanceId, ContractOpKind, DelegateContext)>,
         contract_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>>,
     ) -> Self {
         Self {
@@ -965,19 +990,26 @@ impl ParkGuard {
             );
         }
 
-        // Same count-not-set reconciliation as the upserts above, for the same
-        // reason (#5544 F1/F3): `owed_contract_ops` is a multiset.
-        let mut resolved_ops: HashMap<(ContractInstanceId, ContractOpKind), usize> = HashMap::new();
-        for r in &contract_ops {
-            *resolved_ops
-                .entry((r.pending.contract_id, r.pending.kind))
-                .or_default() += 1;
-        }
+        // RECONCILED BY REQUEST IDENTITY, not by `(contract, kind)` count.
+        //
+        // A count gets the NUMBER of unresolved operations right and their
+        // IDENTITY wrong. Two GETs naming one contract are interchangeable
+        // under that key, so when only the second completes, the count consumes
+        // the FIRST owed entry while the real response and the synthesized
+        // failure both carry the SECOND's `DelegateContext` — one request
+        // answered twice, one never, and the delegate's correlation state
+        // swapped underneath it. Matching on `PendingContractOp::id` cannot
+        // confuse two requests, whatever they name.
+        //
+        // This subsumes the multiset reasoning that was here (#5544 F1/F3):
+        // distinct requests have distinct ids, so duplicates are handled by
+        // construction rather than by counting.
+        let resolved_ids: std::collections::HashSet<u64> =
+            contract_ops.iter().map(|r| r.pending.id).collect();
         let mut unresolved_contract_ops = Vec::new();
-        for (id, kind, context) in owed_contract_ops {
-            match resolved_ops.get_mut(&(id, kind)) {
-                Some(n) if *n > 0 => *n -= 1,
-                _ => unresolved_contract_ops.push((id, kind, context)),
+        for (op_id, id, kind, context) in owed_contract_ops {
+            if !resolved_ids.contains(&op_id) {
+                unresolved_contract_ops.push((id, kind, context));
             }
         }
         if !unresolved_contract_ops.is_empty() {
@@ -2447,10 +2479,22 @@ mod tests {
     }
 
     fn net_op(contract: u8, kind: ContractOpKind) -> PendingContractOp {
+        net_op_with(PendingContractOp::next_id(), contract, kind, Vec::new())
+    }
+
+    /// A pending op with an explicit id and context, so a test can express
+    /// TWO DISTINCT requests that look identical under `(contract, kind)`.
+    fn net_op_with(
+        id: u64,
+        contract: u8,
+        kind: ContractOpKind,
+        context: Vec<u8>,
+    ) -> PendingContractOp {
         PendingContractOp {
+            id,
             contract_id: ContractInstanceId::new([contract; 32]),
             kind,
-            context: DelegateContext::default(),
+            context: DelegateContext::new(context),
         }
     }
 
@@ -2483,11 +2527,13 @@ mod tests {
             fetches,
             vec![
                 (
+                    1,
                     ContractInstanceId::new([9; 32]),
                     ContractOpKind::Get,
                     DelegateContext::new(b"ctx-get".to_vec()),
                 ),
                 (
+                    2,
                     ContractInstanceId::new([8; 32]),
                     ContractOpKind::Subscribe,
                     DelegateContext::new(b"ctx-sub".to_vec()),
@@ -2528,10 +2574,12 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let (answers, fetches) = sinks();
         let net_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>> = Default::default();
-        net_ops
-            .lock()
-            .unwrap()
-            .push(resolved_net_op(9, ContractOpKind::Get));
+        // The SECOND request is the one that completed. Under the old
+        // count-based reconciliation this discharged the FIRST owed entry.
+        net_ops.lock().unwrap().push(ResolvedContractOp {
+            pending: net_op_with(12, 9, ContractOpKind::Get, b"second".to_vec()),
+            outcome: ContractOpOutcome::Fetched(None),
+        });
         drop(ParkGuard::new(
             tx,
             key(1),
@@ -2542,14 +2590,16 @@ mod tests {
             fetches,
             vec![
                 (
+                    11,
                     ContractInstanceId::new([9; 32]),
                     ContractOpKind::Get,
-                    DelegateContext::default(),
+                    DelegateContext::new(b"first".to_vec()),
                 ),
                 (
+                    12,
                     ContractInstanceId::new([9; 32]),
                     ContractOpKind::Get,
-                    DelegateContext::default(),
+                    DelegateContext::new(b"second".to_vec()),
                 ),
             ],
             net_ops,
@@ -2565,10 +2615,14 @@ mod tests {
             vec![(
                 ContractInstanceId::new([9; 32]),
                 ContractOpKind::Get,
-                DelegateContext::default()
+                DelegateContext::new(b"first".to_vec())
             )],
-            "one completion must discharge exactly ONE of two identical \
-             obligations, not both"
+            "one completion must discharge exactly ONE of two obligations that \
+             look identical under `(contract, kind)` — and it must discharge \
+             THE ONE THAT COMPLETED. Reconciling by count consumed the FIRST \
+             owed entry while the real response and the synthesized failure \
+             both carried the SECOND's context: one request answered twice, one \
+             never (#5542, Codex P2)"
         );
     }
 
@@ -2581,10 +2635,10 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let (answers, fetches) = sinks();
         let net_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>> = Default::default();
-        net_ops
-            .lock()
-            .unwrap()
-            .push(resolved_net_op(9, ContractOpKind::Get));
+        net_ops.lock().unwrap().push(ResolvedContractOp {
+            pending: net_op_with(21, 9, ContractOpKind::Get, Vec::new()),
+            outcome: ContractOpOutcome::Fetched(None),
+        });
         drop(ParkGuard::new(
             tx,
             key(1),
@@ -2595,11 +2649,13 @@ mod tests {
             fetches,
             vec![
                 (
+                    21,
                     ContractInstanceId::new([9; 32]),
                     ContractOpKind::Get,
                     DelegateContext::default(),
                 ),
                 (
+                    22,
                     ContractInstanceId::new([9; 32]),
                     ContractOpKind::Subscribe,
                     DelegateContext::default(),

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -2498,16 +2498,6 @@ mod tests {
         }
     }
 
-    fn resolved_net_op(contract: u8, kind: ContractOpKind) -> ResolvedContractOp {
-        ResolvedContractOp {
-            pending: net_op(contract, kind),
-            outcome: match kind {
-                ContractOpKind::Get => ContractOpOutcome::Fetched(None),
-                ContractOpKind::Subscribe => ContractOpOutcome::Subscribed,
-            },
-        }
-    }
-
     /// #5542. Every delegate network operation a park owes must produce a
     /// terminal outcome on EVERY exit, including the `Drop` path a panic or a
     /// cancellation takes. Without this the delegate waits forever for a

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -1882,6 +1882,8 @@ mod tests {
             Vec::new(),
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
 
         // The loop takes it off the channel but runs out of budget before
@@ -1988,6 +1990,8 @@ mod tests {
             Vec::new(),
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
 
         tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
@@ -2050,6 +2054,8 @@ mod tests {
             Vec::new(),
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
 
         assert!(
@@ -2101,6 +2107,8 @@ mod tests {
             inbound: vec![answer(1)],
             upserts: Vec::new(),
             unresolved_upserts: Vec::new(),
+            contract_ops: Vec::new(),
+            unresolved_contract_ops: Vec::new(),
         });
 
         tokio::time::advance(PARK_TTL + Duration::from_secs(1)).await;
@@ -2389,11 +2397,172 @@ mod tests {
             .collect()
     }
 
+    fn net_op(contract: u8, kind: ContractOpKind) -> PendingContractOp {
+        PendingContractOp {
+            contract_id: ContractInstanceId::new([contract; 32]),
+            kind,
+            context: DelegateContext::default(),
+        }
+    }
+
+    fn resolved_net_op(contract: u8, kind: ContractOpKind) -> ResolvedContractOp {
+        ResolvedContractOp {
+            pending: net_op(contract, kind),
+            outcome: match kind {
+                ContractOpKind::Get => ContractOpOutcome::Fetched(None),
+                ContractOpKind::Subscribe => ContractOpOutcome::Subscribed,
+            },
+        }
+    }
+
+    /// #5542. Every delegate network operation a park owes must produce a
+    /// terminal outcome on EVERY exit, including the `Drop` path a panic or a
+    /// cancellation takes. Without this the delegate waits forever for a
+    /// `GetContractResponse` nothing remains to produce — the same failure
+    /// #5544 P2 had to fix for prompts and upserts, at a third level.
+    #[tokio::test]
+    async fn drop_reports_every_owed_network_op_as_unresolved() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (answers, fetches) = sinks();
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            Vec::new(),
+            Vec::new(),
+            answers,
+            fetches,
+            vec![
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+                (ContractInstanceId::new([8; 32]), ContractOpKind::Subscribe),
+            ],
+            Default::default(),
+        ));
+        let resume = rx.recv().await.expect("drop must still resume the park");
+        assert_eq!(resume.cause, ResumeCause::TimedOut);
+        assert_eq!(
+            resume.unresolved_contract_ops,
+            vec![
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+                (ContractInstanceId::new([8; 32]), ContractOpKind::Subscribe),
+            ],
+            "every owed network operation must be reported unresolved"
+        );
+    }
+
+    /// #5542, inheriting #5544 F1/F3. `owed_contract_ops` is a MULTISET: one
+    /// `process()` return can emit two `GetContractRequest`s naming the same
+    /// contract. Reconciling by SET membership would let ONE completion
+    /// discharge BOTH obligations, and the delegate would wait forever for the
+    /// second response.
+    #[tokio::test]
+    async fn network_ops_are_reconciled_by_count_not_by_set() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (answers, fetches) = sinks();
+        let net_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>> = Default::default();
+        net_ops
+            .lock()
+            .unwrap()
+            .push(resolved_net_op(9, ContractOpKind::Get));
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            Vec::new(),
+            Vec::new(),
+            answers,
+            fetches,
+            vec![
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+            ],
+            net_ops,
+        ));
+        let resume = rx.recv().await.expect("resume");
+        assert_eq!(
+            resume.contract_ops.len(),
+            1,
+            "the completed operation must survive the drop path"
+        );
+        assert_eq!(
+            resume.unresolved_contract_ops,
+            vec![(ContractInstanceId::new([9; 32]), ContractOpKind::Get)],
+            "one completion must discharge exactly ONE of two identical \
+             obligations, not both"
+        );
+    }
+
+    /// #5542. `kind` is part of the obligation's identity: a GET and a
+    /// SUBSCRIBE naming one contract are two different promises to the
+    /// delegate, and answering the GET must not silently discharge the
+    /// SUBSCRIBE.
+    #[tokio::test]
+    async fn a_get_and_a_subscribe_for_one_contract_are_two_obligations() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (answers, fetches) = sinks();
+        let net_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>> = Default::default();
+        net_ops
+            .lock()
+            .unwrap()
+            .push(resolved_net_op(9, ContractOpKind::Get));
+        drop(ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            Vec::new(),
+            Vec::new(),
+            answers,
+            fetches,
+            vec![
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+                (ContractInstanceId::new([9; 32]), ContractOpKind::Subscribe),
+            ],
+            net_ops,
+        ));
+        let resume = rx.recv().await.expect("resume");
+        assert_eq!(
+            resume.unresolved_contract_ops,
+            vec![(
+                ContractInstanceId::new([9; 32]),
+                ContractOpKind::Subscribe
+            )],
+            "the SUBSCRIBE must still be owed after only the GET completed"
+        );
+    }
+
+    /// #5542. The park's byte cap must charge what a pending network operation
+    /// retains. A delegate chooses its own `DelegateContext`, so charging zero
+    /// for it makes `MAX_PARKED_BYTES` blind to 4 x 64 delegate-supplied
+    /// payloads — the same "count cap standing in for a byte cap" this file
+    /// already fixed twice.
+    #[tokio::test]
+    async fn pending_network_ops_are_charged_for_their_context() {
+        const N: usize = 32 * 1024;
+        let mut op = net_op(9, ContractOpKind::Get);
+        op.context = DelegateContext::new(vec![0u8; N]);
+        let charged = task_bytes(&[], &[], std::slice::from_ref(&op));
+        assert!(
+            charged >= N,
+            "a pending network op must be charged for the context it retains, \
+             got {charged} for a {N}-byte context"
+        );
+    }
+
     #[tokio::test]
     async fn guard_delivers_exactly_one_resume_on_success() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let (answers, fetches) = sinks();
-        let guard = ParkGuard::new(tx, key(1), 0, Vec::new(), Vec::new(), answers, fetches);
+        let guard = ParkGuard::new(
+            tx,
+            key(1),
+            0,
+            Vec::new(),
+            Vec::new(),
+            answers,
+            fetches,
+            Vec::new(),
+            Default::default(),
+        );
         guard.send();
         let resume = rx.recv().await.expect("one resume");
         assert_eq!(resume.cause, ResumeCause::Completed);
@@ -2420,6 +2589,8 @@ mod tests {
             vec![(ContractInstanceId::new([3; 32]), true)],
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
         let resume = rx.recv().await.expect("drop must still resume the park");
         assert_eq!(resume.cause, ResumeCause::TimedOut);
@@ -2454,6 +2625,8 @@ mod tests {
             Vec::new(),
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
         let resume = rx.recv().await.expect("resume");
         let kept: Vec<&InboundDelegateMsg<'static>> = resume
@@ -2497,6 +2670,8 @@ mod tests {
             vec![(contract, true), (contract, true)],
             answers,
             fetches,
+            Vec::new(),
+            Default::default(),
         ));
         let resume = rx.recv().await.expect("resume");
         assert_eq!(

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -312,7 +312,16 @@ pub(super) fn task_bytes(
     // COUNT (4 per park), which is a count cap standing in for a byte cap - the
     // pattern #5551 tracks. Bounding the arriving state properly belongs there,
     // where it can be fixed for both paths at once, not duplicated here.
-    let contract_op_bytes: usize = contract_ops.iter().map(|op| ctx_len(&op.context)).sum();
+    // TWO copies per pending op, deliberately: the off-loop task holds the
+    // `PendingContractOp` and the `ParkGuard` holds a clone of its
+    // `DelegateContext` in `owed_contract_ops`, so a synthesized failure can
+    // hand the delegate back its own continuation state instead of an empty one
+    // (#5542 finding F7). Charging one copy for two would under-count the park
+    // byte cap by exactly the thing that cap exists to bound.
+    let contract_op_bytes: usize = contract_ops
+        .iter()
+        .map(|op| ctx_len(&op.context).saturating_mul(2))
+        .sum();
     prompt_bytes + upsert_bytes + contract_op_bytes
 }
 
@@ -753,7 +762,7 @@ pub(super) struct DelegateResume {
     /// Network operations the off-loop task never resolved, for the same three
     /// reasons as `unresolved_upserts`. Turned into failure responses so the
     /// delegate is told rather than left waiting for one that will never come.
-    pub unresolved_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
+    pub unresolved_contract_ops: Vec<(ContractInstanceId, ContractOpKind, DelegateContext)>,
 }
 
 /// RAII guard guaranteeing an off-loop task delivers EXACTLY ONE
@@ -797,7 +806,15 @@ struct ParkGuardPayload {
     /// contract, and reconciling those by SET membership would let one
     /// completion discharge both obligations, leaving the delegate waiting
     /// forever for a response nothing remained to produce.
-    owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
+    /// Carries the delegate's own `DelegateContext` so a synthesized failure
+    /// hands back the CONTINUATION STATE the request arrived with, not an empty
+    /// one (#5542 finding F7). `DelegateContext` is how a delegate correlates a
+    /// response with its request; handing back `default()` reads to a delegate
+    /// state machine as "start over" rather than "this operation failed", which
+    /// corrupts it instead of merely failing an operation. The obligation is
+    /// outstanding for up to PARK_WORK_BUDGET (75 s), so this is not a
+    /// vanishing window.
+    owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind, DelegateContext)>,
     /// Where the off-loop task deposits finished network operations, shared with
     /// the task for the same reason as `answers` and `fetches`: so `Drop` can
     /// see work that completed before a panic or cancellation (#5544 F2).
@@ -814,7 +831,7 @@ impl ParkGuard {
         owed_upserts: Vec<(ContractInstanceId, bool)>,
         answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
         fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
-        owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
+        owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind, DelegateContext)>,
         contract_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>>,
     ) -> Self {
         Self {
@@ -937,10 +954,10 @@ impl ParkGuard {
                 .or_default() += 1;
         }
         let mut unresolved_contract_ops = Vec::new();
-        for (id, kind) in owed_contract_ops {
+        for (id, kind, context) in owed_contract_ops {
             match resolved_ops.get_mut(&(id, kind)) {
                 Some(n) if *n > 0 => *n -= 1,
-                _ => unresolved_contract_ops.push((id, kind)),
+                _ => unresolved_contract_ops.push((id, kind, context)),
             }
         }
         if !unresolved_contract_ops.is_empty() {
@@ -2445,8 +2462,16 @@ mod tests {
             answers,
             fetches,
             vec![
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
-                (ContractInstanceId::new([8; 32]), ContractOpKind::Subscribe),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Get,
+                    DelegateContext::new(b"ctx-get".to_vec()),
+                ),
+                (
+                    ContractInstanceId::new([8; 32]),
+                    ContractOpKind::Subscribe,
+                    DelegateContext::new(b"ctx-sub".to_vec()),
+                ),
             ],
             Default::default(),
         ));
@@ -2455,10 +2480,21 @@ mod tests {
         assert_eq!(
             resume.unresolved_contract_ops,
             vec![
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
-                (ContractInstanceId::new([8; 32]), ContractOpKind::Subscribe),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Get,
+                    DelegateContext::new(b"ctx-get".to_vec()),
+                ),
+                (
+                    ContractInstanceId::new([8; 32]),
+                    ContractOpKind::Subscribe,
+                    DelegateContext::new(b"ctx-sub".to_vec()),
+                ),
             ],
-            "every owed network operation must be reported unresolved"
+            "every owed network operation must be reported unresolved, WITH the \
+             delegate's own context: a synthesized failure carrying \
+             `DelegateContext::default()` reads to a delegate state machine as \
+             \"start over\" rather than \"this operation failed\" (#5542 F7)"
         );
     }
 
@@ -2485,8 +2521,16 @@ mod tests {
             answers,
             fetches,
             vec![
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Get,
+                    DelegateContext::default(),
+                ),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Get,
+                    DelegateContext::default(),
+                ),
             ],
             net_ops,
         ));
@@ -2498,7 +2542,11 @@ mod tests {
         );
         assert_eq!(
             resume.unresolved_contract_ops,
-            vec![(ContractInstanceId::new([9; 32]), ContractOpKind::Get)],
+            vec![(
+                ContractInstanceId::new([9; 32]),
+                ContractOpKind::Get,
+                DelegateContext::default()
+            )],
             "one completion must discharge exactly ONE of two identical \
              obligations, not both"
         );
@@ -2526,15 +2574,27 @@ mod tests {
             answers,
             fetches,
             vec![
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Get),
-                (ContractInstanceId::new([9; 32]), ContractOpKind::Subscribe),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Get,
+                    DelegateContext::default(),
+                ),
+                (
+                    ContractInstanceId::new([9; 32]),
+                    ContractOpKind::Subscribe,
+                    DelegateContext::default(),
+                ),
             ],
             net_ops,
         ));
         let resume = rx.recv().await.expect("resume");
         assert_eq!(
             resume.unresolved_contract_ops,
-            vec![(ContractInstanceId::new([9; 32]), ContractOpKind::Subscribe)],
+            vec![(
+                ContractInstanceId::new([9; 32]),
+                ContractOpKind::Subscribe,
+                DelegateContext::default()
+            )],
             "the SUBSCRIBE must still be owed after only the GET completed"
         );
     }
@@ -2551,9 +2611,12 @@ mod tests {
         op.context = DelegateContext::new(vec![0u8; N]);
         let charged = task_bytes(&[], &[], std::slice::from_ref(&op));
         assert!(
-            charged >= N,
-            "a pending network op must be charged for the context it retains, \
-             got {charged} for a {N}-byte context"
+            charged >= 2 * N,
+            "a pending network op retains its context TWICE — once in the \
+             off-loop task's `PendingContractOp` and once in the `ParkGuard`'s \
+             `owed_contract_ops`, which is what lets a synthesized failure hand \
+             the delegate back its own continuation state (#5542 F7) — so both \
+             copies must be charged; got {charged} for a {N}-byte context"
         );
     }
 

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -2522,10 +2522,7 @@ mod tests {
         let resume = rx.recv().await.expect("resume");
         assert_eq!(
             resume.unresolved_contract_ops,
-            vec![(
-                ContractInstanceId::new([9; 32]),
-                ContractOpKind::Subscribe
-            )],
+            vec![(ContractInstanceId::new([9; 32]), ContractOpKind::Subscribe)],
             "the SUBSCRIBE must still be owed after only the GET completed"
         );
     }

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -561,6 +561,17 @@ pub(super) struct Continuation {
     /// is correct — and is also why #5558 (a delegate notified of its own
     /// writes) is a separate unbounded loop that this does not close.
     pub iterations: usize,
+    /// Fire-and-forget self-heal GETs this round-trip has already started, so
+    /// `MAX_NETWORK_CONTRACT_OPS_PER_PARK` bounds the WHOLE round-trip rather
+    /// than each leg of it — the same defect as `iterations` above, one budget
+    /// over (#5542 finding B1).
+    ///
+    /// The parked GET/SUBSCRIBE half does not need this because parking itself
+    /// serialises it: `pending_contract_ops` being non-empty ends the run, and
+    /// parks are capped node-wide. The UPDATE self-heal starts a driver and
+    /// lets the loop continue, so nothing serialises it and the count has to be
+    /// carried explicitly.
+    pub self_heal_fetches_started: usize,
     pub params: Parameters<'static>,
     pub origin_contract: Option<ContractInstanceId>,
     pub connection_scope: ConnectionScope,
@@ -1523,6 +1534,7 @@ mod tests {
 
     fn continuation() -> Continuation {
         Continuation {
+            self_heal_fetches_started: 0,
             params: Parameters::from(Vec::new()),
             origin_contract: None,
             connection_scope: ConnectionScope::Local,

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -202,6 +202,32 @@ pub(super) const MAX_PENDING_NOTIFICATION_CONTRACTS: usize = 16;
 /// to the old behaviour beats dropping a delegate's write.
 pub(super) const MAX_DEFERRED_UPSERTS_PER_PARK: usize = 4;
 
+/// Per-park cap on delegate contract operations that must reach the NETWORK
+/// (#5542): a GET or SUBSCRIBE for a contract this node has never seen.
+///
+/// CALLER-SIDE BY DESIGN, and it has to be. `start_sub_op_get` has no
+/// concurrency bound of any kind and must not grow one: each of its existing
+/// callers is bounded by ITSELF, not by the primitive - phantom repair by
+/// `MAX_PHANTOM_REPAIRS_PER_INTERVAL` per pass, the deferred related fetch by
+/// `MAX_DEFERRED_UPSERTS_PER_PARK` x `MAX_RELATED_CONTRACTS_PER_REQUEST`,
+/// subscribe by one per subscribe. A bound inside the primitive would silently
+/// reshape all three, including the phantom-repair path that restores a hosting
+/// invariant.
+///
+/// 4, matching `MAX_DEFERRED_UPSERTS_PER_PARK`. One `process()` return may name
+/// arbitrarily many contracts this node has never seen, and each one is a full
+/// network GET, so the fan-out has to be capped where it is created. Node-wide
+/// worst case is `MAX_PARKED_DELEGATES` (64) x 4 = 256 delegate-originated
+/// network operations in flight, which matches the client path's
+/// `MAX_INFLIGHT_DEFERRALS` (256) rather than exceeding it.
+///
+/// Over the cap the excess is REFUSED, never run inline. #5544's park-cap
+/// fallback to an inline wait is explicitly NOT inheritable here, and says so at
+/// its own call site: "inline" for a delegate GET means a sub-op GET on the
+/// serial `contract_handling` loop for up to 120 s, reachable by any delegate
+/// once the other 63 park slots are taken.
+pub(super) const MAX_NETWORK_CONTRACT_OPS_PER_PARK: usize = 4;
+
 /// Node-wide cap on the bytes a park may hold (#5544 S4).
 ///
 /// `MAX_PARKED_DELEGATES` bounds the NUMBER of parks, which is not the same as
@@ -246,6 +272,7 @@ pub(super) fn continuation_bytes(continuation: &Continuation) -> usize {
 pub(super) fn task_bytes(
     prompts: &[freenet_stdlib::prelude::UserInputRequest<'static>],
     upserts: &[PendingUpsert],
+    contract_ops: &[PendingContractOp],
 ) -> usize {
     let prompt_bytes: usize = prompts
         .iter()
@@ -276,7 +303,17 @@ pub(super) fn task_bytes(
             update + code + related
         })
         .sum();
-    prompt_bytes + upsert_bytes
+    // RESIDUAL, stated rather than papered over: this charges what a pending
+    // network op holds AT ADMISSION - its echoed `DelegateContext` - and cannot
+    // charge the state the network will return, because that size is unknown
+    // until the GET completes. Same shape and same magnitude as the residual
+    // already carried by `PendingUpsert.missing`, whose fetched related states
+    // are likewise uncharged. `MAX_NETWORK_CONTRACT_OPS_PER_PARK` bounds the
+    // COUNT (4 per park), which is a count cap standing in for a byte cap - the
+    // pattern #5551 tracks. Bounding the arriving state properly belongs there,
+    // where it can be fixed for both paths at once, not duplicated here.
+    let contract_op_bytes: usize = contract_ops.iter().map(|op| ctx_len(&op.context)).sum();
+    prompt_bytes + upsert_bytes + contract_op_bytes
 }
 
 /// Approximate bytes a queued delegate request pins.
@@ -618,6 +655,61 @@ pub(super) struct ResolvedUpsert {
     pub fetched: Result<Vec<(ContractInstanceId, WrappedState)>, ExecutorError>,
 }
 
+/// Which delegate-originated network operation a [`PendingContractOp`] carries
+/// (#5542). Part of the identity a [`ParkGuard`] reconciles by, so a GET and a
+/// SUBSCRIBE naming the same contract are two distinct obligations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum ContractOpKind {
+    /// `GetContractRequest` for a contract this node has never seen.
+    Get,
+    /// `SubscribeContractRequest` for a contract this node has never seen.
+    Subscribe,
+}
+
+/// A delegate GET or SUBSCRIBE that the local store could not answer and which
+/// must therefore reach the network (#5542).
+///
+/// Off-loaded for the same reason as [`PendingUpsert`]: the work is a network
+/// operation, and awaiting one on the serial `contract_handling` loop freezes
+/// every contract operation on the node for its whole duration. Unlike an
+/// upsert, nothing has to be re-run on the loop afterwards - the response is
+/// pure data - but the SUBSCRIBE registry insert is still done there, so
+/// `DELEGATE_SUBSCRIPTIONS` is only ever written from one place.
+pub(super) struct PendingContractOp {
+    pub contract_id: ContractInstanceId,
+    pub kind: ContractOpKind,
+    /// Echoed back to the delegate so it can match the response to its request.
+    /// This is the continuation state that survives the park: the delegate's
+    /// own `DelegateContext` round-trips through the response.
+    pub context: DelegateContext,
+}
+
+/// What a [`PendingContractOp`]'s network work produced.
+pub(super) enum ContractOpOutcome {
+    /// A GET completed. `Some` is the state the network returned; `None` means
+    /// the network itself answered NotFound.
+    ///
+    /// NOTE the residual, which this type cannot fix: `GetContractResponse.state`
+    /// is a bare `Option<WrappedState>` in freenet-stdlib, so by the time this
+    /// reaches the delegate, "the network says this contract does not exist"
+    /// and "we could not reach the network" are both `None`. Distinguishing
+    /// them needs a stdlib wire change (#5542 scope item 4) and is deliberately
+    /// not faked here.
+    Fetched(Option<WrappedState>),
+    /// A SUBSCRIBE completed: the contract body was bootstrapped, a network
+    /// subscription was established and demand was registered.
+    Subscribed,
+    /// The operation failed - infrastructure error, exhausted retries, or no
+    /// `OpManager` on this executor.
+    Failed(String),
+}
+
+/// A [`PendingContractOp`] whose off-loop network work has finished.
+pub(super) struct ResolvedContractOp {
+    pub pending: PendingContractOp,
+    pub outcome: ContractOpOutcome,
+}
+
 /// Sent from an off-loop task back to the `contract_handling` loop.
 pub(super) struct DelegateResume {
     pub delegate_key: DelegateKey,
@@ -644,6 +736,13 @@ pub(super) struct DelegateResume {
     /// or ran out of budget. `(contract, is_put)`, turned into failure
     /// responses by the resume handler so the delegate is told.
     pub unresolved_upserts: Vec<(ContractInstanceId, bool)>,
+    /// Delegate GET/SUBSCRIBE operations whose network work finished off-loop
+    /// (#5542), turned into inbound responses on the loop.
+    pub contract_ops: Vec<ResolvedContractOp>,
+    /// Network operations the off-loop task never resolved, for the same three
+    /// reasons as `unresolved_upserts`. Turned into failure responses so the
+    /// delegate is told rather than left waiting for one that will never come.
+    pub unresolved_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
 }
 
 /// RAII guard guaranteeing an off-loop task delivers EXACTLY ONE
@@ -681,6 +780,17 @@ struct ParkGuardPayload {
     /// finished before a panic or cancellation (#5544 F2).
     answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
     fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
+    /// Network operations this park owes a response for, as
+    /// `(contract, kind)` (#5542). A MULTISET for the same reason as
+    /// `owed_upserts`: one `process()` return can emit two GETs naming the same
+    /// contract, and reconciling those by SET membership would let one
+    /// completion discharge both obligations, leaving the delegate waiting
+    /// forever for a response nothing remained to produce.
+    owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
+    /// Where the off-loop task deposits finished network operations, shared with
+    /// the task for the same reason as `answers` and `fetches`: so `Drop` can
+    /// see work that completed before a panic or cancellation (#5544 F2).
+    contract_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>>,
 }
 
 impl ParkGuard {
@@ -693,6 +803,8 @@ impl ParkGuard {
         owed_upserts: Vec<(ContractInstanceId, bool)>,
         answers: std::sync::Arc<std::sync::Mutex<Vec<InboundDelegateMsg<'static>>>>,
         fetches: std::sync::Arc<std::sync::Mutex<Vec<ResolvedUpsert>>>,
+        owed_contract_ops: Vec<(ContractInstanceId, ContractOpKind)>,
+        contract_ops: std::sync::Arc<std::sync::Mutex<Vec<ResolvedContractOp>>>,
     ) -> Self {
         Self {
             payload: Some(ParkGuardPayload {
@@ -703,6 +815,8 @@ impl ParkGuard {
                 owed_upserts,
                 answers,
                 fetches,
+                owed_contract_ops,
+                contract_ops,
             }),
         }
     }
@@ -728,10 +842,13 @@ impl ParkGuard {
             owed_upserts,
             answers,
             fetches,
+            owed_contract_ops,
+            contract_ops,
         } = p;
 
         let mut inbound = std::mem::take(&mut *answers.lock().unwrap());
         let upserts = std::mem::take(&mut *fetches.lock().unwrap());
+        let contract_ops = std::mem::take(&mut *contract_ops.lock().unwrap());
 
         // TERMINAL RESULTS ARE PRODUCED HERE, not in the task body, so that
         // EVERY exit produces them — including a panic or a cancellation, which
@@ -800,6 +917,31 @@ impl ParkGuard {
             );
         }
 
+        // Same count-not-set reconciliation as the upserts above, for the same
+        // reason (#5544 F1/F3): `owed_contract_ops` is a multiset.
+        let mut resolved_ops: HashMap<(ContractInstanceId, ContractOpKind), usize> = HashMap::new();
+        for r in &contract_ops {
+            *resolved_ops
+                .entry((r.pending.contract_id, r.pending.kind))
+                .or_default() += 1;
+        }
+        let mut unresolved_contract_ops = Vec::new();
+        for (id, kind) in owed_contract_ops {
+            match resolved_ops.get_mut(&(id, kind)) {
+                Some(n) if *n > 0 => *n -= 1,
+                _ => unresolved_contract_ops.push((id, kind)),
+            }
+        }
+        if !unresolved_contract_ops.is_empty() {
+            tracing::warn!(
+                delegate = %delegate_key,
+                count = unresolved_contract_ops.len(),
+                "Off-loop delegate work ended without resolving every network \
+                 contract operation; synthesizing failures so the delegate is \
+                 told rather than left waiting (#5542)"
+            );
+        }
+
         if resume_tx
             .send(DelegateResume {
                 delegate_key: delegate_key.clone(),
@@ -808,6 +950,8 @@ impl ParkGuard {
                 inbound,
                 upserts,
                 unresolved_upserts,
+                contract_ops,
+                unresolved_contract_ops,
             })
             .is_err()
         {

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -874,9 +874,29 @@ impl ParkGuard {
             contract_ops,
         } = p;
 
-        let mut inbound = std::mem::take(&mut *answers.lock().unwrap());
-        let upserts = std::mem::take(&mut *fetches.lock().unwrap());
-        let contract_ops = std::mem::take(&mut *contract_ops.lock().unwrap());
+        // NEVER `.unwrap()` HERE. `deliver` runs from `Drop`, `Drop` runs while
+        // the off-loop task is UNWINDING from a panic, and that task holds these
+        // very locks across the expressions it pushes into them — so the mutex
+        // it panicked under is poisoned. `.unwrap()` on a poisoned mutex panics,
+        // and a panic in `Drop` during unwinding ABORTS THE PROCESS: no
+        // unwinding, no other delegate's park resumed, no client answered.
+        //
+        // The poison flag carries no information this path can act on. The data
+        // is a plain `Vec` of already-built results; a writer that died
+        // mid-push leaves it structurally intact, and delivering what is there
+        // is exactly what every other exit does. Take the inner value.
+        //
+        // All three converted together on purpose. Poison-tolerance is a
+        // property of the WHOLE Drop path, not of one lock in it: leaving any
+        // one as `.unwrap()` leaves the abort reachable, so a partial
+        // conversion reads as fixed while the failure mode is unchanged.
+        // (#5606 is converting the first two for this same reason; #5615 added
+        // the third. Whichever lands second must confirm all three, not just
+        // its own.)
+        let mut inbound = std::mem::take(&mut *answers.lock().unwrap_or_else(|e| e.into_inner()));
+        let upserts = std::mem::take(&mut *fetches.lock().unwrap_or_else(|e| e.into_inner()));
+        let contract_ops =
+            std::mem::take(&mut *contract_ops.lock().unwrap_or_else(|e| e.into_inner()));
 
         // TERMINAL RESULTS ARE PRODUCED HERE, not in the task body, so that
         // EVERY exit produces them — including a panic or a cancellation, which

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -288,6 +288,14 @@ impl Executor<Runtime> {
                     subscribers.remove(&key);
                     !subscribers.is_empty()
                 });
+                // ...and give back the local interest those subscriptions took
+                // (#5542). Dropping the subscription without this leaves
+                // `local_interests` permanently above zero for the contract, so
+                // `cleanup_contract_if_no_interest` never fires and the node
+                // holds demand nothing can retire. A pair that took no refcount
+                // — a subscribe answered from the local store, or the V2 host
+                // function — has no hold recorded, so this is a no-op for it.
+                crate::wasm_runtime::delegate_interest::release_delegate(&key);
 
                 // Clean up delegate creation tracking to prevent unbounded growth
                 self.runtime.inherited_origins.remove(&key);

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2433,8 +2433,10 @@ where
                         "Delegate notification channel closed — removing stale subscriptions"
                     );
                     // Receiver is gone; clean up all subscriptions for this contract
-                    // to prevent repeated failed sends on future state updates.
+                    // to prevent repeated failed sends on future state updates,
+                    // and release the interest they took (#5542).
                     crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&instance_id);
+                    crate::wasm_runtime::delegate_interest::release_contract(&instance_id);
                     return;
                 }
             }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -282,6 +282,23 @@ pub(crate) struct OpManager {
     /// Maps contract instance ID to the timestamp (ms since epoch via GlobalSimulationTime)
     /// when the fetch was initiated, with a cooldown to avoid repeated fetch attempts.
     pub(crate) pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>>,
+    /// Identity of this `OpManager` instance, unique for the life of the
+    /// process (#5542 finding C).
+    ///
+    /// Used as the node component of a key in the process-global
+    /// `wasm_runtime::delegate_interest` hold map, which has to distinguish two
+    /// nodes running in ONE process — the in-process multi-node test harness.
+    ///
+    /// A MONOTONIC COUNTER, not `Arc::as_ptr`. The pointer was the obvious
+    /// choice and is wrong: `OpManager` has no `Drop`, and glibc's tcache
+    /// reuses freed allocations LIFO, so a second `OpManager` can land on a
+    /// dropped one's address and silently inherit its identity — at which point
+    /// its `record` is discarded as a duplicate and its refcount leaks. That is
+    /// reachable only under `cargo test`, because the binary uses jemalloc and
+    /// the test harness does not; `cargo test` is the runner `AGENTS.md` tells
+    /// contributors to use, and the one where cross-test interference is
+    /// observable at all (#5314).
+    pub(crate) node_identity: crate::wasm_runtime::delegate_interest::NodeIdentity,
     /// Transactions with an active driver relay-GET driver at this
     /// node. Populated by `start_relay_get` before spawn and removed by
     /// an RAII guard on the driver task. Consulted by the dispatch gate
@@ -373,6 +390,9 @@ impl Clone for OpManager {
             blocked_addresses: self.blocked_addresses.clone(),
             configured_gateways: self.configured_gateways.clone(),
             pending_contract_fetches: self.pending_contract_fetches.clone(),
+            // The SAME node, so the same identity. A fresh id here would make
+            // one node look like two to the delegate-interest hold map.
+            node_identity: self.node_identity,
             active_relay_get_txs: self.active_relay_get_txs.clone(),
             active_relay_update_txs: self.active_relay_update_txs.clone(),
             active_relay_put_txs: self.active_relay_put_txs.clone(),
@@ -566,6 +586,11 @@ impl OpManager {
         result_router_tx: mpsc::Sender<(Transaction, HostResult)>,
         task_monitor: &super::background_task_monitor::BackgroundTaskMonitor,
     ) -> anyhow::Result<Self> {
+        // Monotonic per-process instance id. `Relaxed` is sufficient: the only
+        // requirement is uniqueness, not ordering against other memory.
+        static NEXT_NODE_IDENTITY: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(1);
+        let node_identity = NEXT_NODE_IDENTITY.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let ring = Ring::new(
             config,
             notification_channel.clone(),
@@ -724,6 +749,7 @@ impl OpManager {
                     .collect(),
             ),
             pending_contract_fetches,
+            node_identity,
             active_relay_get_txs,
             active_relay_update_txs,
             active_relay_put_txs,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -339,6 +339,22 @@ impl OpManager {
         use crate::config::GlobalSimulationTime;
         use dashmap::mapref::entry::Entry;
 
+        // EGRESS BAN GATE (#5542 finding B2). `try_auto_fetch_contract`'s
+        // client-originated sibling is reached only from paths that already
+        // passed `reject_if_contract_banned` at `start_client_update`; this one
+        // is reached from a delegate, which never crosses a client entry point.
+        // Without this check a delegate could make this node originate network
+        // traffic for a contract it has banned, defeating the egress half of the
+        // invariant documented at `operations.rs`.
+        if crate::operations::reject_if_contract_banned(self, &instance_id).is_err() {
+            tracing::debug!(
+                contract = %instance_id,
+                phase = "egress_banned_reject",
+                "Not starting a delegate-originated self-heal fetch: contract is banned"
+            );
+            return false;
+        }
+
         // A fetch that cannot possibly route must NOT burn the shared 5-minute
         // slot, and must not be reported to the delegate as started (#5542,
         // review finding 5B). `try_auto_fetch_contract` has the same discipline:
@@ -3480,6 +3496,54 @@ mod tests {
             "a second attempt inside CONTRACT_FETCH_COOLDOWN_MS must be refused, and \
              must REPORT the refusal so the delegate is not promised a repair that \
              is not running"
+        );
+    }
+
+    /// A delegate must not be able to make this node originate network traffic
+    /// for a contract it has BANNED (#5542 finding B2).
+    ///
+    /// `reject_if_contract_banned` runs at the top of every CLIENT originator
+    /// entry point, so the egress half of the ban invariant — a banned contract
+    /// can neither receive new state via this node nor transmit new state via it
+    /// — held for every path that crosses one. The delegate paths call the
+    /// internal drivers directly and crossed none of them, so this fetch was
+    /// reachable for a banned contract.
+    ///
+    /// The assertion on the cooldown map is the one that matters: refusing while
+    /// still taking the slot would be a second bug wearing the first one's fix.
+    #[tokio::test]
+    async fn a_banned_contract_gets_no_delegate_self_heal_fetch() {
+        let (op_manager, _rx, _guard) = build_notification_test_node("selfheal_5542_banned").await;
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([79u8; 32]);
+        let _peer = connect_peer(&op_manager, 45_503, 0.5);
+
+        op_manager.ring.contract_ban_list.ban(
+            instance_id,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(3600),
+            crate::ring::contract_ban_list::BanReason::AutoMad,
+        );
+        assert!(
+            op_manager.ring.contract_ban_list.is_banned(&instance_id),
+            "the ban must be in force, or this test proves nothing"
+        );
+
+        assert!(
+            !op_manager.try_self_heal_fetch_for_local_originator(instance_id),
+            "a banned contract must not get a delegate-originated network fetch"
+        );
+        assert!(
+            !op_manager
+                .pending_contract_fetches
+                .contains_key(&instance_id),
+            "and the refusal must not burn the shared cooldown slot"
+        );
+
+        // An UNBANNED contract on the same node still proceeds, so the refusal
+        // above is the ban and not some unrelated precondition.
+        let allowed = freenet_stdlib::prelude::ContractInstanceId::new([80u8; 32]);
+        assert!(
+            op_manager.try_self_heal_fetch_for_local_originator(allowed),
+            "an unbanned contract must still be fetchable on this node"
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -301,6 +301,78 @@ impl OpManager {
         let _tx = super::get::op_ctx_task::start_targeted_sub_op_get(self, instance_id, sender_pkl);
     }
 
+    /// Self-heal a contract a LOCAL ORIGINATOR asked to update but this node
+    /// does not hold, when there is no sender to fetch it from (#5542).
+    ///
+    /// This is [`try_auto_fetch_contract`](Self::try_auto_fetch_contract)'s
+    /// sibling for the delegate path, and it exists because that function
+    /// cannot serve it — for two independent reasons, both structural:
+    ///
+    /// * it needs a `sender_addr` to resolve a first-hop `PeerKeyLocation`, and
+    ///   a delegate UPDATE has no sender. The delegate IS the originator, on
+    ///   this node. Passing an address that resolves to nothing makes that
+    ///   function log "cannot auto-fetch", release its cooldown slot and return
+    ///   — a silent no-op, which is the worst of the three outcomes.
+    /// * it takes a `&ContractKey`, and for the case that matters here — a
+    ///   contract this node has never seen — a delegate holds only a
+    ///   `ContractInstanceId` and cannot construct one.
+    ///
+    /// So the fetch is an untargeted [`start_sub_op_get`], which routes on the
+    /// instance id alone, rather than a targeted one. Everything else is
+    /// deliberately identical to the originator path, including SHARING
+    /// `pending_contract_fetches` — one cooldown covers both, so a delegate and
+    /// a client asking for the same contract do not fetch it twice.
+    ///
+    /// Returns whether a fetch was started, so the caller can tell the delegate
+    /// honestly whether a retry has anything to wait for.
+    ///
+    /// Fire-and-forget: the caller does NOT await it. The point is the side
+    /// effect — the contract cached locally — so the delegate's next attempt
+    /// succeeds, matching the client contract of "fail now, self-heal in the
+    /// background, the retry succeeds".
+    pub(crate) fn try_self_heal_fetch_for_local_originator(
+        &self,
+        instance_id: freenet_stdlib::prelude::ContractInstanceId,
+    ) -> bool {
+        use crate::config::GlobalSimulationTime;
+        use dashmap::mapref::entry::Entry;
+
+        let now_ms = GlobalSimulationTime::read_time_ms();
+        // Same atomic entry-API rate limit as the originator path, against the
+        // same map, for the same reason: check-then-insert would race.
+        match self.pending_contract_fetches.entry(instance_id) {
+            Entry::Occupied(mut existing) => {
+                let elapsed_ms = now_ms.saturating_sub(*existing.get());
+                if elapsed_ms < CONTRACT_FETCH_COOLDOWN_MS {
+                    tracing::debug!(
+                        contract = %instance_id,
+                        "Delegate-originated self-heal fetch still in cooldown"
+                    );
+                    return false;
+                }
+                *existing.get_mut() = now_ms;
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(now_ms);
+            }
+        }
+
+        tracing::info!(
+            contract = %instance_id,
+            "Auto-fetching a contract a delegate tried to UPDATE but this node \
+             does not hold (#5542)"
+        );
+        // Receiver dropped: the caller wants the caching side effect, not the
+        // result. The driver logs its own outcome and self-terminates at
+        // OPERATION_TTL.
+        let (_tx, _rx) = super::get::op_ctx_task::start_sub_op_get(
+            self,
+            instance_id,
+            /* return_contract_code */ true,
+        );
+        true
+    }
+
     /// The advertised co-hosts of a contract: peers that announced, via the
     /// advertisement layer, that they host it.
     ///

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3440,7 +3440,9 @@ mod tests {
             "the first attempt must start a fetch and say so"
         );
         assert!(
-            op_manager.pending_contract_fetches.contains_key(&instance_id),
+            op_manager
+                .pending_contract_fetches
+                .contains_key(&instance_id),
             "the attempt must be recorded in the SHARED cooldown map, or a client \
              asking for the same contract fetches it a second time"
         );

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -356,22 +356,29 @@ impl OpManager {
         }
 
         // A fetch that cannot possibly route must NOT burn the shared 5-minute
-        // slot, and must not be reported to the delegate as started (#5542,
-        // review finding 5B). `try_auto_fetch_contract` has the same discipline:
-        // it takes the slot, fails to resolve a first-hop peer, and RELEASES the
-        // slot before returning. This path routes untargeted, so it has no
-        // first-hop peer to resolve; the equivalent precondition is having any
-        // connection at all. Checked BEFORE the slot is taken rather than
-        // released after, because there is nothing to undo.
+        // slot, and must not be reported to the delegate as started (#5542
+        // finding 5B). `try_auto_fetch_contract` has the same discipline: it
+        // takes the slot, fails to resolve a first-hop peer, and RELEASES it.
         //
-        // Without this, a node with no connections told the delegate "a
-        // background fetch has been started, so retry shortly" and then refused
-        // every retry for five minutes — the opposite of the honesty this
-        // message exists to provide.
-        if self.ring.connection_manager.num_connections() == 0 {
+        // "CANNOT ROUTE" IS NOT "ZERO PROMOTED CONNECTIONS", and conflating the
+        // two disabled this path for the whole bootstrap window. A node that
+        // has joined but not yet promoted any connection still reaches the
+        // network through a configured gateway: `start_sub_op_get`'s drivers all
+        // consult `bootstrap_gateway_target` for exactly that case, and there is
+        // a pin in `get/op_ctx_task.rs` requiring them to. Checking
+        // `num_connections() == 0` here refused before the primitive could use
+        // the fallback it already has, so delegate UPDATE self-healing was off
+        // until ring promotion — on a path this PR exists to add.
+        //
+        // Ask the same question the driver asks: no promoted connections AND no
+        // usable configured gateway.
+        let can_route = self.ring.connection_manager.connection_count() > 0
+            || crate::operations::bootstrap::bootstrap_gateway_target(self, |_| false).is_some();
+        if !can_route {
             tracing::debug!(
                 contract = %instance_id,
-                "Not starting a delegate-originated self-heal fetch: no connections"
+                "Not starting a delegate-originated self-heal fetch: no promoted \
+                 connections and no usable configured gateway"
             );
             return false;
         }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -324,7 +324,9 @@ impl OpManager {
     /// a client asking for the same contract do not fetch it twice.
     ///
     /// Returns whether a fetch was started, so the caller can tell the delegate
-    /// honestly whether a retry has anything to wait for.
+    /// honestly whether a retry has anything to wait for. `false` for a node
+    /// with no connections and for a contract still inside the shared cooldown;
+    /// neither takes or holds a cooldown slot it cannot use.
     ///
     /// Fire-and-forget: the caller does NOT await it. The point is the side
     /// effect — the contract cached locally — so the delegate's next attempt
@@ -336,6 +338,27 @@ impl OpManager {
     ) -> bool {
         use crate::config::GlobalSimulationTime;
         use dashmap::mapref::entry::Entry;
+
+        // A fetch that cannot possibly route must NOT burn the shared 5-minute
+        // slot, and must not be reported to the delegate as started (#5542,
+        // review finding 5B). `try_auto_fetch_contract` has the same discipline:
+        // it takes the slot, fails to resolve a first-hop peer, and RELEASES the
+        // slot before returning. This path routes untargeted, so it has no
+        // first-hop peer to resolve; the equivalent precondition is having any
+        // connection at all. Checked BEFORE the slot is taken rather than
+        // released after, because there is nothing to undo.
+        //
+        // Without this, a node with no connections told the delegate "a
+        // background fetch has been started, so retry shortly" and then refused
+        // every retry for five minutes — the opposite of the honesty this
+        // message exists to provide.
+        if self.ring.connection_manager.num_connections() == 0 {
+            tracing::debug!(
+                contract = %instance_id,
+                "Not starting a delegate-originated self-heal fetch: no connections"
+            );
+            return false;
+        }
 
         let now_ms = GlobalSimulationTime::read_time_ms();
         // Same atomic entry-API rate limit as the originator path, against the
@@ -3434,6 +3457,12 @@ mod tests {
     async fn delegate_self_heal_fetch_shares_the_originator_cooldown_and_reports_it() {
         let (op_manager, _rx, _guard) = build_notification_test_node("selfheal_5542").await;
         let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([77u8; 32]);
+        // A connection is now a PRECONDITION, not scenery: a node with none
+        // cannot route the fetch, so it refuses rather than burning the shared
+        // cooldown slot (finding 5B, and its own test below). This test is about
+        // the cooldown being SHARED and REPORTED, so give it the connectivity
+        // that case assumes.
+        let _peer = connect_peer(&op_manager, 45_501, 0.25);
 
         assert!(
             op_manager.try_self_heal_fetch_for_local_originator(instance_id),
@@ -3451,6 +3480,49 @@ mod tests {
             "a second attempt inside CONTRACT_FETCH_COOLDOWN_MS must be refused, and \
              must REPORT the refusal so the delegate is not promised a repair that \
              is not running"
+        );
+    }
+
+    /// A node with no connections must NOT burn the shared five-minute cooldown
+    /// slot, and must not tell the delegate a fetch started (#5542, finding 5B).
+    ///
+    /// `try_auto_fetch_contract` already has this discipline: it takes the slot,
+    /// fails to resolve a first-hop peer, and RELEASES it (`update.rs`, the
+    /// `get_peer_by_addr` miss). The self-heal path routes untargeted, so it has
+    /// no first-hop peer to resolve and had no equivalent check — it took the
+    /// slot unconditionally and returned `true`. The delegate was then told "a
+    /// background fetch has been started, so retry shortly" and every retry for
+    /// the next five minutes was refused by the slot the failed attempt had
+    /// taken, which is the exact opposite of the honesty this return value
+    /// exists to provide.
+    #[tokio::test]
+    async fn a_self_heal_fetch_with_no_connections_takes_no_cooldown_slot() {
+        let (op_manager, _rx, _guard) = build_notification_test_node("selfheal_5542_noconn").await;
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([78u8; 32]);
+        assert_eq!(
+            op_manager.ring.connection_manager.num_connections(),
+            0,
+            "this test is only meaningful on a node that cannot route"
+        );
+
+        assert!(
+            !op_manager.try_self_heal_fetch_for_local_originator(instance_id),
+            "a fetch that cannot route must be reported as not started"
+        );
+        assert!(
+            !op_manager
+                .pending_contract_fetches
+                .contains_key(&instance_id),
+            "and it must not hold the shared cooldown slot, or the delegate's \
+             retries are refused for five minutes by an attempt that never ran"
+        );
+
+        // With a connection the same call proceeds, so the refusal above is the
+        // connectivity check and not some unrelated precondition.
+        let _peer = connect_peer(&op_manager, 45_502, 0.75);
+        assert!(
+            op_manager.try_self_heal_fetch_for_local_originator(instance_id),
+            "the same contract must be fetchable once the node can route"
         );
     }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -3422,6 +3422,36 @@ mod tests {
         (op_manager, notifications_receiver, guard)
     }
 
+    /// #5542. The delegate self-heal fetch shares the CLIENT originator path's
+    /// cooldown, and reports honestly whether it actually started one.
+    ///
+    /// Both halves are load-bearing and neither is visible from the call site.
+    /// The shared map is what stops a delegate and a client fetching the same
+    /// contract twice. The return value is what the delegate's error message is
+    /// built from: told "a background fetch has been started" when none was, a
+    /// delegate retries into a five-minute silence with no way to know why.
+    #[tokio::test]
+    async fn delegate_self_heal_fetch_shares_the_originator_cooldown_and_reports_it() {
+        let (op_manager, _rx, _guard) = build_notification_test_node("selfheal_5542").await;
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([77u8; 32]);
+
+        assert!(
+            op_manager.try_self_heal_fetch_for_local_originator(instance_id),
+            "the first attempt must start a fetch and say so"
+        );
+        assert!(
+            op_manager.pending_contract_fetches.contains_key(&instance_id),
+            "the attempt must be recorded in the SHARED cooldown map, or a client \
+             asking for the same contract fetches it a second time"
+        );
+        assert!(
+            !op_manager.try_self_heal_fetch_for_local_originator(instance_id),
+            "a second attempt inside CONTRACT_FETCH_COOLDOWN_MS must be refused, and \
+             must REPORT the refusal so the delegate is not promised a repair that \
+             is not running"
+        );
+    }
+
     /// Connect a peer and return `(pub_key, addr)`.
     fn connect_peer(
         op_manager: &OpManager,

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -4049,8 +4049,7 @@ mod tests {
             ContractInstanceId::new([7u8; 32]),
             CodeHash::new([9u8; 32]),
         );
-        let instance_only =
-            ContractKey::from_id_and_code(*full.id(), CodeHash::new([0u8; 32]));
+        let instance_only = ContractKey::from_id_and_code(*full.id(), CodeHash::new([0u8; 32]));
 
         assert!(manager.add_local_client(&full));
         assert!(manager.has_local_interest(&full));

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -4027,6 +4027,49 @@ mod tests {
         (manager, time_source)
     }
 
+    /// A local-client refcount taken with a FULL `ContractKey` is released by an
+    /// instance-only key, and the hash index is cleaned up with it.
+    ///
+    /// This is the property `contract.rs`'s delegate-subscribe interest hold
+    /// relies on (#5542): a subscribe whose body fetch timed out has no code
+    /// blob, so the code hash is unavailable at release time and the release
+    /// runs against `ContractKey::from_id_and_code(id, CodeHash::new([0; 32]))`.
+    /// It holds because `ContractKey`'s `Hash`/`Eq` are instance-only
+    /// (freenet-stdlib `contract_interface/key.rs`) and `contract_hash` reads
+    /// `id().as_bytes()`.
+    ///
+    /// Pinned HERE rather than trusted, because it is a property of a
+    /// DEPENDENCY. If freenet-stdlib ever folds the code hash into
+    /// `ContractKey`'s equality, that release silently stops matching and the
+    /// leak returns with no other signal.
+    #[test]
+    fn an_instance_only_key_releases_interest_taken_with_the_full_key() {
+        let (manager, _time) = make_manager();
+        let full = ContractKey::from_id_and_code(
+            ContractInstanceId::new([7u8; 32]),
+            CodeHash::new([9u8; 32]),
+        );
+        let instance_only =
+            ContractKey::from_id_and_code(*full.id(), CodeHash::new([0u8; 32]));
+
+        assert!(manager.add_local_client(&full));
+        assert!(manager.has_local_interest(&full));
+        assert!(
+            manager.lookup_by_hash(contract_hash(&full)).contains(&full),
+            "the acquisition must have indexed the contract"
+        );
+
+        assert!(
+            manager.remove_local_client(&instance_only),
+            "releasing with an instance-only key must drop the last interest"
+        );
+        assert!(!manager.has_local_interest(&full));
+        assert!(
+            manager.lookup_by_hash(contract_hash(&full)).is_empty(),
+            "cleanup_contract_if_no_interest must have unindexed it too"
+        );
+    }
+
     /// Wiring pin for the SHADOW-MODE futile-repair detector's attempt
     /// lifetime.
     ///

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -2,6 +2,7 @@ mod contract;
 mod contract_store;
 mod delegate;
 pub(crate) mod delegate_api;
+pub(crate) mod delegate_interest;
 mod delegate_store;
 pub(crate) mod engine;
 mod error;

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -522,8 +522,12 @@ impl ContractStore {
             .map_err(|e| anyhow::anyhow!("Failed to remove contract index: {e}"))?;
         self.key_to_code_part.remove(key.id());
 
-        // Clean up any delegate subscriptions for this contract instance.
+        // Clean up any delegate subscriptions for this contract instance, and
+        // release the local interest they took (#5542). The release is
+        // self-discharging — each hold carries its own node's closure — so this
+        // module keeps no `crate::ring` dependency.
         super::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        super::delegate_interest::release_contract(key.id());
 
         // The WASM blob on disk is keyed by code hash and shared by every
         // contract instance with the same code (e.g. all River rooms share

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -1,0 +1,349 @@
+//! Interest a delegate subscription took, and the obligation to give it back
+//! (#5542).
+//!
+//! # Why this exists
+//!
+//! Before #5542 the V1 delegate SUBSCRIBE arm inserted into
+//! [`DELEGATE_SUBSCRIPTIONS`](super::DELEGATE_SUBSCRIPTIONS) and did nothing
+//! else. The registry is a `HashSet`, so a re-subscribe was idempotent for free
+//! and there was no accounting to get wrong.
+//!
+//! #5542 routes a subscribe for a contract this node does not hold through
+//! `run_executor_subscribe`, which ends in
+//! `InterestManager::add_local_client` — a per-CONTRACT **refcount**, taking no
+//! client id, explicitly non-idempotent. That is the demand registration the
+//! feature needs: without it the contract is evicted out from under the
+//! subscription. But it introduced an asymmetry, because **nothing on any
+//! delegate path can decrement it**. The only decrement outside
+//! `ring/interest.rs` is driven by `remove_client_from_all_subscriptions`
+//! on a WebSocket `Disconnect`, keyed by `ClientId`, and a delegate has no
+//! `ClientId` in this tree.
+//!
+//! The plain happy path was never the problem: a delegate subscription is
+//! permanent, so a permanent local interest matching it is what we want. What
+//! was missing is that subscription **removal** was not wired to interest
+//! **release**, and three routine paths drop a delegate subscription —
+//! `UnregisterDelegate`, contract removal, and notification-channel-closed
+//! cleanup. `UnregisterDelegate` is an everyday operation, not an edge case.
+//! Left unwired, `local_interests` never returns to zero for that contract and
+//! `cleanup_contract_if_no_interest` never fires: demand nothing can retire, on
+//! the interest path #5467 exists to make trustworthy.
+//!
+//! # Shape, and why it is this one
+//!
+//! Each hold is **self-discharging**: it stores the `ContractKey` to release
+//! and a type-erased closure that performs the release. Two consequences, both
+//! deliberate:
+//!
+//! * **No `crate::ring` dependency here.** The removal sites live in
+//!   `wasm_runtime`, `InterestManager` lives in `ring`, and the closure is
+//!   built where an `OpManager` is already in hand. Same trick as the
+//!   `state_write_callback` / `state_admit_callback` hooks on `Runtime`.
+//! * **Per-node, not process-global behaviour.** The map itself is a global,
+//!   matching the registry it shadows, but each hold carries ITS OWN node's
+//!   release closure. A single global callback bound to one node's `OpManager`
+//!   would release the wrong node's interest under the in-process multi-node
+//!   test harness, where these globals are already shared (#4824).
+//!
+//! The closure captures a `Weak<OpManager>`, so a hold never keeps a shut-down
+//! node's `OpManager` alive; a hold that cannot upgrade has nothing left to
+//! release and is simply dropped.
+//!
+//! # What is recorded, and what deliberately is not
+//!
+//! **Only acquisitions this node actually made.** A subscribe answered from the
+//! local store takes no refcount, and neither does the V2
+//! `subscribe_contract_sync` host function — both only insert the registry
+//! hook. So this map is a strict subset of `DELEGATE_SUBSCRIPTIONS`, keyed by
+//! the same pair, and releasing is driven from HERE rather than from the
+//! registry. That is what makes over-release impossible: an entry exists if and
+//! only if `add_local_client` ran for that pair, so a decrement can never fall
+//! on interest some other subscriber holds — which would be strictly worse than
+//! the leak it was trying to fix.
+//!
+//! This is not a mirror of the subscription set that has to be kept in step
+//! with it; it is a record of outstanding obligations, and it may legitimately
+//! be smaller. Anything that removes a subscription may call the release
+//! functions unconditionally: a pair with no hold is a no-op.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, DelegateKey};
+
+/// Performs the actual `InterestManager::remove_local_client`. Type-erased so
+/// this module needs no `crate::ring` or `crate::node` dependency.
+pub type InterestRelease = Arc<dyn Fn(&ContractKey) + Send + Sync>;
+
+struct Hold {
+    key: ContractKey,
+    release: InterestRelease,
+}
+
+/// Outstanding local-interest refcounts taken on behalf of delegate
+/// subscriptions, keyed by the `(contract, delegate)` pair that owns them.
+static DELEGATE_INTEREST_HOLDS: std::sync::LazyLock<
+    DashMap<(ContractInstanceId, DelegateKey), Hold>,
+> = std::sync::LazyLock::new(DashMap::new);
+
+/// Record that one local-interest refcount was taken for
+/// `(contract, delegate)`, and how to give it back.
+///
+/// Idempotent per pair: recording twice keeps ONE obligation, matching the
+/// caller's own guarantee that it increments at most once per pair (the
+/// `already_subscribed` gate plus the in-round de-duplication). If that
+/// guarantee were ever broken, holding one obligation for two increments leaks
+/// — which is the safe direction, since the alternative is releasing interest
+/// that was never taken.
+pub(crate) fn record(
+    contract: ContractInstanceId,
+    delegate: DelegateKey,
+    key: ContractKey,
+    release: InterestRelease,
+) {
+    DELEGATE_INTEREST_HOLDS
+        .entry((contract, delegate))
+        .or_insert(Hold { key, release });
+}
+
+/// Release every hold taken for `delegate`, across all contracts.
+///
+/// Called from `UnregisterDelegate`, which drops the delegate from every
+/// subscription entry.
+pub(crate) fn release_delegate(delegate: &DelegateKey) {
+    // Collect first: `retain` holds shard locks, and a release closure reaches
+    // into `InterestManager`, which takes its own locks. Doing that under a
+    // DashMap shard guard is how lock-order inversions get built.
+    let mut discharged = Vec::new();
+    DELEGATE_INTEREST_HOLDS.retain(|(_, holder), hold| {
+        if holder == delegate {
+            discharged.push((hold.key, hold.release.clone()));
+            false
+        } else {
+            true
+        }
+    });
+    for (key, release) in discharged {
+        release(&key);
+    }
+}
+
+/// Release every hold taken for `contract`, across all delegates.
+///
+/// Called from contract removal and from notification-channel-closed cleanup,
+/// both of which drop every delegate subscription for one contract.
+pub(crate) fn release_contract(contract: &ContractInstanceId) {
+    let mut discharged = Vec::new();
+    DELEGATE_INTEREST_HOLDS.retain(|(id, _), hold| {
+        if id == contract {
+            discharged.push((hold.key, hold.release.clone()));
+            false
+        } else {
+            true
+        }
+    });
+    for (key, release) in discharged {
+        release(&key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! ISOLATION CONTRACT for anything added here: `DELEGATE_INTEREST_HOLDS` is
+    //! a process global and `cargo test` runs these in parallel, so a test must
+    //! (a) use key bytes no sibling uses, and (b) NEVER clear the map or assert
+    //! on its total size. An earlier version of these tests ended with
+    //! `DELEGATE_INTEREST_HOLDS.clear()`, which wiped siblings' entries
+    //! mid-run and made all three fail against correct code. Assert on the
+    //! specific pairs you created.
+    use super::*;
+    use freenet_stdlib::prelude::CodeHash;
+    use std::sync::Mutex;
+
+    fn key(byte: u8) -> ContractKey {
+        ContractKey::from_id_and_code(
+            ContractInstanceId::new([byte; 32]),
+            CodeHash::new([byte; 32]),
+        )
+    }
+
+    fn delegate(byte: u8) -> DelegateKey {
+        DelegateKey::new([byte; 32], CodeHash::new([byte; 32]))
+    }
+
+    /// The three sites that DROP a delegate subscription must each release the
+    /// interest it held. The module tests above prove the mechanism; these
+    /// prove it is actually reached, which is the half that silently rots — a
+    /// release function nobody calls is indistinguishable from the leak it was
+    /// written to close.
+    ///
+    /// Source-level rather than behavioural because two of the three sites sit
+    /// inside `UnregisterDelegate` / notification-dispatch paths that need a
+    /// live executor and a live notification channel to reach. If you make
+    /// those reachable in a unit test, replace these.
+    #[test]
+    fn every_subscription_removal_site_releases_its_interest() {
+        // `UnregisterDelegate` — an ORDINARY operation, not an edge case.
+        let delegates = include_str!("../contract/executor/runtime/delegates.rs");
+        let unregister = delegates
+            .split("DelegateRequest::UnregisterDelegate(key) => {")
+            .nth(1)
+            .expect("the UnregisterDelegate arm must exist");
+        assert!(
+            unregister.contains("delegate_interest::release_delegate(&key)"),
+            "UnregisterDelegate drops the delegate from every subscription entry, \
+             so it must also give back the local interest those subscriptions \
+             took; without it `local_interests` never returns to zero and \
+             `cleanup_contract_if_no_interest` never fires (#5542)"
+        );
+
+        // Contract removal.
+        let store = include_str!("contract_store.rs");
+        assert!(
+            store.contains("delegate_interest::release_contract(key.id())"),
+            "removing a contract drops its delegate subscriptions, so it must \
+             release the interest they took (#5542)"
+        );
+
+        // Notification-channel-closed cleanup.
+        let executor = include_str!("../contract/executor/runtime/executor_impl.rs");
+        assert!(
+            executor.contains("delegate_interest::release_contract(&instance_id)"),
+            "channel-closed cleanup removes every subscription for the contract, \
+             so it must release the interest they took (#5542)"
+        );
+    }
+
+    /// The obligation must be RECORDED where the refcount is taken, or the
+    /// release sites above have nothing to discharge and the whole mechanism is
+    /// inert while looking present.
+    #[test]
+    fn the_subscribe_path_records_the_obligation_it_incurs() {
+        let contract = include_str!("../contract.rs");
+        let body = contract
+            .split("fn apply_resolved_contract_op<CH>(")
+            .nth(1)
+            .expect("apply_resolved_contract_op must exist");
+        let body = &body[..body.find("\nfn ").unwrap_or(body.len())];
+        assert!(
+            body.contains("delegate_interest::record("),
+            "the site that installs the DELEGATE_SUBSCRIPTIONS hook after a \
+             successful network subscribe is the site that took the \
+             `add_local_client` refcount, so it must record the obligation to \
+             release it (#5542)"
+        );
+        assert!(
+            body.contains("remove_local_client"),
+            "the recorded release closure must actually call \
+             `remove_local_client`; recording an obligation that discharges to \
+             nothing is the same leak with more code"
+        );
+    }
+
+    /// A release closure that records what it was asked to release.
+    fn recorder() -> (InterestRelease, Arc<Mutex<Vec<ContractKey>>>) {
+        let seen: Arc<Mutex<Vec<ContractKey>>> = Default::default();
+        let sink = seen.clone();
+        let release: InterestRelease = Arc::new(move |k: &ContractKey| {
+            sink.lock().unwrap().push(*k);
+        });
+        (release, seen)
+    }
+
+    /// `UnregisterDelegate` is an ordinary operation, and it must give back
+    /// every refcount that delegate's subscriptions took. Before #5542 wired
+    /// `run_executor_subscribe` in there was nothing to give back; after it,
+    /// skipping this leaves `local_interests` permanently above zero for the
+    /// contract, so `cleanup_contract_if_no_interest` never fires.
+    #[test]
+    fn unregistering_a_delegate_releases_every_interest_it_held() {
+        let (release, seen) = recorder();
+        let d = delegate(200);
+        record(*key(201).id(), d.clone(), key(201), release.clone());
+        record(*key(202).id(), d.clone(), key(202), release.clone());
+        // A different delegate's hold on one of the same contracts must survive.
+        let other = delegate(203);
+        record(*key(201).id(), other.clone(), key(201), release);
+
+        release_delegate(&d);
+
+        let mut released: Vec<_> = seen.lock().unwrap().clone();
+        released.sort_by_key(|k| k.to_string());
+        assert_eq!(
+            released,
+            vec![key(201), key(202)],
+            "every contract the delegate held interest in must be released"
+        );
+        assert!(
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(201).id(), other)),
+            "another delegate's hold on the same contract must NOT be discharged \
+             — releasing interest a different subscriber holds is worse than the \
+             leak this closes"
+        );
+    }
+
+    /// Contract removal and channel-closed cleanup both drop every delegate
+    /// subscription for one contract, so both must discharge every hold on it.
+    #[test]
+    fn removing_a_contract_releases_every_delegate_hold_on_it() {
+        let (release, seen) = recorder();
+        let target = key(210);
+        record(*target.id(), delegate(211), target, release.clone());
+        record(*target.id(), delegate(212), target, release.clone());
+        record(*key(213).id(), delegate(211), key(213), release);
+
+        release_contract(target.id());
+
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            2,
+            "both delegates' holds on the removed contract must be released"
+        );
+        assert!(
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(213).id(), delegate(211))),
+            "a hold on a DIFFERENT contract must survive"
+        );
+    }
+
+    /// Releasing a pair that never took a refcount must be a no-op, not a
+    /// decrement. A subscribe answered from the local store takes none, and
+    /// neither does the V2 `subscribe_contract_sync` host function — so the
+    /// removal paths call these functions for pairs that hold nothing, and a
+    /// decrement there would fall on interest a real client holds.
+    #[test]
+    fn releasing_a_pair_that_holds_nothing_does_not_decrement() {
+        let (release, seen) = recorder();
+        record(*key(220).id(), delegate(221), key(220), release);
+
+        release_delegate(&delegate(222));
+        release_contract(key(223).id());
+
+        assert!(
+            seen.lock().unwrap().is_empty(),
+            "no hold matched, so nothing may be released"
+        );
+        assert!(
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(220).id(), delegate(221))),
+            "the unrelated hold must be untouched"
+        );
+    }
+
+    /// Recording the same pair twice keeps ONE obligation. The caller
+    /// increments at most once per pair; if that ever broke, leaking one
+    /// refcount is the safe direction, because the alternative is releasing
+    /// interest that was never taken.
+    #[test]
+    fn a_pair_recorded_twice_holds_one_obligation() {
+        let (release, seen) = recorder();
+        record(*key(230).id(), delegate(231), key(230), release.clone());
+        record(*key(230).id(), delegate(231), key(230), release);
+
+        release_delegate(&delegate(231));
+
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            1,
+            "one obligation must produce exactly one release"
+        );
+    }
+}

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -80,15 +80,21 @@ struct Hold {
     release: InterestRelease,
 }
 
-/// In-process identity of the node that took a hold: the address of its
-/// `Arc<OpManager>` (#5542 finding M3/F4).
+/// In-process identity of the node that took a hold (#5542 findings M3/F4 and
+/// C): `OpManager::node_identity`, a monotonic per-process counter.
 ///
-/// The map is process-global, so its key has to be too, and "which node" is
-/// exactly "which `OpManager` instance" — there is no stable node id on
-/// `OpManager` to use instead. In production this is always a single value,
-/// because production runs one node per process; it earns its place in the
-/// in-process multi-node harness, which is the environment the module's own
-/// per-hold-closure design was written for.
+/// The hold map is process-global, so "which node" has to be represented
+/// explicitly, and it means exactly "which `OpManager` instance". In production
+/// there is only ever one; it earns its place in the in-process multi-node
+/// harness, which is the environment this module's per-hold-closure design was
+/// written for in the first place.
+///
+/// NOT the `Arc<OpManager>` address, which was the first implementation and is
+/// unsound here. `OpManager` has no `Drop`, and glibc's tcache reuses freed
+/// allocations LIFO, so a second `OpManager` can land on a dropped one's
+/// address and inherit its identity — its `record` is then discarded as a
+/// duplicate and its refcount leaks. Reachable under `cargo test`, which does
+/// not use the binary's jemalloc.
 pub(crate) type NodeIdentity = usize;
 
 /// Outstanding local-interest refcounts taken on behalf of delegate
@@ -390,9 +396,20 @@ mod tests {
             .split("fn apply_resolved_contract_op<CH>(")
             .nth(1)
             .expect("apply_resolved_contract_op must exist");
-        let body = &body[..body
-            .find("\nfn ")
-            .expect("apply_resolved_contract_op must be followed by another fn")];
+        // BOUNDED BY THE NEXT FUNCTION'S ACTUAL NAME, not by `"\nfn "`.
+        //
+        // `"\nfn "` does not match `async fn`, so the previous bound skipped
+        // past `run_contract_op_off_loop` and landed 1,848 lines later at
+        // `try_recv_delegate_notification`. The window then contained the
+        // LOCAL-branch `record` call added by M4, so deleting the call this pin
+        // exists to guard left it green. That is the same vacuity the sibling
+        // pin above was repaired for in the same commit; this one did not get
+        // the fix, which is why the region helper is used here too.
+        let body = &body[..body.find("async fn run_contract_op_off_loop(").expect(
+            "apply_resolved_contract_op must be followed by \
+                 run_contract_op_off_loop; if that moved, re-anchor this pin \
+                 rather than widening it",
+        )];
         assert!(
             body.contains("delegate_interest::record("),
             "the site that installs the DELEGATE_SUBSCRIPTIONS hook after a \

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -219,6 +219,53 @@ mod tests {
     const NODE_A: NodeIdentity = 0xA;
     const NODE_B: NodeIdentity = 0xB;
 
+    /// A release closure must run with NO `DELEGATE_INTEREST_HOLDS` shard lock
+    /// held — the collect-first discipline in `release_delegate` and
+    /// `release_contract` (#5542 WARNING 4).
+    ///
+    /// Those functions collect the holds inside `retain` and invoke the release
+    /// closures AFTER it returns, because `retain` holds a shard write lock and
+    /// a release closure reaches into `InterestManager`, which takes its own
+    /// locks. Calling out under a shard guard is how lock-order inversions get
+    /// built. The comment saying so was load-bearing and had no counterfactual:
+    /// the existing tests use a closure that only pushes to a `Vec`, so they
+    /// pass identically whether `release(&key)` sits inside the `retain` body or
+    /// after it.
+    ///
+    /// This closes that by having the closure probe the map it was released
+    /// from. `try_get` reports `Locked` rather than blocking, so moving the
+    /// call back inside `retain` makes this FAIL rather than deadlock — a
+    /// hanging test would be a worse guard than none.
+    #[test]
+    fn a_release_closure_runs_with_no_shard_lock_held() {
+        let d = delegate(180);
+        let k = key(181);
+        let pair = (*k.id(), d.clone());
+        let saw_locked: Arc<Mutex<Option<bool>>> = Default::default();
+
+        let probe = saw_locked.clone();
+        let release: InterestRelease = Arc::new(move |_k: &ContractKey| {
+            // Same shard as the entry being released, since it is the same key.
+            let locked = matches!(
+                DELEGATE_INTEREST_HOLDS.try_get(&pair),
+                dashmap::try_result::TryResult::Locked
+            );
+            *probe.lock().unwrap() = Some(locked);
+        });
+        record(*k.id(), d.clone(), k, release, NODE_A);
+
+        release_delegate(&d);
+
+        assert_eq!(
+            *saw_locked.lock().unwrap(),
+            Some(false),
+            "the release closure must run AFTER `retain` has released its shard \
+             lock. `Some(true)` means it ran under the guard, which is the \
+             lock-order inversion the collect-first step exists to prevent; \
+             `None` means the closure never ran and this test proved nothing"
+        );
+    }
+
     /// A pair-keyed lookup must find EVERY node's hold for that pair.
     ///
     /// This is the compatibility constraint the per-delegate subscription cap

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -80,18 +80,41 @@ struct Hold {
     release: InterestRelease,
 }
 
+/// In-process identity of the node that took a hold: the address of its
+/// `Arc<OpManager>` (#5542 finding M3/F4).
+///
+/// The map is process-global, so its key has to be too, and "which node" is
+/// exactly "which `OpManager` instance" — there is no stable node id on
+/// `OpManager` to use instead. In production this is always a single value,
+/// because production runs one node per process; it earns its place in the
+/// in-process multi-node harness, which is the environment the module's own
+/// per-hold-closure design was written for.
+pub(crate) type NodeIdentity = usize;
+
 /// Outstanding local-interest refcounts taken on behalf of delegate
-/// subscriptions, keyed by the `(contract, delegate)` pair that owns them.
+/// subscriptions, keyed by the `(contract, delegate, node)` triple that owns
+/// them.
+///
+/// The NODE component is load-bearing and was missing. Keyed on the pair alone,
+/// `record`'s `or_insert` silently discarded a second node's obligation when two
+/// nodes in one process subscribed the same delegate to the same contract: both
+/// incremented, one hold existed, so release discharged one and leaked the
+/// other permanently. The module already argued that per-node behaviour matters
+/// here — it is why each hold carries its own release closure rather than a
+/// single global callback — but the key did not carry that intent.
 static DELEGATE_INTEREST_HOLDS: std::sync::LazyLock<
-    DashMap<(ContractInstanceId, DelegateKey), Hold>,
+    DashMap<(ContractInstanceId, DelegateKey, NodeIdentity), Hold>,
 > = std::sync::LazyLock::new(DashMap::new);
 
 /// Record that one local-interest refcount was taken for
 /// `(contract, delegate)`, and how to give it back.
 ///
-/// Idempotent per pair: recording twice keeps ONE obligation, matching the
-/// caller's own guarantee that it increments at most once per pair (the
-/// `already_subscribed` gate plus the in-round de-duplication). If that
+/// Idempotent per (pair, node): recording twice for the SAME node keeps ONE
+/// obligation, matching that caller's own guarantee that it increments at most
+/// once per pair (the `already_subscribed` gate plus the in-round
+/// de-duplication). A DIFFERENT node recording the same pair gets its own
+/// obligation, because it took its own refcount on its own `InterestManager` —
+/// collapsing the two is how the second one leaked. If that
 /// guarantee were ever broken, holding one obligation for two increments leaks
 /// — which is the safe direction, since the alternative is releasing interest
 /// that was never taken.
@@ -100,9 +123,10 @@ pub(crate) fn record(
     delegate: DelegateKey,
     key: ContractKey,
     release: InterestRelease,
+    node: NodeIdentity,
 ) {
     DELEGATE_INTEREST_HOLDS
-        .entry((contract, delegate))
+        .entry((contract, delegate, node))
         .or_insert(Hold { key, release });
 }
 
@@ -115,7 +139,7 @@ pub(crate) fn release_delegate(delegate: &DelegateKey) {
     // into `InterestManager`, which takes its own locks. Doing that under a
     // DashMap shard guard is how lock-order inversions get built.
     let mut discharged = Vec::new();
-    DELEGATE_INTEREST_HOLDS.retain(|(_, holder), hold| {
+    DELEGATE_INTEREST_HOLDS.retain(|(_, holder, _), hold| {
         if holder == delegate {
             discharged.push((hold.key, hold.release.clone()));
             false
@@ -134,7 +158,7 @@ pub(crate) fn release_delegate(delegate: &DelegateKey) {
 /// both of which drop every delegate subscription for one contract.
 pub(crate) fn release_contract(contract: &ContractInstanceId) {
     let mut discharged = Vec::new();
-    DELEGATE_INTEREST_HOLDS.retain(|(id, _), hold| {
+    DELEGATE_INTEREST_HOLDS.retain(|(id, _, _), hold| {
         if id == contract {
             discharged.push((hold.key, hold.release.clone()));
             false
@@ -171,6 +195,47 @@ mod tests {
         DelegateKey::new([byte; 32], CodeHash::new([byte; 32]))
     }
 
+    /// Two distinct in-process node identities. In production there is only
+    /// ever one; these stand for two `OpManager`s in one test process.
+    const NODE_A: NodeIdentity = 0xA;
+    const NODE_B: NodeIdentity = 0xB;
+
+    /// Two NODES in one process, subscribing the same delegate to the same
+    /// contract, each hold their own obligation (#5542 finding M3/F4).
+    ///
+    /// Keyed on `(contract, delegate)` alone, `record`'s `or_insert` made the
+    /// second node's call a silent no-op. Both nodes had incremented their own
+    /// `InterestManager`, one hold existed, so release discharged one node's
+    /// refcount and leaked the other's permanently. Exposure is the in-process
+    /// multi-node harness — which is exactly the environment this module's
+    /// per-hold release closure was designed for, so the key had to carry the
+    /// same intent the closure already did.
+    #[test]
+    fn two_nodes_holding_the_same_pair_each_keep_their_obligation() {
+        let (release_a, seen_a) = recorder();
+        let (release_b, seen_b) = recorder();
+        let d = delegate(240);
+        let k = key(241);
+
+        record(*k.id(), d.clone(), k, release_a, NODE_A);
+        record(*k.id(), d.clone(), k, release_b, NODE_B);
+
+        release_delegate(&d);
+
+        assert_eq!(
+            seen_a.lock().unwrap().len(),
+            1,
+            "node A's refcount must be released"
+        );
+        assert_eq!(
+            seen_b.lock().unwrap().len(),
+            1,
+            "node B took its own refcount on its own InterestManager, so it must \
+             get its own release; collapsing the two leaks whichever recorded \
+             second"
+        );
+    }
+
     /// The three sites that DROP a delegate subscription must each release the
     /// interest it held. The module tests above prove the mechanism; these
     /// prove it is actually reached, which is the half that silently rots — a
@@ -202,7 +267,7 @@ mod tests {
         /// Panics rather than returning empty if either anchor is missing, so a
         /// rename fails the pin loudly instead of vacuously passing it.
         fn region(src: &str, start: &str, end: &str) -> String {
-            let stripped = crate::contract::tests::strip_comments(src);
+            let stripped = crate::contract::source_pin_util::strip_comments(src);
             let from = stripped
                 .find(start)
                 .unwrap_or_else(|| panic!("anchor `{start}` must exist"));
@@ -274,7 +339,8 @@ mod tests {
     /// inert while looking present.
     #[test]
     fn the_subscribe_path_records_the_obligation_it_incurs() {
-        let contract = crate::contract::tests::strip_comments(include_str!("../contract.rs"));
+        let contract =
+            crate::contract::source_pin_util::strip_comments(include_str!("../contract.rs"));
         let body = contract
             .split("fn apply_resolved_contract_op<CH>(")
             .nth(1)
@@ -290,10 +356,27 @@ mod tests {
              release it (#5542)"
         );
         assert!(
-            body.contains("remove_local_client"),
-            "the recorded release closure must actually call \
-             `remove_local_client`; recording an obligation that discharges to \
-             nothing is the same leak with more code"
+            body.contains("delegate_interest_release_closure("),
+            "the recorded obligation must be built by the shared release-closure \
+             constructor; there are two sites that take this refcount now, and a \
+             second hand-written closure is where the next divergence lives"
+        );
+        // ...and that constructor must actually decrement. Following the
+        // extraction rather than dropping the assertion: the property being
+        // pinned is "the obligation discharges to a real decrement", and it is
+        // one function further away, not gone.
+        let closure = contract
+            .split("fn delegate_interest_release_closure(")
+            .nth(1)
+            .expect("delegate_interest_release_closure must exist");
+        let closure = &closure[..closure
+            .find("\nfn ")
+            .expect("delegate_interest_release_closure must be followed by another fn")];
+        assert!(
+            closure.contains("remove_local_client"),
+            "the release closure must actually call `remove_local_client`; \
+             recording an obligation that discharges to nothing is the same leak \
+             with more code"
         );
     }
 
@@ -316,11 +399,11 @@ mod tests {
     fn unregistering_a_delegate_releases_every_interest_it_held() {
         let (release, seen) = recorder();
         let d = delegate(200);
-        record(*key(201).id(), d.clone(), key(201), release.clone());
-        record(*key(202).id(), d.clone(), key(202), release.clone());
+        record(*key(201).id(), d.clone(), key(201), release.clone(), NODE_A);
+        record(*key(202).id(), d.clone(), key(202), release.clone(), NODE_A);
         // A different delegate's hold on one of the same contracts must survive.
         let other = delegate(203);
-        record(*key(201).id(), other.clone(), key(201), release);
+        record(*key(201).id(), other.clone(), key(201), release, NODE_A);
 
         release_delegate(&d);
 
@@ -332,7 +415,7 @@ mod tests {
             "every contract the delegate held interest in must be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(201).id(), other)),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(201).id(), other, NODE_A)),
             "another delegate's hold on the same contract must NOT be discharged \
              — releasing interest a different subscriber holds is worse than the \
              leak this closes"
@@ -345,9 +428,9 @@ mod tests {
     fn removing_a_contract_releases_every_delegate_hold_on_it() {
         let (release, seen) = recorder();
         let target = key(210);
-        record(*target.id(), delegate(211), target, release.clone());
-        record(*target.id(), delegate(212), target, release.clone());
-        record(*key(213).id(), delegate(211), key(213), release);
+        record(*target.id(), delegate(211), target, release.clone(), NODE_A);
+        record(*target.id(), delegate(212), target, release.clone(), NODE_A);
+        record(*key(213).id(), delegate(211), key(213), release, NODE_A);
 
         release_contract(target.id());
 
@@ -357,7 +440,7 @@ mod tests {
             "both delegates' holds on the removed contract must be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(213).id(), delegate(211))),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(213).id(), delegate(211), NODE_A)),
             "a hold on a DIFFERENT contract must survive"
         );
     }
@@ -370,7 +453,7 @@ mod tests {
     #[test]
     fn releasing_a_pair_that_holds_nothing_does_not_decrement() {
         let (release, seen) = recorder();
-        record(*key(220).id(), delegate(221), key(220), release);
+        record(*key(220).id(), delegate(221), key(220), release, NODE_A);
 
         release_delegate(&delegate(222));
         release_contract(key(223).id());
@@ -380,7 +463,7 @@ mod tests {
             "no hold matched, so nothing may be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(220).id(), delegate(221))),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(220).id(), delegate(221), NODE_A)),
             "the unrelated hold must be untouched"
         );
     }
@@ -392,8 +475,14 @@ mod tests {
     #[test]
     fn a_pair_recorded_twice_holds_one_obligation() {
         let (release, seen) = recorder();
-        record(*key(230).id(), delegate(231), key(230), release.clone());
-        record(*key(230).id(), delegate(231), key(230), release);
+        record(
+            *key(230).id(),
+            delegate(231),
+            key(230),
+            release.clone(),
+            NODE_A,
+        );
+        record(*key(230).id(), delegate(231), key(230), release, NODE_A);
 
         release_delegate(&delegate(231));
 

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -149,6 +149,31 @@ pub(crate) fn record(
         .or_insert(Hold { key, release });
 }
 
+/// Whether THIS node already holds an interest obligation for
+/// `(contract, delegate)` (#5542, Codex P2).
+///
+/// The subscription registry `DELEGATE_SUBSCRIPTIONS` is process-global and
+/// carries no node identity, so asking it "is this delegate already subscribed"
+/// answers for the PROCESS, not for this node. In an in-process multi-node run
+/// the second node to subscribe the same delegate to the same contract sees the
+/// first node's entry, short-circuits, and returns `Ok(())` without taking its
+/// own local-interest refcount or establishing its own network subscription —
+/// the first-arrival process-global pattern `testing.md` describes.
+///
+/// This map IS node-keyed, so it can answer the per-node question. It is the
+/// right source for the idempotency gate for the same reason it was the right
+/// source for release: an entry exists if and only if THIS node actually took
+/// the refcount.
+pub(crate) fn holds(
+    contract: &ContractInstanceId,
+    delegate: &DelegateKey,
+    node: NodeIdentity,
+) -> bool {
+    DELEGATE_INTEREST_HOLDS
+        .get(&(*contract, delegate.clone()))
+        .is_some_and(|holds| holds.contains_key(&node))
+}
+
 /// Release every hold taken for `delegate`, across all contracts.
 ///
 /// Called from `UnregisterDelegate`, which drops the delegate from every

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -181,14 +181,45 @@ mod tests {
     /// inside `UnregisterDelegate` / notification-dispatch paths that need a
     /// live executor and a live notification channel to reach. If you make
     /// those reachable in a unit test, replace these.
+    ///
+    /// TWO VACUITY TRAPS this pin walked into and now avoids, both of which
+    /// `contract.rs`'s pin helpers were written for after the same defects
+    /// shipped there (#5450 and the #5554-era pins):
+    ///
+    /// * **A commented-out call is still text.** Without stripping comments a
+    ///   scrape cannot tell `foo();` from `// foo();`, so it stays green over a
+    ///   call that no longer runs — and commenting a line out is exactly what
+    ///   someone does while debugging, which is precisely when the pin is the
+    ///   only thing still watching.
+    /// * **An unbounded search passes if the call merely MOVES.** Searching a
+    ///   whole file, or the entire suffix after a match arm's opener, is
+    ///   satisfied by the call existing anywhere later in the file — including
+    ///   in a function that never runs on this path. Each search is now bounded
+    ///   to the region that has to contain it.
     #[test]
     fn every_subscription_removal_site_releases_its_interest() {
+        /// Comment-stripped text between `start` and the next `end` after it.
+        /// Panics rather than returning empty if either anchor is missing, so a
+        /// rename fails the pin loudly instead of vacuously passing it.
+        fn region(src: &str, start: &str, end: &str) -> String {
+            let stripped = crate::contract::tests::strip_comments(src);
+            let from = stripped
+                .find(start)
+                .unwrap_or_else(|| panic!("anchor `{start}` must exist"));
+            let rest = &stripped[from + start.len()..];
+            let to = rest
+                .find(end)
+                .unwrap_or_else(|| panic!("closing anchor `{end}` must follow `{start}`"));
+            rest[..to].to_string()
+        }
+
         // `UnregisterDelegate` — an ORDINARY operation, not an edge case.
-        let delegates = include_str!("../contract/executor/runtime/delegates.rs");
-        let unregister = delegates
-            .split("DelegateRequest::UnregisterDelegate(key) => {")
-            .nth(1)
-            .expect("the UnregisterDelegate arm must exist");
+        // Bounded to that match arm: the next arm's opener ends it.
+        let unregister = region(
+            include_str!("../contract/executor/runtime/delegates.rs"),
+            "DelegateRequest::UnregisterDelegate(key) => {",
+            "DelegateRequest::ApplicationMessages {",
+        );
         assert!(
             unregister.contains("delegate_interest::release_delegate(&key)"),
             "UnregisterDelegate drops the delegate from every subscription entry, \
@@ -197,18 +228,42 @@ mod tests {
              `cleanup_contract_if_no_interest` never fires (#5542)"
         );
 
-        // Contract removal.
-        let store = include_str!("contract_store.rs");
+        // Contract removal, bounded to `ContractStore::remove_contract`.
+        let remove_contract = region(
+            include_str!("contract_store.rs"),
+            "pub fn remove_contract(&mut self, key: &ContractKey) -> RuntimeResult<()> {",
+            "\n    pub fn ",
+        );
         assert!(
-            store.contains("delegate_interest::release_contract(key.id())"),
+            remove_contract.contains("delegate_interest::release_contract(key.id())"),
             "removing a contract drops its delegate subscriptions, so it must \
              release the interest they took (#5542)"
         );
 
-        // Notification-channel-closed cleanup.
-        let executor = include_str!("../contract/executor/runtime/executor_impl.rs");
+        // The simulation/mock backend must agree with the production store, or
+        // a simulation models a node that behaves differently from the shipped
+        // one. It diverged from #3251 until #5542 found it.
+        let in_memory_remove = region(
+            include_str!("simulation_runtime.rs"),
+            "pub fn remove_contract(&self, key: &ContractKey) -> Result<(), anyhow::Error> {",
+            "\n    pub fn ",
+        );
         assert!(
-            executor.contains("delegate_interest::release_contract(&instance_id)"),
+            in_memory_remove.contains("delegate_interest::release_contract(key.id())"),
+            "`InMemoryContractStore::remove_contract` must release delegate \
+             interest exactly as the production `ContractStore` does; a backend \
+             that diverges here makes every simulation model a node that behaves \
+             differently from the one that ships (#5542)"
+        );
+
+        // Notification-channel-closed cleanup, bounded to its own function.
+        let notify = region(
+            include_str!("../contract/executor/runtime/executor_impl.rs"),
+            "fn send_delegate_contract_notifications(&self, key: &ContractKey, new_state: &WrappedState) {",
+            "async fn fetch_related_for_validation(",
+        );
+        assert!(
+            notify.contains("delegate_interest::release_contract(&instance_id)"),
             "channel-closed cleanup removes every subscription for the contract, \
              so it must release the interest they took (#5542)"
         );
@@ -219,12 +274,14 @@ mod tests {
     /// inert while looking present.
     #[test]
     fn the_subscribe_path_records_the_obligation_it_incurs() {
-        let contract = include_str!("../contract.rs");
+        let contract = crate::contract::tests::strip_comments(include_str!("../contract.rs"));
         let body = contract
             .split("fn apply_resolved_contract_op<CH>(")
             .nth(1)
             .expect("apply_resolved_contract_op must exist");
-        let body = &body[..body.find("\nfn ").unwrap_or(body.len())];
+        let body = &body[..body
+            .find("\nfn ")
+            .expect("apply_resolved_contract_op must be followed by another fn")];
         assert!(
             body.contains("delegate_interest::record("),
             "the site that installs the DELEGATE_SUBSCRIPTIONS hook after a \

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -92,18 +92,29 @@ struct Hold {
 pub(crate) type NodeIdentity = usize;
 
 /// Outstanding local-interest refcounts taken on behalf of delegate
-/// subscriptions, keyed by the `(contract, delegate, node)` triple that owns
-/// them.
+/// subscriptions, keyed by the `(contract, delegate)` pair, with one hold per
+/// NODE that took one.
 ///
-/// The NODE component is load-bearing and was missing. Keyed on the pair alone,
-/// `record`'s `or_insert` silently discarded a second node's obligation when two
-/// nodes in one process subscribed the same delegate to the same contract: both
-/// incremented, one hold existed, so release discharged one and leaked the
-/// other permanently. The module already argued that per-node behaviour matters
-/// here — it is why each hold carries its own release closure rather than a
-/// single global callback — but the key did not carry that intent.
+/// The per-node split is load-bearing and was missing. With a single `Hold` per
+/// pair, `record`'s `or_insert` silently discarded a second node's obligation
+/// when two nodes in one process subscribed the same delegate to the same
+/// contract: both incremented their own `InterestManager`, one hold existed, so
+/// release discharged one and leaked the other permanently. The module already
+/// argued that per-node behaviour matters here — it is why each hold carries its
+/// own release closure rather than a single global callback — but the storage
+/// did not carry that intent.
+///
+/// THE OUTER KEY STAYS THE PAIR, deliberately, and this is a compatibility
+/// constraint rather than a style choice. Every release path in the tree
+/// discharges by `(contract, delegate)` — including the per-delegate
+/// subscription cap's eviction path on #5623, which looks a pair up here
+/// directly. Moving the node into the KEY would make those lookups miss, and a
+/// miss here is a silent no-op by design, so the cap would leak again through
+/// exactly the door it closed. Putting the node in the VALUE keeps every
+/// pair-keyed lookup total: remove the pair and every node's hold for it is
+/// discharged.
 static DELEGATE_INTEREST_HOLDS: std::sync::LazyLock<
-    DashMap<(ContractInstanceId, DelegateKey, NodeIdentity), Hold>,
+    DashMap<(ContractInstanceId, DelegateKey), std::collections::HashMap<NodeIdentity, Hold>>,
 > = std::sync::LazyLock::new(DashMap::new);
 
 /// Record that one local-interest refcount was taken for
@@ -126,7 +137,9 @@ pub(crate) fn record(
     node: NodeIdentity,
 ) {
     DELEGATE_INTEREST_HOLDS
-        .entry((contract, delegate, node))
+        .entry((contract, delegate))
+        .or_default()
+        .entry(node)
         .or_insert(Hold { key, release });
 }
 
@@ -139,9 +152,9 @@ pub(crate) fn release_delegate(delegate: &DelegateKey) {
     // into `InterestManager`, which takes its own locks. Doing that under a
     // DashMap shard guard is how lock-order inversions get built.
     let mut discharged = Vec::new();
-    DELEGATE_INTEREST_HOLDS.retain(|(_, holder, _), hold| {
+    DELEGATE_INTEREST_HOLDS.retain(|(_, holder), holds| {
         if holder == delegate {
-            discharged.push((hold.key, hold.release.clone()));
+            discharged.extend(holds.values().map(|hold| (hold.key, hold.release.clone())));
             false
         } else {
             true
@@ -158,9 +171,9 @@ pub(crate) fn release_delegate(delegate: &DelegateKey) {
 /// both of which drop every delegate subscription for one contract.
 pub(crate) fn release_contract(contract: &ContractInstanceId) {
     let mut discharged = Vec::new();
-    DELEGATE_INTEREST_HOLDS.retain(|(id, _, _), hold| {
+    DELEGATE_INTEREST_HOLDS.retain(|(id, _), holds| {
         if id == contract {
-            discharged.push((hold.key, hold.release.clone()));
+            discharged.extend(holds.values().map(|hold| (hold.key, hold.release.clone())));
             false
         } else {
             true
@@ -199,6 +212,38 @@ mod tests {
     /// ever one; these stand for two `OpManager`s in one test process.
     const NODE_A: NodeIdentity = 0xA;
     const NODE_B: NodeIdentity = 0xB;
+
+    /// A pair-keyed lookup must find EVERY node's hold for that pair.
+    ///
+    /// This is the compatibility constraint the per-delegate subscription cap
+    /// (#5623) depends on: its eviction path discharges by `(contract,
+    /// delegate)`. If the node identity moved into the KEY, that lookup would
+    /// miss — and a miss here is a silent no-op by design, so the cap would leak
+    /// again through the door it just closed. Pinned so a future refactor that
+    /// re-keys this map fails here rather than in another PR's runtime.
+    #[test]
+    fn a_pair_keyed_lookup_discharges_every_node_holding_it() {
+        let (release_a, seen_a) = recorder();
+        let (release_b, seen_b) = recorder();
+        let d = delegate(250);
+        let k = key(251);
+        record(*k.id(), d.clone(), k, release_a, NODE_A);
+        record(*k.id(), d.clone(), k, release_b, NODE_B);
+
+        assert!(
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*k.id(), d.clone())),
+            "the pair itself must be the key, so a pair-keyed release path finds it"
+        );
+
+        release_contract(k.id());
+
+        assert_eq!(seen_a.lock().unwrap().len(), 1);
+        assert_eq!(
+            seen_b.lock().unwrap().len(),
+            1,
+            "removing the pair must discharge every node's hold under it"
+        );
+    }
 
     /// Two NODES in one process, subscribing the same delegate to the same
     /// contract, each hold their own obligation (#5542 finding M3/F4).
@@ -415,7 +460,7 @@ mod tests {
             "every contract the delegate held interest in must be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(201).id(), other, NODE_A)),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(201).id(), other)),
             "another delegate's hold on the same contract must NOT be discharged \
              — releasing interest a different subscriber holds is worse than the \
              leak this closes"
@@ -440,7 +485,7 @@ mod tests {
             "both delegates' holds on the removed contract must be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(213).id(), delegate(211), NODE_A)),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(213).id(), delegate(211))),
             "a hold on a DIFFERENT contract must survive"
         );
     }
@@ -463,7 +508,7 @@ mod tests {
             "no hold matched, so nothing may be released"
         );
         assert!(
-            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(220).id(), delegate(221), NODE_A)),
+            DELEGATE_INTEREST_HOLDS.contains_key(&(*key(220).id(), delegate(221))),
             "the unrelated hold must be untouched"
         );
     }

--- a/crates/core/src/wasm_runtime/simulation_runtime.rs
+++ b/crates/core/src/wasm_runtime/simulation_runtime.rs
@@ -127,6 +127,16 @@ impl InMemoryContractStore {
 
     /// Remove a contract by key.
     pub fn remove_contract(&self, key: &ContractKey) -> Result<(), anyhow::Error> {
+        // Conform to `ContractStore::remove_contract`: removing a contract drops
+        // its delegate subscriptions, and those subscriptions may own
+        // `InterestManager` refcounts that must be given back (#5542). This
+        // backend diverged silently, so a simulation or mock-executor run that
+        // removed a contract left both the registry entry and the interest
+        // standing. Not caught by
+        // `delegate_interest::tests::every_subscription_removal_site_releases_its_interest`,
+        // which scrapes the three sites it knows about and cannot see a fourth.
+        super::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        super::delegate_interest::release_contract(key.id());
         let mut inner = self.inner.lock().unwrap();
         inner.instance_to_code.remove(key.id());
         // Only remove code if no other instances reference it

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4358,8 +4358,8 @@ async fn put_and_await(
 /// node without it is chosen, and a run where no such node exists FAILS LOUDLY
 /// instead of passing quietly — a vacuous pass is the outcome to design
 /// against, because it reports success while checking less.
-async fn a_node_without_the_contract<'a>(
-    ctx: &'a mut TestContext,
+async fn a_node_without_the_contract(
+    ctx: &mut TestContext,
     contract: &ContractContainer,
     state: WrappedState,
     candidates: &[&str],

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4384,7 +4384,16 @@ async fn a_node_without_the_contract(
         placement.push(*name);
     }
     bail!(
-        "every candidate node {placement:?} already holds {contract_key} locally, so a          delegate operation on any of them is answered from the local store and this run          cannot observe #5542 at all. Failing rather than passing vacuously — the earlier          version of this test did the latter and was green against unfixed main."
+        "every candidate node {placement:?} already holds {contract_key} locally, so a \
+         delegate operation on any of them is answered from the local store and this run \
+         cannot observe #5542 at all. Failing rather than passing vacuously — the earlier \
+         version of this test did the latter and was green against unfixed main. NOTE \
+         (#5542 finding F6): this precondition is not under the test's control. Under \
+         every-hop placement a PUT stores at every hop, so all candidates holding the \
+         contract is a routine placement outcome rather than an anomaly, and this failure \
+         may be luck rather than a regression. Re-run before investigating; the durable \
+         fix is to select the probe node by ring distance from the contract key, so the \
+         precondition becomes a property of the topology the test builds."
     )
 }
 

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4194,6 +4194,50 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
 // #5542: a V1 delegate's GET and SUBSCRIBE must reach the network
 // ============================================================================
 
+/// Does this node have LOCAL PRESENCE of `key` — hosting it, or holding a
+/// subscription lease for it?
+///
+/// `collect_contract_states` documents absence from `contract_states` as
+/// meaning "not locally present" (it is the same signal the #3945 web
+/// subresource gate relies on), which is what makes it usable as a
+/// precondition here.
+///
+/// It is a PROXY, and the gap is worth naming: this reads the ring's hosting
+/// and subscription view, while the delegate arm under test gates on
+/// `Executor::lookup_key`, i.e. the contract store. A node can in principle
+/// disagree between the two. It is the only local-presence answer a client can
+/// get — `NodeQuery::NeighborHostingInfo`, which would answer more directly, is
+/// unimplemented (`client_events.rs`: "NeighborHostingInfo query not yet
+/// implemented").
+async fn node_has_contract_locally(client: &mut WebApi, key: ContractKey) -> anyhow::Result<bool> {
+    let config = freenet_stdlib::client_api::NodeDiagnosticsConfig {
+        include_node_info: false,
+        include_network_info: false,
+        include_subscriptions: false,
+        contract_keys: vec![key],
+        include_system_metrics: false,
+        include_detailed_peer_info: false,
+        include_subscriber_peer_ids: false,
+    };
+    client
+        .send(ClientRequest::NodeQueries(
+            freenet_stdlib::client_api::NodeQuery::NodeDiagnostics { config },
+        ))
+        .await?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Ok(HostResponse::QueryResponse(QueryResponse::NodeDiagnostics(response)))) => {
+                return Ok(response.contract_states.contains_key(&key.to_string()));
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "ignoring while awaiting diagnostics"),
+            Ok(Err(e)) => bail!("websocket error awaiting diagnostics: {e}"),
+            Err(_) => {}
+        }
+    }
+    bail!("no NodeDiagnostics response within 30s")
+}
+
 /// Drive one `test-delegate-capabilities` command over `client` and return the
 /// `DelegateCommandResponse` the delegate produced.
 ///
@@ -4272,36 +4316,95 @@ async fn register_delegate(
     bail!("delegate registration was not acknowledged within 60s")
 }
 
+/// PUT `contract` from `client` and wait for the `PutResponse`.
+async fn put_and_await(
+    client: &mut WebApi,
+    contract: &ContractContainer,
+    state: WrappedState,
+) -> anyhow::Result<()> {
+    let contract_key = contract.key();
+    // `subscribe: false`. Subscribing the publisher pulls the contract onto more
+    // peers, and every extra peer holding it is one fewer candidate for
+    // `a_node_without_the_contract` — which is the resource this test is short
+    // of. Nothing here needs the publisher to be subscribed.
+    make_put(client, state, contract.clone(), false).await?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+                ensure!(key == contract_key, "PUT response for the wrong contract");
+                return Ok(());
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "ignoring while awaiting PUT"),
+            Ok(Err(e)) => bail!("websocket error awaiting PUT: {e}"),
+            Err(_) => {}
+        }
+    }
+    bail!("no PutResponse within 60s")
+}
+
+/// Set up the shared world both #5542 tests need, and return a client on a node
+/// that PROVABLY does not hold the contract.
+///
+/// **Why the search, and why it can fail.** The whole point of #5542 is a node
+/// that has never seen the contract, and on a small test network a PUT can
+/// legitimately place the contract on every peer — in which case the delegate
+/// operation is answered from the local store and the test would pass without
+/// exercising the network path at all.
+///
+/// That is not hypothetical. The first version of these tests picked `node-b`
+/// unconditionally and PASSED against `main` WITHOUT the fix. They were
+/// measuring nothing. So local presence is now checked rather than assumed, a
+/// node without it is chosen, and a run where no such node exists FAILS LOUDLY
+/// instead of passing quietly — a vacuous pass is the outcome to design
+/// against, because it reports success while checking less.
+async fn a_node_without_the_contract<'a>(
+    ctx: &'a mut TestContext,
+    contract: &ContractContainer,
+    state: WrappedState,
+    candidates: &[&str],
+) -> anyhow::Result<WebApi> {
+    let contract_key = contract.key();
+
+    let publisher = ctx.node("node-a")?;
+    let (stream_a, _) = connect_async(&publisher.ws_url()).await?;
+    let mut client_a = WebApi::start(stream_a);
+    put_and_await(&mut client_a, contract, state).await?;
+
+    let mut placement = Vec::new();
+    for name in candidates {
+        let node = ctx.node(name)?;
+        let (stream, _) = connect_async(&node.ws_url()).await?;
+        let mut client = WebApi::start(stream);
+        let holds = node_has_contract_locally(&mut client, contract_key).await?;
+        tracing::info!(node = %name, holds, "#5542: local-presence probe");
+        if !holds {
+            return Ok(client);
+        }
+        placement.push(*name);
+    }
+    bail!(
+        "every candidate node {placement:?} already holds {contract_key} locally, so a          delegate operation on any of them is answered from the local store and this run          cannot observe #5542 at all. Failing rather than passing vacuously — the earlier          version of this test did the latter and was green against unfixed main."
+    )
+}
+
 /// Regression test for #5542: a delegate GET reaches the NETWORK for a contract
 /// this node has never seen.
 ///
 /// **This test cannot be single-node.** Both pre-existing delegate E2E tests
 /// (`test_delegate_contract_get`, `test_delegate_contract_put_and_update`) run
 /// `nodes = ["gateway"]`, and on one node every contract a delegate can name is
-/// necessarily already in the local store — which is precisely the case the bug
-/// handled correctly. The gap only exists on a node that has NOT seen the
-/// contract, so observing it needs a second node.
+/// necessarily already in the local store — the case the bug handled correctly.
+/// The gap exists only on a node that has NOT seen the contract.
 ///
-/// Shape:
-///   1. node-a PUTs the contract with a distinctive state.
-///   2. node-b registers the delegate. node-b issues no contract operation of
-///      its own for this contract, so nothing primes its local store — which is
-///      exactly the situation of a delegate running with the browser tab shut.
-///   3. node-b's delegate GETs the contract. Before this fix it received
-///      `state: None`, silently, and could not tell that from an empty
-///      contract. It must now receive the state node-a published.
-///
-/// **Stated residual.** Placement is not under the test's control: a PUT on a
-/// small network can legitimately place the contract on node-b as a host, in
-/// which case the delegate GET is answered from the local store and the run is
-/// vacuous — it passes without exercising the network path at all. There is no
-/// client-visible "is this in your store, locally, right now" query to gate on,
-/// so this is recorded rather than defended against. Non-vacuity was
-/// established the only way available: by running this test against `main`
-/// without the fix, where it fails with a `None` state.
+/// node-a publishes; a peer with no local presence of the contract registers
+/// the delegate and issues no contract operation of its own, which is the
+/// situation of a delegate running with the browser tab shut. Before this fix
+/// its GET returned `state: None`, silently, indistinguishable from an empty
+/// contract.
 #[freenet_test(
     health_check_readiness = true,
-    nodes = ["gateway", "node-a", "node-b"],
+    nodes = ["gateway", "node-a", "node-b", "node-c", "node-d"],
     timeout_secs = 600,
     startup_wait_secs = 40,
     tokio_flavor = "multi_thread",
@@ -4314,48 +4417,18 @@ async fn test_delegate_get_reaches_the_network_for_an_unseen_contract(
     const TEST_CONTRACT: &str = "test-contract-integration";
 
     let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
-    let contract_key = contract.key();
-    let contract_id = *contract_key.id();
+    let contract_id = *contract.key().id();
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
-    let node_a = ctx.node("node-a")?;
-    let node_b = ctx.node("node-b")?;
-    let (stream_a, _) = connect_async(&node_a.ws_url()).await?;
-    let mut client_a = WebApi::start(stream_a);
-    let (stream_b, _) = connect_async(&node_b.ws_url()).await?;
-    let mut client_b = WebApi::start(stream_b);
+    let state = WrappedState::from(test_utils::create_todo_list_with_item("Published by node-a"));
+    let mut client = a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"])
+        .await?;
 
-    // --- 1. node-a publishes the contract ---------------------------------
-    let initial_state = test_utils::create_todo_list_with_item("Published by node-a");
-    make_put(
-        &mut client_a,
-        WrappedState::from(initial_state.clone()),
-        contract.clone(),
-        true,
-    )
-    .await?;
-    let mut put_ok = false;
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
-    while !put_ok && std::time::Instant::now() < deadline {
-        match timeout(Duration::from_secs(5), client_a.recv()).await {
-            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
-                ensure!(key == contract_key, "PUT response for the wrong contract");
-                put_ok = true;
-            }
-            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting PUT"),
-            Ok(Err(e)) => bail!("node-a: websocket error awaiting PUT: {e}"),
-            Err(_) => {}
-        }
-    }
-    ensure!(put_ok, "node-a: no PutResponse within 60s");
+    register_delegate(&mut client, &delegate, &delegate_key).await?;
 
-    // --- 2. node-b registers the delegate, and nothing else ---------------
-    register_delegate(&mut client_b, &delegate, &delegate_key).await?;
-
-    // --- 3. the delegate GETs a contract node-b has never asked for -------
     let response = run_delegate_command(
-        &mut client_b,
+        &mut client,
         &delegate_key,
         &DelegateCommand::GetContractState { contract_id },
         Duration::from_secs(120),
@@ -4394,23 +4467,21 @@ async fn test_delegate_get_reaches_the_network_for_an_unseen_contract(
 /// waiting on a per-address contract to learn that a payment landed has no
 /// other way to name it.
 ///
-/// **What this test does and does not establish.** It establishes that the gate
-/// is open and that the subscribe is reported successful, which fails against
-/// `main`. It does NOT by itself establish that notifications subsequently flow:
-/// that needs an update on another peer to be observed arriving at this
-/// delegate, and the notification-driven delegate run routes its output through
-/// the app registry rather than back to this client, so it is not observable
-/// on this socket. That second half is what makes `run_executor_subscribe` the
-/// right entry point (it bootstraps the body, registers demand AND establishes
-/// the network subscription, where the old arm did none of the three), and it
-/// deserves its own test rather than an assertion this one cannot make. Stated
-/// rather than implied, because "subscribe returned Ok" reading as "the delegate
-/// will now hear about changes" is exactly the silent failure #5467 describes.
-///
-/// The same placement residual as the GET test above applies.
+/// **What this establishes, and what it does not.** It establishes that the
+/// gate is open and the subscribe is reported successful. It does NOT establish
+/// that notifications subsequently flow: that needs an update on another peer
+/// observed arriving at this delegate, and a notification-driven delegate run
+/// routes its output through the app registry rather than back to this client,
+/// so it is not observable on this socket. That second half is exactly why
+/// `run_executor_subscribe` is the right entry point — it bootstraps the body,
+/// registers demand AND establishes the network subscription, where the old arm
+/// did none of the three — and it deserves its own test rather than an
+/// assertion this one cannot make. Said plainly, because "subscribe returned
+/// Ok" reading as "the delegate will now hear about changes" is precisely the
+/// silent failure #5467 describes.
 #[freenet_test(
     health_check_readiness = true,
-    nodes = ["gateway", "node-a", "node-b"],
+    nodes = ["gateway", "node-a", "node-b", "node-c", "node-d"],
     timeout_secs = 600,
     startup_wait_secs = 40,
     tokio_flavor = "multi_thread",
@@ -4423,45 +4494,18 @@ async fn test_delegate_subscribe_reaches_the_network_for_an_unseen_contract(
     const TEST_CONTRACT: &str = "test-contract-integration";
 
     let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
-    let contract_key = contract.key();
-    let contract_id = *contract_key.id();
+    let contract_id = *contract.key().id();
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
-    let node_a = ctx.node("node-a")?;
-    let node_b = ctx.node("node-b")?;
-    let (stream_a, _) = connect_async(&node_a.ws_url()).await?;
-    let mut client_a = WebApi::start(stream_a);
-    let (stream_b, _) = connect_async(&node_b.ws_url()).await?;
-    let mut client_b = WebApi::start(stream_b);
+    let state = WrappedState::from(test_utils::create_todo_list_with_item("Published by node-a"));
+    let mut client = a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"])
+        .await?;
 
-    let initial_state = test_utils::create_todo_list_with_item("Published by node-a");
-    make_put(
-        &mut client_a,
-        WrappedState::from(initial_state),
-        contract.clone(),
-        true,
-    )
-    .await?;
-    let mut put_ok = false;
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
-    while !put_ok && std::time::Instant::now() < deadline {
-        match timeout(Duration::from_secs(5), client_a.recv()).await {
-            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
-                ensure!(key == contract_key, "PUT response for the wrong contract");
-                put_ok = true;
-            }
-            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting PUT"),
-            Ok(Err(e)) => bail!("node-a: websocket error awaiting PUT: {e}"),
-            Err(_) => {}
-        }
-    }
-    ensure!(put_ok, "node-a: no PutResponse within 60s");
-
-    register_delegate(&mut client_b, &delegate, &delegate_key).await?;
+    register_delegate(&mut client, &delegate, &delegate_key).await?;
 
     let response = run_delegate_command(
-        &mut client_b,
+        &mut client,
         &delegate_key,
         &DelegateCommand::SubscribeContract { contract_id },
         Duration::from_secs(180),

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4360,40 +4360,69 @@ async fn put_and_await(
 /// against, because it reports success while checking less.
 async fn a_node_without_the_contract(
     ctx: &mut TestContext,
-    contract: &ContractContainer,
+    contract_name: &str,
     state: WrappedState,
     candidates: &[&str],
-) -> anyhow::Result<WebApi> {
-    let contract_key = contract.key();
-
-    let publisher = ctx.node("node-a")?;
-    let (stream_a, _) = connect_async(&publisher.ws_url()).await?;
-    let mut client_a = WebApi::start(stream_a);
-    put_and_await(&mut client_a, contract, state).await?;
-
+) -> anyhow::Result<(WebApi, ContractContainer)> {
+    // RETRY WITH A FRESH KEY rather than failing on the first unlucky placement
+    // (#5542 F6). The precondition this helper establishes is not under the
+    // test's control: under every-hop placement a PUT stores at every hop, so
+    // every candidate holding the contract is a routine outcome rather than an
+    // anomaly, and failing on it makes a correct implementation look broken.
+    //
+    // Each attempt PUTs a DIFFERENT instance of the same code — the parameters
+    // change the instance id, so each is an independent draw against the same
+    // topology. Covering every candidate once is ordinary; covering every
+    // candidate on all four independent keys is not, so a failure after that is
+    // signal rather than luck.
+    //
+    // ATTEMPT 0 USES EMPTY PARAMETERS, byte-identical to what this test did
+    // before, so the path CI has already exercised is unchanged and the retry
+    // only runs in the case that previously failed outright.
+    const MAX_PLACEMENT_ATTEMPTS: u8 = 4;
     let mut placement = Vec::new();
-    for name in candidates {
-        let node = ctx.node(name)?;
-        let (stream, _) = connect_async(&node.ws_url()).await?;
-        let mut client = WebApi::start(stream);
-        let holds = node_has_contract_locally(&mut client, contract_key).await?;
-        tracing::info!(node = %name, holds, "#5542: local-presence probe");
-        if !holds {
-            return Ok(client);
+    for attempt in 0..MAX_PLACEMENT_ATTEMPTS {
+        let params = if attempt == 0 {
+            Parameters::from(vec![])
+        } else {
+            Parameters::from(vec![attempt])
+        };
+        let contract = load_contract(contract_name, params)?;
+        let contract_key = contract.key();
+
+        let publisher = ctx.node("node-a")?;
+        let (stream_a, _) = connect_async(&publisher.ws_url()).await?;
+        let mut client_a = WebApi::start(stream_a);
+        put_and_await(&mut client_a, &contract, state.clone()).await?;
+
+        placement.clear();
+        for name in candidates {
+            let node = ctx.node(name)?;
+            let (stream, _) = connect_async(&node.ws_url()).await?;
+            let mut client = WebApi::start(stream);
+            let holds = node_has_contract_locally(&mut client, contract_key).await?;
+            tracing::info!(node = %name, attempt, holds, "#5542: local-presence probe");
+            if !holds {
+                return Ok((client, contract));
+            }
+            placement.push(*name);
         }
-        placement.push(*name);
+        tracing::warn!(
+            attempt,
+            ?placement,
+            "#5542: every candidate holds this instance; retrying with a fresh key"
+        );
     }
     bail!(
-        "every candidate node {placement:?} already holds {contract_key} locally, so a \
-         delegate operation on any of them is answered from the local store and this run \
-         cannot observe #5542 at all. Failing rather than passing vacuously — the earlier \
-         version of this test did the latter and was green against unfixed main. NOTE \
-         (#5542 finding F6): this precondition is not under the test's control. Under \
-         every-hop placement a PUT stores at every hop, so all candidates holding the \
-         contract is a routine placement outcome rather than an anomaly, and this failure \
-         may be luck rather than a regression. Re-run before investigating; the durable \
-         fix is to select the probe node by ring distance from the contract key, so the \
-         precondition becomes a property of the topology the test builds."
+        "every candidate node {placement:?} holds all {MAX_PLACEMENT_ATTEMPTS} independently \
+         keyed instances of this contract, so a delegate operation on any of them is \
+         answered from the local store and this run cannot observe #5542 at all. Failing \
+         rather than passing vacuously: the earlier version of this test did the latter and \
+         was green against unfixed main. One unlucky placement is ordinary and is retried; \
+         {MAX_PLACEMENT_ATTEMPTS} in a row is not, so treat this as signal about placement \
+         rather than as flakiness. The fully deterministic fix is to select the probe node \
+         by ring distance from the contract key, which needs the multi-node harness to \
+         validate."
     )
 }
 
@@ -4425,16 +4454,18 @@ async fn test_delegate_get_reaches_the_network_for_an_unseen_contract(
     const TEST_DELEGATE: &str = "test-delegate-capabilities";
     const TEST_CONTRACT: &str = "test-contract-integration";
 
-    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
-    let contract_id = *contract.key().id();
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
     let state = WrappedState::from(test_utils::create_todo_list_with_item(
         "Published by node-a",
     ));
-    let mut client =
-        a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"]).await?;
+    // The helper chooses the instance, because it may need several to find a
+    // node that does not hold one (#5542 F6).
+    let (mut client, contract) =
+        a_node_without_the_contract(ctx, TEST_CONTRACT, state, &["node-b", "node-c", "node-d"])
+            .await?;
+    let contract_id = *contract.key().id();
 
     register_delegate(&mut client, &delegate, &delegate_key).await?;
 
@@ -4504,16 +4535,18 @@ async fn test_delegate_subscribe_reaches_the_network_for_an_unseen_contract(
     const TEST_DELEGATE: &str = "test-delegate-capabilities";
     const TEST_CONTRACT: &str = "test-contract-integration";
 
-    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
-    let contract_id = *contract.key().id();
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
     let state = WrappedState::from(test_utils::create_todo_list_with_item(
         "Published by node-a",
     ));
-    let mut client =
-        a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"]).await?;
+    // The helper chooses the instance, because it may need several to find a
+    // node that does not hold one (#5542 F6).
+    let (mut client, contract) =
+        a_node_without_the_contract(ctx, TEST_CONTRACT, state, &["node-b", "node-c", "node-d"])
+            .await?;
+    let contract_id = *contract.key().id();
 
     register_delegate(&mut client, &delegate, &delegate_key).await?;
 

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4421,9 +4421,11 @@ async fn test_delegate_get_reaches_the_network_for_an_unseen_contract(
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
-    let state = WrappedState::from(test_utils::create_todo_list_with_item("Published by node-a"));
-    let mut client = a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"])
-        .await?;
+    let state = WrappedState::from(test_utils::create_todo_list_with_item(
+        "Published by node-a",
+    ));
+    let mut client =
+        a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"]).await?;
 
     register_delegate(&mut client, &delegate, &delegate_key).await?;
 
@@ -4498,9 +4500,11 @@ async fn test_delegate_subscribe_reaches_the_network_for_an_unseen_contract(
     let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
     let delegate_key = delegate.key().clone();
 
-    let state = WrappedState::from(test_utils::create_todo_list_with_item("Published by node-a"));
-    let mut client = a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"])
-        .await?;
+    let state = WrappedState::from(test_utils::create_todo_list_with_item(
+        "Published by node-a",
+    ));
+    let mut client =
+        a_node_without_the_contract(ctx, &contract, state, &["node-b", "node-c", "node-d"]).await?;
 
     register_delegate(&mut client, &delegate, &delegate_key).await?;
 

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4191,6 +4191,301 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
 }
 
 // ============================================================================
+// #5542: a V1 delegate's GET and SUBSCRIBE must reach the network
+// ============================================================================
+
+/// Drive one `test-delegate-capabilities` command over `client` and return the
+/// `DelegateCommandResponse` the delegate produced.
+///
+/// Shared by the two #5542 tests so they exercise byte-identical plumbing; the
+/// interesting difference between them is the command, not the transport.
+async fn run_delegate_command(
+    client: &mut WebApi,
+    delegate_key: &DelegateKey,
+    command: &DelegateCommand,
+    wait: Duration,
+) -> anyhow::Result<DelegateCommandResponse> {
+    let payload = bincode::serialize(command)?;
+    client
+        .send(ClientRequest::DelegateOp(
+            freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                key: delegate_key.clone(),
+                params: Parameters::from(vec![]),
+                inbound: vec![InboundDelegateMsg::ApplicationMessage(
+                    ApplicationMessage::new(payload),
+                )],
+            },
+        ))
+        .await?;
+
+    let deadline = std::time::Instant::now() + wait;
+    while std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Ok(HostResponse::DelegateResponse { key, values })) => {
+                ensure!(&key == delegate_key, "delegate key mismatch on response");
+                if let Some(parsed) = values.iter().find_map(|v| {
+                    if let OutboundDelegateMsg::ApplicationMessage(msg) = v {
+                        bincode::deserialize::<DelegateCommandResponse>(&msg.payload).ok()
+                    } else {
+                        None
+                    }
+                }) {
+                    return Ok(parsed);
+                }
+                tracing::debug!(?values, "delegate response with no parsable app message");
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "ignoring while awaiting delegate response"),
+            Ok(Err(e)) => bail!("websocket error awaiting delegate response: {e}"),
+            Err(_) => {}
+        }
+    }
+    bail!("no delegate response within {wait:?}")
+}
+
+/// Register `delegate` on `client` and wait for the acknowledgement.
+async fn register_delegate(
+    client: &mut WebApi,
+    delegate: &freenet_stdlib::prelude::DelegateContainer,
+    delegate_key: &DelegateKey,
+) -> anyhow::Result<()> {
+    client
+        .send(ClientRequest::DelegateOp(
+            freenet_stdlib::client_api::DelegateRequest::RegisterDelegate {
+                delegate: delegate.clone(),
+                cipher: TEST_DELEGATE_CIPHER,
+                nonce: TEST_DELEGATE_NONCE,
+            },
+        ))
+        .await?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Ok(HostResponse::DelegateResponse { key, .. })) => {
+                ensure!(&key == delegate_key, "delegate key mismatch on register");
+                return Ok(());
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "ignoring while awaiting registration"),
+            Ok(Err(e)) => bail!("websocket error awaiting registration: {e}"),
+            Err(_) => {}
+        }
+    }
+    bail!("delegate registration was not acknowledged within 60s")
+}
+
+/// Regression test for #5542: a delegate GET reaches the NETWORK for a contract
+/// this node has never seen.
+///
+/// **This test cannot be single-node.** Both pre-existing delegate E2E tests
+/// (`test_delegate_contract_get`, `test_delegate_contract_put_and_update`) run
+/// `nodes = ["gateway"]`, and on one node every contract a delegate can name is
+/// necessarily already in the local store — which is precisely the case the bug
+/// handled correctly. The gap only exists on a node that has NOT seen the
+/// contract, so observing it needs a second node.
+///
+/// Shape:
+///   1. node-a PUTs the contract with a distinctive state.
+///   2. node-b registers the delegate. node-b issues no contract operation of
+///      its own for this contract, so nothing primes its local store — which is
+///      exactly the situation of a delegate running with the browser tab shut.
+///   3. node-b's delegate GETs the contract. Before this fix it received
+///      `state: None`, silently, and could not tell that from an empty
+///      contract. It must now receive the state node-a published.
+///
+/// **Stated residual.** Placement is not under the test's control: a PUT on a
+/// small network can legitimately place the contract on node-b as a host, in
+/// which case the delegate GET is answered from the local store and the run is
+/// vacuous — it passes without exercising the network path at all. There is no
+/// client-visible "is this in your store, locally, right now" query to gate on,
+/// so this is recorded rather than defended against. Non-vacuity was
+/// established the only way available: by running this test against `main`
+/// without the fix, where it fails with a `None` state.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway", "node-a", "node-b"],
+    timeout_secs = 600,
+    startup_wait_secs = 40,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_delegate_get_reaches_the_network_for_an_unseen_contract(
+    ctx: &mut TestContext,
+) -> TestResult {
+    const TEST_DELEGATE: &str = "test-delegate-capabilities";
+    const TEST_CONTRACT: &str = "test-contract-integration";
+
+    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
+    let contract_key = contract.key();
+    let contract_id = *contract_key.id();
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    let node_a = ctx.node("node-a")?;
+    let node_b = ctx.node("node-b")?;
+    let (stream_a, _) = connect_async(&node_a.ws_url()).await?;
+    let mut client_a = WebApi::start(stream_a);
+    let (stream_b, _) = connect_async(&node_b.ws_url()).await?;
+    let mut client_b = WebApi::start(stream_b);
+
+    // --- 1. node-a publishes the contract ---------------------------------
+    let initial_state = test_utils::create_todo_list_with_item("Published by node-a");
+    make_put(
+        &mut client_a,
+        WrappedState::from(initial_state.clone()),
+        contract.clone(),
+        true,
+    )
+    .await?;
+    let mut put_ok = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while !put_ok && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_a.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+                ensure!(key == contract_key, "PUT response for the wrong contract");
+                put_ok = true;
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting PUT"),
+            Ok(Err(e)) => bail!("node-a: websocket error awaiting PUT: {e}"),
+            Err(_) => {}
+        }
+    }
+    ensure!(put_ok, "node-a: no PutResponse within 60s");
+
+    // --- 2. node-b registers the delegate, and nothing else ---------------
+    register_delegate(&mut client_b, &delegate, &delegate_key).await?;
+
+    // --- 3. the delegate GETs a contract node-b has never asked for -------
+    let response = run_delegate_command(
+        &mut client_b,
+        &delegate_key,
+        &DelegateCommand::GetContractState { contract_id },
+        Duration::from_secs(120),
+    )
+    .await?;
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    match response {
+        DelegateCommandResponse::ContractState { state, .. } => {
+            let bytes = state.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "delegate GET returned `None` for a contract that exists on the \
+                     network. This is the #5542 bug: the delegate never reached the \
+                     network, and cannot tell this answer from an empty contract"
+                )
+            })?;
+            let todo: test_utils::TodoList = serde_json::from_slice(&bytes)?;
+            ensure!(
+                todo.tasks.len() == 1 && todo.tasks[0].title == "Published by node-a",
+                "delegate GET returned the wrong state: {todo:?}"
+            );
+        }
+        other => bail!("expected ContractState from the delegate, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Regression test for #5542: a delegate SUBSCRIBE succeeds for a contract this
+/// node has never seen.
+///
+/// Before this fix the SUBSCRIBE arm gated on a local-store lookup and answered
+/// `Err("Contract not found")`, so a delegate could only ever subscribe to
+/// contracts something else had already fetched for it. Subscribing to a
+/// contract the node has never seen is the PRIMARY use case — a delegate
+/// waiting on a per-address contract to learn that a payment landed has no
+/// other way to name it.
+///
+/// **What this test does and does not establish.** It establishes that the gate
+/// is open and that the subscribe is reported successful, which fails against
+/// `main`. It does NOT by itself establish that notifications subsequently flow:
+/// that needs an update on another peer to be observed arriving at this
+/// delegate, and the notification-driven delegate run routes its output through
+/// the app registry rather than back to this client, so it is not observable
+/// on this socket. That second half is what makes `run_executor_subscribe` the
+/// right entry point (it bootstraps the body, registers demand AND establishes
+/// the network subscription, where the old arm did none of the three), and it
+/// deserves its own test rather than an assertion this one cannot make. Stated
+/// rather than implied, because "subscribe returned Ok" reading as "the delegate
+/// will now hear about changes" is exactly the silent failure #5467 describes.
+///
+/// The same placement residual as the GET test above applies.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway", "node-a", "node-b"],
+    timeout_secs = 600,
+    startup_wait_secs = 40,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_delegate_subscribe_reaches_the_network_for_an_unseen_contract(
+    ctx: &mut TestContext,
+) -> TestResult {
+    const TEST_DELEGATE: &str = "test-delegate-capabilities";
+    const TEST_CONTRACT: &str = "test-contract-integration";
+
+    let contract = load_contract(TEST_CONTRACT, Parameters::from(vec![]))?;
+    let contract_key = contract.key();
+    let contract_id = *contract_key.id();
+    let delegate = load_delegate(TEST_DELEGATE, Parameters::from(vec![]))?;
+    let delegate_key = delegate.key().clone();
+
+    let node_a = ctx.node("node-a")?;
+    let node_b = ctx.node("node-b")?;
+    let (stream_a, _) = connect_async(&node_a.ws_url()).await?;
+    let mut client_a = WebApi::start(stream_a);
+    let (stream_b, _) = connect_async(&node_b.ws_url()).await?;
+    let mut client_b = WebApi::start(stream_b);
+
+    let initial_state = test_utils::create_todo_list_with_item("Published by node-a");
+    make_put(
+        &mut client_a,
+        WrappedState::from(initial_state),
+        contract.clone(),
+        true,
+    )
+    .await?;
+    let mut put_ok = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while !put_ok && std::time::Instant::now() < deadline {
+        match timeout(Duration::from_secs(5), client_a.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { key }))) => {
+                ensure!(key == contract_key, "PUT response for the wrong contract");
+                put_ok = true;
+            }
+            Ok(Ok(other)) => tracing::debug!(?other, "node-a: ignoring while awaiting PUT"),
+            Ok(Err(e)) => bail!("node-a: websocket error awaiting PUT: {e}"),
+            Err(_) => {}
+        }
+    }
+    ensure!(put_ok, "node-a: no PutResponse within 60s");
+
+    register_delegate(&mut client_b, &delegate, &delegate_key).await?;
+
+    let response = run_delegate_command(
+        &mut client_b,
+        &delegate_key,
+        &DelegateCommand::SubscribeContract { contract_id },
+        Duration::from_secs(180),
+    )
+    .await?;
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    match response {
+        DelegateCommandResponse::ContractSubscribeResult { success, error, .. } => {
+            ensure!(
+                success,
+                "delegate SUBSCRIBE to a contract this node has never seen was \
+                 refused ({error:?}). This is the #5542 bug: the arm gated on a \
+                 local-store lookup, so a delegate could only subscribe to what \
+                 something else had already fetched for it"
+            );
+        }
+        other => bail!("expected ContractSubscribeResult from the delegate, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // #5479: a V2 delegate's contract write must reach the network
 // ============================================================================
 


### PR DESCRIPTION
Fixes the V1 half of #5542.

## The gap

A delegate could only interact with contracts this node had **already seen**. Every delegate-facing contract operation except PUT gated on a local-store lookup and gave up on a miss, so something else (in practice a client GET over the WebSocket) had to prime the store first. That is exactly what is absent when the browser tab is closed, which is the whole reason delegates exist.

GET was the worst of the three: it returned `state: None` silently, so a delegate could not tell "this contract is empty" from "this node has never heard of it".

## What this does

* **GET** on a local miss fetches from the network via `start_sub_op_get(.., return_contract_code: true)`.
* **SUBSCRIBE** on a local miss bootstraps via `run_executor_subscribe`.
* **UPDATE** for a contract this node does not hold keeps failing, and now also self-heals in the background, so the delegate's retry succeeds, matching the contract a client UPDATE already has on this node.

"Local" means a **state**, not a known key: `lookup_key` answering `Some` says this node knows the contract's *code*, and `fetch_contract` can still return `Ok((None, _))`. All three local-miss shapes fall through to the network path.

Neither GET nor SUBSCRIBE is awaited on the serial `contract_handling` loop. A sub-op GET runs to `SUB_OP_FETCH_TIMEOUT` (120 s), and awaiting one there would freeze every operation on the node for that long. The work is off-loaded through #5544's `delegate_park` continuation machinery, and the delegate's own `DelegateContext` round-trips through the response.

Both entry points take a bare `ContractInstanceId`, which is all a delegate has, so **no stdlib change and no change to any operation primitive**.

## Interest accounting: the part that took the most review

`run_executor_subscribe` ends in `InterestManager::add_local_client`: a per-**contract** refcount, taking no client id, explicitly non-idempotent. That is the demand registration the feature needs: without it the contract is evicted out from under the subscription. But every decrement in the tree is reached only from a `ClientId`-keyed context (the WebSocket disconnect sweep, and eviction's `remove_evicted_in_use`), and a delegate has no `ClientId`.

`wasm_runtime::delegate_interest` records that obligation where the refcount is taken and discharges it at every path that drops a delegate subscription. Each hold is self-discharging: it carries the `ContractKey` plus a type-erased release closure, so the module needs no `crate::ring` dependency and each hold releases through **its own node's** `OpManager`. The closure holds a `Weak`, so a hold never keeps a shut-down node's manager alive.

Keyed by `(contract, delegate)` with one hold per **node**. The pair is the outer key deliberately: other release paths (including the per-delegate subscription cap on #5623) look a pair up directly, and a miss here is a silent no-op by design. Node identity is a monotonic per-process counter, not an `Arc` address, because `OpManager` has no `Drop` and glibc reuses freed allocations LIFO.

**Four** paths drop a delegate subscription, not three: `UnregisterDelegate`, `ContractStore::remove_contract`, the notification-channel-closed sweep, and `InMemoryContractStore::remove_contract`. The fourth had diverged from the production store since #3251, and it did so in the **simulation** backend, so simulations were modelling a node that behaves differently from the one that ships.

## Containment

Every delegate-originated network operation is bounded and gated.

* **Fan-out.** `MAX_NETWORK_CONTRACT_OPS_PER_PARK = 4`, giving a node-wide ceiling of `MAX_PARKED_DELEGATES` (64) × 4 = **256**, matching the client path's `MAX_INFLIGHT_DEFERRALS` rather than exceeding it. The budget rides on `RunSeed` and `Continuation`, so it spans the whole round trip and neither a further iteration nor a park resets it. The UPDATE self-heal's fire-and-forget fetches are charged against the same budget. **A new delegate-originated caller of `start_sub_op_get` must join it, not open its own.**
* **Egress ban gate.** `reject_if_contract_banned` runs on all four delegate paths: GET, SUBSCRIBE (local branch and network branch alike), and the UPDATE self-heal. Gated at admission rather than inside `start_sub_op_get`, which would reshape that primitive's other callers including the phantom-repair path.
* **Refusal, never inline.** Over the cap, with no park available, or with no network handle, the request is refused. #5544's park-cap fallback to an inline wait is explicitly not inheritable by an operation that reaches the network.

## Named, not fixed

`GetContractResponse.state` is a bare `Option<WrappedState>` with no error channel, so a refusal, a network NotFound and an unreachable network all reach the delegate as `None`. An empty contract returns `Some(WrappedState(vec![]))`, so "found and empty" is distinguishable. But **absence versus ignorance is not expressible without a stdlib wire change**. It belongs with #5565. Every site where this bites logs at `warn!`.

## Out of scope, deliberately

* **The V2 sync host functions** (`get_contract_state_sync`, `subscribe_contract_sync`) are synchronous `fn`s inside `inbound_app_message`, which already holds `&mut Executor`. Reaching the network there needs #5485's buffer-and-replay. This costs nothing today: a census of river, delta, harvest, ghostkeys, atlas, freenet-bitcoin, raven and freenet-core found **zero production callers**.
* **Unsubscribe (#5600), wakeups, and refusal visibility (#5565)** are untouched.

## Review history

Two full review rounds after the first CI-green head. Round one found the interest refcount had no reachable decrement; round two found three blockers, **two of them in code added by round one's fixes**:

* the fan-out budget was declared inside the iteration loop, making the real ceiling 100× the documented one;
* delegate-originated network ops bypassed the contract-ban egress gate entirely;
* a resolved SUBSCRIBE whose resume was dropped on epoch mismatch stranded its refcount permanently, reachable by node load alone.

Round three found the local SUBSCRIBE branch had inherited no ban gate when it gained a demand registration two commits after the gate landed.

**Three guards in this PR could not fail and were repaired**: a source scrape blind to a binding's lexical scope, two scrapes that passed over commented-out and relocated calls, and one whose region bound skipped 1,848 lines because `"\nfn "` does not match `async fn`. `tests::production_code` now fails closed rather than falling back to scraping the whole file. Each blocker has a test demonstrated red before its fix.

## Known residuals

* Contract removal racing a parked subscribe resurrects the subscription and a hold until the next removal (stale subscription, not a leak).
* The multi-node tests' precondition (finding a node that does not hold the contract) is not under the test's control, since every-hop placement can legitimately put it everywhere. It fails loudly rather than passing vacuously, and the failure message says so.
* Cancelling `run_executor_subscribe` between `add_local_client` and its return leaks one refcount. Closing it means making the registration transactional inside `subscribe`.

## Verification

`cargo clippy -p freenet --all-targets -- -D warnings` clean; `cargo test -p freenet --lib` green; `cargo fmt -- --check` clean. Two multi-node integration tests (`nodes = ["gateway", "node-a", "node-b"]`) reuse the existing `test-delegate-capabilities` fixture unchanged.

https://claude.ai/code/session_015k3AmivdXMHWaZb8qGuQQz

