### PR TITLE
feat(delegates): bound how many contracts one delegate may subscribe to

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -710,10 +710,9 @@ fn already_subscribed(
         ),
         // No `OpManager`: no refcount can have been taken, so the registry is
         // the only record there is, and a mock executor has exactly one node.
-        None => crate::wasm_runtime::delegate_subscriptions::is_subscribed(
-            contract_id,
-            delegate_key,
-        ),
+        None => {
+            crate::wasm_runtime::delegate_subscriptions::is_subscribed(contract_id, delegate_key)
+        }
     }
 }
 

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -681,7 +681,7 @@ where
 ///
 /// Extracted so the non-idempotency guard in the SUBSCRIBE arm has a name, and
 /// so it can be unit-tested without a running loop. See that call site for why
-/// the guard exists: `add_local_client` is a refcount, `DELEGATE_SUBSCRIPTIONS`
+/// the guard exists: `add_local_client` is a refcount, the subscription registry
 /// is a set, and wiring the network path in without this makes a re-subscribe
 /// leak demand.
 fn already_subscribed(
@@ -691,7 +691,7 @@ fn already_subscribed(
 ) -> bool {
     match op_manager {
         // PER-NODE, because the question is "has THIS node established it"
-        // (#5542, Codex P2). `DELEGATE_SUBSCRIPTIONS` is process-global and
+        // (#5542, Codex P2). The subscription registry is process-global and
         // carries no node identity, so consulting it alone answers for the
         // PROCESS: in an in-process multi-node run the second node to subscribe
         // the same delegate to the same contract saw the first node's entry,
@@ -710,9 +710,10 @@ fn already_subscribed(
         ),
         // No `OpManager`: no refcount can have been taken, so the registry is
         // the only record there is, and a mock executor has exactly one node.
-        None => crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .get(contract_id)
-            .is_some_and(|subs| subs.contains(delegate_key)),
+        None => crate::wasm_runtime::delegate_subscriptions::is_subscribed(
+            contract_id,
+            delegate_key,
+        ),
     }
 }
 
@@ -865,7 +866,7 @@ where
 ///
 /// Releases only for `(Subscribe, Subscribed)`, the same evidence
 /// `delegate_interest::record` gates on, so it can never decrement interest a
-/// different subscriber holds. Installs no `DELEGATE_SUBSCRIPTIONS` hook: the
+/// different subscriber holds. Installs no subscription-registry hook: the
 /// delegate is not told it is subscribed, and nothing advertises a delivery
 /// path that will not be served.
 ///
@@ -925,10 +926,10 @@ fn release_stranded_subscribe_interest<CH>(
 /// Finish a resolved delegate network operation ON the loop (#5542).
 ///
 /// The network work happened off-loop; what is left is the part that must be
-/// serial. For a successful SUBSCRIBE that is the `DELEGATE_SUBSCRIPTIONS`
-/// insert — done HERE and only on success, so the registry never claims a
-/// delivery path that was not established, and so the registry has exactly one
-/// writer on this path.
+/// serial. For a successful SUBSCRIBE that is the subscription-registry insert
+/// — done HERE and only on success, so the registry never claims a delivery
+/// path that was not established, and so the registry has exactly one writer on
+/// this path.
 fn apply_resolved_contract_op<CH>(
     contract_handler: &mut CH,
     resolved: delegate_park::ResolvedContractOp,
@@ -945,10 +946,14 @@ where
             delegate_park::ContractOpOutcome::Subscribed
         )
     ) {
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .entry(pending.contract_id)
-            .or_default()
-            .insert(delegate_key.clone());
+        // Third of the three registration paths, and bounded like the other
+        // two: a cap enforced at some of them would be an opt-out rather than a
+        // cap. This is also the ONLY path that takes an interest refcount, so
+        // if admission evicts a colder subscription to make room, that
+        // subscription's hold has to be given back — `subscribe` does that
+        // itself (see `SubscribeOutcome::RegisteredEvicting`), because a caller
+        // that ignores the outcome compiles fine and two of the three do.
+        crate::wasm_runtime::delegate_subscriptions::subscribe(pending.contract_id, delegate_key);
         // RECORD THE OBLIGATION THIS SUBSCRIBE JUST INCURRED (#5542).
         //
         // `run_executor_subscribe` ended in
@@ -2008,7 +2013,8 @@ where
         }
 
         // Process SUBSCRIBE requests
-        // There are two registration paths that converge on DELEGATE_SUBSCRIPTIONS:
+        // There are two registration paths that converge on the delegate
+        // subscription registry (`wasm_runtime::delegate_subscriptions`):
         // 1. V2 delegates: subscribe_contract() host function (native_api.rs) registers
         //    during WASM execution and returns success/error synchronously.
         // 2. V1 delegates: emit SubscribeContractRequest in process() outbound, handled here.
@@ -2100,7 +2106,7 @@ where
                         // local path end in `InterestManager::add_local_client`,
                         // which is a REFCOUNT and is explicitly NOT idempotent (see
                         // the `!is_renewal` gate at `operations/subscribe.rs`).
-                        // `DELEGATE_SUBSCRIPTIONS` is a map keyed by delegate, so
+                        // the subscription registry is keyed by delegate, so
                         // the pre-#5542 arm was idempotent for free and a delegate
                         // re-subscribing in a loop cost nothing. Without this gate
                         // each repeat takes another interest refcount for one
@@ -2173,10 +2179,10 @@ where
                             interest_registered,
                             "Delegate subscribed to a contract this node already holds"
                         );
-                        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-                            .entry(contract_id)
-                            .or_default()
-                            .insert(delegate_key.clone());
+                        crate::wasm_runtime::delegate_subscriptions::subscribe(
+                            contract_id,
+                            delegate_key,
+                        );
                         Ok(())
                     } else if parking.is_some()
                         && can_reach_network
@@ -2195,7 +2201,7 @@ where
                         //
                         // OPENING THIS GATE ALONE WOULD SHIP THE FEATURE SILENT.
                         // The arm above does one thing — insert into
-                        // `DELEGATE_SUBSCRIPTIONS` — which is a local notification
+                        // the subscription registry — which is a local notification
                         // hook that nothing in `ring/` reads. It establishes no
                         // network subscription, so a delegate would subscribe
                         // successfully to a contract it has never seen and then
@@ -2212,7 +2218,7 @@ where
                         //      from under the subscription),
                         //   3. establish the real network subscription.
                         //
-                        // The notification hook (the `DELEGATE_SUBSCRIPTIONS`
+                        // The notification hook (the registry
                         // insert) is then done on the loop when the park resumes, and
                         // ONLY on success — so a failed subscribe leaves no hook
                         // claiming a delivery path that does not exist.
@@ -2458,7 +2464,7 @@ where
             // If
             // notification-driven inter-delegate messaging is ever wanted, it
             // must come back with the originating scope RECORDED ON THE
-            // SUBSCRIPTION (both `DELEGATE_SUBSCRIPTIONS` registration paths) and
+            // SUBSCRIPTION (both `delegate_subscriptions` registration paths) and
             // propagated here — never with a hardcoded `Local`.
             //
             // `info!`, not `debug!`: the crate sets `release_max_level_info`, so
@@ -4089,7 +4095,7 @@ fn route_notification_outbound(delegate_key: &DelegateKey, outbound: Vec<Outboun
     // the residual ApplicationMessages are the delegate's replies meant for
     // connected apps. A notification-driven invocation has no originating
     // client request to answer, so we fan them out via the delegate->apps
-    // registry (delegate_app_registry) — the mirror of DELEGATE_SUBSCRIPTIONS,
+    // registry (delegate_app_registry) — the mirror of delegate_subscriptions,
     // populated when an app talks to the delegate over its WS connection.
     let app_messages: Vec<OutboundDelegateMsg> = outbound
         .into_iter()
@@ -4492,7 +4498,7 @@ where
     }
     // Delegate network GET/SUBSCRIBE results (#5542). Nothing has to be re-run
     // on the loop for these — the network work is done — but a successful
-    // SUBSCRIBE installs its `DELEGATE_SUBSCRIPTIONS` hook here, on the loop and
+    // SUBSCRIBE installs its subscription-registry hook here, on the loop and
     // only on success, so the registry never advertises a delivery path that was
     // never established.
     for resolved in contract_ops {
@@ -8575,7 +8581,7 @@ mod hol_4391_tests {
         }
     }
 
-    /// #5542. The `DELEGATE_SUBSCRIPTIONS` hook is installed ONLY when the
+    /// #5542. The subscription-registry hook is installed ONLY when the
     /// network subscription actually succeeded.
     ///
     /// This is the concrete form of the warning on the issue: that map is a
@@ -8596,8 +8602,8 @@ mod hol_4391_tests {
         let bad_id = ContractInstanceId::new([23u8; 32]);
         // Global registry: use ids unique to this test so it does not race the
         // rest of the suite.
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&ok_id);
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&ok_id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&bad_id);
 
         let (mut handler, _send) = build_handler(vec![]).await;
         let _ = apply_resolved_contract_op(
@@ -8636,8 +8642,8 @@ mod hol_4391_tests {
             "a FAILED subscribe must not install a hook: it would advertise a \
              delivery path that was never established"
         );
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&ok_id);
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&bad_id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&ok_id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&bad_id);
     }
 
     /// Build a real `OpManager` backed by a temp-dir `Config`, mirroring
@@ -8799,7 +8805,7 @@ mod hol_4391_tests {
                 .into(),
             );
         }
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(key.id());
 
         let handle = GlobalExecutor::spawn(contract_handling(
             handler,
@@ -8844,7 +8850,7 @@ mod hol_4391_tests {
         );
 
         handle.abort();
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(key.id());
     }
 
     /// #5542 findings M4 and N2, together, because they are two halves of one
@@ -8906,7 +8912,7 @@ mod hol_4391_tests {
                 )]
                 .into(),
             );
-            crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+            crate::wasm_runtime::delegate_subscriptions::remove_contract(key.id());
         }
 
         let handle = GlobalExecutor::spawn(contract_handling(
@@ -8977,7 +8983,7 @@ mod hol_4391_tests {
 
         handle.abort();
         for key in [banned_key, allowed_key] {
-            crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+            crate::wasm_runtime::delegate_subscriptions::remove_contract(key.id());
         }
     }
 
@@ -9354,7 +9360,7 @@ mod hol_4391_tests {
         // The key `add_local_client` was called with: the FULL key, carrying the
         // real code hash, because the subscribe op knew it.
         let full_key = ContractKey::from_id_and_code(id, CodeHash::new([33u8; 32]));
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&id);
 
         // Stand in for what `run_executor_subscribe` did before returning Ok.
         assert!(
@@ -9390,7 +9396,7 @@ mod hol_4391_tests {
              subscription is dropped, even though the contract body never \
              landed and the full `ContractKey` could not be resolved (#5542)"
         );
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&id);
+        crate::wasm_runtime::delegate_subscriptions::remove_contract(&id);
     }
 
     /// #5542. A delegate SUBSCRIBE that cannot reach the network must still get

--- a/crates/core/src/contract/delegate_app_registry.rs
+++ b/crates/core/src/contract/delegate_app_registry.rs
@@ -2,8 +2,8 @@
 //! talk to it, so notification-driven delegate invocations can route their
 //! outbound [`ApplicationMessage`]s back to those apps.
 //!
-//! This is the mirror of [`crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS`]:
-//! `DELEGATE_SUBSCRIPTIONS` maps `contract -> delegates` (which delegates want
+//! This is the mirror of [`crate::wasm_runtime::delegate_subscriptions`]:
+//! that registry maps `contract -> delegates` (which delegates want
 //! to hear about a contract's state changes); this registry maps
 //! `delegate -> apps` (which client connections should receive the delegate's
 //! resulting `ApplicationMessage`s).
@@ -423,7 +423,7 @@ mod tests {
     use freenet_stdlib::prelude::CodeHash;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    // The registry is a process-global (mirroring DELEGATE_SUBSCRIPTIONS), so
+    // The registry is a process-global (mirroring delegate_subscriptions), so
     // these unit tests run against SHARED state under plain `cargo test`'s
     // in-process parallelism. Each test therefore carves out its OWN key/id
     // namespace from a global counter instead of relying on clear_for_test()

--- a/crates/core/src/contract/delegate_park.rs
+++ b/crates/core/src/contract/delegate_park.rs
@@ -122,7 +122,7 @@
 //! process global. It holds this node's client responders and gates this
 //! node's loop, and an in-process multi-node simulation must not share either.
 //! Same reasoning as `client_events::user_op_rate_limit`, and deliberately
-//! unlike the older `DELEGATE_SUBSCRIPTIONS` global.
+//! unlike the older `delegate_subscriptions` global registry.
 
 use std::collections::{HashMap, VecDeque};
 use std::time::Duration;
@@ -693,8 +693,11 @@ pub(super) enum ContractOpKind {
 /// operation, and awaiting one on the serial `contract_handling` loop freezes
 /// every contract operation on the node for its whole duration. Unlike an
 /// upsert, nothing has to be re-run on the loop afterwards - the response is
-/// pure data - but the SUBSCRIBE registry insert is still done there, so
-/// `DELEGATE_SUBSCRIPTIONS` is only ever written from one place.
+/// pure data - but the SUBSCRIBE registry insert is still done there, so this
+/// path writes the subscription registry from exactly one place. (The registry
+/// as a whole has three writers - this one, the V1 local-state arm and the V2
+/// host function - all of which go through
+/// `wasm_runtime::delegate_subscriptions::subscribe`.)
 pub(super) struct PendingContractOp {
     /// Unique per request, for the lifetime of the process.
     ///

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use crate::config::ConfigArgs;
 use crate::contract::executor::{ContractExecutor, Executor, OperationMode};
 use crate::node::OpManager;
-use crate::wasm_runtime::{DELEGATE_SUBSCRIPTIONS, MockStateStorage};
+use crate::wasm_runtime::MockStateStorage;
 
 use super::super::mock_runtime::test::create_test_contract as test_contract;
 
@@ -82,9 +82,9 @@ async fn build_op_manager(
 }
 
 /// Registers one delegate against one contract in the process-global
-/// `DELEGATE_SUBSCRIPTIONS` map and removes the entry on drop.
+/// subscription registry and removes the entry on drop.
 ///
-/// `DELEGATE_SUBSCRIPTIONS` is process-global (#4824), and CI runs
+/// the subscription registry is process-global (#4824), and CI runs
 /// `cargo nextest` (process per test) while contributors run plain
 /// `cargo test` (one process for all of them) — see
 /// `.claude/rules/testing.md`. So each test uses a contract key derived
@@ -97,10 +97,7 @@ struct SubscriptionGuard {
 
 impl SubscriptionGuard {
     fn register(instance_id: ContractInstanceId, delegate: DelegateKey) -> Self {
-        DELEGATE_SUBSCRIPTIONS
-            .entry(instance_id)
-            .or_default()
-            .insert(delegate.clone());
+        crate::wasm_runtime::delegate_subscriptions::subscribe(instance_id, &delegate);
         Self {
             instance_id,
             delegate,
@@ -115,12 +112,7 @@ impl Drop for SubscriptionGuard {
         // test's subscription if the keys ever collided, which is the shape
         // `.claude/rules/testing.md` warns about for shared globals. Mirrors
         // how production cleans up in `runtime/delegates.rs`.
-        DELEGATE_SUBSCRIPTIONS.retain(|id, subs| {
-            if id == &self.instance_id {
-                subs.remove(&self.delegate);
-            }
-            !subs.is_empty()
-        });
+        crate::wasm_runtime::delegate_subscriptions::unsubscribe(&self.instance_id, &self.delegate);
     }
 }
 

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_tests.rs
@@ -221,6 +221,73 @@ async fn initial_state_install_notifies_subscribed_delegates() {
     );
 }
 
+/// Delivering a notification must MARK the subscription as used, and this pins
+/// the production call rather than the helper.
+///
+/// `delegate_subscriptions::note_notified` is what orders cap eviction: the
+/// victim is the delegate's least-recently-NOTIFIED subscription, so a
+/// subscription that is actually delivering stays warm. The helper has unit
+/// coverage in its own module, but that coverage calls it directly — so
+/// deleting the call in `send_delegate_contract_notifications` leaves every
+/// stamp frozen at registration time and the whole suite still green. Eviction
+/// would then pick by subscription age, which for a delegate at its cap means
+/// evicting its BUSIEST subscription first: the exact inversion the ordering
+/// exists to prevent, arriving silently.
+///
+/// Behavioural rather than a source scrape, because the executor and the
+/// notification channel are both reachable here — a scrape would pass on a
+/// commented-out call.
+#[tokio::test(flavor = "current_thread")]
+async fn delivering_a_notification_marks_the_subscription_as_used() {
+    let (op_manager, _notifications, _guards) =
+        build_op_manager("delegate-notify-marks-used").await;
+    let contract = test_contract(b"delegate_notify_marks_used_contract");
+    let key = contract.key();
+    let state = WrappedState::new((1u8..=32).collect::<Vec<u8>>());
+
+    let delegate = test_delegate_key(9);
+    let _subscription = SubscriptionGuard::register(*key.id(), delegate.clone());
+
+    // The stamp as `subscribe` left it. Eviction compares these, so what
+    // matters is that delivery moves it, not its absolute value.
+    let at_registration =
+        crate::wasm_runtime::delegate_subscriptions::last_notified(key.id(), &delegate)
+            .expect("the subscription must be registered before the commit");
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    let mut executor = build_executor(&op_manager).await;
+    executor.set_delegate_notification_tx(tx);
+
+    executor
+        .upsert_contract_state(
+            key,
+            Either::Left(state.clone()),
+            RelatedContracts::default(),
+            Some(contract.clone()),
+        )
+        .await
+        .expect("initial install");
+
+    // Receiving first is what makes this deterministic rather than a race: the
+    // stamp is written on successful enqueue, which happens before the value
+    // can be received.
+    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("a notification must be delivered for a subscribed delegate")
+        .expect("delegate notification channel closed");
+
+    let after_delivery =
+        crate::wasm_runtime::delegate_subscriptions::last_notified(key.id(), &delegate)
+            .expect("the subscription must still be registered after delivery");
+
+    assert!(
+        after_delivery > at_registration,
+        "delivering a notification must stamp the subscription as used; without \
+         that call, cap eviction orders by registration age instead of by use \
+         and evicts the delegate's busiest subscription first"
+    );
+}
+
 /// Control for the test above: the MERGE path has always notified
 /// delegates (`commit_state_update` → `send_delegate_contract_notifications`).
 ///

--- a/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/delegate_notification_wasm_tests.rs
@@ -49,9 +49,7 @@ use crate::config::ConfigArgs;
 use crate::contract::executor::{ContractExecutor, DelegateNotification, Executor, OperationMode};
 use crate::node::OpManager;
 use crate::operations::get::GetResult;
-use crate::wasm_runtime::{
-    ContractStore, DELEGATE_SUBSCRIPTIONS, DelegateStore, Runtime, SecretsStore, StateStore,
-};
+use crate::wasm_runtime::{ContractStore, DelegateStore, Runtime, SecretsStore, StateStore};
 
 /// The same mock-aligned fixture `wasm_conformance_tests` uses: its
 /// `validate_state` always returns `Valid`, so a PUT of arbitrary bytes lands
@@ -70,7 +68,7 @@ const DELTA_TRAP_CONTRACT: &str = "test-contract-delta-trap";
 
 /// Every test loads its contracts under DISTINCT parameters.
 ///
-/// `DELEGATE_SUBSCRIPTIONS` is process-global (#4824) and keyed by
+/// the subscription registry is process-global (#4824) and keyed by
 /// `ContractInstanceId`. CI runs `cargo nextest` (process per test) but
 /// contributors run plain `cargo test` (one process for all of them), and a
 /// contract's instance id is `hash(code, params)` — so two tests loading the
@@ -83,7 +81,7 @@ fn params(tag: u8) -> Parameters<'static> {
 }
 
 /// Registers one delegate against one contract and removes exactly that
-/// registration on drop — `DELEGATE_SUBSCRIPTIONS` is process-global (#4824),
+/// registration on drop — the subscription registry is process-global (#4824),
 /// so a blanket `remove` would delete a concurrent test's entry under plain
 /// `cargo test`. Mirrors the guard in the sibling module.
 struct SubscriptionGuard {
@@ -93,10 +91,7 @@ struct SubscriptionGuard {
 
 impl SubscriptionGuard {
     fn register(instance_id: ContractInstanceId, delegate: DelegateKey) -> Self {
-        DELEGATE_SUBSCRIPTIONS
-            .entry(instance_id)
-            .or_default()
-            .insert(delegate.clone());
+        crate::wasm_runtime::delegate_subscriptions::subscribe(instance_id, &delegate);
         Self {
             instance_id,
             delegate,
@@ -106,12 +101,7 @@ impl SubscriptionGuard {
 
 impl Drop for SubscriptionGuard {
     fn drop(&mut self) {
-        DELEGATE_SUBSCRIPTIONS.retain(|id, subs| {
-            if id == &self.instance_id {
-                subs.remove(&self.delegate);
-            }
-            !subs.is_empty()
-        });
+        crate::wasm_runtime::delegate_subscriptions::unsubscribe(&self.instance_id, &self.delegate);
     }
 }
 

--- a/crates/core/src/contract/executor/runtime/delegates.rs
+++ b/crates/core/src/contract/executor/runtime/delegates.rs
@@ -283,11 +283,12 @@ impl Executor<Runtime> {
             DelegateRequest::UnregisterDelegate(key) => {
                 self.delegate_origin_ids.remove(&key);
 
-                // Remove delegate from all contract subscription entries
-                crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.retain(|_, subscribers| {
-                    subscribers.remove(&key);
-                    !subscribers.is_empty()
-                });
+                // Remove delegate from all contract subscription entries. Goes
+                // through the registry's own function so the reverse index used
+                // for the per-delegate cap is cleared too — a stale entry there
+                // would hold cap budget for a delegate that no longer exists,
+                // and nothing ages it out.
+                crate::wasm_runtime::delegate_subscriptions::remove_delegate(&key);
                 // ...and give back the local interest those subscriptions took
                 // (#5542). Dropping the subscription without this leaves
                 // `local_interests` permanently above zero for the contract, so

--- a/crates/core/src/contract/executor/runtime/executor_impl.rs
+++ b/crates/core/src/contract/executor/runtime/executor_impl.rs
@@ -2378,7 +2378,7 @@ where
 
     /// Send notifications to delegates subscribed to a contract's state changes.
     ///
-    /// Checks the global `DELEGATE_SUBSCRIPTIONS` registry and sends a
+    /// Checks the global `delegate_subscriptions` registry and sends a
     /// `DelegateNotification` for each subscribed delegate through the channel.
     ///
     /// This is a **best-effort, lossy** notification path: if the bounded channel
@@ -2392,14 +2392,12 @@ where
         };
 
         let instance_id = *key.id();
-        // Snapshot subscribers and release the DashMap read-lock before sending
-        let subscribers: Vec<DelegateKey> = {
-            let entry = crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.get(&instance_id);
-            match entry {
-                Some(ref s) if !s.is_empty() => s.iter().cloned().collect(),
-                _ => return,
-            }
-        };
+        // Snapshot subscribers; the registry returns an owned Vec so no shard
+        // lock is held across the sends below.
+        let subscribers = crate::wasm_runtime::delegate_subscriptions::subscribers_of(&instance_id);
+        if subscribers.is_empty() {
+            return;
+        }
 
         tracing::debug!(
             contract = %key,
@@ -2416,7 +2414,18 @@ where
                 contract_id: instance_id,
                 new_state: Arc::clone(&shared_state),
             }) {
-                Ok(()) => {}
+                Ok(()) => {
+                    // Ordinary use, which is what orders cap eviction: a
+                    // subscription that is actually delivering stays warm, so
+                    // the one dropped under pressure is whichever this delegate
+                    // has heard about least recently. Stamped on successful
+                    // enqueue only — a notification dropped by a full channel is
+                    // not evidence the delegate is using the subscription.
+                    crate::wasm_runtime::delegate_subscriptions::note_notified(
+                        &instance_id,
+                        &delegate_key,
+                    );
+                }
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     static DROPPED: AtomicUsize = AtomicUsize::new(0);
                     let total = DROPPED.fetch_add(1, Ordering::Relaxed) + 1;
@@ -2435,7 +2444,7 @@ where
                     // Receiver is gone; clean up all subscriptions for this contract
                     // to prevent repeated failed sends on future state updates,
                     // and release the interest they took (#5542).
-                    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.remove(&instance_id);
+                    crate::wasm_runtime::delegate_subscriptions::remove_contract(&instance_id);
                     crate::wasm_runtime::delegate_interest::release_contract(&instance_id);
                     return;
                 }

--- a/crates/core/src/wasm_runtime.rs
+++ b/crates/core/src/wasm_runtime.rs
@@ -4,6 +4,7 @@ mod delegate;
 pub(crate) mod delegate_api;
 pub(crate) mod delegate_interest;
 mod delegate_store;
+pub(crate) mod delegate_subscriptions;
 pub(crate) mod engine;
 mod error;
 pub(crate) mod mock_state_storage;
@@ -77,7 +78,7 @@ pub(crate) use module_cache::{
     MAX_DEFAULT_MODULE_CACHE_BUDGET_BYTES, MIN_DEFAULT_MODULE_CACHE_BUDGET_BYTES,
 };
 pub(crate) use native_api::{
-    DELEGATE_SUBSCRIPTIONS, DelegateContextCache, SharedDelegateCounter, SharedInheritedOrigins,
+    DelegateContextCache, SharedDelegateCounter, SharedInheritedOrigins,
     new_delegate_context_cache, new_delegate_counter, new_inherited_origins,
     release_created_delegate_slot,
 };

--- a/crates/core/src/wasm_runtime/contract_store.rs
+++ b/crates/core/src/wasm_runtime/contract_store.rs
@@ -526,7 +526,7 @@ impl ContractStore {
         // release the local interest they took (#5542). The release is
         // self-discharging — each hold carries its own node's closure — so this
         // module keeps no `crate::ring` dependency.
-        super::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        super::delegate_subscriptions::remove_contract(key.id());
         super::delegate_interest::release_contract(key.id());
 
         // The WASM blob on disk is keyed by code hash and shared by every

--- a/crates/core/src/wasm_runtime/delegate/test.rs
+++ b/crates/core/src/wasm_runtime/delegate/test.rs
@@ -3509,7 +3509,7 @@ async fn test_contract_notification_delivered() -> Result<(), Box<dyn std::error
 ///
 /// Verifies the full pipeline:
 /// 1. Delegate subscribes to a contract via SubscribeContractRequest
-/// 2. Subscription is registered in DELEGATE_SUBSCRIPTIONS
+/// 2. Subscription is registered in the delegate subscription registry
 /// 3. ContractNotification is delivered to the delegate
 /// 4. Delegate responds with ContractNotificationReceived
 /// 5. Cleanup: unregister delegate removes subscription entries
@@ -3602,10 +3602,10 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
         .code_hash_from_id(&subscribe_req.contract_id)
         .is_some()
     {
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .entry(subscribe_req.contract_id)
-            .or_default()
-            .insert(delegate_key.clone());
+        crate::wasm_runtime::delegate_subscriptions::subscribe(
+            subscribe_req.contract_id,
+            &delegate_key,
+        );
         Ok(())
     } else {
         Err("Contract not found".to_string())
@@ -3663,10 +3663,11 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
 
     // --- Step 2: Verify registry is populated ---
     {
-        let entry = crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.get(&contract_instance_id);
-        let subscribers = entry.as_ref().unwrap();
         assert!(
-            subscribers.contains(&delegate_key),
+            crate::wasm_runtime::delegate_subscriptions::is_subscribed(
+                &contract_instance_id,
+                &delegate_key
+            ),
             "Delegate should be registered as subscriber"
         );
     }
@@ -3733,15 +3734,12 @@ async fn test_subscribe_then_notify_roundtrip() -> Result<(), Box<dyn std::error
     }
 
     // --- Step 5: Cleanup on delegate unregister ---
-    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.retain(|_, subscribers| {
-        subscribers.remove(&delegate_key);
-        !subscribers.is_empty()
-    });
+    crate::wasm_runtime::delegate_subscriptions::remove_delegate(&delegate_key);
 
     // Verify cleanup
-    let entry = crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.get(&contract_instance_id);
     assert!(
-        entry.is_none() || entry.as_ref().unwrap().is_empty(),
+        crate::wasm_runtime::delegate_subscriptions::subscribers_of(&contract_instance_id)
+            .is_empty(),
         "Subscription should be cleaned up after delegate unregister"
     );
 
@@ -3830,10 +3828,10 @@ async fn test_notification_application_message_routed_to_registered_app()
         OutboundDelegateMsg::SubscribeContractRequest(req) => req.clone(),
         other => panic!("Expected SubscribeContractRequest, got {other:?}"),
     };
-    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-        .entry(subscribe_req.contract_id)
-        .or_default()
-        .insert(delegate_key.clone());
+    crate::wasm_runtime::delegate_subscriptions::subscribe(
+        subscribe_req.contract_id,
+        &delegate_key,
+    );
     // Feed the subscribe response back so the delegate finishes subscribing.
     let _ = runtime.inbound_app_message(
         &delegate_key,
@@ -3936,15 +3934,12 @@ async fn test_notification_application_message_routed_to_registered_app()
         "after disconnect no app should remain registered"
     );
 
-    crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS.retain(|_, subs| {
-        subs.remove(&delegate_key);
-        !subs.is_empty()
-    });
+    crate::wasm_runtime::delegate_subscriptions::remove_delegate(&delegate_key);
     std::mem::drop(temp_dir);
     Ok(())
 }
 
-/// Test: removing a contract cleans up DELEGATE_SUBSCRIPTIONS.
+/// Test: removing a contract cleans up its delegate subscriptions.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_contract_removal_cleans_subscriptions() -> Result<(), Box<dyn std::error::Error>> {
     use crate::contract::storages::Storage;
@@ -3975,19 +3970,13 @@ async fn test_contract_removal_cleans_subscriptions() -> Result<(), Box<dyn std:
     // Simulate delegate subscriptions
     let delegate_key_a = DelegateKey::new([1u8; 32], CodeHash::new([10u8; 32]));
     let delegate_key_b = DelegateKey::new([2u8; 32], CodeHash::new([20u8; 32]));
-    {
-        let mut entry = crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .entry(contract_instance_id)
-            .or_default();
-        entry.insert(delegate_key_a);
-        entry.insert(delegate_key_b);
-    }
+    crate::wasm_runtime::delegate_subscriptions::subscribe(contract_instance_id, &delegate_key_a);
+    crate::wasm_runtime::delegate_subscriptions::subscribe(contract_instance_id, &delegate_key_b);
 
     // Verify subscriptions exist
-    assert!(
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .get(&contract_instance_id)
-            .is_some()
+    assert_eq!(
+        crate::wasm_runtime::delegate_subscriptions::subscribers_of(&contract_instance_id).len(),
+        2
     );
 
     // Remove the contract — should clean up subscriptions
@@ -3995,10 +3984,19 @@ async fn test_contract_removal_cleans_subscriptions() -> Result<(), Box<dyn std:
 
     // Verify subscriptions are cleaned up
     assert!(
-        crate::wasm_runtime::DELEGATE_SUBSCRIPTIONS
-            .get(&contract_instance_id)
-            .is_none(),
-        "DELEGATE_SUBSCRIPTIONS should be cleaned up when contract is removed"
+        crate::wasm_runtime::delegate_subscriptions::subscribers_of(&contract_instance_id)
+            .is_empty(),
+        "delegate subscriptions should be cleaned up when contract is removed"
+    );
+    // The reverse index must be cleared too, or the removed contract would keep
+    // holding cap budget for both delegates with nothing to age it out.
+    assert_eq!(
+        crate::wasm_runtime::delegate_subscriptions::subscription_count(&delegate_key_a),
+        0
+    );
+    assert_eq!(
+        crate::wasm_runtime::delegate_subscriptions::subscription_count(&delegate_key_b),
+        0
     );
 
     std::mem::drop(temp_dir);

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -152,7 +152,7 @@ pub(crate) fn record(
 /// Whether THIS node already holds an interest obligation for
 /// `(contract, delegate)` (#5542, Codex P2).
 ///
-/// The subscription registry `DELEGATE_SUBSCRIPTIONS` is process-global and
+/// The subscription registry is process-global and
 /// carries no node identity, so asking it "is this delegate already subscribed"
 /// answers for the PROCESS, not for this node. In an in-process multi-node run
 /// the second node to subscribe the same delegate to the same contract sees the
@@ -226,10 +226,20 @@ pub(crate) fn release_pair(contract: &ContractInstanceId, delegate: &DelegateKey
     // doing that under a DashMap guard is how lock-order inversions get built.
     // `remove` hands back the owned entry, so the guard is gone by the time the
     // closure runs.
-    let Some((_, hold)) = DELEGATE_INTEREST_HOLDS.remove(&(*contract, delegate.clone())) else {
+    // EVERY node's hold under this pair, not the first. The value is a map
+    // keyed by node identity (#5542 M3), because two nodes in an in-process run
+    // each take their own refcount on their own `InterestManager`. Discharging
+    // one and dropping the entry would leave the other's interest standing with
+    // nothing left to release it, which is the leak this whole module exists to
+    // close, reintroduced by an eviction. #5615's
+    // `a_pair_keyed_lookup_discharges_every_node_holding_it` pins the same
+    // property from the other side.
+    let Some((_, holds)) = DELEGATE_INTEREST_HOLDS.remove(&(*contract, delegate.clone())) else {
         return;
     };
-    (hold.release)(&hold.key);
+    for hold in holds.into_values() {
+        (hold.release)(&hold.key);
+    }
 }
 
 /// Release every hold taken for `contract`, across all delegates.

--- a/crates/core/src/wasm_runtime/delegate_interest.rs
+++ b/crates/core/src/wasm_runtime/delegate_interest.rs
@@ -3,10 +3,10 @@
 //!
 //! # Why this exists
 //!
-//! Before #5542 the V1 delegate SUBSCRIBE arm inserted into
-//! [`DELEGATE_SUBSCRIPTIONS`](super::DELEGATE_SUBSCRIPTIONS) and did nothing
-//! else. The registry is a `HashSet`, so a re-subscribe was idempotent for free
-//! and there was no accounting to get wrong.
+//! Before #5542 the V1 delegate SUBSCRIBE arm inserted into the subscription
+//! registry ([`super::delegate_subscriptions`]) and did nothing else. The
+//! registry is a set, so a re-subscribe was idempotent for free and there was
+//! no accounting to get wrong.
 //!
 //! #5542 routes a subscribe for a contract this node does not hold through
 //! `run_executor_subscribe`, which ends in
@@ -54,7 +54,7 @@
 //! **Only acquisitions this node actually made.** A subscribe answered from the
 //! local store takes no refcount, and neither does the V2
 //! `subscribe_contract_sync` host function — both only insert the registry
-//! hook. So this map is a strict subset of `DELEGATE_SUBSCRIPTIONS`, keyed by
+//! hook. So this map is a strict subset of the subscription registry, keyed by
 //! the same pair, and releasing is driven from HERE rather than from the
 //! registry. That is what makes over-release impossible: an entry exists if and
 //! only if `add_local_client` ran for that pair, so a decrement can never fall
@@ -194,6 +194,42 @@ pub(crate) fn release_delegate(delegate: &DelegateKey) {
     for (key, release) in discharged {
         release(&key);
     }
+}
+
+/// Release the hold taken for exactly ONE `(contract, delegate)` pair, leaving
+/// every other delegate's hold on that contract and every other hold of that
+/// delegate alone.
+///
+/// The two functions above discharge a whole delegate or a whole contract,
+/// which is right for the three sites that drop subscriptions in bulk
+/// (`UnregisterDelegate`, contract removal, channel-closed cleanup). Neither
+/// fits a drop of a SINGLE pair: `release_delegate` would discharge holds on
+/// contracts the delegate still subscribes to, and `release_contract` would
+/// discharge holds belonging to OTHER delegates — over-release, which is
+/// strictly worse than the leak, because the decrement falls on interest a real
+/// subscriber holds.
+///
+/// The caller is the per-delegate subscription cap: when a delegate at its cap
+/// admits a new contract, the coldest subscription is evicted, and the refcount
+/// that subscription took has to come back with it. Without this, an evicted
+/// pair's `add_local_client` stands forever, `local_interests` never returns to
+/// zero and `cleanup_contract_if_no_interest` never fires — the leak this
+/// module exists to close, arriving through a door it did not have when it was
+/// written.
+///
+/// A no-op for a pair holding nothing, exactly like the other two: most pairs
+/// take no refcount at all (a subscribe answered from the local store, and the
+/// V2 host function).
+pub(crate) fn release_pair(contract: &ContractInstanceId, delegate: &DelegateKey) {
+    // Remove first and release afterwards, outside the shard guard: a release
+    // closure reaches into `InterestManager`, which takes its own locks, and
+    // doing that under a DashMap guard is how lock-order inversions get built.
+    // `remove` hands back the owned entry, so the guard is gone by the time the
+    // closure runs.
+    let Some((_, hold)) = DELEGATE_INTEREST_HOLDS.remove(&(*contract, delegate.clone())) else {
+        return;
+    };
+    (hold.release)(&hold.key);
 }
 
 /// Release every hold taken for `contract`, across all delegates.
@@ -484,7 +520,7 @@ mod tests {
         )];
         assert!(
             body.contains("delegate_interest::record("),
-            "the site that installs the DELEGATE_SUBSCRIPTIONS hook after a \
+            "the site that installs the subscription-registry hook after a \
              successful network subscribe is the site that took the \
              `add_local_client` refcount, so it must record the obligation to \
              release it (#5542)"

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -360,12 +360,22 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
     }
 
     owned.insert(contract, now);
-    drop(owned);
-
+    // Under the SAME guard as the reverse-index insert above, not after it.
+    //
+    // Dropping the guard first leaves a window in which another task
+    // subscribing for this delegate can reach the cap, pick this very contract
+    // as its coldest victim, and call `drop_from_contract_map` for a forward
+    // entry that has not been written yet — a no-op — before this task writes
+    // it. The reverse index would then have lost the contract while the forward
+    // index gained it: the split-brain state again, in a third direction, and
+    // one that leaves the delegate on the delivery path for a subscription it
+    // is not counted as holding. This is not hypothetical; the concurrency test
+    // below caught it on its first run.
     BY_CONTRACT
         .entry(contract)
         .or_default()
         .insert(delegate.clone());
+    drop(owned);
 
     match evicted {
         Some(id) => {
@@ -759,6 +769,87 @@ mod tests {
         assert_eq!(subscription_count(&victim), 1);
         cleanup(&victim);
         cleanup(&hog);
+    }
+
+    /// The cap must hold under genuine concurrent contention, which is the one
+    /// thing every other test in this file cannot show.
+    ///
+    /// `subscribe` holds the `BY_DELEGATE` entry write guard across the whole
+    /// check-evict-insert sequence, and the comment at that site names the race
+    /// it exists to prevent: two concurrent subscribes for the same delegate
+    /// both observing `len() == cap - 1` and both inserting. Every other test
+    /// here calls `subscribe` sequentially from one task, so **the guard could
+    /// be deleted and all of them would still pass** — the mechanism the
+    /// implementation was built to survive would be the one nothing drives.
+    ///
+    /// Multi-threaded on purpose: a current-thread runtime interleaves at await
+    /// points, and `subscribe` is synchronous, so on one worker the sequence is
+    /// atomic for free and the test would prove nothing. The barrier makes the
+    /// tasks start together rather than trickling in.
+    ///
+    /// Deliberately over-subscribes by 2x the cap so eviction, which is the part
+    /// that reads and mutates under the same guard, is contended rather than
+    /// incidental.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_subscribes_never_exceed_the_cap() {
+        use std::sync::Arc;
+
+        const TASKS: u16 = 8;
+        const PER_TASK: u16 = 64;
+        const BASE: u16 = 20000;
+
+        let d = dkey(16);
+        let barrier = Arc::new(tokio::sync::Barrier::new(TASKS as usize));
+        let mut handles = Vec::new();
+        for t in 0..TASKS {
+            let delegate = d.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                for i in 0..PER_TASK {
+                    subscribe(cid(BASE + t * PER_TASK + i), &delegate);
+                }
+            }));
+        }
+        for h in handles {
+            h.await.expect("no subscribing task may panic");
+        }
+
+        let held = subscription_count(&d);
+        assert!(
+            held <= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+            "the cap must hold under concurrency: {TASKS} tasks x {PER_TASK} \
+             subscribes left {held} held against a cap of \
+             {MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE}. Exceeding it means \
+             check-evict-insert was not atomic and two subscribes both admitted \
+             against the same free slot"
+        );
+        assert_eq!(
+            held,
+            MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+            "and it must be exactly full: {} subscribes for distinct contracts \
+             cannot leave the delegate under its cap",
+            TASKS * PER_TASK
+        );
+
+        // The two indexes must still agree afterwards. A racing evict that
+        // cleared one half and not the other would leave the count right and
+        // the registry wrong, which the count assertions above cannot see.
+        let mut listed = 0;
+        for t in 0..TASKS {
+            for i in 0..PER_TASK {
+                if is_subscribed(&cid(BASE + t * PER_TASK + i), &d) {
+                    listed += 1;
+                }
+            }
+        }
+        assert_eq!(
+            listed, held,
+            "every contract the reverse index counts must also be listed in the \
+             forward index; a mismatch is the split-brain state under a race"
+        );
+
+        cleanup(&d);
     }
 
     /// The two indexes can disagree, and a re-subscribe must repair it rather

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -260,6 +260,24 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
         // means "last notification delivered", and letting a delegate refresh it
         // by re-subscribing in a loop would let it pin an entry it never hears
         // from, defeating the eviction order.
+        //
+        // It DOES re-assert the forward-map half, which is not redundant. This
+        // function dedups on the reverse index while `is_subscribed` answers
+        // from the forward map, and while ONE map existed those were the same
+        // question by construction. They are no longer, so a state where the
+        // two disagree is now representable, and without this line it would be
+        // PERMANENT: the early return above happens before the forward-map
+        // insert below, so no later subscribe would ever repair it, and
+        // `remove_contract` early-returns on a missing forward entry so no
+        // removal would clean it either. The subscription would be dead —
+        // silently receiving nothing — while still holding a unit of cap budget
+        // that nothing ages out. A `HashSet` insert is idempotent and the
+        // reverse index is untouched here, so this cannot admit past the cap or
+        // double-count; it only makes every subscribe self-healing.
+        BY_CONTRACT
+            .entry(contract)
+            .or_default()
+            .insert(delegate.clone());
         return SubscribeOutcome::AlreadySubscribed;
     }
 
@@ -351,12 +369,31 @@ pub(crate) fn note_notified(contract: &ContractInstanceId, delegate: &DelegateKe
 
 /// Drop every subscription held by `delegate` (delegate unregistered).
 pub(crate) fn remove_delegate(delegate: &DelegateKey) {
-    let Some((_, owned)) = BY_DELEGATE.remove(delegate) else {
+    // Hold the reverse-index guard across the forward-map cleanup, rather than
+    // removing the entry and then walking a detached snapshot.
+    //
+    // Executors are a pool, so `UnregisterDelegate` does not run on the same
+    // thread as the V2 host call or `apply_resolved_contract_op`. A `subscribe`
+    // for this delegate completing inside a snapshot walk would recreate the
+    // reverse-index entry and insert into the forward map, and the walk would
+    // then strip the forward half back out — leaving exactly the disagreement
+    // the re-subscribe path above has to heal. Holding the guard makes such a
+    // `subscribe` wait instead, so the window does not exist in this direction
+    // at all. Same lock order as `subscribe` (reverse index, then forward), so
+    // it cannot deadlock against it.
+    let Some(mut owned) = BY_DELEGATE.get_mut(delegate) else {
         return;
     };
-    for contract in owned.keys() {
+    let contracts: Vec<ContractInstanceId> = owned.keys().copied().collect();
+    owned.clear();
+    for contract in &contracts {
         drop_from_contract_map(contract, delegate);
     }
+    drop(owned);
+    // Re-checked under the removal guard: a `subscribe` that was waiting on the
+    // guard above may have refilled the entry, and removing a non-empty one
+    // would silently unsubscribe it.
+    BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
 }
 
 /// Drop every subscription to `contract` (contract removed, or its notification
@@ -648,6 +685,123 @@ mod tests {
         assert_eq!(subscription_count(&victim), 1);
         cleanup(&victim);
         cleanup(&hog);
+    }
+
+    /// The two indexes can disagree, and a re-subscribe must repair it rather
+    /// than dedup against the half that survived.
+    ///
+    /// `subscribe` dedups on the reverse index; `is_subscribed` answers from
+    /// the forward one. While there was a single map those were the same
+    /// question by construction — splitting the registry to enforce the cap
+    /// turned a structural property into one nothing enforces, so it is pinned
+    /// here instead.
+    ///
+    /// The disagreement is reachable: `remove_contract` snapshots the forward
+    /// entry and then walks it clearing reverse entries, and a `subscribe`
+    /// completing inside that walk is re-stripped from the forward map. The
+    /// consequence is what makes this worth a test rather than a comment —
+    /// without the repair, the early return happens BEFORE the forward-map
+    /// insert, so no later subscribe fixes it, `remove_contract` early-returns
+    /// on the missing forward entry so no removal cleans it, and the
+    /// subscription is permanently dead while still holding cap budget.
+    #[tokio::test]
+    async fn a_resubscribe_repairs_a_half_lost_registration() {
+        let d = dkey(12);
+        let c = cid(8500);
+        subscribe(c, &d);
+
+        // Exactly what a `subscribe` racing a removal walk leaves behind: the
+        // reverse index still claims the subscription, the forward index has
+        // lost it.
+        drop_from_contract_map(&c, &d);
+        assert!(
+            !is_subscribed(&c, &d),
+            "precondition: the forward half must be missing, or this test is \
+             not exercising the repair"
+        );
+        assert_eq!(subscription_count(&d), 1, "the reverse half must survive");
+
+        assert_eq!(
+            subscribe(c, &d),
+            SubscribeOutcome::AlreadySubscribed,
+            "the reverse index still holds it, so this is a re-subscribe"
+        );
+        assert!(
+            is_subscribed(&c, &d),
+            "a re-subscribe must re-assert the forward half; without it the \
+             subscription is permanently dead and permanently holds cap budget, \
+             because nothing else writes that entry and nothing ages it out"
+        );
+        assert_eq!(
+            subscription_count(&d),
+            1,
+            "repairing must not double-count against the cap"
+        );
+        cleanup(&d);
+    }
+
+    /// The mirror disagreement — forward half present, reverse half lost, which
+    /// is what a `subscribe` racing `remove_contract`'s walk leaves — must also
+    /// converge, and must not double-count.
+    #[tokio::test]
+    async fn a_resubscribe_repairs_a_lost_reverse_half() {
+        let d = dkey(13);
+        let c = cid(8600);
+        subscribe(c, &d);
+
+        if let Some(mut owned) = BY_DELEGATE.get_mut(&d) {
+            owned.remove(&c);
+        }
+        assert_eq!(subscription_count(&d), 0, "precondition: reverse half gone");
+        assert!(is_subscribed(&c, &d), "precondition: forward half survives");
+
+        assert_eq!(
+            subscribe(c, &d),
+            SubscribeOutcome::Registered,
+            "the reverse index lost it, so this registers rather than dedups"
+        );
+        assert!(is_subscribed(&c, &d));
+        assert_eq!(
+            subscription_count(&d),
+            1,
+            "the forward half was already present; re-registering must not \
+             leave the contract counted twice"
+        );
+        assert_eq!(
+            subscribers_of(&c),
+            vec![d.clone()],
+            "and must not duplicate the subscriber"
+        );
+        cleanup(&d);
+    }
+
+    /// Removing a delegate must leave the two indexes agreeing, including for a
+    /// delegate that still holds many subscriptions — the walk clears the
+    /// forward half for every one of them.
+    #[tokio::test]
+    async fn remove_delegate_leaves_both_indexes_agreeing() {
+        let d = dkey(14);
+        let others = dkey(15);
+        let shared = cid(8700);
+        subscribe(shared, &others);
+        for i in 0..8u16 {
+            subscribe(cid(8700 + i), &d);
+        }
+
+        remove_delegate(&d);
+
+        assert_eq!(subscription_count(&d), 0);
+        for i in 0..8u16 {
+            assert!(
+                !is_subscribed(&cid(8700 + i), &d),
+                "every forward entry must be cleared, not just the first"
+            );
+        }
+        assert!(
+            is_subscribed(&shared, &others),
+            "another delegate's subscription to the same contract must survive"
+        );
+        cleanup(&others);
     }
 
     /// Cap eviction drops ONE (contract, delegate) pair, and the local-interest

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -993,6 +993,74 @@ mod tests {
         cleanup(&d);
     }
 
+    /// Cap eviction must discharge EVERY node's hold under the evicted pair,
+    /// not just the first.
+    ///
+    /// #5615 keys the hold map by `(contract, delegate)` with node identity in
+    /// the VALUE, because two nodes in an in-process run each take their own
+    /// refcount on their own `InterestManager`. So `release_pair` has to drain
+    /// the whole per-node map. Discharging one and dropping the entry leaves the
+    /// other node's interest standing with nothing left to release it, which is
+    /// the leak `delegate_interest` exists to close, reintroduced through
+    /// eviction.
+    ///
+    /// This fails against a `release_pair` that takes the first hold and
+    /// returns, which is the shape the single-`Hold` value type before #5615's
+    /// M3 fix would naturally have produced.
+    #[tokio::test(start_paused = true)]
+    async fn cap_eviction_discharges_every_node_holding_the_evicted_pair() {
+        use crate::wasm_runtime::delegate_interest;
+        use std::sync::{Arc, Mutex};
+
+        const NODE_A: delegate_interest::NodeIdentity = 0xA1;
+        const NODE_B: delegate_interest::NodeIdentity = 0xB1;
+
+        let d = dkey(17);
+        let victim = cid(8800);
+
+        let released: Arc<Mutex<Vec<delegate_interest::NodeIdentity>>> = Default::default();
+        let make_release = |node| {
+            let sink = released.clone();
+            let release: delegate_interest::InterestRelease = Arc::new(move |_k| {
+                sink.lock().unwrap().push(node);
+            });
+            release
+        };
+        let ckey = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+            victim,
+            CodeHash::new([0xD5; 32]),
+        );
+
+        subscribe(victim, &d);
+        // Two nodes each took their own refcount for the same pair.
+        delegate_interest::record(victim, d.clone(), ckey, make_release(NODE_A), NODE_A);
+        delegate_interest::record(victim, d.clone(), ckey, make_release(NODE_B), NODE_B);
+
+        for i in 1..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            subscribe(cid(8800 + i as u16), &d);
+        }
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+
+        assert_eq!(
+            subscribe(cid(9200), &d),
+            SubscribeOutcome::RegisteredEvicting(victim),
+            "the victim must be the eviction target, or this test proves nothing"
+        );
+
+        let mut seen = released.lock().unwrap().clone();
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            vec![NODE_A, NODE_B],
+            "evicting a pair must give back EVERY node's refcount for it; \
+             discharging only the first leaves the second node's interest \
+             standing with nothing able to release it"
+        );
+
+        cleanup(&d);
+    }
+
     /// The two indexes can disagree, and a re-subscribe must repair it rather
     /// than dedup against the half that survived.
     ///
@@ -1157,8 +1225,16 @@ mod tests {
 
         // Both took an interest refcount, as the network-resolved subscribe
         // path does.
-        delegate_interest::record(victim, d.clone(), ckey(victim), make_release(victim));
-        delegate_interest::record(sibling, d.clone(), ckey(sibling), make_release(sibling));
+        // One node; the multi-node case is the test below.
+        const NODE: delegate_interest::NodeIdentity = 0xC1;
+        delegate_interest::record(victim, d.clone(), ckey(victim), make_release(victim), NODE);
+        delegate_interest::record(
+            sibling,
+            d.clone(),
+            ckey(sibling),
+            make_release(sibling),
+            NODE,
+        );
 
         for i in 2..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
             tokio::time::advance(std::time::Duration::from_millis(1)).await;

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -189,6 +189,13 @@ static BY_DELEGATE: LazyLock<
 static CAP_EVICTIONS: AtomicU64 = AtomicU64::new(0);
 
 /// What [`subscribe`] did.
+///
+/// Deliberately NOT `#[must_use]`. The obligation that would justify it —
+/// releasing the evicted pair's interest hold — is discharged by [`subscribe`]
+/// itself, precisely because relying on callers to notice an enum arm is what
+/// this design avoids. Two of the three registration paths correctly ignore the
+/// return value, so `#[must_use]` would buy nothing and cost a `let _ =` at
+/// those sites, which reads as an obligation being waived when none exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SubscribeOutcome {
     /// A new (contract, delegate) pair was recorded.
@@ -308,6 +315,18 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
         // which already costs milliseconds, and the scan is bounded by the cap.
         // Evicting more than strictly necessary would also discard legitimate
         // standing interest that nothing will re-establish.
+        //
+        // The scan runs UNDER the reverse-index write guard, which the same
+        // rule warns about and which the paragraph above does not answer. It is
+        // deliberate and it is what makes the cap exact: check, evict and
+        // insert have to be one atomic step, or two concurrent subscribes for
+        // the same delegate both observe `len() == cap - 1` and both insert.
+        // The cost is bounded and small — at most
+        // `MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE` (256) `Instant` comparisons
+        // over an in-memory map, holding ONE DashMap shard, contended only by
+        // other operations on delegates hashing to that same shard. Releasing
+        // the guard to scan would trade an exact bound for a lock-free one, and
+        // an off-by-a-few cap is not worth a re-entrancy hazard here.
         let coldest = owned
             .iter()
             .min_by_key(|(_, stamp)| **stamp)
@@ -316,16 +335,26 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
             owned.remove(&coldest);
             drop_from_contract_map(&coldest, delegate);
             let total = CAP_EVICTIONS.fetch_add(1, Ordering::Relaxed) + 1;
-            tracing::warn!(
-                %delegate,
-                evicted_contract = %coldest,
-                new_contract = %contract,
-                cap = MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
-                cap_evictions_total = total,
-                "Delegate at its contract-subscription cap; evicted its coldest \
-                 subscription to admit a new one. The delegate is NOT told, and \
-                 will stop receiving notifications for the evicted contract."
-            );
+            // Throttled, and the throttle is the point rather than tidiness. A
+            // delegate parked at its cap evicts on EVERY subscribe, so an
+            // unthrottled line here is an amplifier: the cheapest possible
+            // remote action produces one log write each, which is the shape a
+            // refusal path must never have. The first eviction is always
+            // reported so a node that sheds once is not silent, and the running
+            // total on every line it does emit carries the rate, so nothing is
+            // lost by dropping the ones in between.
+            if total == 1 || total % 64 == 0 {
+                tracing::warn!(
+                    %delegate,
+                    evicted_contract = %coldest,
+                    new_contract = %contract,
+                    cap = MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+                    cap_evictions_total = total,
+                    "Delegate at its contract-subscription cap; evicted its coldest \
+                     subscription to admit a new one. The delegate is NOT told, and \
+                     will stop receiving notifications for the evicted contract."
+                );
+            }
             evicted = Some(coldest);
         }
     }
@@ -471,12 +500,19 @@ fn drop_from_contract_map(contract: &ContractInstanceId, delegate: &DelegateKey)
 /// [`MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE`] instead of relying on eviction.
 /// Promote it out of `cfg(test)` when that lands.
 #[cfg(test)]
-pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey) {
+pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey) -> bool {
+    // Both halves are cleared whichever one the pair is recorded in, rather
+    // than gating the forward-map removal on the reverse-index hit. The two can
+    // disagree (see `subscribe`), and an unsubscribe that honoured only the
+    // reverse index would leave a delegate on the delivery path it just asked
+    // to leave. Returns whether anything was actually held, which is what #5600
+    // needs to answer "not subscribed" rather than reporting a silent success.
     let removed = match BY_DELEGATE.get_mut(delegate) {
         Some(mut owned) => owned.remove(contract).is_some(),
         None => false,
     };
-    if removed {
+    let was_listed = is_subscribed(contract, delegate);
+    if removed || was_listed {
         drop_from_contract_map(contract, delegate);
         BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
         // Same obligation as the eviction branch of `subscribe`: this drops one
@@ -491,6 +527,7 @@ pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey)
         // it later means finding it as a production leak.
         crate::wasm_runtime::delegate_interest::release_pair(contract, delegate);
     }
+    removed || was_listed
 }
 
 /// Cap evictions since process start. See [`CAP_EVICTIONS`].

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -73,14 +73,31 @@ use freenet_stdlib::prelude::{ContractInstanceId, DelegateKey};
 ///
 /// # What it bounds, and what it does not
 ///
-/// The worst case is not this number: a hostile app may spawn child delegates,
-/// each with its own budget, so the reachable total is
-/// `MAX_CREATED_DELEGATES_PER_NODE` (1024) x this. That composition is BOUNDED,
-/// which is the property that matters and the one the client-side cap does not
-/// have — `MAX_SUBSCRIPTIONS_PER_CLIENT` is per-`ClientId` and a client mints a
-/// fresh `ClientId` by opening another WebSocket, so that cap bounds nothing in
-/// aggregate. This one cannot be reset that way: a delegate key is derived from
-/// its code and params, and creating more delegates is separately capped.
+/// **This bounds one delegate. It does NOT give the node an aggregate ceiling,
+/// and an earlier version of this comment claimed it did.** That claim said the
+/// reachable total was `MAX_CREATED_DELEGATES_PER_NODE` (1024) x this, and it is
+/// wrong: that counter is incremented only by the `create_delegate` host
+/// function (`native_api.rs`), and `delegates.rs` states outright that
+/// "delegates registered directly by apps were never counted". So an app that
+/// registers delegates over its own WebSocket increments nothing, each distinct
+/// code+params pair is a distinct `DelegateKey`, and each such key gets a fresh
+/// budget of its own. The number of delegates is not bounded on that path, so
+/// neither is the product.
+///
+/// What IS bounded is the delegate-spawns-delegate composition: a delegate
+/// created by another delegate does pass through the counter, so that path is
+/// capped at 1024 x this.
+///
+/// State the residual rather than leaving the reader to find it: against an app
+/// that will register unlimited distinct delegates, this constant limits the
+/// blast radius of any ONE of them and nothing more. That is still worth having
+/// — it is what stops a single delegate accumulating an unbounded standing
+/// claim — but it is a per-principal bound, not a node-wide one, and the
+/// node-wide ceiling has to come from bounding delegate registration, which is
+/// not this change. The comparison with `MAX_SUBSCRIPTIONS_PER_CLIENT` (per
+/// `ClientId`, and a client mints a fresh one by opening another WebSocket) is
+/// therefore a similarity and not a contrast, which is the opposite of what this
+/// paragraph used to say.
 ///
 /// **A count is not a byte budget** (`.claude/rules/code-style.md`, clause 4), so
 /// state the byte story explicitly rather than leaving a count to imply one. Two
@@ -197,9 +214,11 @@ pub(crate) enum SubscribeOutcome {
     ///    incremented per subscribe and never decremented on eviction leaks, and
     ///    a leaked count never falls back to zero.
     ///
-    /// Ignoring this variant compiles (it is one arm of an enum), so the risk is
-    /// a caller that matches only `Registered` and treats the rest as success.
-    /// Match it explicitly.
+    /// **The `delegate_interest` hold is discharged by [`subscribe`] itself**, so
+    /// a caller does not have to remember to do it — ignoring this variant
+    /// compiles, it is one arm of an enum, and two of the three registration
+    /// paths ignore the return value entirely. Any OTHER per-pair resource a
+    /// future caller takes at registration must still be released here.
     RegisteredEvicting(ContractInstanceId),
 }
 
@@ -484,6 +503,24 @@ pub(crate) fn cap_evictions_total() -> u64 {
 #[cfg(test)]
 pub(crate) fn subscription_count(delegate: &DelegateKey) -> usize {
     BY_DELEGATE.get(delegate).map_or(0, |owned| owned.len())
+}
+
+/// When a notification for `contract` was last delivered to `delegate`.
+///
+/// Exists so a test can pin the PRODUCTION call to [`note_notified`] rather than
+/// only the helper. The helper being correct says nothing about it being wired
+/// up, and the wiring is the half that rots: delete the call in
+/// `send_delegate_contract_notifications` and every stamp stays at its
+/// registration time, so eviction starts targeting the delegate's BUSIEST
+/// subscription instead of its coldest, silently and with the suite still green.
+#[cfg(test)]
+pub(crate) fn last_notified(
+    contract: &ContractInstanceId,
+    delegate: &DelegateKey,
+) -> Option<tokio::time::Instant> {
+    BY_DELEGATE
+        .get(delegate)
+        .and_then(|owned| owned.get(contract).copied())
 }
 
 /// Whether `delegate` is subscribed to `contract`.

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -332,8 +332,10 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
             .min_by_key(|(_, stamp)| **stamp)
             .map(|(id, _)| *id);
         if let Some(coldest) = coldest {
-            owned.remove(&coldest);
-            drop_from_contract_map(&coldest, delegate);
+            // Through the shared writer, not inline: eviction is a removal that
+            // does not look like one, so it is the path a future durable half
+            // would be added everywhere except. See `forget_one`.
+            forget_one(Some(owned.value_mut()), &coldest, delegate);
             let total = CAP_EVICTIONS.fetch_add(1, Ordering::Relaxed) + 1;
             // Throttled, and the throttle is the point rather than tidiness. A
             // delegate parked at its cap evicts on EVERY subscribe, so an
@@ -478,6 +480,46 @@ pub(crate) fn remove_contract(contract: &ContractInstanceId) {
     }
 }
 
+/// The ONE place a single `(contract, delegate)` subscription is dropped, and
+/// therefore the only place anything that must happen when a subscription goes
+/// away belongs.
+///
+/// Takes the caller's ALREADY-HELD reverse-index guard as `owned` rather than
+/// acquiring its own. That is forced, not stylistic: the cap is exact only
+/// because `subscribe` holds that guard across the whole check-evict-insert
+/// sequence, so a writer that re-acquired it would deadlock against its own
+/// caller. `None` is for callers that hold no guard because the delegate has no
+/// reverse entry at all, which is reachable — the forward index can still list
+/// the pair after a `remove_contract` divergence, and clearing that is still a
+/// drop.
+///
+/// **Both removal callers go through here on purpose.** Cap eviction and
+/// `unsubscribe` drop exactly one pair, and eviction is the one that gets
+/// written separately and forgotten, because it does not look like a removal
+/// path — it looks like part of admission. A future durable half (#5493) has to
+/// be discharged HERE: an eviction that cleared the in-memory indexes and left a
+/// durable row would have the row replayed at the next boot, which does not
+/// merely undo the eviction — it restores the evicted subscription ALONGSIDE the
+/// newer ones and leaves the delegate ABOVE its cap, permanently, from the
+/// ordinary act of restarting a node.
+///
+/// Returns whether anything was actually held, so a caller can tell a real drop
+/// from a no-op.
+fn forget_one(
+    owned: Option<&mut HashMap<ContractInstanceId, tokio::time::Instant>>,
+    contract: &ContractInstanceId,
+    delegate: &DelegateKey,
+) -> bool {
+    let removed = owned.is_some_and(|o| o.remove(contract).is_some());
+    // Checked independently of the reverse half: the two can disagree, and a
+    // drop that honoured only one would leave the other behind.
+    let listed = is_subscribed(contract, delegate);
+    if removed || listed {
+        drop_from_contract_map(contract, delegate);
+    }
+    removed || listed
+}
+
 /// Remove `delegate` from `contract`'s subscriber set, dropping the contract's
 /// entry entirely once nothing is subscribed to it.
 ///
@@ -511,20 +553,22 @@ fn drop_from_contract_map(contract: &ContractInstanceId, delegate: &DelegateKey)
 /// Promote it out of `cfg(test)` when that lands.
 #[cfg(test)]
 pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey) -> bool {
-    // Both halves are cleared whichever one the pair is recorded in, rather
-    // than gating the forward-map removal on the reverse-index hit. The two can
-    // disagree (see `subscribe`), and an unsubscribe that honoured only the
-    // reverse index would leave a delegate on the delivery path it just asked
-    // to leave. Returns whether anything was actually held, which is what #5600
-    // needs to answer "not subscribed" rather than reporting a silent success.
-    let removed = match BY_DELEGATE.get_mut(delegate) {
-        Some(mut owned) => owned.remove(contract).is_some(),
-        None => false,
+    // Through the same writer cap eviction uses, so the two cannot drift: they
+    // are the only two paths that drop a single pair. Returns whether anything
+    // was held, which is what #5600 needs to answer "not subscribed" rather than
+    // reporting a silent success.
+    let dropped = match BY_DELEGATE.get_mut(delegate) {
+        Some(mut owned) => {
+            let dropped = forget_one(Some(owned.value_mut()), contract, delegate);
+            drop(owned);
+            BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
+            dropped
+        }
+        // No reverse entry: the forward index may still list the pair after a
+        // `remove_contract` divergence, and clearing that is still a drop.
+        None => forget_one(None, contract, delegate),
     };
-    let was_listed = is_subscribed(contract, delegate);
-    if removed || was_listed {
-        drop_from_contract_map(contract, delegate);
-        BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
+    if dropped {
         // Same obligation as the eviction branch of `subscribe`: this drops one
         // pair, so one pair's interest hold has to come back.
         //
@@ -537,7 +581,7 @@ pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey)
         // it later means finding it as a production leak.
         crate::wasm_runtime::delegate_interest::release_pair(contract, delegate);
     }
-    removed || was_listed
+    dropped
 }
 
 /// Cap evictions since process start. See [`CAP_EVICTIONS`].
@@ -795,61 +839,71 @@ mod tests {
         use std::sync::Arc;
 
         const TASKS: u16 = 8;
-        const PER_TASK: u16 = 64;
+        const PER_TASK: u16 = 40;
+        const ROUNDS: u16 = 60;
         const BASE: u16 = 20000;
 
+        // LOOPED ON PURPOSE, and the loop is the difference between a guard and
+        // an ornament. A single round detected the admission race roughly one
+        // time in seven when it was measured against the broken code — and the
+        // `ci` nextest profile sets `retries = 2`, so a probabilistic test is
+        // WORSE than none: the 1-in-7 run that catches the regression is retried
+        // twice, almost certainly passes, and CI reports green. The retry
+        // converts a real catch into a pass. Driving the window ~60 times per
+        // execution makes a single run fail essentially always, which is the
+        // only shape that survives a retry.
+        //
+        // Multi-threaded for the same reason: `subscribe` is synchronous, so on
+        // a current-thread runtime the sequence is atomic for free and the test
+        // would prove nothing.
         let d = dkey(16);
-        let barrier = Arc::new(tokio::sync::Barrier::new(TASKS as usize));
-        let mut handles = Vec::new();
-        for t in 0..TASKS {
-            let delegate = d.clone();
-            let barrier = Arc::clone(&barrier);
-            handles.push(tokio::spawn(async move {
-                barrier.wait().await;
+        for round in 0..ROUNDS {
+            let barrier = Arc::new(tokio::sync::Barrier::new(TASKS as usize));
+            let mut handles = Vec::new();
+            for t in 0..TASKS {
+                let delegate = d.clone();
+                let barrier = Arc::clone(&barrier);
+                handles.push(tokio::spawn(async move {
+                    barrier.wait().await;
+                    for i in 0..PER_TASK {
+                        subscribe(cid(BASE + t * PER_TASK + i), &delegate);
+                    }
+                }));
+            }
+            for h in handles {
+                h.await.expect("no subscribing task may panic");
+            }
+
+            let held = subscription_count(&d);
+            assert!(
+                held <= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+                "round {round}: the cap must hold under concurrency — {held} held \
+                 against a cap of {MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE}. \
+                 Exceeding it means check-evict-insert was not atomic and two \
+                 subscribes both admitted against the same free slot"
+            );
+
+            // The two indexes must agree. This is the assertion that caught the
+            // real admission race: the counts alone cannot see a pair that is
+            // listed for delivery but not counted against the budget.
+            let mut listed = 0;
+            for t in 0..TASKS {
                 for i in 0..PER_TASK {
-                    subscribe(cid(BASE + t * PER_TASK + i), &delegate);
-                }
-            }));
-        }
-        for h in handles {
-            h.await.expect("no subscribing task may panic");
-        }
-
-        let held = subscription_count(&d);
-        assert!(
-            held <= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
-            "the cap must hold under concurrency: {TASKS} tasks x {PER_TASK} \
-             subscribes left {held} held against a cap of \
-             {MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE}. Exceeding it means \
-             check-evict-insert was not atomic and two subscribes both admitted \
-             against the same free slot"
-        );
-        assert_eq!(
-            held,
-            MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
-            "and it must be exactly full: {} subscribes for distinct contracts \
-             cannot leave the delegate under its cap",
-            TASKS * PER_TASK
-        );
-
-        // The two indexes must still agree afterwards. A racing evict that
-        // cleared one half and not the other would leave the count right and
-        // the registry wrong, which the count assertions above cannot see.
-        let mut listed = 0;
-        for t in 0..TASKS {
-            for i in 0..PER_TASK {
-                if is_subscribed(&cid(BASE + t * PER_TASK + i), &d) {
-                    listed += 1;
+                    if is_subscribed(&cid(BASE + t * PER_TASK + i), &d) {
+                        listed += 1;
+                    }
                 }
             }
-        }
-        assert_eq!(
-            listed, held,
-            "every contract the reverse index counts must also be listed in the \
-             forward index; a mismatch is the split-brain state under a race"
-        );
+            assert_eq!(
+                listed, held,
+                "round {round}: every contract the reverse index counts must also \
+                 be listed in the forward index. A forward-only pair leaves the \
+                 delegate on the delivery path for a subscription that occupies \
+                 none of its budget and that cap eviction can never choose"
+            );
 
-        cleanup(&d);
+            cleanup(&d);
+        }
     }
 
     /// The two indexes can disagree, and a re-subscribe must repair it rather

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -229,6 +229,60 @@ pub(crate) enum SubscribeOutcome {
     RegisteredEvicting(ContractInstanceId),
 }
 
+/// A test-only pause between the two index writes in [`subscribe`], used to make
+/// the guard OBSERVABLE rather than to catch a race by luck.
+///
+/// The window this exists for is a handful of instructions wide, and whether it
+/// opens depends on whether the thread happens to be descheduled inside it. That
+/// makes an unaided concurrency test a property of machine load rather than of
+/// the code: measured against a deliberately broken build it caught the defect
+/// on a heavily loaded box and **0 times in 5 on a quiet one**. A test that
+/// passes on an idle CI runner and fails on a busy one is indistinguishable
+/// from flakiness and gets "fixed" with a retry.
+///
+/// Pausing at the exact point turns that into a decision rather than a race.
+/// The call sits between the reverse-index write and the forward-index write,
+/// so its position RELATIVE TO THE GUARD is the thing under test:
+///
+///  * guard held across both writes (correct): the pause happens while holding
+///    it, every other subscriber for that delegate blocks on the guard, and
+///    nothing can interleave. The test passes.
+///  * guard dropped before the forward write (the defect): the pause happens
+///    with nothing held, other subscribers proceed, fill the cap and evict this
+///    very contract before its forward entry is written. The test fails, every
+///    time.
+///
+/// So the hook is live in BOTH versions — it is not scaffolding that only means
+/// something against a reverted fix.
+///
+/// A pause and not a barrier, deliberately: a rendezvous here deadlocks the
+/// correct version, because the guard holder would wait for a task the guard is
+/// blocking. Armed for ONE designated contract so a test pays a single delay
+/// rather than one per subscribe.
+#[cfg(test)]
+pub(crate) mod race_hook {
+    use super::ContractInstanceId;
+    use std::sync::Mutex;
+
+    static ARMED: Mutex<Option<ContractInstanceId>> = Mutex::new(None);
+
+    /// Pause the next `subscribe` for `contract` inside the window.
+    pub(crate) fn arm(contract: ContractInstanceId) {
+        *ARMED.lock().unwrap() = Some(contract);
+    }
+
+    pub(crate) fn disarm() {
+        *ARMED.lock().unwrap() = None;
+    }
+
+    pub(super) fn maybe_pause(contract: &ContractInstanceId) {
+        let armed = *ARMED.lock().unwrap() == Some(*contract);
+        if armed {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+    }
+}
+
 /// Record `delegate`'s interest in `contract`, enforcing the per-delegate cap.
 ///
 /// # Why this evicts instead of refusing at the cap
@@ -362,6 +416,10 @@ pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) ->
     }
 
     owned.insert(contract, now);
+    // Between the two writes, so a test can prove the guard actually spans them.
+    // A no-op unless armed; see `race_hook`.
+    #[cfg(test)]
+    race_hook::maybe_pause(&contract);
     // Under the SAME guard as the reverse-index insert above, not after it.
     //
     // Dropping the guard first leaves a window in which another task
@@ -838,72 +896,101 @@ mod tests {
     async fn concurrent_subscribes_never_exceed_the_cap() {
         use std::sync::Arc;
 
-        const TASKS: u16 = 8;
-        const PER_TASK: u16 = 40;
-        const ROUNDS: u16 = 60;
+        const FILLERS: u16 = 8;
+        const PER_FILLER: u16 = 40;
         const BASE: u16 = 20000;
+        const VICTIM: u16 = 19999;
 
-        // LOOPED ON PURPOSE, and the loop is the difference between a guard and
-        // an ornament. A single round detected the admission race roughly one
-        // time in seven when it was measured against the broken code — and the
-        // `ci` nextest profile sets `retries = 2`, so a probabilistic test is
-        // WORSE than none: the 1-in-7 run that catches the regression is retried
-        // twice, almost certainly passes, and CI reports green. The retry
-        // converts a real catch into a pass. Driving the window ~60 times per
-        // execution makes a single run fail essentially always, which is the
-        // only shape that survives a retry.
+        // DETERMINISTIC, not probabilistic, and the difference is the whole
+        // value of this test. Racing `subscribe` unaided caught the real
+        // admission defect 0 times in 5 against a deliberately broken build on
+        // an idle machine, and once on a loaded one — detection was a property
+        // of machine load, not of the code, which is the kind of test that goes
+        // green on a quiet CI runner and gets a retry bolted on when it is not.
         //
-        // Multi-threaded for the same reason: `subscribe` is synchronous, so on
-        // a current-thread runtime the sequence is atomic for free and the test
-        // would prove nothing.
+        // `race_hook` pauses ONE subscribe between the reverse-index write and
+        // the forward-index write. That makes the guard's SPAN observable: with
+        // both writes under one guard the fillers below block and cannot
+        // interleave, and with the forward write outside it they proceed, fill
+        // the cap, and evict the victim before its forward entry exists.
         let d = dkey(16);
-        for round in 0..ROUNDS {
-            let barrier = Arc::new(tokio::sync::Barrier::new(TASKS as usize));
-            let mut handles = Vec::new();
-            for t in 0..TASKS {
-                let delegate = d.clone();
-                let barrier = Arc::clone(&barrier);
-                handles.push(tokio::spawn(async move {
-                    barrier.wait().await;
-                    for i in 0..PER_TASK {
-                        subscribe(cid(BASE + t * PER_TASK + i), &delegate);
-                    }
-                }));
-            }
-            for h in handles {
-                h.await.expect("no subscribing task may panic");
-            }
+        let victim = cid(VICTIM);
+        race_hook::arm(victim);
 
-            let held = subscription_count(&d);
-            assert!(
-                held <= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
-                "round {round}: the cap must hold under concurrency — {held} held \
-                 against a cap of {MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE}. \
-                 Exceeding it means check-evict-insert was not atomic and two \
-                 subscribes both admitted against the same free slot"
-            );
+        let start = Arc::new(tokio::sync::Barrier::new(2));
+        let victim_task = {
+            let delegate = d.clone();
+            let start = Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                tokio::task::spawn_blocking(move || subscribe(victim, &delegate))
+                    .await
+                    .expect("victim subscribe must not panic")
+            })
+        };
 
-            // The two indexes must agree. This is the assertion that caught the
-            // real admission race: the counts alone cannot see a pair that is
-            // listed for delivery but not counted against the budget.
-            let mut listed = 0;
-            for t in 0..TASKS {
-                for i in 0..PER_TASK {
-                    if is_subscribed(&cid(BASE + t * PER_TASK + i), &d) {
-                        listed += 1;
-                    }
+        // Enough subscribes to fill the cap and then keep evicting, so the
+        // victim ages into being the coldest entry while it is paused.
+        let fillers = {
+            let delegate = d.clone();
+            let start = Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                let mut handles = Vec::new();
+                for t in 0..FILLERS {
+                    let delegate = delegate.clone();
+                    handles.push(tokio::task::spawn_blocking(move || {
+                        for i in 0..PER_FILLER {
+                            subscribe(cid(BASE + t * PER_FILLER + i), &delegate);
+                        }
+                    }));
+                }
+                for h in handles {
+                    h.await.expect("no filler task may panic");
+                }
+            })
+        };
+
+        victim_task.await.expect("victim task joined");
+        fillers.await.expect("filler task joined");
+        race_hook::disarm();
+
+        let held = subscription_count(&d);
+        assert!(
+            held <= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+            "the cap must hold under concurrency: {held} held against a cap of \
+             {MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE}"
+        );
+
+        // The assertion that matters. A pair present in the forward index but
+        // absent from the reverse one leaves the delegate on the delivery path
+        // for a subscription that occupies none of its budget and that cap
+        // eviction can never choose as a victim, because eviction picks from the
+        // index that lost it.
+        assert!(
+            !(is_subscribed(&victim, &d) && last_notified(&victim, &d).is_none()),
+            "the victim is listed in the forward index but absent from the \
+             reverse one: the two index writes did not happen under one guard, \
+             so a concurrent subscriber evicted it in the window between them"
+        );
+        let mut listed = 0;
+        for t in 0..FILLERS {
+            for i in 0..PER_FILLER {
+                if is_subscribed(&cid(BASE + t * PER_FILLER + i), &d) {
+                    listed += 1;
                 }
             }
-            assert_eq!(
-                listed, held,
-                "round {round}: every contract the reverse index counts must also \
-                 be listed in the forward index. A forward-only pair leaves the \
-                 delegate on the delivery path for a subscription that occupies \
-                 none of its budget and that cap eviction can never choose"
-            );
-
-            cleanup(&d);
         }
+        if is_subscribed(&victim, &d) {
+            listed += 1;
+        }
+        assert_eq!(
+            listed, held,
+            "every contract the forward index lists must also be counted in the \
+             reverse index"
+        );
+
+        cleanup(&d);
     }
 
     /// The two indexes can disagree, and a re-subscribe must repair it rather

--- a/crates/core/src/wasm_runtime/delegate_subscriptions.rs
+++ b/crates/core/src/wasm_runtime/delegate_subscriptions.rs
@@ -1,0 +1,778 @@
+//! Registry of which delegates want to hear about which contracts' state
+//! changes, and the bound on how much of that one delegate may hold.
+//!
+//! This is the sibling of [`crate::contract::delegate_app_registry`], and the
+//! two are deliberately shaped alike: that one maps `delegate -> apps` (where a
+//! delegate's output goes), this one maps `contract -> delegates` (which
+//! delegates hear about a contract). Both are process-global, both are written
+//! from paths an external actor influences, and both therefore carry caps
+//! enforced at insertion. Read `delegate_app_registry`'s header alongside this
+//! one; where this module departs from its shape, it says so.
+//!
+//! # Why this module exists rather than a bare `DashMap`
+//!
+//! Until this module the registry was a single public `DashMap` mutated from
+//! five call sites across `wasm_runtime` and `contract`. Bounding it requires a
+//! second, reverse index (`delegate -> contracts`) so the per-delegate cap can
+//! be checked in O(1) rather than by scanning every contract. Two maps that must
+//! agree are only safe if nothing outside can desynchronise them, so both are
+//! private here and every mutation goes through a function in this file. That is
+//! the same reason `delegate_app_registry` owns both `DELEGATE_APPS` and
+//! `CLIENT_REGISTRATION_COUNTS` rather than exporting them.
+//!
+//! # The two registration paths
+//!
+//! Both converge here, and a bound that missed either would be free to bypass:
+//!
+//!  1. **V2** delegates call the `subscribe_contract` host function, which
+//!     reaches [`subscribe`] via `native_api::DelegateCallEnv::subscribe_contract_sync`.
+//!  2. **V1** delegates emit `OutboundDelegateMsg::SubscribeContractRequest`,
+//!     handled in `contract::handle_delegate_with_contract_requests`.
+//!
+//! A delegate chooses which of the two it gets: `Runtime::prepare_delegate_call`
+//! selects `DelegateApiVersion::V2` iff the module imports the async host
+//! functions, and `V1` otherwise. So the version is not a property the node
+//! assigns — it is a property of the guest WASM, and a bound applied to only one
+//! path is an opt-out rather than a bound.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+use freenet_stdlib::prelude::{ContractInstanceId, DelegateKey};
+
+/// Maximum number of distinct contracts one delegate may hold a subscription to.
+///
+/// # What one subscription costs
+///
+/// A subscription is a standing claim: every commit to the contract wakes this
+/// delegate with the full new state (`Executor::send_delegate_contract_notifications`),
+/// and delegate execution is globally serialised on the contract-handling loop,
+/// so the cost is paid in that loop's time. The claim also outlives the app that
+/// asked for it — there is no unsubscribe (#5600) and, deliberately, no TTL (see
+/// [`subscribe`]).
+///
+/// # Derivation
+///
+/// The directly analogous constant is
+/// `contract::executor::MAX_SUBSCRIPTIONS_PER_CLIENT` (500) — "maximum total
+/// subscriptions a single client may hold across all contracts". Its history is
+/// the useful part: it was **raised from 50 to 500** on 2026-08-22 because 50
+/// "was hit almost immediately" by apps that subscribe to one contract per
+/// discoverable peer. A cap that real apps hit is worse than no cap, because it
+/// converts an amplification bound into an app-compatibility bug, so this one is
+/// set well above any plausible legitimate use rather than as tight as the
+/// arithmetic would allow.
+///
+/// Legitimate use, measured rather than guessed: River's chat delegate holds one
+/// subscription per room **it owns the signing key for** (`EnsureRoomSubscription`
+/// fires only for owner-mode rooms). That is single digits for an ordinary user
+/// and tens for a heavy one. 256 leaves an order of magnitude of headroom over
+/// the heavy case.
+///
+/// # What it bounds, and what it does not
+///
+/// The worst case is not this number: a hostile app may spawn child delegates,
+/// each with its own budget, so the reachable total is
+/// `MAX_CREATED_DELEGATES_PER_NODE` (1024) x this. That composition is BOUNDED,
+/// which is the property that matters and the one the client-side cap does not
+/// have — `MAX_SUBSCRIPTIONS_PER_CLIENT` is per-`ClientId` and a client mints a
+/// fresh `ClientId` by opening another WebSocket, so that cap bounds nothing in
+/// aggregate. This one cannot be reset that way: a delegate key is derived from
+/// its code and params, and creating more delegates is separately capped.
+///
+/// **A count is not a byte budget** (`.claude/rules/code-style.md`, clause 4), so
+/// state the byte story explicitly rather than leaving a count to imply one. Two
+/// separate mechanisms carry it, and NEITHER is this constant:
+///
+///  * **In flight**: a notification does not copy the state per subscriber —
+///    `send_delegate_contract_notifications` clones it into one `Arc` shared
+///    across every subscriber, sent over a bounded, lossy channel
+///    (`DELEGATE_NOTIFICATION_CHANNEL_SIZE`, dropped when full rather than
+///    queued). So in-flight bytes are bounded by channel depth, not by how many
+///    subscriptions exist.
+///  * **At rest**: a held subscription raises hosting demand, but it does not
+///    pin residency. `HostingCache::evict_over_budget`
+///    (`ring/hosting/cache.rs`) treats subscriber count as the eviction
+///    ORDERING, not as a filter — a subscribed contract sorts last and is still
+///    evicted when nothing cheaper is eligible and the node is over either the
+///    state-byte budget or the resident-overhead budget. Both budgets are
+///    enforced regardless of local demand.
+///
+/// What this constant adds on top is a bound on how much of those SHARED
+/// node-wide pools one delegate can claim before that reactive eviction has to
+/// pull the node back under budget — eviction is a last resort, and reaching it
+/// costs churn borne by every other subscriber on the node, not just the
+/// delegate that caused it.
+///
+/// **If you are about to conclude 256 is too generous, this is the paragraph you
+/// want.** The pessimistic arithmetic — 256 x `MAX_STATE_SIZE` = 12.8 GiB per
+/// delegate — is the calculation to do when a count cap IS the only byte bound,
+/// and that is not the case here: a subscription ORDERS its contract last for
+/// eviction, it does not pin it, so the byte budgets above still reclaim it.
+/// This was checked against `evict_over_budget` rather than assumed, because the
+/// two readings differ by an order of magnitude in what cap they justify, and
+/// the wrong one produces a cap real apps hit. If a future change ever makes a
+/// held subscription genuinely un-evictable, that check lapses and this number
+/// has to be re-derived against bytes rather than against River's room count.
+///
+/// # Interaction with in-flight work
+///
+/// PR #5615 removes the "the contract must already be local" precondition on the
+/// V1 subscribe path, letting a delegate name any instance id and have the node
+/// fetch it from the network. That widens the reachable set from "contracts this
+/// node happens to hold" to "any contract that exists", which makes this bound
+/// more load-bearing than it is today, not less. #5615's own
+/// `MAX_NETWORK_CONTRACT_OPS_PER_PARK` throttles concurrent fetches in flight;
+/// it does not bound the steady-state count, which is this constant's job.
+///
+/// # Not configurable, deliberately
+///
+/// Same reason as `MAX_SUBSCRIPTIONS_PER_CLIENT`, where making it a per-node
+/// option was proposed and explicitly rejected (Ian, 2026-08-22): a configurable
+/// cap means a dApp works on some peers and not others, which is exactly the
+/// non-uniformity Freenet must avoid.
+pub(crate) const MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE: usize = 256;
+
+/// `contract -> delegates`. The fan-out direction, read on every state commit.
+static BY_CONTRACT: LazyLock<DashMap<ContractInstanceId, HashSet<DelegateKey>>> =
+    LazyLock::new(DashMap::default);
+
+/// `delegate -> its subscribed contracts, each stamped with the last time a
+/// notification was delivered for it`.
+///
+/// The reverse index of [`BY_CONTRACT`], maintained so the per-delegate cap is
+/// an O(1) lookup instead of a scan over every subscribed contract — the same
+/// role `CLIENT_REGISTRATION_COUNTS` plays in `delegate_app_registry`. It holds
+/// stamps rather than a bare count because the cap evicts rather than refuses,
+/// and eviction needs to know which entry is coldest.
+///
+/// `tokio::time::Instant` (not `std::time::Instant`) so tests using
+/// `tokio::time::pause` / `advance` can drive eviction order deterministically,
+/// matching `AppRegistration::last_seen` and `DelegateContextEntry`.
+static BY_DELEGATE: LazyLock<
+    DashMap<DelegateKey, HashMap<ContractInstanceId, tokio::time::Instant>>,
+> = LazyLock::new(DashMap::default);
+
+/// Total cap evictions since process start.
+///
+/// An operator needs the aggregate, not one log line per event: a node shedding
+/// subscriptions steadily looks identical, line by line, to one that shed a
+/// single subscription an hour ago. Reported as a field on the `warn!` in
+/// [`subscribe`] rather than only through the test accessor, so the running
+/// total is in RELEASE builds where saturation has to be visible
+/// (`.claude/rules/code-style.md`) — the same shape as the `total_dropped`
+/// counter on the delegate-notification drop path.
+///
+/// Surfacing it through `HostingCacheStats`-style telemetry alongside
+/// `subscribed_evictions_total` is worth doing and is deliberately NOT done
+/// here: this registry is a process-global with no stats struct to hang it on,
+/// and inventing one belongs in its own change rather than on this bound.
+static CAP_EVICTIONS: AtomicU64 = AtomicU64::new(0);
+
+/// What [`subscribe`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SubscribeOutcome {
+    /// A new (contract, delegate) pair was recorded.
+    Registered,
+    /// The pair was already present; the call was a no-op. Both registration
+    /// paths are documented as idempotent, so this is an ordinary result and not
+    /// a failure.
+    AlreadySubscribed,
+    /// A new pair was recorded, and this contract's subscription was dropped to
+    /// make room for it because the delegate was at
+    /// [`MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE`].
+    ///
+    /// **A caller that took a resource when it registered the subscription MUST
+    /// release it for the evicted contract here.** This variant exists so the
+    /// registry cannot silently drop a subscription that something else is still
+    /// accounting for, and two in-flight changes make that concrete:
+    ///
+    ///  * #5493 registers hosting demand alongside the subscription. Demand
+    ///    released nowhere would outlive the subscription that justified it —
+    ///    the durable claim this cap exists to bound.
+    ///  * #5615 routes the V1 path through `add_local_client`, a **refcount**
+    ///    rather than the set-insert this registry used to be. A refcount
+    ///    incremented per subscribe and never decremented on eviction leaks, and
+    ///    a leaked count never falls back to zero.
+    ///
+    /// Ignoring this variant compiles (it is one arm of an enum), so the risk is
+    /// a caller that matches only `Registered` and treats the rest as success.
+    /// Match it explicitly.
+    RegisteredEvicting(ContractInstanceId),
+}
+
+/// Record `delegate`'s interest in `contract`, enforcing the per-delegate cap.
+///
+/// # Why this evicts instead of refusing at the cap
+///
+/// `.claude/rules/code-style.md` allows refuse-at-cap only for entries that age
+/// out on their own, "so a newcomer's wait is bounded". **These entries never age
+/// out.** There is no TTL (below) and no unsubscribe (#5600); a subscription is
+/// removed only when the delegate is unregistered, the contract is removed from
+/// the store, or the notification channel closes. So refusing at the cap would
+/// hand the whole budget permanently to whichever contracts a delegate happened
+/// to subscribe to first, with no recovery path for any later one — the exact
+/// permanent-starvation failure that rule describes, in a stronger form than the
+/// refreshed-entry case it was written for (there, an idle incumbent at least
+/// eventually rolls off; here it never does).
+///
+/// So the coldest entry is evicted instead. Eviction is contained to the
+/// delegate that exceeded its own budget — one delegate can never evict
+/// another's subscription — so this cannot be turned into a way to silence a
+/// victim.
+///
+/// **The cost, stated plainly: eviction is silent to the delegate.** It has no
+/// way to learn that a subscription it believes it holds has been dropped, and
+/// will simply stop receiving notifications for that contract. That is the price
+/// of not having refusal starve it instead, and it is why the cap is set far
+/// above legitimate use rather than tightly: no well-behaved delegate should
+/// ever reach it. #5600 (unsubscribe) is what would let a delegate manage its
+/// own budget and make this avoidable; until then the eviction is logged at
+/// `warn!` so saturation is visible in release builds, as that rule requires.
+///
+/// # Why there is deliberately no TTL
+///
+/// **Do not "fix" the missing TTL here.** An idle-expiry would silently break
+/// River. Its UI fires `EnsureRoomSubscription` once per session behind a dedup
+/// and retries only "on next cold load"
+/// (`ui/src/components/app/freenet_api/response_handler.rs`), so a subscription
+/// that expired under a long-lived tab would never be re-established, and the
+/// delegate's private-room secret rotation — which is driven entirely by these
+/// notifications — would stop for that room with no error anywhere. A room quiet
+/// for longer than any plausible TTL is precisely the case where the next
+/// membership change most needs to be seen.
+///
+/// The bound that AGENTS.md asks for is supplied by the cap instead: the map
+/// cannot grow without limit, and the entries it holds are removed by
+/// [`remove_delegate`] and [`remove_contract`].
+pub(crate) fn subscribe(contract: ContractInstanceId, delegate: &DelegateKey) -> SubscribeOutcome {
+    let now = tokio::time::Instant::now();
+
+    // Take the reverse index first and hold it across the forward-map write.
+    // The two maps are only ever locked in this order, here and in every
+    // removal below, so they cannot deadlock against each other.
+    let mut owned = BY_DELEGATE.entry(delegate.clone()).or_default();
+
+    if owned.contains_key(&contract) {
+        // Idempotent re-subscribe. Deliberately does NOT restamp: the stamp
+        // means "last notification delivered", and letting a delegate refresh it
+        // by re-subscribing in a loop would let it pin an entry it never hears
+        // from, defeating the eviction order.
+        return SubscribeOutcome::AlreadySubscribed;
+    }
+
+    let mut evicted = None;
+    if owned.len() >= MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+        // Evict the coldest entry. One, not a batch: the rule's batching advice
+        // is aimed at a full scan per admission "on the receive path", and this
+        // is not that — subscribing happens inside delegate WASM execution,
+        // which already costs milliseconds, and the scan is bounded by the cap.
+        // Evicting more than strictly necessary would also discard legitimate
+        // standing interest that nothing will re-establish.
+        let coldest = owned
+            .iter()
+            .min_by_key(|(_, stamp)| **stamp)
+            .map(|(id, _)| *id);
+        if let Some(coldest) = coldest {
+            owned.remove(&coldest);
+            drop_from_contract_map(&coldest, delegate);
+            let total = CAP_EVICTIONS.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::warn!(
+                %delegate,
+                evicted_contract = %coldest,
+                new_contract = %contract,
+                cap = MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+                cap_evictions_total = total,
+                "Delegate at its contract-subscription cap; evicted its coldest \
+                 subscription to admit a new one. The delegate is NOT told, and \
+                 will stop receiving notifications for the evicted contract."
+            );
+            evicted = Some(coldest);
+        }
+    }
+
+    owned.insert(contract, now);
+    drop(owned);
+
+    BY_CONTRACT
+        .entry(contract)
+        .or_default()
+        .insert(delegate.clone());
+
+    match evicted {
+        Some(id) => {
+            // Give back the local interest the evicted subscription took, now
+            // that every DashMap guard above is released — a release closure
+            // reaches into `InterestManager`, which takes its own locks.
+            //
+            // Done HERE rather than left to the caller. The obligation is real
+            // for one of the three registration paths (the network-resolved
+            // one, which is the only path that takes an `add_local_client`
+            // refcount), but a caller that ignores this outcome compiles fine,
+            // and two of the three do exactly that. The leak it would cause is
+            // invisible in testing: the symptom is a refcount that never
+            // returns to zero, so `cleanup_contract_if_no_interest` silently
+            // never fires. A no-op for a pair holding nothing, which is most of
+            // them.
+            crate::wasm_runtime::delegate_interest::release_pair(&id, delegate);
+            SubscribeOutcome::RegisteredEvicting(id)
+        }
+        None => SubscribeOutcome::Registered,
+    }
+}
+
+/// Snapshot the delegates subscribed to `contract`.
+///
+/// Returns an owned `Vec` so the caller does not hold a shard lock while
+/// sending on a channel.
+pub(crate) fn subscribers_of(contract: &ContractInstanceId) -> Vec<DelegateKey> {
+    BY_CONTRACT
+        .get(contract)
+        .map(|s| s.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Record that a notification for `contract` was delivered to `delegate`.
+///
+/// This is the "ordinary use" that orders eviction: a subscription that is
+/// actually producing notifications stays warm, and the one evicted under
+/// pressure is whichever the delegate has heard about least recently. Cheap
+/// enough for the commit path — one map write per subscribed delegate, on a path
+/// that is already cloning and sending the new state.
+pub(crate) fn note_notified(contract: &ContractInstanceId, delegate: &DelegateKey) {
+    if let Some(mut owned) = BY_DELEGATE.get_mut(delegate) {
+        if let Some(stamp) = owned.get_mut(contract) {
+            *stamp = tokio::time::Instant::now();
+        }
+    }
+}
+
+/// Drop every subscription held by `delegate` (delegate unregistered).
+pub(crate) fn remove_delegate(delegate: &DelegateKey) {
+    let Some((_, owned)) = BY_DELEGATE.remove(delegate) else {
+        return;
+    };
+    for contract in owned.keys() {
+        drop_from_contract_map(contract, delegate);
+    }
+}
+
+/// Drop every subscription to `contract` (contract removed, or its notification
+/// channel closed).
+pub(crate) fn remove_contract(contract: &ContractInstanceId) {
+    let Some((_, delegates)) = BY_CONTRACT.remove(contract) else {
+        return;
+    };
+    for delegate in &delegates {
+        let now_empty = match BY_DELEGATE.get_mut(delegate) {
+            Some(mut owned) => {
+                owned.remove(contract);
+                owned.is_empty()
+            }
+            None => false,
+        };
+        // Only the delegates this contract actually touched, and each re-checked
+        // under the removal guard. A blanket `BY_DELEGATE.retain(..)` here would
+        // scan every delegate on the node on every contract removal, and would
+        // race a concurrent `subscribe` that had just refilled an entry.
+        if now_empty {
+            BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
+        }
+    }
+}
+
+/// Remove `delegate` from `contract`'s subscriber set, dropping the contract's
+/// entry entirely once nothing is subscribed to it.
+///
+/// Forward-map half only — the caller owns the reverse-index half. Private so
+/// the two halves cannot be applied separately from outside.
+fn drop_from_contract_map(contract: &ContractInstanceId, delegate: &DelegateKey) {
+    let now_empty = match BY_CONTRACT.get_mut(contract) {
+        Some(mut delegates) => {
+            delegates.remove(delegate);
+            delegates.is_empty()
+        }
+        None => false,
+    };
+    if now_empty {
+        // Re-check under the removal guard: another delegate may have subscribed
+        // between the two locks, and removing a non-empty entry would silently
+        // unsubscribe it.
+        BY_CONTRACT.remove_if(contract, |_, delegates| delegates.is_empty());
+    }
+}
+
+/// Drop exactly one (contract, delegate) subscription, leaving every other
+/// subscriber of `contract` and every other subscription of `delegate` alone.
+///
+/// Currently reachable only from tests, which use it to clean up a registration
+/// without disturbing a concurrent test's entry in this process-global map. It
+/// is deliberately written as the general operation rather than a test helper,
+/// because it is also the operation #5600 needs: a delegate that could
+/// unsubscribe would be able to manage its own budget under
+/// [`MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE`] instead of relying on eviction.
+/// Promote it out of `cfg(test)` when that lands.
+#[cfg(test)]
+pub(crate) fn unsubscribe(contract: &ContractInstanceId, delegate: &DelegateKey) {
+    let removed = match BY_DELEGATE.get_mut(delegate) {
+        Some(mut owned) => owned.remove(contract).is_some(),
+        None => false,
+    };
+    if removed {
+        drop_from_contract_map(contract, delegate);
+        BY_DELEGATE.remove_if(delegate, |_, owned| owned.is_empty());
+        // Same obligation as the eviction branch of `subscribe`: this drops one
+        // pair, so one pair's interest hold has to come back.
+        //
+        // Wired now even though this function is `cfg(test)` and its callers
+        // record no holds, so it discharges nothing today. When #5600 promotes
+        // it to the real unsubscribe path the pairs WILL hold refcounts, and
+        // the diff that promotes it is an attribute change — a reviewer reading
+        // that diff sees a `#[cfg(test)]` come off and no reason to re-audit a
+        // function that already existed. Closing it here costs a line; closing
+        // it later means finding it as a production leak.
+        crate::wasm_runtime::delegate_interest::release_pair(contract, delegate);
+    }
+}
+
+/// Cap evictions since process start. See [`CAP_EVICTIONS`].
+#[cfg(test)]
+pub(crate) fn cap_evictions_total() -> u64 {
+    CAP_EVICTIONS.load(Ordering::Relaxed)
+}
+
+/// Number of contracts `delegate` is currently subscribed to.
+#[cfg(test)]
+pub(crate) fn subscription_count(delegate: &DelegateKey) -> usize {
+    BY_DELEGATE.get(delegate).map_or(0, |owned| owned.len())
+}
+
+/// Whether `delegate` is subscribed to `contract`.
+///
+/// Production use is the V1 SUBSCRIBE arm's pre-branch guard: it asks this
+/// BEFORE deciding whether to reach the network, because
+/// `InterestManager::add_local_client` is a refcount and a repeat subscribe
+/// that fell through to the network path would take a second one for a single
+/// logical subscriber. That is a different question from
+/// [`SubscribeOutcome::AlreadySubscribed`], which reports what an admission
+/// that already happened did, so the two are not interchangeable.
+pub(crate) fn is_subscribed(contract: &ContractInstanceId, delegate: &DelegateKey) -> bool {
+    BY_CONTRACT
+        .get(contract)
+        .is_some_and(|delegates| delegates.contains(delegate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_stdlib::prelude::CodeHash;
+
+    fn dkey(seed: u8) -> DelegateKey {
+        let mut bytes = [seed; 32];
+        bytes[31] = TEST_ID_NAMESPACE;
+        DelegateKey::new(bytes, CodeHash::new([seed; 32]))
+    }
+
+    /// Namespace marker in the last id byte, keeping this module's contract ids
+    /// away from every other test in the process: the registry is a
+    /// process-global and CI runs tests in threads, so colliding ids would make
+    /// these tests see each other's entries (the hazard #4824 records for this
+    /// same map). The delegate keys are namespaced by construction — `dkey`
+    /// seeds all 32 bytes — so only the contract ids need this.
+    const TEST_ID_NAMESPACE: u8 = 0xD5;
+
+    fn cid(seed: u16) -> ContractInstanceId {
+        let mut bytes = [0u8; 32];
+        bytes[0..2].copy_from_slice(&seed.to_le_bytes());
+        bytes[31] = TEST_ID_NAMESPACE;
+        ContractInstanceId::new(bytes)
+    }
+
+    /// Every test cleans up after itself, for the same reason `cid` namespaces:
+    /// the registry outlives any one test.
+    fn cleanup(delegate: &DelegateKey) {
+        remove_delegate(delegate);
+    }
+
+    #[tokio::test]
+    async fn subscribe_is_idempotent() {
+        let d = dkey(1);
+        let c = cid(1);
+        assert_eq!(subscribe(c, &d), SubscribeOutcome::Registered);
+        assert_eq!(subscribe(c, &d), SubscribeOutcome::AlreadySubscribed);
+        assert_eq!(subscription_count(&d), 1);
+        assert_eq!(subscribers_of(&c), vec![d.clone()]);
+        cleanup(&d);
+    }
+
+    /// The bound itself: a delegate cannot accumulate subscriptions without
+    /// limit. Without the cap this reaches `cap + 50`.
+    #[tokio::test]
+    async fn a_delegate_cannot_exceed_its_subscription_cap() {
+        let d = dkey(2);
+        for i in 0..(MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE + 50) {
+            subscribe(cid(1000 + i as u16), &d);
+        }
+        assert_eq!(
+            subscription_count(&d),
+            MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE,
+            "a delegate must not hold more than its cap"
+        );
+        cleanup(&d);
+    }
+
+    /// Admission past the cap must EVICT, not refuse — a refusal would starve
+    /// every later subscription permanently, since these entries never age out.
+    ///
+    /// Time is paused and advanced explicitly between subscribes. Without that
+    /// the stamps can tie, and `min_by_key` over a `HashMap` breaks ties in
+    /// iteration order, which is not deterministic — the identity assertion
+    /// below would then pass or fail by luck.
+    #[tokio::test(start_paused = true)]
+    async fn subscribing_at_the_cap_admits_the_newcomer_and_evicts() {
+        let d = dkey(3);
+        let first = cid(2000);
+        subscribe(first, &d);
+        for i in 1..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            subscribe(cid(2000 + i as u16), &d);
+        }
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+
+        let newcomer = cid(9000);
+        // The counter is process-global and other tests in this binary evict
+        // too, so assert it ADVANCED rather than asserting an absolute value.
+        let evictions_before = cap_evictions_total();
+        let outcome = subscribe(newcomer, &d);
+        assert!(
+            cap_evictions_total() > evictions_before,
+            "an eviction must be counted, or an operator sees only isolated log \
+             lines and cannot tell steady shedding from a one-off"
+        );
+        assert_eq!(
+            outcome,
+            SubscribeOutcome::RegisteredEvicting(first),
+            "the coldest (never-notified, oldest) subscription must be the victim"
+        );
+        assert!(
+            is_subscribed(&newcomer, &d),
+            "the newcomer must be admitted, not refused"
+        );
+        assert!(
+            !is_subscribed(&first, &d),
+            "the evicted subscription must be gone from BOTH indexes"
+        );
+        cleanup(&d);
+    }
+
+    /// The eviction victim is the least recently NOTIFIED, not the oldest —
+    /// otherwise a delegate's busiest subscription would be evicted first.
+    #[tokio::test(start_paused = true)]
+    async fn eviction_picks_the_least_recently_notified() {
+        let d = dkey(4);
+        let oldest = cid(3000);
+        subscribe(oldest, &d);
+        for i in 1..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            subscribe(cid(3000 + i as u16), &d);
+        }
+
+        // The oldest subscription is the busy one: it has just been notified,
+        // while the second-oldest has never been.
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        note_notified(&oldest, &d);
+        let expected_victim = cid(3001);
+
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        assert_eq!(
+            subscribe(cid(9001), &d),
+            SubscribeOutcome::RegisteredEvicting(expected_victim),
+            "a subscription that is actively delivering notifications must not \
+             be the eviction victim merely for being old"
+        );
+        assert!(
+            is_subscribed(&oldest, &d),
+            "the busy subscription must survive"
+        );
+        cleanup(&d);
+    }
+
+    /// A re-subscribe must not count as use. Otherwise a delegate could pin an
+    /// entry it never hears from by re-subscribing in a loop.
+    #[tokio::test(start_paused = true)]
+    async fn resubscribing_does_not_refresh_the_eviction_stamp() {
+        let d = dkey(5);
+        let a = cid(4000);
+        let b = cid(4001);
+        subscribe(a, &d);
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        subscribe(b, &d);
+
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        subscribe(a, &d); // idempotent re-subscribe, must not restamp
+
+        for i in 2..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            subscribe(cid(4000 + i as u16), &d);
+        }
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        assert_eq!(
+            subscribe(cid(9002), &d),
+            SubscribeOutcome::RegisteredEvicting(a),
+            "re-subscribing must not refresh a subscription's eviction stamp"
+        );
+        cleanup(&d);
+    }
+
+    /// One delegate hitting its cap must never evict another delegate's
+    /// subscription — otherwise the cap becomes a way to silence a victim.
+    #[tokio::test]
+    async fn eviction_never_crosses_delegates() {
+        let victim = dkey(6);
+        let hog = dkey(7);
+        let shared = cid(5000);
+        subscribe(shared, &victim);
+
+        subscribe(shared, &hog);
+        for i in 1..(MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE + 20) {
+            subscribe(cid(5000 + i as u16), &hog);
+        }
+
+        assert!(
+            is_subscribed(&shared, &victim),
+            "a delegate at its cap must not evict a DIFFERENT delegate's \
+             subscription to the same contract"
+        );
+        assert_eq!(subscription_count(&victim), 1);
+        cleanup(&victim);
+        cleanup(&hog);
+    }
+
+    /// Cap eviction drops ONE (contract, delegate) pair, and the local-interest
+    /// refcount that pair took must come back with it.
+    ///
+    /// This is the only per-pair subscription drop in production, and neither
+    /// of `delegate_interest`'s bulk release functions fits it: `release_contract`
+    /// would discharge other delegates' holds on the same contract and
+    /// `release_delegate` would discharge this delegate's holds on contracts it
+    /// still subscribes to. So the assertion is two-sided on purpose — the
+    /// evicted pair released EXACTLY once (catching the under-release, which is
+    /// the leak) and the sibling pair not at all (catching the over-release,
+    /// which is worse, because the decrement lands on interest a real
+    /// subscriber holds). A test that checked only the evicted pair would pass
+    /// against a fix that reached for `release_delegate`.
+    ///
+    /// The victim is given a REAL recorded hold rather than relying on the
+    /// registry alone: `release_pair` is a no-op for a pair that holds nothing,
+    /// so a victim with no hold would make this pass without exercising
+    /// anything.
+    #[tokio::test(start_paused = true)]
+    async fn cap_eviction_releases_the_evicted_pair_and_only_that_pair() {
+        use crate::wasm_runtime::delegate_interest;
+        use std::sync::{Arc, Mutex};
+
+        let d = dkey(11);
+        let victim = cid(8000);
+        let sibling = cid(8001);
+
+        let released: Arc<Mutex<Vec<ContractInstanceId>>> = Default::default();
+        let make_release = |id: ContractInstanceId| {
+            let sink = released.clone();
+            let release: delegate_interest::InterestRelease = Arc::new(move |_k| {
+                sink.lock().unwrap().push(id);
+            });
+            release
+        };
+        let ckey = |id: ContractInstanceId| {
+            freenet_stdlib::prelude::ContractKey::from_id_and_code(id, CodeHash::new([0xD5; 32]))
+        };
+
+        // The victim subscribes first, so it is the coldest and therefore the
+        // eviction target.
+        subscribe(victim, &d);
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        subscribe(sibling, &d);
+
+        // Both took an interest refcount, as the network-resolved subscribe
+        // path does.
+        delegate_interest::record(victim, d.clone(), ckey(victim), make_release(victim));
+        delegate_interest::record(sibling, d.clone(), ckey(sibling), make_release(sibling));
+
+        for i in 2..MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE {
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+            subscribe(cid(8000 + i as u16), &d);
+        }
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+
+        assert_eq!(
+            subscribe(cid(9100), &d),
+            SubscribeOutcome::RegisteredEvicting(victim),
+            "the coldest subscription must be the victim, or this test is not \
+             exercising what it claims to"
+        );
+
+        assert_eq!(
+            *released.lock().unwrap(),
+            vec![victim],
+            "the evicted pair's interest refcount must be given back exactly \
+             once; left standing, `local_interests` never returns to zero for \
+             that contract and `cleanup_contract_if_no_interest` never fires"
+        );
+
+        // The hold must also be GONE, not merely discharged: a later bulk
+        // release must not discharge it a second time. Releasing the delegate
+        // now should therefore report the sibling and nothing else.
+        delegate_interest::release_delegate(&d);
+        assert_eq!(
+            *released.lock().unwrap(),
+            vec![victim, sibling],
+            "the sibling's hold must survive the eviction and discharge exactly \
+             once afterwards; a second release of the evicted pair would \
+             decrement interest that nothing holds"
+        );
+
+        cleanup(&d);
+    }
+
+    /// Both indexes must be cleared together, or a stale reverse-index entry
+    /// would hold budget a delegate no longer uses — permanently, since these
+    /// entries never age out.
+    #[tokio::test]
+    async fn removal_paths_clear_both_indexes() {
+        let d = dkey(8);
+        let c = cid(6000);
+
+        subscribe(c, &d);
+        remove_delegate(&d);
+        assert_eq!(subscription_count(&d), 0);
+        assert!(subscribers_of(&c).is_empty());
+
+        subscribe(c, &d);
+        remove_contract(&c);
+        assert_eq!(
+            subscription_count(&d),
+            0,
+            "removing a contract must free the budget it held in the reverse index"
+        );
+        assert!(subscribers_of(&c).is_empty());
+        cleanup(&d);
+    }
+
+    /// Removing one delegate's subscription must not disturb another's to the
+    /// same contract.
+    #[tokio::test]
+    async fn removing_one_delegate_leaves_other_subscribers() {
+        let a = dkey(9);
+        let b = dkey(10);
+        let c = cid(7000);
+        subscribe(c, &a);
+        subscribe(c, &b);
+
+        remove_delegate(&a);
+        assert_eq!(subscribers_of(&c), vec![b.clone()]);
+        assert_eq!(subscription_count(&b), 1);
+        cleanup(&b);
+    }
+}

--- a/crates/core/src/wasm_runtime/native_api.rs
+++ b/crates/core/src/wasm_runtime/native_api.rs
@@ -5,7 +5,6 @@ use freenet_stdlib::prelude::{
     ContractInstanceId, ContractKey, DelegateKey, SecretsId, encode_secret_key_list,
 };
 
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
@@ -75,16 +74,6 @@ pub(super) static DELEGATE_ENV: LazyLock<DashMap<InstanceId, DelegateEnvSlot>> =
 /// or dropping it before the guest returns, silently reintroduces the hazard.
 pub(super) static LIVE_DELEGATE_GUESTS: LazyLock<dashmap::DashSet<InstanceId>> =
     LazyLock::new(dashmap::DashSet::default);
-
-/// Global registry of delegate subscriptions to contracts.
-///
-/// When a V2 delegate calls `subscribe_contract()`, the (contract, delegate) pair is
-/// recorded here. When this node commits a new contract state,
-/// `Executor::finalize_state_commit` checks this registry and sends
-/// notifications to subscribed delegates.
-pub(crate) static DELEGATE_SUBSCRIPTIONS: LazyLock<
-    DashMap<ContractInstanceId, HashSet<DelegateKey>>,
-> = LazyLock::new(DashMap::default);
 
 /// Shared, in-memory cache of `DelegateContext` bytes keyed by `DelegateKey`.
 ///
@@ -1486,10 +1475,17 @@ impl DelegateCallEnv {
 
     /// Register a subscription interest for a contract.
     ///
-    /// Validates the contract is known and records the (contract, delegate) pair in
-    /// the global subscription registry. When this node commits a new state for the
-    /// contract, `Executor::finalize_state_commit` sends a `ContractNotification`
-    /// to the delegate.
+    /// Validates the contract is known and records the (contract, delegate) pair
+    /// in the global subscription registry. When this node commits a new state
+    /// for the contract, `Executor::finalize_state_commit` sends a
+    /// `ContractNotification` to the delegate.
+    ///
+    /// Registration goes through `delegate_subscriptions::subscribe` rather than
+    /// touching the registry directly, so this path is bounded by
+    /// `MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE` exactly as the V1 path is. A
+    /// bound applied to only one of the two would be an opt-out: a delegate
+    /// selects V1 simply by not importing the async host functions
+    /// (`Runtime::prepare_delegate_call`).
     pub(super) fn subscribe_contract_sync(
         &self,
         instance_id: &ContractInstanceId,
@@ -1497,11 +1493,10 @@ impl DelegateCallEnv {
         // Validate the contract is known
         let _contract_key = self.resolve_contract_key(instance_id)?;
 
-        // Register in global subscription registry
-        DELEGATE_SUBSCRIPTIONS
-            .entry(*instance_id)
-            .or_default()
-            .insert(self.delegate_key.clone());
+        // Register in global subscription registry, under the per-delegate cap.
+        // The cap evicts rather than refuses, so this cannot fail and cannot
+        // starve a delegate that reaches it; see `delegate_subscriptions`.
+        crate::wasm_runtime::delegate_subscriptions::subscribe(*instance_id, &self.delegate_key);
 
         Ok(())
     }
@@ -2905,7 +2900,7 @@ pub(super) mod delegate_contracts {
     /// Implementation of subscribe_contract.
     ///
     /// Validates that the contract is known (code hash resolvable) and registers
-    /// subscription interest in the global `DELEGATE_SUBSCRIPTIONS` registry.
+    /// subscription interest in the global `delegate_subscriptions` registry.
     /// When the subscribed contract's state changes, `Executor::finalize_state_commit`
     /// delivers a `ContractNotification` to this delegate.
     ///

--- a/crates/core/src/wasm_runtime/simulation_runtime.rs
+++ b/crates/core/src/wasm_runtime/simulation_runtime.rs
@@ -135,7 +135,7 @@ impl InMemoryContractStore {
         // standing. Not caught by
         // `delegate_interest::tests::every_subscription_removal_site_releases_its_interest`,
         // which scrapes the three sites it knows about and cannot see a fourth.
-        super::DELEGATE_SUBSCRIPTIONS.remove(key.id());
+        super::delegate_subscriptions::remove_contract(key.id());
         super::delegate_interest::release_contract(key.id());
         let mut inner = self.inner.lock().unwrap();
         inner.instance_to_code.remove(key.id());


### PR DESCRIPTION
> **Closes the growth vector #5615 left open.** #5615 removed the local-store gate on delegate SUBSCRIBE, so a delegate can now reach the network for any contract it can name, and nothing in that PR bounds how many DISTINCT contracts one delegate accumulates over its lifetime. Each is a permanent `add_local_client` refcount pinning a contract resident against eviction. #5615's own comments defer that bound to this PR by number. It was stacked on #5615 and is now rebased onto `main` at `55ab53832`, with clippy and the lib suite re-run at the rebased SHA.

## Problem

A delegate's subscription set was unbounded. Nothing capped how many distinct contracts one delegate could hold a subscription to, there is no TTL, and a delegate cannot unsubscribe (#5600), so a subscription was removed only on `UnregisterDelegate`, on contract removal, or when the notification channel closed.

Each subscription is a standing claim on shared node resources rather than a one-off cost. Every commit to the contract wakes the delegate with the new state, and delegate execution is serialised on the contract-handling loop, so the cost is paid in that loop's time. The claim also outlives the app that asked for it.

#5615 makes this more load-bearing rather than less: it removes the "the contract must already be local" precondition on the V1 subscribe path, so a delegate can name any instance id and have the node fetch it. That widens the reachable set from "contracts this node happens to hold" to "any contract that exists". #5615's `MAX_NETWORK_CONTRACT_OPS_PER_PARK` throttles concurrent fetches in flight; it does not bound the steady-state count.

## Approach

Adds `MAX_CONTRACT_SUBSCRIPTIONS_PER_DELEGATE` (256), enforced where every registration path converges.

Two related pieces, and the second is not obvious from the title: the cap itself, and the interest-release work the cap makes necessary. Cap eviction drops a single (contract, delegate) subscription, and this PR is based on #5615, where such a subscription can be holding a local-interest refcount. Evicting without giving that refcount back reintroduces the leak #5615 exists to close.

**Enforced at all three registration paths, not some of them.** A delegate selects its own API version by whether its WASM imports the async host functions (`Runtime::prepare_delegate_call`), so a bound applied to only the V2 host function would be an opt-out rather than a bound. The three paths are the V2 `subscribe_contract` host function, the V1 `SubscribeContractRequest` handler for a contract with local state, and, new in #5615, `apply_resolved_contract_op`. All three go through one admission function.

**A `wasm_runtime::delegate_subscriptions` module owns the registry.** Enforcing a per-delegate bound needs a reverse index, since the registry is keyed contract-first. Two maps that must agree are only safe if nothing outside can desynchronise them, so the former public `DELEGATE_SUBSCRIPTIONS` map is replaced by a module owning both indexes with every mutation behind a function. This mirrors `contract::delegate_app_registry`, which owns its two maps for the same reason.

**One writer for dropping a single subscription.** Cap eviction and `unsubscribe` are the only two paths that drop one (contract, delegate) pair, and eviction used to do it inline. Both now go through `forget_one`, which is documented as the only place a single pair is dropped and therefore the only place anything that must happen on removal belongs. Eviction is the path that gets missed, because it does not look like a removal path, it looks like part of admission. `forget_one` takes the caller's already-held reverse-index guard rather than acquiring its own; that is forced rather than stylistic, because the cap is exact only while `subscribe` holds that guard across check-evict-insert, so a re-acquiring writer would deadlock against its own caller.

**The cap evicts the least-recently-notified subscription rather than refusing.** `code-style.md` permits refuse-at-cap only for entries that age out, "so a newcomer's wait is bounded". These never age out, so refusal would hand a delegate's whole budget permanently to whatever it subscribed to first, with no recovery path. Eviction is contained to the delegate that exceeded its own budget, so it cannot be used to silence another delegate. The cost, stated plainly: eviction is silent to the delegate, which is why the cap is set far above legitimate use and why each eviction is logged with a running total.

**Deliberately no TTL**, and the reason is in the code so it is not "fixed" later: River fires `EnsureRoomSubscription` once per session behind a dedup and retries only on next cold load, so an idle-expiry would silently stop private-room secret rotation for a quiet room.

Why 256: the analogous `MAX_SUBSCRIPTIONS_PER_CLIENT` was raised from 50 to 500 because 50 "was hit almost immediately". A cap real apps hit is worse than no cap. River's chat delegate holds one subscription per room it owns the signing key for, single digits for an ordinary user and tens for a heavy one. Full derivation is in the constant's rustdoc, including why the pessimistic `256 x MAX_STATE_SIZE` arithmetic does not apply.

**What this cap counts:** distinct contracts one `DelegateKey` subscribes to, in the registry's reverse index. Not `client_subscriptions`, not #5493's pins, not durable rows, not `DELEGATE_INTEREST_HOLDS`. After #5493 lands, this and its pin cap count genuinely different sets.

### Interaction with #5615's interest holds

Cap eviction is a per-pair drop, and neither of #5615's release functions fits one: `release_contract` would discharge other delegates' holds on the same contract, and `release_delegate` would discharge this delegate's holds on contracts it still subscribes to. Both are over-release, which is worse than a leak, because the decrement lands on interest a real subscriber holds. Doing nothing is under-release: the evicted pair's `add_local_client` stands forever and `cleanup_contract_if_no_interest` never fires.

So this adds `delegate_interest::release_pair`, called from inside the admission function rather than left to the three call sites, because a caller that ignores `SubscribeOutcome::RegisteredEvicting` compiles fine and two of the three ignore the return value today. It iterates every node's hold under the pair, so a pair-keyed lookup stays total against #5615's per-node hold-map value.

`release_pair` is also wired into the `cfg(test)` `unsubscribe`, which discharges nothing today because no test records a hold. That is deliberate: the function's own doc says to promote it out of `cfg(test)` when #5600 lands, and on that day its pairs will hold real refcounts. The diff that promotes it is an attribute change, so a reviewer sees a `#[cfg(test)]` come off and no reason to re-audit a function that already existed.

`already_subscribed()` is replaced by `delegate_subscriptions::is_subscribed`; it read the raw static this module makes private. It is a pre-branch query deciding whether to reach the network, not a post-subscribe result, so `SubscribeOutcome::AlreadySubscribed` does not substitute for it.

## Residuals and deviations

Recorded here rather than only in code comments, so the next reader finds decisions instead of re-litigating them.

**Deviation: the eviction scan runs under the reverse-index write guard.** `code-style.md`'s per-key-collection rule says plainly this should not happen. Kept, with reviewer sign-off, because the call site is inside already-expensive delegate WASM execution, the scan is bounded to 256 `Instant` comparisons over an in-memory map holding one shard, and evicting a batch as the rule instructs would over-evict standing interest that never ages out. The rule is written against the receive path and this is not that path. Do not restructure it to satisfy the rule literally.

**Residual: the V1 gate's leak is bounded, not eliminated.** #5615's gate is checked before `subscribe` runs, so on a desynchronised pair it reads false, falls through to the local branch, and takes one extra refcount that `record`'s `or_insert` will not track. `subscribe` then heals the index and the gate reads true from then on. One leaked refcount per occurrence rather than unbounded growth. Eliminating it would mean healing before the gate rather than after.

**Residual: `remove_contract` can diverge, and "self-healing" understates it.** See #5631. It removes the forward entry, releases, then walks writing reverse entries, so a `subscribe` completing inside the walk keeps its forward half and loses its reverse one. While diverged: the cap goes soft, because it counts the reverse index; delivery continues, because `subscribers_of` reads the forward index, so the delegate receives notifications for a subscription occupying none of its budget; and the orphan is unevictable, because eviction picks victims from the index that lost it. Convergence is real but unbounded in time, since the repair trigger is a re-subscribe for that exact pair and may never fire. It is not closed the way the other two directions were because holding the forward guard across reverse writes is the opposite lock order from `subscribe` and a genuine deadlock. Two directions are prevented, this one is repaired, and the lock order decides which technique is available.

## Testing

Thirteen unit tests on the registry: idempotent re-subscribe, the bound, evict-not-refuse, victim is least-recently-notified rather than oldest, re-subscribe does not refresh the stamp, eviction never crosses delegates, both indexes cleared on every removal path, index repair in both directions, and the interest-release behaviour.

Every guard here was confirmed to fail before the fix it guards, not merely to pass after it. The interest-release test reports `left: []` with `release_pair` unwired. Mutating that fix to `release_delegate`, the plausible wrong fix, makes it report two releases instead of one, so the over-release half is load-bearing too. The `note_notified` wiring is pinned behaviourally in `pool_tests` rather than by a source scrape, because a scrape passes on a commented-out call; deleting the production call fails that test and leaves the rest of the suite green.

### What a green suite does not establish

Worth recording, because this PR is a compact example of it.

At `7c156ab98` this branch had clippy clean, 5591 tests passed, 0 failed, and a clean tree. All of that was true, and the same tree contained a live split-brain race: `subscribe` wrote the reverse index under a guard and the forward index after releasing it, so a concurrent subscriber could evict a contract in the window and leave the delegate on the delivery path for a subscription it was not counted as holding. Four independent review lenses had read that code.

It was found by a concurrency test that exists only because an automated rule review demanded one, and it was found on that test's first run.

**And then the same test could not reliably find it again.** Measured against a deliberately broken build: one catch on a heavily loaded machine, then 0 catches in 5 runs on a quiet one. The window is a handful of instructions and only opens if the thread is descheduled inside it, so detection was a property of machine load rather than of the code. The natural inference from "there is a concurrency test" is the wrong one, which is why it is written down here.

That is why the guard is now a deterministic one. `race_hook` pauses one designated subscribe between the two index writes. It does not detect the bug; it makes the guard's span observable, and it is live in both versions rather than being scaffolding that only means something against a reverted fix. With both writes under one guard the other subscribers block and nothing interleaves. With the forward write outside it they proceed, fill the cap, and evict the paused contract before its forward entry exists. A pause and not a barrier, because a rendezvous deadlocks the correct version: the guard holder would wait on a task the guard is blocking.

Measured against a deliberately broken build: **5 caught out of 5**, and green on the fixed code. Naive concurrent racing, for comparison, was 0 out of 5 on a quiet machine and roughly 1 in 7 on a loaded one.

One more number is worth recording, because it is about measurement rather than about this code. An earlier run of the deterministic test reported 1 caught out of 5, which looked like the approach failing. It was not: the mutation used to produce the "broken" build had left the pause *inside* the guard, so both variants blocked the other subscribers and the test was discriminating nothing. Same test, same defect, same machine: pause inside the guard, 1 in 5; pause in the real window, 5 in 5. **The number was never measuring the test.** A measurement attached to the wrong subject reads exactly like a measurement, which is the only reason it is written down here.

## A note on this branch's history

The pre-rebase head amended its parent with `cargo fmt` output only. That was verified rather than taken from the commit message: stripping all whitespace from both versions of the four changed files and diffing character by character leaves exactly six single-comma differences, each a trailing comma rustfmt adds when it expands an argument or `use` list and drops when it collapses one. No other token differs, and no file outside those four changed.

The rebase onto `main` used `git rebase --onto`, not a plain rebase. The merge base is the stdlib bump, so a plain rebase would have replayed 19 commits, including all of #5615's, which are already in `main` as a squash.

Four conflict hunks, all in the SUBSCRIBE arm and its helper, and one of them is worth naming because the wrong resolution was the tidy-looking one. `main` now computes that arm's idempotency gate **per node**, consulting `delegate_interest::holds` rather than the registry, because a process-global answer let a second node short-circuit on the first node's entry having taken no refcount of its own and established no network subscription. `already_subscribed` is therefore kept exactly as `main` wrote it, three-argument signature and per-node body intact, and only its `None` fallback branch is changed, because that branch read the static this PR makes private. Replacing the helper with a registry lookup would have reinstated that defect while reading as a rename.

This does not close #5600. It bounds the set; it does not give a delegate any way to manage its own budget. Until it can, eviction is what keeps the bound from starving it.

[AI-assisted - Claude]
