### PR TITLE
fix(docker/freenet-gateway): move off EOL bullseye base, cap build parallelism

### DIFF
--- a/docker/freenet-gateway/Dockerfile
+++ b/docker/freenet-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-bullseye-slim
+FROM node:26-bookworm-slim
 
 # Install required dependencies
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -35,8 +35,21 @@ RUN git clone https://github.com/freenet/freenet-core.git "$FREENET_DIR/freenet-
   && git submodule update --init --recursive
 
 # Build Freenet
+#
+# CARGO_BUILD_JOBS caps rustc/linker parallelism. Left unset, cargo defaults to
+# one job per logical core, and this workspace pulls in enough heavyweight
+# dependencies (wasmtime among them) that full-width parallelism can exceed
+# available memory on smaller build hosts and get the build OOM-killed. Left
+# as a build arg (default empty = cargo's own default) rather than a fixed
+# number, so CI and larger machines keep full parallelism unless a builder
+# opts into a cap.
 WORKDIR $FREENET_DIR/freenet-core/crates/core
-RUN cargo install --path .
+ARG CARGO_BUILD_JOBS=
+RUN if [ -n "$CARGO_BUILD_JOBS" ]; then \
+      cargo install --path . --jobs "$CARGO_BUILD_JOBS"; \
+    else \
+      cargo install --path .; \
+    fi
 
 # Copy the gateway startup script
 COPY freenet-gateway-startup.sh /usr/local/bin/freenet-gateway-startup.sh


### PR DESCRIPTION
## Summary

Two problems with `docker/freenet-gateway/Dockerfile` I hit while switching my own gateway deployment over to the official image (#5516):

- `node:26-bullseye-slim` no longer builds reliably. `bullseye-security` 404s on the live Debian mirror, and even the `bullseye` snapshot on `archive.debian.org` (the standard fallback for EOL releases) predates the point-release packages already baked into that base image — apt hits unsatisfiable exact-version pins on `libc6-dev`, `libssl-dev`, and `perl` that no sources.list/apt-flag combination resolves. Switches the base to `node:26-bookworm-slim` (current Debian stable, live mirror). Nothing else in the build is bullseye-specific.
- `cargo install --path .` has no job cap, so it defaults to one job per logical core. This workspace's dependency graph (wasmtime included) is heavy enough that full-width parallelism can OOM a smaller build host mid-link. Added an opt-in `CARGO_BUILD_JOBS` build arg — left unset by default so CI and larger machines keep full parallelism, but a memory-constrained builder can cap it.

Fixes #5634 (repro details there).


## Test plan
- [x] Built locally with `--build-arg CARGO_BUILD_JOBS=3` on a 30GB/10-core box (this exact combination previously OOM'd unconstrained)
- [x] Resulting image deployed as a real gateway (`freenet network --is-gateway`), transport keypair preserved, container stable, reachable over its P2P port
