### PR TITLE
fix(conformance): bound evidence size and make the evidence decoder strict

### DIFF
--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -77,10 +77,10 @@ pub enum EvidenceError {
     #[error("encode: {0}")]
     Encode(String),
     #[error(
-        "evidence body is {found} bytes, more than any evidence this build accepts \
+        "evidence payload is {found} bytes, more than any evidence this build accepts \
          ({limit}); it was not decoded"
     )]
-    TooLarge { found: usize, limit: usize },
+    PayloadTooLarge { found: usize, limit: usize },
     #[error("decode: {0}")]
     Decode(String),
 }
@@ -111,7 +111,9 @@ pub const MAX_EVIDENCE_RELATED: usize = 8;
 /// sentence containing two byte counts.
 pub const MAX_EVIDENCE_TEXT_BYTES: usize = 1024;
 
-/// Hard ceiling on the encoded body of one evidence object, enforced while decoding.
+/// Hard ceiling on the encoded payload of one evidence object, enforced while
+/// decoding. It measures the payload after the 10-byte header (8-byte magic, 2-byte
+/// schema version), not the whole file.
 ///
 /// [`ConformanceEvidence::check_bounds`] can only inspect an object that decoding
 /// has already built, so a limit applied there arrives after the allocation it
@@ -500,7 +502,7 @@ impl ConformanceEvidence {
             });
         }
         let evidence = decode_body(&bytes[HEADER_LEN..]).map_err(|error| match error {
-            BodyError::TooLarge { found } => EvidenceError::TooLarge {
+            BodyError::TooLarge { found } => EvidenceError::PayloadTooLarge {
                 found,
                 limit: MAX_EVIDENCE_ENCODED_BYTES,
             },
@@ -540,10 +542,12 @@ impl ConformanceEvidence {
         let legacy_version = u16::from_le_bytes([bytes[0], bytes[1]]);
         if legacy_version == 2 {
             return decode_body(bytes).map_err(|error| match error {
-                BodyError::TooLarge { found } => EvidenceError::TooLarge {
-                    found,
-                    limit: MAX_EVIDENCE_ENCODED_BYTES,
-                },
+                // Hedged like the other two: an oversized file that happens to begin
+                // `02 00` is not thereby evidence.
+                BodyError::TooLarge { found } => EvidenceError::LegacyUndecodable(format!(
+                    "it is {found} bytes, more than any evidence this build accepts \
+                     ({MAX_EVIDENCE_ENCODED_BYTES})"
+                )),
                 BodyError::EndedEarly => {
                     EvidenceError::LegacyUndecodable("it ends early".to_string())
                 }
@@ -562,9 +566,14 @@ impl ConformanceEvidence {
 // `decode_file` decodes an unframed schema-2 payload with the CURRENT struct, which
 // is right only while the current schema is 2. Bumping the schema has to revisit
 // that branch, so the build refuses to compile until someone has.
+//
+// Editing the `2` below to match the new schema silences this without making the
+// decision it exists to force: `decode_file` would then decode old unframed files
+// with a struct they were never written with. The fix belongs in `decode_file`.
 const _: () = assert!(
     EVIDENCE_SCHEMA_VERSION == 2,
-    "EVIDENCE_SCHEMA_VERSION changed: decide what decode_file does with unframed schema-2 files"
+    "EVIDENCE_SCHEMA_VERSION changed: decide in decode_file what happens to unframed \
+     schema-2 files; changing the number in this assert is not that decision"
 );
 
 /// The bincode configuration evidence is decoded with.
@@ -578,9 +587,16 @@ const _: () = assert!(
 /// deserializing from a slice replaces the configured limit with `Infinite`
 /// (`internal::deserialize_seed` in bincode 1.3), so `.with_limit(..)` here would
 /// read as a bound and bound nothing. The bound is the length check at the top of
-/// [`decode_body`], which runs before bincode reads a byte. Allocation stays within
-/// the input regardless: a slice reader refuses a byte string longer than the input
-/// that remains before allocating it, and serde caps a sequence's up-front capacity.
+/// [`decode_body`], which runs before bincode reads a byte.
+///
+/// What that leaves for allocation, stated precisely because a receive path will
+/// rely on it: a `String` is bounded by the input, since the slice reader refuses a
+/// declared length longer than the input that remains before allocating. A `Vec` is
+/// not. serde preallocates `min(declared, 1 MiB / element size)` before reading a
+/// single element, so a few dozen hostile bytes declaring `u64::MAX` elements for a
+/// nested `Vec<Vec<u8>>` cost about 2 MiB of transient capacity before decoding
+/// fails. Allocation is therefore bounded by the input plus a small constant, not by
+/// the input alone.
 fn evidence_bincode() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_fixint_encoding()

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -27,6 +27,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use bincode::Options as _;
 use freenet_stdlib::prelude::{ContractInstanceId, RelatedContracts, State};
 use serde::{Deserialize, Serialize};
 
@@ -60,20 +61,52 @@ pub enum EvidenceError {
     MismatchedBodySchema { header: u16, body: u16 },
     #[error("encode: {0}")]
     Encode(String),
+    #[error(
+        "evidence body is {found} bytes, more than any evidence this build accepts \
+         ({limit}); it was not decoded"
+    )]
+    TooLarge { found: usize, limit: usize },
     #[error("decode: {0}")]
     Decode(String),
 }
 
-/// Hard ceiling on one evidence object's input bytes.
+/// Hard ceiling on one evidence object's input bytes: the states, deltas, summary,
+/// related states and parameters that verifying it will execute.
 ///
 /// Chosen so that verifying evidence is unambiguously cheaper than the update
 /// traffic a non-converging contract already generates, and so an attacker cannot
 /// use evidence as an amplification vector. Operational tunable, not a protocol
 /// constant.
+///
+/// This counts execution inputs only. The two free-text fields are bounded
+/// separately by [`MAX_EVIDENCE_TEXT_BYTES`], and the encoded object as a whole by
+/// [`MAX_EVIDENCE_ENCODED_BYTES`] while it is decoded.
 pub const MAX_EVIDENCE_INPUT_BYTES: usize = 512 * 1024;
 
 /// Hard ceiling on how many related-contract states one evidence object may carry.
 pub const MAX_EVIDENCE_RELATED: usize = 8;
+
+/// Hard ceiling on each free-text field the sender writes: `observed.detail` and
+/// `runtime.core_version`.
+///
+/// Neither is an execution input, so [`ConformanceEvidence::input_bytes`] does not
+/// count them, and before #5581 they were the one part of an evidence object whose
+/// size the sender chose freely. Both are diagnostics that a recipient never acts
+/// on. A kilobyte is far more than this crate writes: its longest detail is a
+/// sentence containing two byte counts.
+pub const MAX_EVIDENCE_TEXT_BYTES: usize = 1024;
+
+/// Hard ceiling on the encoded body of one evidence object, enforced while decoding.
+///
+/// [`ConformanceEvidence::check_bounds`] can only inspect an object that decoding
+/// has already built, so a limit applied there arrives after the allocation it
+/// exists to prevent. This one is applied before bincode parses anything. It is
+/// sized to hold the largest object `check_bounds` accepts: [`MAX_EVIDENCE_INPUT_BYTES`]
+/// of inputs, two [`MAX_EVIDENCE_TEXT_BYTES`] fields, and the fixed-size fields and
+/// length prefixes around them, which come to a few kilobytes. The rest is slack.
+/// `every_evidence_check_bounds_accepts_fits_the_decode_limit` pins that the two
+/// limits agree.
+pub const MAX_EVIDENCE_ENCODED_BYTES: usize = MAX_EVIDENCE_INPUT_BYTES + 16 * 1024;
 
 /// A content hash identifying one reproducer, used for deduplication so a peer
 /// neither re-verifies nor re-forwards a case it has already seen.
@@ -121,6 +154,13 @@ pub enum EvidenceRejected {
     TooLarge { found: usize, limit: usize },
     #[error("evidence carries {found} related contracts, limit is {limit}")]
     TooManyRelated { found: usize, limit: usize },
+    /// A sender-written text field is longer than [`MAX_EVIDENCE_TEXT_BYTES`].
+    #[error("evidence field {field} is {found} bytes, limit is {limit}")]
+    TextTooLong {
+        field: &'static str,
+        found: usize,
+        limit: usize,
+    },
     /// The property is not self-verifying, so no amount of re-execution could
     /// establish its premise. See [`PremiseSource`].
     #[error(
@@ -176,7 +216,13 @@ impl ConformanceEvidence {
             deltas: case.deltas.iter().map(|d| d.to_vec()).collect(),
             summary: case.summary.as_ref().map(|s| s.to_vec()),
             related: related_to_pairs(&case.related),
-            observed,
+            // Truncated so that evidence this crate writes always passes its own
+            // `check_bounds`. fdev's writer skips evidence that fails it, so an
+            // overlong detail would otherwise drop the finding without a word.
+            observed: observed.map(|mut violation| {
+                truncate_text(&mut violation.detail, MAX_EVIDENCE_TEXT_BYTES);
+                violation
+            }),
             runtime: RuntimeIdentity::current(),
         }
     }
@@ -242,6 +288,12 @@ impl ConformanceEvidence {
                 limit: MAX_EVIDENCE_INPUT_BYTES,
             });
         }
+        // The two text fields are not execution inputs, so `input_bytes` does not
+        // count them. Without this the sender alone decides their size (#5581).
+        if let Some(observed) = &self.observed {
+            check_text_len("observed.detail", &observed.detail)?;
+        }
+        check_text_len("runtime.core_version", &self.runtime.core_version)?;
         if self.related.len() > MAX_EVIDENCE_RELATED {
             return Err(EvidenceRejected::TooManyRelated {
                 found: self.related.len(),
@@ -350,8 +402,9 @@ impl ConformanceEvidence {
     /// rebuild itself cannot fail. So an [`EvidenceRejected`] here means the evidence
     /// carries an unsupported [`EVIDENCE_SCHEMA_VERSION`], rests on provenance the
     /// bytes cannot carry ([`EvidenceRejected::NotSelfVerifying`]), exceeds
-    /// [`MAX_EVIDENCE_INPUT_BYTES`] or [`MAX_EVIDENCE_RELATED`], or does not carry
-    /// exactly the state and delta counts its property requires.
+    /// [`MAX_EVIDENCE_INPUT_BYTES`], [`MAX_EVIDENCE_RELATED`] or
+    /// [`MAX_EVIDENCE_TEXT_BYTES`], or does not carry exactly the state and delta
+    /// counts its property requires.
     ///
     /// Note for callers upgrading past the signature change: this returned
     /// `ConformanceCase` directly until the gate moved inside, so a caller that
@@ -406,6 +459,9 @@ impl ConformanceEvidence {
     ///    wrote evidence without the header). Schema 2 files from those releases are
     ///    byte-compatible with the current struct, so a successful decode is returned
     ///    rather than an error. Schema 1 is refused: the struct changed between 1 and 2.
+    ///
+    /// Both payload paths go through [`decode_body`], which refuses a payload larger
+    /// than [`MAX_EVIDENCE_ENCODED_BYTES`] or followed by trailing bytes.
     pub fn decode(bytes: &[u8]) -> Result<Self, EvidenceError> {
         const HEADER_LEN: usize = EVIDENCE_MAGIC.len() + 2;
 
@@ -423,8 +479,7 @@ impl ConformanceEvidence {
                     supported: EVIDENCE_SCHEMA_VERSION,
                 });
             }
-            let evidence: Self = bincode::deserialize(&bytes[HEADER_LEN..])
-                .map_err(|e| EvidenceError::Decode(e.to_string()))?;
+            let evidence = decode_body(&bytes[HEADER_LEN..])?;
             if evidence.schema_version != version {
                 return Err(EvidenceError::MismatchedBodySchema {
                     header: version,
@@ -452,7 +507,7 @@ impl ConformanceEvidence {
                 });
             }
             if legacy_version == 2 {
-                if let Ok(evidence) = bincode::deserialize::<Self>(bytes) {
+                if let Ok(evidence) = decode_body(bytes) {
                     return Ok(evidence);
                 }
                 // Not a real legacy evidence file; fall through to BadMagic.
@@ -461,6 +516,69 @@ impl ConformanceEvidence {
 
         Err(EvidenceError::BadMagic)
     }
+}
+
+/// The bincode configuration evidence is decoded with.
+///
+/// Byte-compatible with `bincode::serialize`, which [`ConformanceEvidence::encode`]
+/// uses: fixint and little-endian, like bincode 1.x's free functions. It differs
+/// from `bincode::deserialize` in the two ways #5581 asks for. Bytes are counted
+/// against [`MAX_EVIDENCE_ENCODED_BYTES`], so a length prefix claiming more than that
+/// is refused before anything is allocated for it. And bytes left over after a
+/// complete payload are an error instead of being ignored.
+fn evidence_bincode() -> impl bincode::Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(MAX_EVIDENCE_ENCODED_BYTES as u64)
+        .reject_trailing_bytes()
+}
+
+/// Decode an evidence payload, refusing an oversized one before bincode reads it.
+fn decode_body(body: &[u8]) -> Result<ConformanceEvidence, EvidenceError> {
+    if body.len() > MAX_EVIDENCE_ENCODED_BYTES {
+        return Err(EvidenceError::TooLarge {
+            found: body.len(),
+            limit: MAX_EVIDENCE_ENCODED_BYTES,
+        });
+    }
+    evidence_bincode().deserialize(body).map_err(|error| {
+        // A length prefix inside the payload claimed more than the limit. The
+        // payload itself is within it, so this is malformed rather than
+        // oversized, and says which limit it hit.
+        let detail = if matches!(*error, bincode::ErrorKind::SizeLimit) {
+            format!(
+                "a length inside the payload claims more than the \
+                     {MAX_EVIDENCE_ENCODED_BYTES}-byte evidence limit"
+            )
+        } else {
+            error.to_string()
+        };
+        EvidenceError::Decode(detail)
+    })
+}
+
+/// Refuse a sender-written text field longer than [`MAX_EVIDENCE_TEXT_BYTES`].
+fn check_text_len(field: &'static str, text: &str) -> Result<(), EvidenceRejected> {
+    if text.len() > MAX_EVIDENCE_TEXT_BYTES {
+        return Err(EvidenceRejected::TextTooLong {
+            field,
+            found: text.len(),
+            limit: MAX_EVIDENCE_TEXT_BYTES,
+        });
+    }
+    Ok(())
+}
+
+/// Shorten `text` to at most `max` bytes without splitting a UTF-8 character.
+fn truncate_text(text: &mut String, max: usize) {
+    if text.len() <= max {
+        return;
+    }
+    let mut end = max;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text.truncate(end);
 }
 
 /// Length-prefix each blob so `["ab", "c"]` and `["a", "bc"]` cannot collide.

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -49,12 +49,27 @@ pub enum EvidenceError {
     #[error("not conformance evidence (bad magic)")]
     BadMagic,
     #[error(
-        "evidence file is truncated: magic matched but the 10-byte framing header is incomplete \
-         ({len} byte(s)); the file was likely cut off mid-write and should be regenerated"
+        "evidence is truncated: it ends after {len} byte(s), before it is complete; the \
+         file was likely cut off mid-write and should be regenerated"
     )]
     Truncated { len: usize },
     #[error("evidence uses schema version {found}, this build understands {supported}")]
     UnsupportedSchema { found: u16, supported: u16 },
+    /// An unframed file whose first two bytes read as a schema version this build
+    /// cannot decode. Worded as "looks like" because any binary file can begin with
+    /// the same two bytes.
+    #[error(
+        "this looks like unframed evidence written by an older build (schema {found}), \
+         which this build cannot read; re-capture it with this build"
+    )]
+    LegacyUnsupported { found: u16 },
+    /// An unframed file that starts like pre-framing schema-2 evidence but does not
+    /// decode as it.
+    #[error(
+        "this starts like unframed schema-2 evidence from v0.2.133 but does not decode \
+         as it ({0}); if it is evidence, the file is damaged or truncated"
+    )]
+    LegacyUndecodable(String),
     #[error(
         "evidence framing header specifies schema {header}, but deserialized payload specifies {body}"
     )]
@@ -437,6 +452,14 @@ impl ConformanceEvidence {
     /// Encode with framing: 8-byte magic (`FRNTEVD1`), 2-byte schema version (LE),
     /// followed by the bincode-serialized payload.
     pub fn encode(&self) -> Result<Vec<u8>, EvidenceError> {
+        // The header is written from this field, so any other value would produce a
+        // file that `decode` then refuses as an unsupported schema.
+        if self.schema_version != EVIDENCE_SCHEMA_VERSION {
+            return Err(EvidenceError::Encode(format!(
+                "schema_version is {}, but this build writes only schema {EVIDENCE_SCHEMA_VERSION}",
+                self.schema_version
+            )));
+        }
         let mut out = Vec::with_capacity(self.input_bytes() + 128);
         out.extend_from_slice(EVIDENCE_MAGIC);
         out.extend_from_slice(&self.schema_version.to_le_bytes());
@@ -445,115 +468,155 @@ impl ConformanceEvidence {
         Ok(out)
     }
 
-    /// Decode an evidence file, verifying magic and schema version *before*
-    /// attempting bincode deserialization.
+    /// Decode evidence from an untrusted source: framed evidence only.
     ///
-    /// The check order matters:
-    /// 1. Magic first — so a truncated framed file (`b"FRNTEVD1"` with nothing after)
-    ///    reports [`EvidenceError::Truncated`] rather than [`EvidenceError::BadMagic`].
-    ///    A disk that fills mid-write produces a partial file; telling the user "not
-    ///    conformance evidence" sends them hunting for the wrong problem.
-    /// 2. Length second — once the magic matches, a short header is a truncation.
-    /// 3. Legacy sniff — if the magic did not match and the first two bytes look like
-    ///    a schema version, try to decode the raw bincode payload (v0.2.129–v0.2.133
-    ///    wrote evidence without the header). Schema 2 files from those releases are
-    ///    byte-compatible with the current struct, so a successful decode is returned
-    ///    rather than an error. Schema 1 is refused: the struct changed between 1 and 2.
+    /// This is the decoder for anything a peer could have written. It accepts only
+    /// the framed format (8-byte magic, 2-byte schema version, payload), so every
+    /// input must match the full magic first. Files written before framing existed
+    /// are read by [`Self::decode_file`], which is for files an operator points at
+    /// and must never see bytes from a peer.
     ///
-    /// Both payload paths go through [`decode_body`], which refuses a payload larger
-    /// than [`MAX_EVIDENCE_ENCODED_BYTES`] or followed by trailing bytes.
+    /// The check order matters. Magic first, so a file cut short inside its header
+    /// reports [`EvidenceError::Truncated`] rather than claiming it is not evidence:
+    /// a disk that fills mid-write produces exactly that, and "not conformance
+    /// evidence" sends its owner looking for the wrong problem. The payload then goes
+    /// through [`decode_body`], which refuses one larger than
+    /// [`MAX_EVIDENCE_ENCODED_BYTES`] or followed by trailing bytes, and a payload
+    /// that ends early is reported as truncated as well.
     pub fn decode(bytes: &[u8]) -> Result<Self, EvidenceError> {
         const HEADER_LEN: usize = EVIDENCE_MAGIC.len() + 2;
+        if !bytes.starts_with(EVIDENCE_MAGIC) {
+            return Err(EvidenceError::BadMagic);
+        }
+        if bytes.len() < HEADER_LEN {
+            return Err(EvidenceError::Truncated { len: bytes.len() });
+        }
+        let version =
+            u16::from_le_bytes([bytes[EVIDENCE_MAGIC.len()], bytes[EVIDENCE_MAGIC.len() + 1]]);
+        if version != EVIDENCE_SCHEMA_VERSION {
+            return Err(EvidenceError::UnsupportedSchema {
+                found: version,
+                supported: EVIDENCE_SCHEMA_VERSION,
+            });
+        }
+        let evidence = decode_body(&bytes[HEADER_LEN..]).map_err(|error| match error {
+            BodyError::TooLarge { found } => EvidenceError::TooLarge {
+                found,
+                limit: MAX_EVIDENCE_ENCODED_BYTES,
+            },
+            BodyError::EndedEarly => EvidenceError::Truncated { len: bytes.len() },
+            BodyError::Malformed(detail) => EvidenceError::Decode(detail),
+        })?;
+        if evidence.schema_version != version {
+            return Err(EvidenceError::MismatchedBodySchema {
+                header: version,
+                body: evidence.schema_version,
+            });
+        }
+        Ok(evidence)
+    }
 
-        // Check magic FIRST so a truncated framed file is recognized as such rather
-        // than misreported as "not conformance evidence".
+    /// Decode an evidence FILE, also accepting the unframed format that builds
+    /// v0.2.129 to v0.2.133 wrote.
+    ///
+    /// For files an operator chose, such as `fdev verify-merge --evidence`. Never
+    /// pass it bytes from a peer: the unframed format is recognised by two bytes
+    /// rather than the 8-byte magic, and a receive path that accepted it would
+    /// accept a second wire format permanently. [`Self::decode`] is the decoder for
+    /// untrusted input.
+    ///
+    /// A framed file is decoded exactly as [`Self::decode`] would decode it. An
+    /// unframed one is raw bincode whose first field is `schema_version` (LE `u16`).
+    /// Schema 2 is byte-compatible with the current struct and is decoded, through
+    /// the same bounded [`decode_body`]. Schema 1 is not, because `settling` was
+    /// added to `Violation` when the schema moved to 2.
+    pub fn decode_file(bytes: &[u8]) -> Result<Self, EvidenceError> {
         if bytes.starts_with(EVIDENCE_MAGIC) {
-            if bytes.len() < HEADER_LEN {
-                return Err(EvidenceError::Truncated { len: bytes.len() });
-            }
-            let version =
-                u16::from_le_bytes([bytes[EVIDENCE_MAGIC.len()], bytes[EVIDENCE_MAGIC.len() + 1]]);
-            if version != EVIDENCE_SCHEMA_VERSION {
-                return Err(EvidenceError::UnsupportedSchema {
-                    found: version,
-                    supported: EVIDENCE_SCHEMA_VERSION,
-                });
-            }
-            let evidence = decode_body(&bytes[HEADER_LEN..])?;
-            if evidence.schema_version != version {
-                return Err(EvidenceError::MismatchedBodySchema {
-                    header: version,
-                    body: evidence.schema_version,
-                });
-            }
-            return Ok(evidence);
+            return Self::decode(bytes);
         }
-
-        // Legacy sniff: pre-0.2.134 builds wrote raw bincode without the framing header.
-        // The first field is `schema_version: u16` in LE, so a real legacy file begins
-        // `01 00` (schema 1) or `02 00` (schema 2).
-        //
-        // Schema 1 is refused: the struct layout changed when `settling` was added.
-        // Schema 2 is byte-compatible with the current struct, so we attempt a direct
-        // bincode decode and return it if it succeeds. Failure (e.g. a random file that
-        // happens to start with `02 00`) falls through to BadMagic rather than exposing
-        // a decode error for input that is almost certainly not evidence at all.
-        if bytes.len() >= 2 {
-            let legacy_version = u16::from_le_bytes([bytes[0], bytes[1]]);
-            if legacy_version == 1 {
-                return Err(EvidenceError::UnsupportedSchema {
-                    found: 1,
-                    supported: EVIDENCE_SCHEMA_VERSION,
-                });
-            }
-            if legacy_version == 2 {
-                if let Ok(evidence) = decode_body(bytes) {
-                    return Ok(evidence);
+        if bytes.len() < 2 {
+            return Err(EvidenceError::BadMagic);
+        }
+        let legacy_version = u16::from_le_bytes([bytes[0], bytes[1]]);
+        if legacy_version == 2 {
+            return decode_body(bytes).map_err(|error| match error {
+                BodyError::TooLarge { found } => EvidenceError::TooLarge {
+                    found,
+                    limit: MAX_EVIDENCE_ENCODED_BYTES,
+                },
+                BodyError::EndedEarly => {
+                    EvidenceError::LegacyUndecodable("it ends early".to_string())
                 }
-                // Not a real legacy evidence file; fall through to BadMagic.
-            }
+                BodyError::Malformed(detail) => EvidenceError::LegacyUndecodable(detail),
+            });
         }
-
+        if legacy_version == 1 {
+            return Err(EvidenceError::LegacyUnsupported {
+                found: legacy_version,
+            });
+        }
         Err(EvidenceError::BadMagic)
     }
 }
+
+// `decode_file` decodes an unframed schema-2 payload with the CURRENT struct, which
+// is right only while the current schema is 2. Bumping the schema has to revisit
+// that branch, so the build refuses to compile until someone has.
+const _: () = assert!(
+    EVIDENCE_SCHEMA_VERSION == 2,
+    "EVIDENCE_SCHEMA_VERSION changed: decide what decode_file does with unframed schema-2 files"
+);
 
 /// The bincode configuration evidence is decoded with.
 ///
 /// Byte-compatible with `bincode::serialize`, which [`ConformanceEvidence::encode`]
 /// uses: fixint and little-endian, like bincode 1.x's free functions. It differs
-/// from `bincode::deserialize` in the two ways #5581 asks for. Bytes are counted
-/// against [`MAX_EVIDENCE_ENCODED_BYTES`], so a length prefix claiming more than that
-/// is refused before anything is allocated for it. And bytes left over after a
-/// complete payload are an error instead of being ignored.
+/// from `bincode::deserialize` in refusing bytes left over after a complete
+/// payload, instead of ignoring them.
+///
+/// It deliberately sets no size limit, because bincode would ignore one:
+/// deserializing from a slice replaces the configured limit with `Infinite`
+/// (`internal::deserialize_seed` in bincode 1.3), so `.with_limit(..)` here would
+/// read as a bound and bound nothing. The bound is the length check at the top of
+/// [`decode_body`], which runs before bincode reads a byte. Allocation stays within
+/// the input regardless: a slice reader refuses a byte string longer than the input
+/// that remains before allocating it, and serde caps a sequence's up-front capacity.
 fn evidence_bincode() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_fixint_encoding()
-        .with_limit(MAX_EVIDENCE_ENCODED_BYTES as u64)
         .reject_trailing_bytes()
 }
 
+/// Why a payload failed to decode, before the caller decides how to report it.
+///
+/// The two callers report the same failure differently: a framed file that ends
+/// early is [`EvidenceError::Truncated`], while an unframed one that fails is
+/// [`EvidenceError::LegacyUndecodable`], since it may not be evidence at all.
+enum BodyError {
+    /// Larger than [`MAX_EVIDENCE_ENCODED_BYTES`]; not parsed at all.
+    TooLarge { found: usize },
+    /// The bytes ran out before a complete payload.
+    EndedEarly,
+    /// Anything else, with bincode's description of it.
+    Malformed(String),
+}
+
 /// Decode an evidence payload, refusing an oversized one before bincode reads it.
-fn decode_body(body: &[u8]) -> Result<ConformanceEvidence, EvidenceError> {
+fn decode_body(body: &[u8]) -> Result<ConformanceEvidence, BodyError> {
     if body.len() > MAX_EVIDENCE_ENCODED_BYTES {
-        return Err(EvidenceError::TooLarge {
-            found: body.len(),
-            limit: MAX_EVIDENCE_ENCODED_BYTES,
-        });
+        return Err(BodyError::TooLarge { found: body.len() });
     }
     evidence_bincode().deserialize(body).map_err(|error| {
-        // A length prefix inside the payload claimed more than the limit. The
-        // payload itself is within it, so this is malformed rather than
-        // oversized, and says which limit it hit.
-        let detail = if matches!(*error, bincode::ErrorKind::SizeLimit) {
-            format!(
-                "a length inside the payload claims more than the \
-                     {MAX_EVIDENCE_ENCODED_BYTES}-byte evidence limit"
-            )
+        if matches!(
+            &*error,
+            bincode::ErrorKind::Io(io) if io.kind() == std::io::ErrorKind::UnexpectedEof
+        ) {
+            // Includes a length prefix claiming more bytes than the payload holds:
+            // the payload ends before what it declares.
+            BodyError::EndedEarly
         } else {
-            error.to_string()
-        };
-        EvidenceError::Decode(detail)
+            BodyError::Malformed(error.to_string())
+        }
     })
 }
 

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -48,9 +48,9 @@ pub const EVIDENCE_MAGIC: &[u8; 8] = b"FRNTEVD1";
 pub enum EvidenceError {
     #[error("not conformance evidence (bad magic)")]
     BadMagic,
-    /// The input ended before the payload it declares was complete. bincode reports
-    /// a hostile length prefix, one claiming more bytes than follow, the same way, so
-    /// this says nothing about whether the sender is honest.
+    /// The input ended before its header, or the payload the header declares, was
+    /// complete. bincode reports a hostile length prefix, one claiming more bytes than
+    /// follow, the same way, so this says nothing about whether the sender is honest.
     #[error(
         "evidence is truncated: it ends after {len} byte(s), before it is complete; the \
          file was likely cut off mid-write and should be regenerated"
@@ -490,8 +490,8 @@ impl ConformanceEvidence {
     ///
     /// The check order matters. Magic first, so a file whose 8-byte magic is intact
     /// but which is cut short after it reports [`EvidenceError::Truncated`] rather than
-    /// claiming it is not evidence (a cut inside the magic itself cannot be told apart
-    /// from a short foreign file, and reports [`EvidenceError::BadMagic`]):
+    /// claiming it is not evidence. (A cut inside the 8-byte magic itself is, by
+    /// choice, not recognised, and reports [`EvidenceError::BadMagic`].)
     /// a disk that fills mid-write produces exactly that, and "not conformance
     /// evidence" sends its owner looking for the wrong problem. The payload then goes
     /// through [`decode_body`], which refuses one larger than
@@ -558,11 +558,11 @@ impl ConformanceEvidence {
                 // `02 00` is not thereby evidence.
                 BodyError::TooLarge { found } => EvidenceError::LegacyUndecodable(format!(
                     "is {found} bytes, more than any evidence this build accepts \
-                     ({MAX_EVIDENCE_ENCODED_BYTES}), so it was not read"
+                     ({MAX_EVIDENCE_ENCODED_BYTES}), so it was not decoded"
                 )),
                 BodyError::EndedEarly => EvidenceError::LegacyUndecodable(
                     "ends before a complete payload; if it is evidence, the file is \
-                         truncated"
+                         truncated or damaged"
                         .to_string(),
                 ),
                 BodyError::Malformed(detail) => EvidenceError::LegacyUndecodable(format!(
@@ -611,16 +611,16 @@ const _: () = assert!(
 /// preallocates `min(declared, 1 MiB / element size)` before reading an element, so a
 /// few dozen hostile bytes can reserve about 2 MiB that is never filled. And each
 /// element of a `Vec<Vec<u8>>` costs 8 input bytes but a 24-byte header, grown by
-/// doubling. Reviewers estimated from the serde and bincode sources that a payload
-/// which decodes successfully can allocate about 4 to 7 times its own size.
+/// doubling, so a payload that decodes successfully can allocate up to about 6 times
+/// its own size.
 ///
-/// So allocation is linear in the input, but NOT bounded by it. What bounds a single
-/// decode is the length check: with the payload capped at
-/// [`MAX_EVIDENCE_ENCODED_BYTES`], one decode allocates at most a few MiB (on the
-/// order of 6 MiB at worst, by the same estimate). Tighter bounds, such as refusing a
-/// declared element count above what `check_bounds` allows before allocating, are
-/// recorded for the Phase 4 receive path on #5377, where decodes run concurrently and
-/// the multiplier starts to matter.
+/// So allocation is NOT bounded by the input: it is up to about 2 MiB of
+/// preallocation plus a small multiple of the input. What bounds a single decode is
+/// the length check. With the payload capped at [`MAX_EVIDENCE_ENCODED_BYTES`], the
+/// worst case worked out from the serde and bincode sources is about 4.6 MiB for one
+/// decode. Tighter bounds, such as refusing a declared element count above what
+/// `check_bounds` allows before allocating, are recorded for the Phase 4 receive path
+/// on #5377, where decodes run concurrently and the multiplier starts to matter.
 fn evidence_bincode() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_fixint_encoding()

--- a/crates/core/src/conformance/evidence.rs
+++ b/crates/core/src/conformance/evidence.rs
@@ -48,6 +48,9 @@ pub const EVIDENCE_MAGIC: &[u8; 8] = b"FRNTEVD1";
 pub enum EvidenceError {
     #[error("not conformance evidence (bad magic)")]
     BadMagic,
+    /// The input ended before the payload it declares was complete. bincode reports
+    /// a hostile length prefix, one claiming more bytes than follow, the same way, so
+    /// this says nothing about whether the sender is honest.
     #[error(
         "evidence is truncated: it ends after {len} byte(s), before it is complete; the \
          file was likely cut off mid-write and should be regenerated"
@@ -65,10 +68,7 @@ pub enum EvidenceError {
     LegacyUnsupported { found: u16 },
     /// An unframed file that starts like pre-framing schema-2 evidence but does not
     /// decode as it.
-    #[error(
-        "this starts like unframed schema-2 evidence from v0.2.133 but does not decode \
-         as it ({0}); if it is evidence, the file is damaged or truncated"
-    )]
+    #[error("this starts like unframed schema-2 evidence from v0.2.133, but {0}")]
     LegacyUndecodable(String),
     #[error(
         "evidence framing header specifies schema {header}, but deserialized payload specifies {body}"
@@ -466,6 +466,16 @@ impl ConformanceEvidence {
         out.extend_from_slice(EVIDENCE_MAGIC);
         out.extend_from_slice(&self.schema_version.to_le_bytes());
         let body = bincode::serialize(self).map_err(|e| EvidenceError::Encode(e.to_string()))?;
+        // Same reasoning as the schema guard above: never write what `decode` refuses.
+        // Evidence that passed `check_bounds` always fits; this catches a caller that
+        // encodes without checking bounds first.
+        if body.len() > MAX_EVIDENCE_ENCODED_BYTES {
+            return Err(EvidenceError::Encode(format!(
+                "the payload is {} bytes, more than the {MAX_EVIDENCE_ENCODED_BYTES} that \
+                 decode accepts",
+                body.len()
+            )));
+        }
         out.extend_from_slice(&body);
         Ok(out)
     }
@@ -478,8 +488,10 @@ impl ConformanceEvidence {
     /// are read by [`Self::decode_file`], which is for files an operator points at
     /// and must never see bytes from a peer.
     ///
-    /// The check order matters. Magic first, so a file cut short inside its header
-    /// reports [`EvidenceError::Truncated`] rather than claiming it is not evidence:
+    /// The check order matters. Magic first, so a file whose 8-byte magic is intact
+    /// but which is cut short after it reports [`EvidenceError::Truncated`] rather than
+    /// claiming it is not evidence (a cut inside the magic itself cannot be told apart
+    /// from a short foreign file, and reports [`EvidenceError::BadMagic`]):
     /// a disk that fills mid-write produces exactly that, and "not conformance
     /// evidence" sends its owner looking for the wrong problem. The payload then goes
     /// through [`decode_body`], which refuses one larger than
@@ -545,13 +557,17 @@ impl ConformanceEvidence {
                 // Hedged like the other two: an oversized file that happens to begin
                 // `02 00` is not thereby evidence.
                 BodyError::TooLarge { found } => EvidenceError::LegacyUndecodable(format!(
-                    "it is {found} bytes, more than any evidence this build accepts \
-                     ({MAX_EVIDENCE_ENCODED_BYTES})"
+                    "is {found} bytes, more than any evidence this build accepts \
+                     ({MAX_EVIDENCE_ENCODED_BYTES}), so it was not read"
                 )),
-                BodyError::EndedEarly => {
-                    EvidenceError::LegacyUndecodable("it ends early".to_string())
-                }
-                BodyError::Malformed(detail) => EvidenceError::LegacyUndecodable(detail),
+                BodyError::EndedEarly => EvidenceError::LegacyUndecodable(
+                    "ends before a complete payload; if it is evidence, the file is \
+                         truncated"
+                        .to_string(),
+                ),
+                BodyError::Malformed(detail) => EvidenceError::LegacyUndecodable(format!(
+                    "does not decode as it ({detail}); if it is evidence, the file is damaged"
+                )),
             });
         }
         if legacy_version == 1 {
@@ -589,14 +605,22 @@ const _: () = assert!(
 /// read as a bound and bound nothing. The bound is the length check at the top of
 /// [`decode_body`], which runs before bincode reads a byte.
 ///
-/// What that leaves for allocation, stated precisely because a receive path will
-/// rely on it: a `String` is bounded by the input, since the slice reader refuses a
-/// declared length longer than the input that remains before allocating. A `Vec` is
-/// not. serde preallocates `min(declared, 1 MiB / element size)` before reading a
-/// single element, so a few dozen hostile bytes declaring `u64::MAX` elements for a
-/// nested `Vec<Vec<u8>>` cost about 2 MiB of transient capacity before decoding
-/// fails. Allocation is therefore bounded by the input plus a small constant, not by
-/// the input alone.
+/// What that leaves for allocation. A `String` costs no more than the input, since
+/// the slice reader refuses a declared length longer than what remains before
+/// allocating. A `Vec` costs more than the input it came from, in two ways. serde
+/// preallocates `min(declared, 1 MiB / element size)` before reading an element, so a
+/// few dozen hostile bytes can reserve about 2 MiB that is never filled. And each
+/// element of a `Vec<Vec<u8>>` costs 8 input bytes but a 24-byte header, grown by
+/// doubling. Reviewers estimated from the serde and bincode sources that a payload
+/// which decodes successfully can allocate about 4 to 7 times its own size.
+///
+/// So allocation is linear in the input, but NOT bounded by it. What bounds a single
+/// decode is the length check: with the payload capped at
+/// [`MAX_EVIDENCE_ENCODED_BYTES`], one decode allocates at most a few MiB (on the
+/// order of 6 MiB at worst, by the same estimate). Tighter bounds, such as refusing a
+/// declared element count above what `check_bounds` allows before allocating, are
+/// recorded for the Phase 4 receive path on #5377, where decodes run concurrently and
+/// the multiplier starts to matter.
 fn evidence_bincode() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_fixint_encoding()

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -2513,9 +2513,12 @@ fn a_payload_exactly_at_the_limit_passes_the_size_gate() {
     bytes.extend_from_slice(&2u16.to_le_bytes());
     bytes.resize(bytes.len() + MAX_EVIDENCE_ENCODED_BYTES, 0xff);
     let result = ConformanceEvidence::decode(&bytes);
+    // All 0xff: the schema field reads 0xffff, the contract takes 32 bytes, then
+    // `parameters` declares u64::MAX bytes and runs out of input.
     assert!(
-        !matches!(result, Err(EvidenceError::PayloadTooLarge { .. })),
-        "a payload exactly at the limit must pass the size gate, got {result:?}"
+        matches!(result, Err(EvidenceError::Truncated { .. })),
+        "a payload exactly at the limit must pass the size gate and then fail to \
+         parse, got {result:?}"
     );
 }
 
@@ -3365,6 +3368,79 @@ fn encode_refuses_a_payload_that_decode_would_refuse_as_too_large() {
         ),
         other => panic!("expected an encode refusal, got {other:?}"),
     }
+}
+
+/// Both size guards at the exact boundary: evidence whose payload is exactly
+/// `MAX_EVIDENCE_ENCODED_BYTES` encodes, and decodes back to itself. Pins `>`
+/// against `>=` in `encode()`, as `a_payload_exactly_at_the_limit_passes_the_size_gate`
+/// does for `decode_body`. bincode is fixint, so the payload is the state's length
+/// plus a constant; the fixture measures that constant rather than assuming it.
+#[test]
+fn evidence_whose_payload_is_exactly_the_limit_encodes_and_decodes() {
+    let build = |len: usize| {
+        let case = ConformanceCase::new(
+            ConformanceProperty::StateIdempotence,
+            vec![Arc::from(vec![0u8; len].as_slice())],
+        );
+        ConformanceEvidence::new(instance(1), vec![], &case, None)
+    };
+    // 8-byte magic plus 2-byte schema version precede the payload.
+    let header = 10;
+    let overhead = build(0).encode().expect("encode").len() - header;
+    let evidence = build(MAX_EVIDENCE_ENCODED_BYTES - overhead);
+    let bytes = evidence
+        .encode()
+        .expect("a payload exactly at the limit must encode");
+    assert_eq!(
+        bytes.len() - header,
+        MAX_EVIDENCE_ENCODED_BYTES,
+        "the fixture must land exactly on the limit"
+    );
+    assert_eq!(
+        ConformanceEvidence::decode(&bytes).expect("and must decode"),
+        evidence
+    );
+}
+
+/// The delta half of `check_bounds`' exact-arity check. Every other arity test
+/// supplies a wrong number of STATES; this one supplies the right number of states
+/// and the wrong number of deltas, so deleting the deltas comparison fails here.
+#[test]
+fn evidence_with_the_right_states_but_the_wrong_deltas_is_rejected() {
+    let property = ConformanceProperty::DeltaIdempotence;
+    assert!(
+        property.is_self_verifying(),
+        "the fixture needs a shippable property, or check_bounds refuses it earlier"
+    );
+    assert_eq!((property.state_arity(), property.delta_arity()), (1, 1));
+    let case = case(property, &[&[1]]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    assert!(
+        evidence.deltas.is_empty(),
+        "the fixture must carry no deltas"
+    );
+    assert!(matches!(
+        evidence.check_bounds(),
+        Err(EvidenceRejected::Arity {
+            want_deltas: 1,
+            got_deltas: 0,
+            ..
+        })
+    ));
+}
+
+/// `decode_file` decodes a framed file exactly as `decode` does. Without the
+/// delegation, framed input would fall through to the legacy sniff, read `FR` as a
+/// schema number, and be refused as not evidence.
+#[test]
+fn decode_file_decodes_framed_evidence_as_decode_does() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let bytes = evidence.encode().expect("encode");
+    assert_eq!(
+        ConformanceEvidence::decode_file(&bytes).expect("decode_file"),
+        evidence
+    );
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -2481,22 +2481,27 @@ fn decode_refuses_bytes_after_a_complete_payload() {
     ));
 }
 
-/// #5581. The size gate has to run during DECODE. `check_bounds` only ever sees an
-/// object that decoding has already allocated, so a limit applied there alone
-/// arrives after the cost it exists to prevent.
+/// #5581. The size gate has to run during DECODE, before bincode parses anything:
+/// `check_bounds` only ever sees an object that decoding has already built, so a
+/// limit applied there alone arrives after the cost it exists to prevent.
+///
+/// The fixture is deliberately NOT valid evidence. With a valid oversized payload,
+/// moving the length check to after a successful parse would still report
+/// `PayloadTooLarge`, and this test would pass. With a payload bincode cannot parse,
+/// only a check that runs first reports `PayloadTooLarge`; a check moved later never
+/// gets the chance, because the parse fails first.
 #[test]
 fn decode_refuses_a_payload_larger_than_any_evidence_check_bounds_accepts() {
-    let big = vec![0u8; MAX_EVIDENCE_INPUT_BYTES * 4];
-    let case = ConformanceCase::new(
-        ConformanceProperty::StateIdempotence,
-        vec![Arc::from(big.as_slice())],
-    );
-    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
-    let bytes = evidence.encode().expect("encode");
-    assert!(matches!(
-        ConformanceEvidence::decode(&bytes),
-        Err(EvidenceError::TooLarge { .. })
-    ));
+    let mut bytes = b"FRNTEVD1".to_vec();
+    bytes.extend_from_slice(&2u16.to_le_bytes());
+    bytes.resize(bytes.len() + MAX_EVIDENCE_ENCODED_BYTES + 1, 0xff);
+    match ConformanceEvidence::decode(&bytes) {
+        Err(EvidenceError::PayloadTooLarge { found, limit }) => {
+            assert_eq!(found, MAX_EVIDENCE_ENCODED_BYTES + 1);
+            assert_eq!(limit, MAX_EVIDENCE_ENCODED_BYTES);
+        }
+        other => panic!("expected PayloadTooLarge before any parse, got {other:?}"),
+    }
 }
 
 /// The counterpart to the two text-field rejections: exactly at the limit passes.
@@ -2559,6 +2564,8 @@ fn every_evidence_check_bounds_accepts_fits_the_decode_limit() {
         .collect();
     let case = ConformanceCase::new(property, states);
     let mut violation = violation_with_detail(MAX_EVIDENCE_TEXT_BYTES);
+    violation.property = property;
+    violation.severity = property.severity();
     violation.settling = Some(IdempotenceSettling::SettledAfter(u32::MAX));
     let mut evidence = ConformanceEvidence::new(instance(1), vec![7; side], &case, Some(violation));
     evidence.summary = Some(vec![8; side]);
@@ -3221,6 +3228,50 @@ fn a_payload_declaring_more_than_it_holds_reports_truncated() {
     match ConformanceEvidence::decode(&bytes) {
         Err(EvidenceError::Truncated { len }) => assert_eq!(len, bytes.len()),
         other => panic!("expected Truncated, got {other:?}"),
+    }
+}
+
+/// `decode_file` on input too short to carry a schema version, and on an unframed
+/// file whose first two bytes are not a schema this build knows, reports that it is
+/// not evidence. The length guard matters beyond the message: without it an empty or
+/// one-byte file would index past its end and panic `fdev verify-merge`.
+#[test]
+fn decode_file_refuses_short_input_and_unknown_legacy_versions_as_not_evidence() {
+    for input in [&[][..], &[0u8][..], &[2u8][..]] {
+        assert!(
+            matches!(
+                ConformanceEvidence::decode_file(input),
+                Err(EvidenceError::BadMagic)
+            ),
+            "{input:?} must be refused as not evidence, not panic or be misread"
+        );
+    }
+    for version in [0u16, 3, u16::MAX] {
+        let mut input = version.to_le_bytes().to_vec();
+        input.extend_from_slice(&[0xff; 16]);
+        assert!(
+            matches!(
+                ConformanceEvidence::decode_file(&input),
+                Err(EvidenceError::BadMagic)
+            ),
+            "legacy version {version} must be refused as not evidence"
+        );
+    }
+}
+
+/// An oversized unframed file that begins `02 00` is refused before it is parsed,
+/// and hedged like the other legacy refusals: beginning with those two bytes does
+/// not make a file evidence.
+#[test]
+fn decode_file_refuses_an_oversized_unframed_file_without_calling_it_evidence() {
+    let mut input = 2u16.to_le_bytes().to_vec();
+    input.resize(MAX_EVIDENCE_ENCODED_BYTES + 1, 0xff);
+    match ConformanceEvidence::decode_file(&input) {
+        Err(EvidenceError::LegacyUndecodable(detail)) => assert!(
+            detail.contains("more than any evidence this build accepts"),
+            "expected the size refusal, got: {detail}"
+        ),
+        other => panic!("expected a hedged size refusal, got {other:?}"),
     }
 }
 

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -3081,18 +3081,19 @@ fn evidence_encode_decode_roundtrip() {
 
 #[test]
 fn legacy_unframed_schema_1_is_refused() {
-    use super::evidence::{ConformanceEvidence, EVIDENCE_SCHEMA_VERSION, EvidenceError};
-
     // Schema 1 legacy files: struct layout changed when `settling` was added, so
-    // deserializing them would silently produce garbage. Always refused.
+    // deserializing them would silently produce garbage. Always refused, and
+    // described as LOOKING like old evidence, since any file can begin `01 00`.
     let legacy_schema_1 = [1u8, 0u8, 0xff, 0xff, 0xff];
-    match ConformanceEvidence::decode(&legacy_schema_1) {
-        Err(EvidenceError::UnsupportedSchema { found, supported }) => {
-            assert_eq!(found, 1);
-            assert_eq!(supported, EVIDENCE_SCHEMA_VERSION);
-        }
-        other => panic!("expected schema 1 refusal for legacy file, got {other:?}"),
+    match ConformanceEvidence::decode_file(&legacy_schema_1) {
+        Err(EvidenceError::LegacyUnsupported { found }) => assert_eq!(found, 1),
+        other => panic!("expected the legacy schema-1 refusal, got {other:?}"),
     }
+    // The strict decoder does not recognise the unframed format at all.
+    assert!(matches!(
+        ConformanceEvidence::decode(&legacy_schema_1),
+        Err(EvidenceError::BadMagic)
+    ));
 }
 
 #[test]
@@ -3100,8 +3101,8 @@ fn legacy_unframed_schema_2_decodes_if_the_payload_is_valid() {
     use super::evidence::ConformanceEvidence;
 
     // v0.2.133 evidence: no framing header, raw bincode payload. The struct layout
-    // is byte-identical to the current schema 2, so decode must succeed rather than
-    // returning an error. This is the regression Ian's review caught.
+    // is byte-identical to the current schema 2, so a FILE decode must succeed rather
+    // than returning an error.
     let idem_case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
     let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &idem_case, None);
 
@@ -3113,24 +3114,124 @@ fn legacy_unframed_schema_2_decodes_if_the_payload_is_valid() {
         "first field must be schema_version = 2 in LE"
     );
 
-    let decoded = ConformanceEvidence::decode(&raw).expect("legacy schema 2 must decode cleanly");
+    let decoded =
+        ConformanceEvidence::decode_file(&raw).expect("legacy schema 2 must decode as a file");
     assert_eq!(decoded, evidence);
+
+    // #5581: the strict decoder, the one a receive path uses, refuses the same bytes.
+    // Accepting them there would make the unframed format a second wire format,
+    // recognised by two bytes instead of the 8-byte magic.
+    assert!(matches!(
+        ConformanceEvidence::decode(&raw),
+        Err(EvidenceError::BadMagic)
+    ));
 }
 
+/// #5578 review finding 3: a file that starts like v0.2.133 evidence but does not
+/// decode used to report `BadMagic`, "not conformance evidence", which is the
+/// misdiagnosis `Truncated` exists to prevent. It now says what it looks like and
+/// that it does not decode, so the owner of a damaged file is pointed at the file.
 #[test]
-fn legacy_sniff_02_00_with_garbage_payload_is_bad_magic() {
-    use super::evidence::{ConformanceEvidence, EvidenceError};
+fn a_file_starting_like_schema_2_evidence_that_does_not_decode_says_so() {
+    let looks_like_evidence = [2u8, 0u8, 0xff, 0xff, 0xff];
+    assert!(matches!(
+        ConformanceEvidence::decode_file(&looks_like_evidence),
+        Err(EvidenceError::LegacyUndecodable(_))
+    ));
+    assert!(matches!(
+        ConformanceEvidence::decode(&looks_like_evidence),
+        Err(EvidenceError::BadMagic)
+    ));
+}
 
-    // A file that happens to start with `02 00` but whose bincode deserialization fails
-    // is not evidence at all; fall through to BadMagic rather than a confusing decode error.
-    let not_evidence = [2u8, 0u8, 0xff, 0xff, 0xff];
+/// The realistic form of the case above: a real v0.2.133 file, cut short.
+#[test]
+fn a_truncated_v0_2_133_file_is_reported_as_damaged_not_as_foreign() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let raw = bincode::serialize(&evidence).expect("serialize");
     assert!(
-        matches!(
-            ConformanceEvidence::decode(&not_evidence),
-            Err(EvidenceError::BadMagic)
-        ),
-        "a garbage file starting with 02 00 must not produce a decode error"
+        ConformanceEvidence::decode_file(&raw).is_ok(),
+        "control: the whole file must decode, or the refusal below proves nothing"
     );
+    assert!(matches!(
+        ConformanceEvidence::decode_file(&raw[..raw.len() - 1]),
+        Err(EvidenceError::LegacyUndecodable(_))
+    ));
+}
+
+/// #5578 review finding 4: `Truncated` promised the disk-full case but covered only
+/// a cut inside the 10-byte header. A cut inside the payload now reports it too.
+#[test]
+fn a_framed_file_cut_inside_its_payload_reports_truncated() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let bytes = evidence.encode().expect("encode");
+    let cut = &bytes[..bytes.len() - 5];
+    assert!(
+        cut.len() > 10,
+        "the cut must fall inside the payload, not the header"
+    );
+    match ConformanceEvidence::decode(cut) {
+        Err(EvidenceError::Truncated { len }) => assert_eq!(len, cut.len()),
+        other => panic!("expected Truncated for a cut payload, got {other:?}"),
+    }
+}
+
+/// Encode evidence and return it with the offset of the length prefix of its last
+/// string, `runtime.core_version`. The payload ends with `runtime`: an 8-byte
+/// length, the version string, then a 2-byte schema field.
+fn encoded_with_version_prefix_offset() -> (Vec<u8>, usize, usize) {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let bytes = evidence.encode().expect("encode");
+    let version_len = evidence.runtime.core_version.len();
+    let prefix_at = bytes.len() - 2 - version_len - 8;
+    assert_eq!(
+        &bytes[prefix_at..prefix_at + 8],
+        &(version_len as u64).to_le_bytes(),
+        "the fixture must be locating the version string's length prefix"
+    );
+    (bytes, prefix_at, version_len)
+}
+
+/// #5578 review finding 6: a valid header followed by a payload that bincode
+/// rejects for a reason other than running out of bytes, which nothing tested. The
+/// fixture keeps every length intact and makes the last string in the payload
+/// invalid UTF-8.
+#[test]
+fn a_framed_file_with_an_undecodable_payload_reports_decode() {
+    let (mut bytes, prefix_at, version_len) = encoded_with_version_prefix_offset();
+    bytes[prefix_at + 8..prefix_at + 8 + version_len].fill(0xff);
+    assert!(matches!(
+        ConformanceEvidence::decode(&bytes),
+        Err(EvidenceError::Decode(_))
+    ));
+}
+
+/// A length prefix claiming more bytes than the payload holds is reported as
+/// truncation: the payload ends before what it declares. Pinned because the
+/// opposite was assumed while writing this module. bincode 1.3 ignores a configured
+/// size limit when decoding a slice, so no size-limit error can come from it here,
+/// and a test expecting one failed with exactly this `Truncated`.
+#[test]
+fn a_payload_declaring_more_than_it_holds_reports_truncated() {
+    let (mut bytes, prefix_at, _) = encoded_with_version_prefix_offset();
+    bytes[prefix_at..prefix_at + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+    match ConformanceEvidence::decode(&bytes) {
+        Err(EvidenceError::Truncated { len }) => assert_eq!(len, bytes.len()),
+        other => panic!("expected Truncated, got {other:?}"),
+    }
+}
+
+/// `encode` writes the header from `schema_version`, so it must refuse any value
+/// `decode` would then reject, instead of producing a file nothing can read.
+#[test]
+fn encode_refuses_a_schema_version_this_build_does_not_write() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let mut evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    evidence.schema_version = 999;
+    assert!(matches!(evidence.encode(), Err(EvidenceError::Encode(_))));
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -19,7 +19,8 @@ use freenet_stdlib::prelude::{
 };
 
 use super::evidence::{
-    ConformanceEvidence, EvidenceRejected, MAX_EVIDENCE_INPUT_BYTES, MAX_EVIDENCE_RELATED,
+    ConformanceEvidence, EvidenceError, EvidenceRejected, MAX_EVIDENCE_ENCODED_BYTES,
+    MAX_EVIDENCE_INPUT_BYTES, MAX_EVIDENCE_RELATED, MAX_EVIDENCE_TEXT_BYTES,
 };
 use super::generator::{Corpus, GeneratorConfig, generate_cases};
 use super::oracle::{ConformanceOracle, OracleError};
@@ -2433,7 +2434,13 @@ fn evidence_whose_only_large_field_is_the_observed_detail_is_rejected() {
         evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
         "the fixture must be small in every metered field, or it tests the wrong limit"
     );
-    assert!(evidence.check_bounds().is_err());
+    assert!(matches!(
+        evidence.check_bounds(),
+        Err(EvidenceRejected::TextTooLong {
+            field: "observed.detail",
+            ..
+        })
+    ));
 }
 
 /// #5581. The second unmetered field: `runtime.core_version` is also a `String` the
@@ -2447,7 +2454,13 @@ fn evidence_whose_only_large_field_is_the_runtime_version_is_rejected() {
         evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
         "the fixture must be small in every metered field, or it tests the wrong limit"
     );
-    assert!(evidence.check_bounds().is_err());
+    assert!(matches!(
+        evidence.check_bounds(),
+        Err(EvidenceRejected::TextTooLong {
+            field: "runtime.core_version",
+            ..
+        })
+    ));
 }
 
 /// #5581. bincode 1.x's free `deserialize` allows trailing bytes, so a valid payload
@@ -2462,7 +2475,10 @@ fn decode_refuses_bytes_after_a_complete_payload() {
         "control: the unmodified bytes must decode, or the refusal below proves nothing"
     );
     bytes.push(0);
-    assert!(ConformanceEvidence::decode(&bytes).is_err());
+    assert!(matches!(
+        ConformanceEvidence::decode(&bytes),
+        Err(EvidenceError::Decode(_))
+    ));
 }
 
 /// #5581. The size gate has to run during DECODE. `check_bounds` only ever sees an
@@ -2477,7 +2493,98 @@ fn decode_refuses_a_payload_larger_than_any_evidence_check_bounds_accepts() {
     );
     let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
     let bytes = evidence.encode().expect("encode");
-    assert!(ConformanceEvidence::decode(&bytes).is_err());
+    assert!(matches!(
+        ConformanceEvidence::decode(&bytes),
+        Err(EvidenceError::TooLarge { .. })
+    ));
+}
+
+/// The counterpart to the two text-field rejections: exactly at the limit passes.
+/// Without it, an off-by-one that refused every evidence object carrying a detail
+/// would still pass the tests above.
+#[test]
+fn evidence_text_exactly_at_the_limit_is_accepted() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let mut evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    evidence.observed = Some(violation_with_detail(MAX_EVIDENCE_TEXT_BYTES));
+    evidence.runtime.core_version = "9".repeat(MAX_EVIDENCE_TEXT_BYTES);
+    assert_eq!(evidence.check_bounds(), Ok(()));
+}
+
+/// `new` truncates an overlong detail rather than letting the writer's own
+/// `check_bounds` refuse it, and must not split a character doing so. `€` is three
+/// bytes and the limit is not a multiple of three, so the limit falls inside a
+/// character and the boundary search actually runs.
+#[test]
+fn new_truncates_an_overlong_detail_at_a_character_boundary() {
+    assert_ne!(
+        MAX_EVIDENCE_TEXT_BYTES % 3,
+        0,
+        "the fixture needs the limit to fall inside a character"
+    );
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let mut violation = violation_with_detail(0);
+    violation.detail = "€".repeat(MAX_EVIDENCE_TEXT_BYTES);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, Some(violation));
+    let detail = &evidence.observed.as_ref().expect("observed is kept").detail;
+    assert!(detail.len() <= MAX_EVIDENCE_TEXT_BYTES);
+    assert!(
+        detail.len() > MAX_EVIDENCE_TEXT_BYTES - 3,
+        "truncated further than one character short of the limit"
+    );
+    assert!(detail.chars().all(|c| c == '€'));
+    assert_eq!(evidence.check_bounds(), Ok(()));
+}
+
+/// Every object `check_bounds` accepts must also decode. If the decode limit were
+/// tighter than the bounds, the largest valid evidence would be written and then be
+/// unreadable. So this builds the maximum of everything `check_bounds` meters: inputs
+/// summing to exactly `MAX_EVIDENCE_INPUT_BYTES` spread over the property with the
+/// most states, the most related contracts, and both text fields at their limit.
+#[test]
+fn every_evidence_check_bounds_accepts_fits_the_decode_limit() {
+    let property = ConformanceProperty::StateAssociativity;
+    assert_eq!(
+        property.state_arity(),
+        3,
+        "the fixture assumes the property with the most states"
+    );
+    let side = 1024;
+    let states_total = MAX_EVIDENCE_INPUT_BYTES - side * (2 + MAX_EVIDENCE_RELATED);
+    let states: Vec<Bytes> = (0..3u8)
+        .map(|i| {
+            let len = states_total / 3 + usize::from(i == 2) * (states_total % 3);
+            Arc::from(vec![i; len].as_slice())
+        })
+        .collect();
+    let case = ConformanceCase::new(property, states);
+    let mut violation = violation_with_detail(MAX_EVIDENCE_TEXT_BYTES);
+    violation.settling = Some(IdempotenceSettling::SettledAfter(u32::MAX));
+    let mut evidence = ConformanceEvidence::new(instance(1), vec![7; side], &case, Some(violation));
+    evidence.summary = Some(vec![8; side]);
+    evidence.related = (0..MAX_EVIDENCE_RELATED)
+        .map(|i| (instance(i as u8 + 10), vec![9; side]))
+        .collect();
+    evidence.runtime.core_version = "9".repeat(MAX_EVIDENCE_TEXT_BYTES);
+    assert_eq!(
+        evidence.input_bytes(),
+        MAX_EVIDENCE_INPUT_BYTES,
+        "the fixture must sit exactly at the input limit"
+    );
+    assert_eq!(evidence.check_bounds(), Ok(()));
+
+    let bytes = evidence.encode().expect("encode");
+    // 8-byte magic plus 2-byte schema version precede the payload.
+    let body_len = bytes.len() - 10;
+    assert!(
+        body_len <= MAX_EVIDENCE_ENCODED_BYTES,
+        "the largest accepted evidence encodes to {body_len} bytes, over the \
+         {MAX_EVIDENCE_ENCODED_BYTES}-byte decode limit"
+    );
+    assert_eq!(
+        ConformanceEvidence::decode(&bytes).expect("decode"),
+        evidence
+    );
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -2504,6 +2504,21 @@ fn decode_refuses_a_payload_larger_than_any_evidence_check_bounds_accepts() {
     }
 }
 
+/// The counterpart: a payload of exactly `MAX_EVIDENCE_ENCODED_BYTES` passes the size
+/// gate. It is not valid evidence, so decoding still fails, but for a parse reason.
+/// Without this, `>` becoming `>=` in `decode_body` would pass every other test.
+#[test]
+fn a_payload_exactly_at_the_limit_passes_the_size_gate() {
+    let mut bytes = b"FRNTEVD1".to_vec();
+    bytes.extend_from_slice(&2u16.to_le_bytes());
+    bytes.resize(bytes.len() + MAX_EVIDENCE_ENCODED_BYTES, 0xff);
+    let result = ConformanceEvidence::decode(&bytes);
+    assert!(
+        !matches!(result, Err(EvidenceError::PayloadTooLarge { .. })),
+        "a payload exactly at the limit must pass the size gate, got {result:?}"
+    );
+}
+
 /// The counterpart to the two text-field rejections: exactly at the limit passes.
 /// Without it, an off-by-one that refused every evidence object carrying a detail
 /// would still pass the tests above.
@@ -2539,6 +2554,23 @@ fn new_truncates_an_overlong_detail_at_a_character_boundary() {
     );
     assert!(detail.chars().all(|c| c == '€'));
     assert_eq!(evidence.check_bounds(), Ok(()));
+
+    // Two ASCII bytes first put the character boundaries at 2 + 3k, so the limit sits
+    // two bytes into a character and the search must step back twice. A search that
+    // stepped back at most once would stop off a boundary, and `truncate` panics.
+    // Boundaries sit at 2 + 3k, so `MAX - 2` is one exactly when `MAX - 4` is a
+    // multiple of 3.
+    assert_eq!(
+        (MAX_EVIDENCE_TEXT_BYTES - 4) % 3,
+        0,
+        "the fixture needs a boundary two bytes below the limit"
+    );
+    let mut violation = violation_with_detail(0);
+    violation.detail = format!("ab{}", "€".repeat(MAX_EVIDENCE_TEXT_BYTES));
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, Some(violation));
+    let detail = &evidence.observed.as_ref().expect("observed is kept").detail;
+    assert_eq!(detail.len(), MAX_EVIDENCE_TEXT_BYTES - 2);
+    assert!(detail.starts_with("ab"));
 }
 
 /// Every object `check_bounds` accepts must also decode. If the decode limit were
@@ -3161,10 +3193,40 @@ fn a_truncated_v0_2_133_file_is_reported_as_damaged_not_as_foreign() {
         ConformanceEvidence::decode_file(&raw).is_ok(),
         "control: the whole file must decode, or the refusal below proves nothing"
     );
-    assert!(matches!(
-        ConformanceEvidence::decode_file(&raw[..raw.len() - 1]),
-        Err(EvidenceError::LegacyUndecodable(_))
-    ));
+    match ConformanceEvidence::decode_file(&raw[..raw.len() - 1]) {
+        Err(EvidenceError::LegacyUndecodable(detail)) => assert!(
+            detail.contains("ends before a complete payload"),
+            "expected the truncation reason, got: {detail}"
+        ),
+        other => panic!("expected LegacyUndecodable, got {other:?}"),
+    }
+}
+
+/// The other failing arm of the legacy path: every length is intact, but the content
+/// does not decode. Told apart from truncation by its reason, so a change that merged
+/// the two arms fails one of these two tests.
+#[test]
+fn an_unframed_file_with_undecodable_content_reports_why() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1, 2, 3]]);
+    let evidence = ConformanceEvidence::new(instance(42), vec![7, 8], &case, None);
+    let mut raw = bincode::serialize(&evidence).expect("serialize");
+    // The payload ends with `runtime`: an 8-byte length, the version string, then a
+    // 2-byte schema field. Make the version string invalid UTF-8, lengths intact.
+    let version_len = evidence.runtime.core_version.len();
+    let prefix_at = raw.len() - 2 - version_len - 8;
+    assert_eq!(
+        &raw[prefix_at..prefix_at + 8],
+        &(version_len as u64).to_le_bytes(),
+        "the fixture must be locating the version string's length prefix"
+    );
+    raw[prefix_at + 8..prefix_at + 8 + version_len].fill(0xff);
+    match ConformanceEvidence::decode_file(&raw) {
+        Err(EvidenceError::LegacyUndecodable(detail)) => assert!(
+            detail.contains("does not decode as it"),
+            "expected the content reason, got: {detail}"
+        ),
+        other => panic!("expected LegacyUndecodable, got {other:?}"),
+    }
 }
 
 /// #5578 review finding 4: `Truncated` promised the disk-full case but covered only
@@ -3283,6 +3345,26 @@ fn encode_refuses_a_schema_version_this_build_does_not_write() {
     let mut evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
     evidence.schema_version = 999;
     assert!(matches!(evidence.encode(), Err(EvidenceError::Encode(_))));
+}
+
+/// The size half of the same rule: `encode` refuses a payload that `decode` would
+/// refuse as too large, rather than writing a file nothing can read. Found by the
+/// external review of #5641.
+#[test]
+fn encode_refuses_a_payload_that_decode_would_refuse_as_too_large() {
+    let big = vec![0u8; MAX_EVIDENCE_ENCODED_BYTES + 1];
+    let case = ConformanceCase::new(
+        ConformanceProperty::StateIdempotence,
+        vec![Arc::from(big.as_slice())],
+    );
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    match evidence.encode() {
+        Err(EvidenceError::Encode(detail)) => assert!(
+            detail.contains("that decode accepts"),
+            "expected the size refusal, got: {detail}"
+        ),
+        other => panic!("expected an encode refusal, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/core/src/conformance/tests.rs
+++ b/crates/core/src/conformance/tests.rs
@@ -25,7 +25,7 @@ use super::generator::{Corpus, GeneratorConfig, generate_cases};
 use super::oracle::{ConformanceOracle, OracleError};
 use super::property::{
     ConformanceProperty, IdempotenceSettling, Inconclusive, OutputDigest, PremiseSource,
-    PropertyOutcome, Severity,
+    PropertyOutcome, Severity, Violation,
 };
 use super::verifier::{Bytes, ConformanceCase, verify_case};
 
@@ -2401,6 +2401,83 @@ fn oversized_evidence_is_rejected_before_any_execution() {
         evidence.check_bounds(),
         Err(EvidenceRejected::TooLarge { .. })
     ));
+}
+
+/// A `Violation` whose `detail` is `len` bytes. `detail` is free text the SENDER
+/// chooses, so this stands in for what a hostile peer can put there.
+fn violation_with_detail(len: usize) -> Violation {
+    Violation {
+        property: ConformanceProperty::StateIdempotence,
+        severity: ConformanceProperty::StateIdempotence.severity(),
+        left: OutputDigest::of(&[1]),
+        right: OutputDigest::of(&[2]),
+        detail: "x".repeat(len),
+        settling: None,
+    }
+}
+
+/// #5581. `observed.detail` is sender-chosen text that `input_bytes()` does not
+/// count, so the byte limit said nothing about it.
+///
+/// Every metered field is kept tiny on purpose. A fixture with large `states` would
+/// be rejected by the input-byte limit whether or not the text field were bounded,
+/// so it could not detect that bound being deleted.
+#[test]
+fn evidence_whose_only_large_field_is_the_observed_detail_is_rejected() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let mut evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    // Assigned on the struct rather than passed to `new`: a hostile sender writes the
+    // bytes directly and never runs our constructor.
+    evidence.observed = Some(violation_with_detail(1024 * 1024));
+    assert!(
+        evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
+        "the fixture must be small in every metered field, or it tests the wrong limit"
+    );
+    assert!(evidence.check_bounds().is_err());
+}
+
+/// #5581. The second unmetered field: `runtime.core_version` is also a `String` the
+/// sender writes, and was not counted either.
+#[test]
+fn evidence_whose_only_large_field_is_the_runtime_version_is_rejected() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let mut evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    evidence.runtime.core_version = "9".repeat(1024 * 1024);
+    assert!(
+        evidence.input_bytes() < MAX_EVIDENCE_INPUT_BYTES,
+        "the fixture must be small in every metered field, or it tests the wrong limit"
+    );
+    assert!(evidence.check_bounds().is_err());
+}
+
+/// #5581. bincode 1.x's free `deserialize` allows trailing bytes, so a valid payload
+/// with anything appended decoded as though the appendix were not there.
+#[test]
+fn decode_refuses_bytes_after_a_complete_payload() {
+    let case = case(ConformanceProperty::StateIdempotence, &[&[1]]);
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    let mut bytes = evidence.encode().expect("encode");
+    assert!(
+        ConformanceEvidence::decode(&bytes).is_ok(),
+        "control: the unmodified bytes must decode, or the refusal below proves nothing"
+    );
+    bytes.push(0);
+    assert!(ConformanceEvidence::decode(&bytes).is_err());
+}
+
+/// #5581. The size gate has to run during DECODE. `check_bounds` only ever sees an
+/// object that decoding has already allocated, so a limit applied there alone
+/// arrives after the cost it exists to prevent.
+#[test]
+fn decode_refuses_a_payload_larger_than_any_evidence_check_bounds_accepts() {
+    let big = vec![0u8; MAX_EVIDENCE_INPUT_BYTES * 4];
+    let case = ConformanceCase::new(
+        ConformanceProperty::StateIdempotence,
+        vec![Arc::from(big.as_slice())],
+    );
+    let evidence = ConformanceEvidence::new(instance(1), vec![], &case, None);
+    let bytes = evidence.encode().expect("encode");
+    assert!(ConformanceEvidence::decode(&bytes).is_err());
 }
 
 #[test]

--- a/crates/fdev/src/conformance.rs
+++ b/crates/fdev/src/conformance.rs
@@ -475,7 +475,9 @@ fn parse_properties(names: &[String]) -> anyhow::Result<Vec<ConformanceProperty>
 /// differ, and both are worth knowing.
 async fn verify_evidence(config: &ConformanceConfig, path: &PathBuf) -> anyhow::Result<()> {
     let bytes = read_file(path)?;
-    let evidence = ConformanceEvidence::decode(&bytes)
+    // A file the operator chose, so evidence written before framing existed is
+    // accepted here. A path receiving bytes from a peer must use the strict `decode`.
+    let evidence = ConformanceEvidence::decode_file(&bytes)
         .with_context(|| format!("decoding evidence {}", path.display()))?;
 
     // Bounds-check with the same function a receiving peer uses, so this command
@@ -3213,6 +3215,28 @@ mod tests {
         assert!(
             msg.contains("not conformance evidence (bad magic)"),
             "error should indicate bad magic; got: {msg}"
+        );
+    }
+
+    /// `--evidence` reads files, which may predate framing, so it uses `decode_file`
+    /// rather than the strict `decode`, and recognises a pre-framing file as old
+    /// evidence instead of calling it foreign. Switching `verify_evidence` back to
+    /// `decode` makes this fail: the same file then reads as bad magic.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn verify_evidence_recognises_a_file_written_before_framing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let evidence_path = dir.path().join("evidence.bin");
+        // An unframed schema-1 payload, as v0.2.129 to v0.2.132 wrote.
+        std::fs::write(&evidence_path, [1u8, 0, 0xff, 0xff, 0xff]).expect("write file");
+
+        let config = wasm_only_config(None);
+        let err = verify_evidence(&config, &evidence_path)
+            .await
+            .expect_err("a schema-1 file must be refused");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("written by an older build"),
+            "a pre-framing file must be recognised as old evidence; got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Problem

`check_bounds()` is documented as "the front door of the untrusted path" for conformance evidence, and `MAX_EVIDENCE_INPUT_BYTES` reads like a bound on how large an evidence object may be. It was not one, for two reasons (#5581):

1. **Two sender-written `String` fields were never counted.** `input_bytes()` sums the execution inputs (states, deltas, summary, related states, parameters) and nothing else, so `observed.detail` and `runtime.core_version` could be any size. A 1 MiB value in either passed `check_bounds()` clean. The issue names `observed.detail`; `runtime.core_version` has the same shape and is fixed alongside it.
2. **Decoding ran before any limit.** `decode()` used bincode 1.x's free `deserialize`, which has no size limit and ignores trailing bytes. So a payload four times larger than `check_bounds()` accepts was fully decoded before anything refused it, and a valid payload with arbitrary bytes appended decoded as if the appendix were not there.

None of this is reachable from the network today: evidence is a local file that `fdev verify-merge --evidence` reads. It becomes the receive path when RFC #5320 Phase 4 (#5377) makes evidence something peers send each other, and the fix is small and independent, so it lands first.

## Approach

- **`MAX_EVIDENCE_TEXT_BYTES` (1 KiB)** bounds each sender-written text field, checked in `check_bounds()` as a new `EvidenceRejected::TextTooLong { field, .. }`. A dedicated cap rather than folding the text into `input_bytes()`: the text is diagnostics that recipients never act on, so a small fixed ceiling removes the problem rather than accounting for it, and it leaves `input_bytes()` meaning what the rest of the module uses it for (bytes that verification will execute).
- **`ConformanceEvidence::new` truncates an overlong detail** at a character boundary. fdev's writer skips any evidence that fails `check_bounds()`, so without this an overlong detail would silently drop a real finding.
- **`MAX_EVIDENCE_ENCODED_BYTES`** bounds the encoded payload, checked before bincode reads a byte. bincode then decodes with `reject_trailing_bytes()`, keeping fixint little-endian so it stays byte-compatible with every file `bincode::serialize` has written.
- **Not `bincode::options().with_limit(..)`**, although #5581 and three reviewers of #5578 suggested it. bincode 1.3 replaces the configured limit with `Infinite` when it deserializes from a slice (`internal::deserialize_seed`), so it would read as a bound and bound nothing. This was found because a test written against it failed: a declared length of `u64::MAX` came back as `Truncated`, not a size-limit error. The length check is the bound, and `a_payload_declaring_more_than_it_holds_reports_truncated` pins what bincode actually does. Allocation is not bounded by the input: serde preallocates up to 1 MiB for a `Vec` from its declared length, and each element of a `Vec<Vec<u8>>` costs 8 input bytes but a 24-byte header, grown by doubling. So a decode can allocate up to about 2 MiB of preallocation plus a small multiple of the input. The payload cap is what bounds a single decode: worked out from the serde and bincode sources, the worst case at the cap is about 4.6 MiB. Tighter structural bounds are recorded for Phase 4 on #5377. This claim was stated wrongly three times during review, which is why it now gives the computed ceiling rather than a general guarantee.

### The decoder restructure, which also closes #5578's review findings

The Full-tier review of #5578 found six Should Fix items, all in `decode()` and all about it becoming a network receive path. They were deferred to this PR by stated disposition on #5578, because this is the PR that rewrites `decode()` for the untrusted path.

- **`decode()` is strict: framed evidence only.** #5578 put the pre-framing sniff (files v0.2.129 to v0.2.133 wrote as raw bincode) inside the canonical decoder, which is right for local files and wrong for the receive path Phase 4 plans: it would accept a second, unframed wire format permanently, recognised by two bytes instead of the 8-byte magic. That sniff now lives in **`decode_file()`**, which fdev's `verify_evidence` calls and nothing that handles peer bytes should. (#5578 findings 1 and 2)
- **Both paths go through the same bounded decode**, so the legacy branch #5578 added gets the same length check and trailing-byte refusal as the framed one. (finding 2)
- **A legacy file that fails to decode is no longer reported as "not conformance evidence".** It reports that it starts like unframed schema-2 evidence and does not decode as it, so a truncated v0.2.133 file points its owner at the file rather than at the tool. (finding 3)
- **A framed file cut short inside its body reports `Truncated`**, not an opaque bincode I/O error. `Truncated` previously covered only 8- and 9-byte inputs, although its documentation promised the disk-full case. (finding 4)
- **A file beginning `01 00` is described as looking like old evidence**, not asserted to be schema-1 evidence, since any binary file can begin that way. (finding 5)
- **A framed file with an undecodable body has a test.** (finding 6)
- **`encode()` refuses anything `decode()` would refuse**: a `schema_version` other than the current one, and a payload over `MAX_EVIDENCE_ENCODED_BYTES`, instead of writing a file nothing can read. (The size half was found by the external review.)
- The reviewer's name in a `tests.rs` comment is replaced by the invariant it was describing.

## Testing

Written first and confirmed failing on `main` at their final assertions, with their controls passing:

- `evidence_whose_only_large_field_is_the_observed_detail_is_rejected`
- `evidence_whose_only_large_field_is_the_runtime_version_is_rejected`
- `decode_refuses_bytes_after_a_complete_payload`
- `decode_refuses_a_payload_larger_than_any_evidence_check_bounds_accepts`

The two text-field fixtures keep every metered field tiny on purpose. A fixture with large `states` is rejected by the input limit whether or not the text is bounded, so it could not detect that bound being deleted, which is exactly the test #5581 warns against.

Added with the fix:

- `evidence_text_exactly_at_the_limit_is_accepted`: the off-by-one counterpart.
- `new_truncates_an_overlong_detail_at_a_character_boundary`: uses a 3-byte character with a limit that is not a multiple of 3, so the boundary search actually runs.
- `every_evidence_check_bounds_accepts_fits_the_decode_limit`: builds the largest object `check_bounds()` accepts (inputs at exactly the limit, the widest property, the most related contracts, both text fields at their cap) and proves it encodes under the decode limit and round-trips. Without this, the two limits could drift apart and the largest valid evidence would be written and then be unreadable.

Added during review:

- `a_payload_exactly_at_the_limit_passes_the_size_gate` and `evidence_whose_payload_is_exactly_the_limit_encodes_and_decodes`: the `>` against `>=` boundary of the decode and encode size guards respectively.
- `evidence_with_the_right_states_but_the_wrong_deltas_is_rejected`: the delta half of `check_bounds`' exact-arity check, which no test covered before (every arity test supplied a wrong number of states).
- `decode_file_decodes_framed_evidence_as_decode_does`, plus tests for `decode_file`'s short-input guard, its unknown-version fallthrough, and each legacy failure reason asserted on its own message.

**Mutation testing:** 21 mutations, chosen by an independent agent from the diff rather than by the author, run in a worktree of their own: 15 at `a81afb9fb`, then 6 at `9abf5037e` covering the code changed in review. **19 killed; 2 survived, and both are equivalent mutants** that no input can distinguish:

- `truncate_text`'s `text.len() <= max` becoming `< max`: at exactly `max` the mutant calls `truncate(max)` on a string of length `max`, which does nothing.
- Deleting `.reject_trailing_bytes()`: `DefaultOptions` already rejects trailing bytes by default (`bincode-1.3.3/src/config/mod.rs`). The call is kept because it states the intent at the point where it matters; the free `bincode::deserialize` this replaces explicitly allows trailing bytes.

Killed mutations include: deleting either text-length check or the truncation in `new`; `>` becoming `>=` in `check_text_len`, `decode_body` and `encode()`; moving the size check after the parse; shrinking the payload limit's slack; deleting the header schema check, the body schema check, `encode()`'s schema guard or its size guard; weakening `decode_file`'s short-input guard (the test panics out of bounds); deleting the schema-1 branch; swapping legacy error variants or merging their messages; mapping `EndedEarly` to `Decode` instead of `Truncated`; replacing the boundary search loop with a single step (panics); and fdev calling `decode` instead of `decode_file`.

Separately, each of the three tests added by the final re-check was run against the mutation it targets (`encode()`'s `>=`, the missing deltas comparison, `decode_file` without its framed delegation), and each fails.

Closes #5581
Closes #5582

#5582's two companion should-fixes (a round-trip test for `write_evidence`, and a pin on the on-disk format) landed in #5578, not here.

#5582's open design question, that the format accepts exactly one schema version so evidence stops flowing between peers during a rollout, is not addressed here. It belongs to #5377.

[AI-assisted - Claude]

https://claude.ai/code/session_01FNSEvSyKGgM1phK8SqYMfZ
